### PR TITLE
backend/fix: #5 Validate if search request is still valid before proc…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers.hs
@@ -96,5 +96,5 @@ sendSearchRequestToDrivers' driverPoolConfig searchReq merchant baseFare driverM
                 incrementFailedTaskCounter = Metrics.incrementFailedTaskCounter merchant.name,
                 putTaskDuration = Metrics.putTaskDuration merchant.name
               },
-          ifSearchRequestIsCancelled = I.ifSearchRequestIsCancelled searchReq.id
+                    ifSearchRequestIsValid = IfSearchRequestIsValid {cancelled = I.ifSearchRequestIsCancelled searchReq.id, expired = I.ifSearchRequestIsExpired searchReq.id}
         }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SearchRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SearchRequest.hs
@@ -77,3 +77,14 @@ getStatus searchRequestId = do
     where_ $
       searchT ^. SearchRequestTId ==. val (toKey searchRequestId)
     return $ searchT ^. SearchRequestStatus
+
+getValidTill ::
+  (Transactionable m) =>
+  Id SearchRequest ->
+  m (Maybe UTCTime)
+getValidTill searchRequestId = do
+  findOne $ do
+    searchT <- from $ table @SearchRequestT
+    where_ $
+      searchT ^. SearchRequestTId ==. val (toKey searchRequestId)
+    return $ searchT ^. SearchRequestValidTill


### PR DESCRIPTION
Validate if search request is still valid before processing Alloctor job

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

When the allocator starts processing the job, it should first check whether the Ride request is valid before processing it. If its not then it should end the preprocessing with relevant log line.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes



## Motivation and Context

This change is required to stop the processing of driver pool when search request is expired


## How did you test it?

By expiring a search request


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
