### PR TITLE
backend/fix: BKN-2865 Pass origin and destination address along …

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Confirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Confirm.hs
@@ -47,4 +47,4 @@ buildConfirmReq req = do
       { ..
       }
   where
-    castAddress Confirm.Address {..} = DBL.LocationAddress {areaCode = area_code, ..}
+    castAddress Confirm.Address {..} = DBL.LocationAddress {areaCode = area_code, area = locality, ..}

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnConfirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnConfirm.hs
@@ -106,4 +106,4 @@ mkFulfillmentInfo fromLoc toLoc startTime =
             }
     }
   where
-    castAddress DBL.LocationAddress {..} = OnConfirm.Address {area_code = areaCode, ..}
+    castAddress DBL.LocationAddress {..} = OnConfirm.Address {area_code = areaCode, locality = area, ward = Nothing, door = Nothing, ..}

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Select.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Select.hs
@@ -61,7 +61,8 @@ buildSelectReq subscriber req = do
         pickupAddress = pickup.location.address,
         dropAddrress = dropOff.location.address,
         variant = castVariant item.descriptor.code.vehicleVariant,
-        autoAssignEnabled = order.fulfillment.tags.auto_assign_enabled
+        autoAssignEnabled = order.fulfillment.tags.auto_assign_enabled,
+        customerLanguage = order.fulfillment.tags.customer_language
       }
 
 castVariant :: OS.VehicleVariant -> Variant

--- a/Backend/app/provider-platform/static-offer-driver-app/Main/src/Beckn/ACL/Confirm.hs
+++ b/Backend/app/provider-platform/static-offer-driver-app/Main/src/Beckn/ACL/Confirm.hs
@@ -49,4 +49,4 @@ buildConfirmReq subscriber req = do
       { ..
       }
   where
-    castAddress Confirm.Address {..} = DBL.LocationAddress {areaCode = area_code, ..}
+    castAddress Confirm.Address {..} = DBL.LocationAddress {areaCode = area_code, area = locality, ..}

--- a/Backend/app/provider-platform/static-offer-driver-app/Main/src/Beckn/ACL/OnConfirm.hs
+++ b/Backend/app/provider-platform/static-offer-driver-app/Main/src/Beckn/ACL/OnConfirm.hs
@@ -93,7 +93,7 @@ mkFulfillmentInfo fromLoc mbToLoc startTime =
               }
     }
   where
-    castAddress DBL.LocationAddress {..} = OnConfirm.Address {area_code = areaCode, ..}
+    castAddress DBL.LocationAddress {..} = OnConfirm.Address {area_code = areaCode, ward = Nothing, locality = area, door = Nothing, ..}
 
 mkPrice :: Money -> Money -> OnConfirm.QuotePrice
 mkPrice estimatedFare estimatedTotalFare =

--- a/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/Confirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/Confirm.hs
@@ -83,6 +83,9 @@ mkLocation DBL.LocationAddress {..} =
     { address =
         Confirm.Address
           { area_code = areaCode,
+            locality = area,
+            ward = ward,
+            door = door,
             ..
           }
     }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Profile.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Profile.hs
@@ -24,6 +24,7 @@ import qualified Domain.Types.Person as Person
 import Environment
 import Kernel.External.Encryption
 import qualified Kernel.External.FCM.Types as FCM
+import qualified Kernel.External.Maps as Maps
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto (runInReplica, runTransaction)
 import Kernel.Storage.Esqueleto.Config (EsqDBReplicaFlow)
@@ -47,7 +48,8 @@ data UpdateProfileReq = UpdateProfileReq
     lastName :: Maybe Text,
     email :: Maybe Text,
     deviceToken :: Maybe FCM.FCMRecipientToken,
-    referralCode :: Maybe Text
+    referralCode :: Maybe Text,
+    language :: Maybe Maps.Language
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
 
@@ -73,6 +75,7 @@ updatePerson personId req = do
       refCode
       mbEncEmail
       (req.deviceToken)
+      (req.language)
   pure APISuccess.Success
 
 validateRefferalCode :: (CacheFlow m r, EsqDBFlow m r, EncFlow m r, HasBapInfo r m, CoreMetrics m) => Id Person.Person -> Text -> m (Maybe Text)

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
@@ -192,6 +192,7 @@ buildPerson req bundleVersion clientVersion merchantId = do
         mobileCountryCode = Just $ req.mobileCountryCode,
         identifier = Nothing,
         rating = Nothing,
