### PR TITLE
Jenkins: use Groovy library for cachix/docker

### DIFF
--- a/Backend/nix/docker.nix
+++ b/Backend/nix/docker.nix
@@ -8,8 +8,6 @@ let
 in
 {
   config = {
-    flake.dockerImageName = imageName + ":" + imageTag;
-    flake.dockerImageTag = imageTag;
     perSystem = { self', pkgs, lib, ... }: {
       packages = lib.optionalAttrs pkgs.stdenv.isLinux {
         dockerImage =

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,13 @@
+// This library is defined in https://github.com/juspay/jenkins-nix-ci
+// and provides: cachixUse, cachixPush, dockerPush
+@Library('jenkins-nix-ci') _
+
 pipeline {
     agent any
     stages {
         stage ('Cachix setup') {
             steps {
-                sh 'cachix use nammayatri'
+                cachixUse 'nammayatri'
             }
         }
         stage ('Nix Build') {
@@ -18,22 +22,14 @@ pipeline {
         }
         stage ('Docker image') {
             when { branch 'main' }
-            environment {
-              DOCKER_USER = credentials('docker-user')
-              DOCKER_PASS = credentials('docker-pass')
-              DOCKER_SERVER = 'ghcr.io'
-            }
             steps {
-                sh 'nix run github:juspay/jenkins-nix-ci#docker-push dockerImage'
+                dockerPush "dockerImage", "ghcr.io"
             }
         }
-        stage ('Push to cachix') {
-          environment {
-            CACHIX_AUTH_TOKEN = credentials('cachix-auth-token')
-          }
-          steps {
-            sh 'nix run github:juspay/jenkins-nix-ci#cachix-push nammayatri'
-          }
+        stage ('Cachix push') {
+            steps {
+              cachixPush "nammayatri"
+            }
         }
     }
 }


### PR DESCRIPTION
Using: https://github.com/juspay/jenkins-nix-ci/pull/6

Going forward, we'll be using these library functions for doing common tasks. These functions, being located in [the same repo](https://github.com/juspay/jenkins-nix-ci), are automatically aware of the associated credentials; so we do not have to provide them ourselves. Thus it simplifies our `Jenkinsfile`.