### PR TITLE
Nix: reduce docker image size

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,9 @@
       perSystem = { config, self', system, pkgs, lib, ... }: {
         cachix-push.packages = [ "all" ];
 
-        packages.default = self'.packages.rider-app;
+        packages.default =
+          pkgs.haskell.lib.justStaticExecutables
+            self'.packages.rider-app;
 
         # A dummy package to force build of all local Haskell packages. 
         # Useful in CI.


### PR DESCRIPTION
The nix built docker image currently takes 7.36GB, due to depending on rider-app *library*. `justStaticExecutables` will strip that, leading to the image now weighing only 315MB

```
ghcr.io/nammayatri/nammayatri   e83520bc7   b874638941b8   57 seconds ago      315M
```