### PR TITLE
backend/feat: #115 seperate config for pickup and trip

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Route.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Route.hs
@@ -35,9 +35,25 @@ type API =
     :> TokenAuth
     :> ReqBody '[JSON] Maps.GetRoutesReq
     :> Post '[JSON] Maps.GetRoutesResp
+    :<|> "pickup"
+      :> "route"
+      :> TokenAuth
+      :> ReqBody '[JSON] Maps.GetRoutesReq
+      :> Post '[JSON] Maps.GetRoutesResp
+    :<|> "trip"
+      :> "route"
+      :> TokenAuth
+      :> ReqBody '[JSON] Maps.GetRoutesReq
+      :> Post '[JSON] Maps.GetRoutesResp
 
 handler :: FlowServer API
-handler = getRoute
+handler = getRoute :<|> getPickupRoute :<|> getTripRoute
 
 getRoute :: Id Person.Person -> Maps.GetRoutesReq -> FlowHandler Maps.GetRoutesResp
 getRoute personId = withFlowHandlerAPI . withPersonIdLogTag personId . DRoute.getRoutes personId
+
+getPickupRoute :: Id Person.Person -> Maps.GetRoutesReq -> FlowHandler Maps.GetRoutesResp
+getPickupRoute personId = withFlowHandlerAPI . withPersonIdLogTag personId . DRoute.getPickupRoutes personId
+
+getTripRoute :: Id Person.Person -> Maps.GetRoutesReq -> FlowHandler Maps.GetRoutesResp
+getTripRoute personId = withFlowHandlerAPI . withPersonIdLogTag personId . DRoute.getTripRoutes personId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Route.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Route.hs
@@ -16,6 +16,8 @@ module Domain.Action.UI.Route
   ( Maps.GetRoutesReq,
     Maps.GetRoutesResp,
     getRoutes,
+    getPickupRoutes,
+    getTripRoutes,
   )
 where
 
@@ -33,3 +35,13 @@ getRoutes :: (EncFlow m r, CacheFlow m r, EsqDBFlow m r, CoreMetrics m) => Id DP
 getRoutes personId req = do
   person <- QP.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
   Maps.getRoutes person.merchantId req
+
+getPickupRoutes :: (EncFlow m r, CacheFlow m r, EsqDBFlow m r, CoreMetrics m) => Id DP.Person -> Maps.GetRoutesReq -> m Maps.GetRoutesResp
+getPickupRoutes personId req = do
+  person <- QP.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
+  Maps.getPickupRoutes person.merchantId req
+
+getTripRoutes :: (EncFlow m r, CacheFlow m r, EsqDBFlow m r, CoreMetrics m) => Id DP.Person -> Maps.GetRoutesReq -> m Maps.GetRoutesResp
+getTripRoutes personId req = do
+  person <- QP.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
+  Maps.getTripRoutes person.merchantId req

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/MerchantServiceUsageConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/MerchantServiceUsageConfig.hs
@@ -27,6 +27,8 @@ data MerchantServiceUsageConfigD (s :: UsageSafety) = MerchantServiceUsageConfig
     getDistances :: MapsService,
     getEstimatedPickupDistances :: MapsService,
     getRoutes :: MapsService,
+    getPickupRoutes :: MapsService,
+    getTripRoutes :: MapsService,
     snapToRoad :: MapsService,
     getPlaceName :: MapsService,
     getPlaceDetails :: MapsService,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Tabular/Merchant/MerchantServiceUsageConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Tabular/Merchant/MerchantServiceUsageConfig.hs
@@ -38,6 +38,8 @@ mkPersist
       getDistances MapsService
       getEstimatedPickupDistances MapsService
       getRoutes MapsService
+      getPickupRoutes MapsService
+      getTripRoutes MapsService
       snapToRoad MapsService
       getPlaceName MapsService
       getPlaceDetails MapsService

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Maps.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Maps.hs
@@ -22,6 +22,8 @@ module Tools.Maps
     getPlaceName,
     getRoutes,
     snapToRoad,
+    getPickupRoutes,
+    getTripRoutes,
   )
 where
 
@@ -88,6 +90,12 @@ getEstimatedPickupDistances = runWithServiceConfig Maps.getDistances (.getEstima
 
 getRoutes :: (EncFlow m r, CacheFlow m r, EsqDBFlow m r, CoreMetrics m) => Id Merchant -> GetRoutesReq -> m GetRoutesResp
 getRoutes = runWithServiceConfig Maps.getRoutes (.getRoutes)
+
+getPickupRoutes :: (EncFlow m r, CacheFlow m r, EsqDBFlow m r, CoreMetrics m) => Id Merchant -> GetRoutesReq -> m GetRoutesResp
+getPickupRoutes = runWithServiceConfig Maps.getRoutes (.getPickupRoutes)
+
+getTripRoutes :: (EncFlow m r, CacheFlow m r, EsqDBFlow m r, CoreMetrics m) => Id Merchant -> GetRoutesReq -> m GetRoutesResp
+getTripRoutes = runWithServiceConfig Maps.getRoutes (.getTripRoutes)
 
 snapToRoad ::
   ( EncFlow m r,

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0112-add-trip-and-pickup-route.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0112-add-trip-and-pickup-route.sql
@@ -1,0 +1,2 @@
+ALTER TABLE atlas_driver_offer_bpp.merchant_service_usage_config ADD COLUMN get_pickup_routes text DEFAULT 'Google';
+ALTER TABLE atlas_driver_offer_bpp.merchant_service_usage_config ADD COLUMN get_trip_routes text DEFAULT 'Google';


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
We are using route api as proxy for frontend to call the directions api of Google. Frontend call this api in case of both driver to pickup route and trip route. As we are just having one route proxy api for both, we can not change the map service just for one to OSRM. Please create two more route api pickup/route and trip/route with having to different configuration in MerchantServiceUsageConfig.


### Additional Changes

- [x] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context
We are using route api as proxy for frontend to call the directions api of Google. Frontend call this api in case of both driver to pickup route and trip route. As we are just having one route proxy api for both, we can not change the map service just for one to OSRM. Please create two more route api pickup/route and trip/route with having to different configuration in MerchantServiceUsageConfig.


## How did you test it?
Calling the API


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