+        language = Nothing,
         isNew = True,
         enabled = True,
         deviceToken = Nothing,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/SavedReqLocation.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/SavedReqLocation.hs
@@ -45,7 +45,8 @@ data CreateSavedReqLocationReq = CreateSavedReqLocationReq
     areaCode :: Maybe Text,
     area :: Maybe Text,
     tag :: Text,
-    placeId :: Maybe Text
+    placeId :: Maybe Text,
+    ward :: Maybe Text
   }
   deriving (Generic, FromJSON, ToJSON, Show, ToSchema)
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search/Common.hs
@@ -58,7 +58,8 @@ buildSearchRequest person pickup mbDrop mbDistance now bundleVersion clientVersi
         merchantId = person.merchantId,
         createdAt = now,
         bundleVersion = bundleVersion,
-        clientVersion = clientVersion
+        clientVersion = clientVersion,
+        language = person.language
       }
   where
     getSearchRequestExpiry :: (HasFlowEnv m r '["searchRequestExpiry" ::: Maybe Seconds]) => UTCTime -> m UTCTime

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Select.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Select.hs
@@ -30,6 +30,7 @@ import qualified Domain.Types.Quote as DQuote
 import qualified Domain.Types.SearchRequest as DSearchReq
 import Domain.Types.VehicleVariant (VehicleVariant)
 import Environment
+import qualified Kernel.External.Maps as Maps
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto (runInReplica)
 import qualified Kernel.Storage.Esqueleto as Esq
@@ -49,7 +50,8 @@ data DSelectRes = DSelectRes
     estimateId :: Id DEstimate.Estimate,
     providerId :: Text,
     providerUrl :: BaseUrl,
-    variant :: VehicleVariant
+    variant :: VehicleVariant,
+    customerLanguage :: Maybe Maps.Language
   }
 
 newtype DEstimateSelectReq = DEstimateSelect
@@ -81,6 +83,7 @@ select personId estimateId = do
       { providerId = estimate.providerId,
         providerUrl = estimate.providerUrl,
         variant = estimate.vehicleVariant,
+        customerLanguage = searchRequest.language,
         ..
       }
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/LocationAddress.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/LocationAddress.hs
@@ -25,6 +25,8 @@ data LocationAddress = LocationAddress
     country :: Maybe Text,
     building :: Maybe Text,
     areaCode :: Maybe Text,
-    area :: Maybe Text
+    area :: Maybe Text,
+    ward :: Maybe Text,
+    placeId :: Maybe Text
   }
   deriving (Generic, FromJSON, ToJSON, ToSchema, Show, Eq, PrettyShow)

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Person.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Person.hs
@@ -30,6 +30,7 @@ import Kernel.Types.Id
 import Kernel.Types.Version
 import Kernel.Utils.Common (maskText)
 import Servant.API
+import qualified Kernel.External.Maps as Maps
 
 data Role
   = USER
@@ -86,6 +87,7 @@ data PersonE e = Person
     passwordHash :: Maybe DbHash,
     identifier :: Maybe Text,
     rating :: Maybe Text,
+    language :: Maybe Maps.Language,
     isNew :: Bool,
     enabled :: Bool,
     deviceToken :: Maybe FCM.FCMRecipientToken,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/SavedReqLocation.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/SavedReqLocation.hs
@@ -34,7 +34,8 @@ data SavedReqLocation = SavedReqLocation
     updatedAt :: UTCTime,
     tag :: Text,
     riderId :: Id Person,
-    placeId :: Maybe Text
+    placeId :: Maybe Text,
+    ward :: Maybe Text
   }
   deriving (Generic, Show)
 
@@ -50,7 +51,8 @@ data SavedReqLocationAPIEntity = SavedReqLocationAPIEntity
     areaCode :: Maybe Text,
     area :: Maybe Text,
     tag :: Text,
-    placeId :: Maybe Text
+    placeId :: Maybe Text,
+    ward :: Maybe Text
   }
   deriving (Generic, FromJSON, ToJSON, Show, ToSchema)
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/SearchRequest.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/SearchRequest.hs
@@ -18,6 +18,7 @@ module Domain.Types.SearchRequest where
 import qualified Domain.Types.Merchant as DMerchant
 import qualified Domain.Types.Person as DP
 import qualified Domain.Types.SearchRequest.SearchReqLocation as DLoc
