### PR TITLE
Jenkins: revamp cachix and docker steps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         ./Backend/default.nix
       ];
       perSystem = { self', pkgs, ... }: {
-        cachix-push.packages = [ "nammayatri" ];
+        packages.default = self'.packages.nammayatri;
       };
     };
 }


### PR DESCRIPTION
- Re-enable `cachix push`
- Externalize docker steps to https://github.com/juspay/jenkins-nix-ci/pull/4
