### PR TITLE
Add Github Actions CI for Nix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+name: "CI"
+on:
+  push:
+  pull_request:
+jobs:
+  Nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v12
+        with:
+          # TODO: configure official cache once provisioned.
+          # Using personal cache for now, and pushing manually.
+          name: srid-nammayatri
+      - name: Download from Nix cache (cachix)
+        run: |
+          nix develop -j 4 -c echo
+      - name: Build all packages 🔨
+        id: build-nix
+        run: |
+          nix build -L .#all
+      - name: Build Docker image 🔨
+        id: build-docker
+        run: |
+          nix build -L --no-allow-dirty .#dockerImage
+      - name: Flake checks 🧪
+        run: |
+          # Because 'nix flake check' is not system-aware
+          # See https://srid.ca/haskell-template/checks
+          nix run nixpkgs#sd \
+            'systems = nixpkgs.lib.systems.flakeExposed' \
+            'systems = [ "x86_64-linux" ]' \
+            flake.nix
+
+          # Sandbox must be disabed for:
+          # https://github.com/srid/haskell-flake/issues/21
+          nix \
+            --option sandbox false \
+            flake check -L

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,9 @@ jobs:
           name: srid-nammayatri
       - name: Download from Nix cache (cachix)
         run: |
-          nix develop -j 4 -c echo
+          # TODO: Use regular shell here, eventually, once CI starts pushing to
+          # cachix.
+          nix develop -j 4 .#all -c echo
       - name: Build all packages 🔨
         id: build-nix
         run: |

--- a/nix/cachix.nix
+++ b/nix/cachix.nix
@@ -1,0 +1,33 @@
+{ self, ... }:
+
+let
+  cachixName = "srid-nammayatri";
+in
+{
+  perSystem = { pkgs, ... }: {
+    apps.cachix = pkgs.writeShellApplication {
+      name = "cachix-push";
+      buildInputs = with pkgs; [
+        nix
+        cachix
+        jq
+      ];
+      text = ''
+        set -e
+        # Push shell
+        echo 'Pushing nix shell ...'
+        nix develop --profile $TMP/dev-profile 
+        cachix push ${cachixName} $TMP/dev-profile
+        # Push packages
+        echo 'Pushing nix packages ...'
+        nix build .#all --json | \
+         jq -r '.[].outputs | to_entries[].value' | \
+         cachix push ${cachixName}
+        # Push docker image
+        echo 'Pushing docker image drv ...'
+        nix build .#dockerImage --json | \
+         jq -r '.[].outputs | to_entries[].value' | \
+         cachix push ${cachixName}
+      '';
+    };
+  }


### PR DESCRIPTION
To merge into #14

I'm using my personal cachix (https://srid-nammayatri.cachix.org/) cache for now (pushing manually from laptop), but eventually once @vimalkumar or somebody else creates the official nammayatri cache, we should switch to it (at which point, the CI can push to cachix automatically). 

Regardless, we still need to manually push (made convenient via the flake app, run as `nix run .#cachix`) from macOS machines because Github Actions has no[^ci] ARM macOS builder: https://github.com/actions/runner-images/issues/2187

[^ci]: Instead of waiting for Microsoft to implement this, we could as well switch to either Jenkins or Hercules CI.