+import qualified Kernel.External.Maps as Maps
 import Kernel.Prelude
 import Kernel.Types.Common (HighPrecMeters)
 import Kernel.Types.Id
@@ -37,6 +38,7 @@ data SearchRequest = SearchRequest
     merchantId :: Id DMerchant.Merchant, -- remove when searchRequest will not be used in CustomerSupport
     createdAt :: UTCTime,
     bundleVersion :: Maybe Version,
-    clientVersion :: Maybe Version
+    clientVersion :: Maybe Version,
+    language :: Maybe Maps.Language
   }
   deriving (Generic, Show)

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Person.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Person.hs
@@ -26,6 +26,7 @@ import Kernel.Types.Common
 import Kernel.Types.Id
 import Kernel.Types.Version
 import Storage.Tabular.Person
+import Kernel.External.Maps (Language)
 
 create :: Person -> SqlDB ()
 create = Esq.create
@@ -170,8 +171,9 @@ updatePersonalInfo ::
   Maybe Text ->
   Maybe (EncryptedHashed Text) ->
   Maybe FCMRecipientToken ->
+  Maybe Language -> 
   SqlDB ()
-updatePersonalInfo personId mbFirstName mbMiddleName mbLastName mbReferralCode mbEncEmail mbDeviceToken = do
+updatePersonalInfo personId mbFirstName mbMiddleName mbLastName mbReferralCode mbEncEmail mbDeviceToken mbLanguage = do
   now <- getCurrentTime
   let mbEmailEncrypted = mbEncEmail <&> unEncrypted . (.encrypted)
   let mbEmailHash = mbEncEmail <&> (.hash)
@@ -187,6 +189,7 @@ updatePersonalInfo personId mbFirstName mbMiddleName mbLastName mbReferralCode m
           <> updateWhenJust_ (\x -> PersonDeviceToken =. val (Just x)) mbDeviceToken
           <> updateWhenJust_ (\x -> PersonReferralCode =. val (Just x)) mbReferralCode
           <> updateWhenJust_ (\_ -> PersonReferredAt =. val (Just now)) mbReferralCode
+          <> updateWhenJust_ (\x -> PersonLanguage =. val (Just x)) mbLanguage
       )
     where_ $ tbl ^. PersonId ==. val (getId personId)
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/Booking/BookingLocation.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/Booking/BookingLocation.hs
@@ -41,6 +41,7 @@ mkPersist
       building Text Maybe
       areaCode Text Maybe
       area Text Maybe
+      ward Text Maybe
       createdAt UTCTime
       updatedAt UTCTime
       Primary id
@@ -54,7 +55,7 @@ instance TEntityKey BookingLocationT where
 
 instance TType BookingLocationT Domain.BookingLocation where
   fromTType BookingLocationT {..} = do
-    let address = Domain.LocationAddress {..}
+    let address = Domain.LocationAddress {placeId = Nothing, ..}
     return $
       Domain.BookingLocation
         { id = Id id,

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/Person.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/Person.hs
@@ -29,11 +29,14 @@ import Kernel.Storage.Esqueleto
 import Kernel.Types.Id
 import Kernel.Utils.Version
 import qualified Storage.Tabular.Merchant as SMerchant
+import Kernel.External.Maps (Language)
+
 
 derivePersistField "Domain.Role"
 derivePersistField "Domain.Gender"
 derivePersistField "Domain.IdentifierType"
 derivePersistField "OptApiMethods"
+derivePersistField "Language"
 
 mkPersist
   defaultSqlSettings
@@ -55,6 +58,7 @@ mkPersist
       passwordHash DbHash Maybe
       identifier Text Maybe
       rating Text Maybe
+      language Language Maybe
       isNew Bool
       enabled Bool
       deviceToken FCMRecipientToken Maybe

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/SavedReqLocation.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/SavedReqLocation.hs
@@ -46,6 +46,7 @@ mkPersist
       updatedAt UTCTime
       tag  Text
       riderId Person.PersonTId
+      ward Text Maybe
       Primary id
       deriving Generic
     |]

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/SearchRequest.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/SearchRequest.hs
@@ -21,6 +21,7 @@
 module Storage.Tabular.SearchRequest where
 
 import qualified Domain.Types.SearchRequest as Domain
+import Kernel.External.Maps (Language)
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto
 import Kernel.Types.Common hiding (id)
@@ -45,6 +46,7 @@ mkPersist
       createdAt UTCTime
       bundleVersion Text Maybe
       clientVersion Text Maybe
+      language Language Maybe
       Primary id
       deriving Generic
     |]

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/SearchRequest/SearchReqLocation.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Tabular/SearchRequest/SearchReqLocation.hs
@@ -41,6 +41,8 @@ mkPersist
       building Text Maybe
       areaCode Text Maybe
       area Text Maybe
+      ward Text Maybe 
+      placeId Text Maybe
       createdAt UTCTime
       updatedAt UTCTime
       Primary id

--- a/Backend/dev/migrations/rider-app/1083-add-language-in-person-and-placeId-in-search-req-loc.sql
+++ b/Backend/dev/migrations/rider-app/1083-add-language-in-person-and-placeId-in-search-req-loc.sql
@@ -1,0 +1,6 @@
+ALTER TABLE atlas_app.person ADD COLUMN language character varying(255);
+ALTER TABLE atlas_app.search_request_location ADD COLUMN ward character varying(255);
+ALTER TABLE atlas_app.search_request_location ADD COLUMN place_id character varying(255);
+ALTER TABLE atlas_app.search_request ADD COLUMN language character varying(255);
+ALTER TABLE atlas_app.booking_location ADD COLUMN ward character varying(255);
+ALTER TABLE atlas_app.saved_location ADD COLUMN ward character varying(255);

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Common/Address.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Common/Address.hs
@@ -19,13 +19,15 @@ import Kernel.Prelude
 import Kernel.Utils.Schema (genericDeclareUnNamedSchema)
 
 data Address = Address
-  { area :: Maybe Text,
+  { locality :: Maybe Text,
     state :: Maybe Text,
     country :: Maybe Text,
     building :: Maybe Text,
     street :: Maybe Text,
     city :: Maybe Text,
-    area_code :: Maybe Text
+    area_code :: Maybe Text,
+    ward :: Maybe Text,
+    door :: Maybe Text
   }
   deriving (Generic, Show, ToJSON, FromJSON)
 

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Select/Fulfillment.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Select/Fulfillment.hs
@@ -22,6 +22,7 @@ import Beckn.Types.Core.Taxi.Select.StopInfo
 import Data.Aeson
 import Data.OpenApi (ToSchema (..), defaultSchemaOptions, fromAesonOptions)
 import EulerHS.Prelude hiding (id)
+import Kernel.External.Types (Language)
 import Kernel.Utils.Schema (genericDeclareUnNamedSchema)
 
 -- If end = Nothing, then bpp sends quotes only for RENTAL
@@ -33,8 +34,9 @@ data FulfillmentInfo = FulfillmentInfo
   }
   deriving (Generic, FromJSON, ToJSON, Show)
 
-newtype Tags = Tags
-  { auto_assign_enabled :: Bool
+data Tags = Tags
+  { auto_assign_enabled :: Bool,
+    customer_language :: Maybe Language
   }
   deriving (Generic, Show)
 

--- a/Backend/test/src/Mobility/Fixtures/Routes.hs
+++ b/Backend/test/src/Mobility/Fixtures/Routes.hs
@@ -38,7 +38,9 @@ defaultSearchReqAddress =
       country = Nothing,
       building = Nothing,
       areaCode = Nothing,
-      area = Nothing
+      area = Nothing,
+      ward = Nothing,
+      placeId = Nothing
     }
 
 type LocationUpdates = NonEmpty (NonEmpty LatLong)


### PR DESCRIPTION
…with lat/lon in search request to BPP and add language to person customer table

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Currently we are only sending lat/lon from BAP to BPP in search request and at BPP we are reverse looking up address via geocode API.
Send this address from BAP to BPP in search request itself. At BPPs end, if address is present then use it, if not then make call geocode API. (this fallback should be present since not all BAPs might send this)
Also added Language to Customer person table, which is passed to BPP to check persons language.
This will improve the quality of address which is being stored at BAP and BPP side
https://juspay.atlassian.net/browse/BKN-2928


### Additional Changes

- [x] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
- reduce one geocode api call at BPP
- This will improve the quality of address which is being stored at BAP and BPP side
- customer will be able to see the same address at booking confirm which he sees during rideSearch 


## How did you test it?
tested locally on postman


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
