### PR TITLE
Docker: include `/swagger` and `/dhall-configs` in the right location

### DIFF
--- a/Backend/default.nix
+++ b/Backend/default.nix
@@ -33,16 +33,32 @@
         };
     };
 
-    # The final nammayatri package containing the various executables.
-    packages.nammayatri =
-      let
-        localCabalPackages = builtins.map
-          (p: pkgs.haskell.lib.justStaticExecutables p.package)
-          (lib.attrValues config.haskellProjects.default.outputs.packages);
-      in
-      pkgs.symlinkJoin {
-        name = "nammayatri-exes";
-        paths = localCabalPackages;
+    packages = {
+      # The final nammayatri package containing the various executables.
+      nammayatri =
+        let
+          localCabalPackages = builtins.map
+            (p: pkgs.haskell.lib.justStaticExecutables p.package)
+            (lib.attrValues config.haskellProjects.default.outputs.packages);
+        in
+        pkgs.symlinkJoin {
+          name = "nammayatri-exes";
+          paths = localCabalPackages;
+        };
+      # The nammayatri dist to be deployed in Docker image
+      nammayatri-dist = pkgs.symlinkJoin {
+        name = "nammayatri-dist";
+        paths = [ self'.packages.nammayatri ];
+        postBuild = ''
+          mkdir $out/opt
+          # Rationale: Our k8s deployment config is hardcoded to look for exes
+          # under /opt/app.
+          mv $out/bin $out/opt/app
+          cp -r ${./dhall-configs} $out/opt/app/dhall-configs
+          cp -r ${./swagger} $out/opt/app/swagger
+        '';
       };
+    };
+
   };
 }

--- a/Backend/nix/docker.nix
+++ b/Backend/nix/docker.nix
@@ -10,51 +10,33 @@ in
   config = {
     perSystem = { self', pkgs, lib, ... }: {
       packages = {
-        dockerImage =
-          let
-            # Wrap the nammayaatri package so that its binaries are in /opt/app.
-            #
-            # Rationale: Our k8s deployment config is hardcoded to look for exes
-            # under /opt/app
-            nammayatri-in-opt = pkgs.symlinkJoin {
-              name = "nammayatri-exes-opt";
-              paths = [ self'.packages.nammayatri ];
-              postBuild = ''
-                mkdir $out/opt && mv $out/bin $out/opt/app
-              '';
-            };
-          in
-          pkgs.dockerTools.buildImage {
-            name = imageName;
-            created = "now";
-            tag = imageTag;
-            copyToRoot = pkgs.buildEnv {
-              paths = with pkgs; [
-                cacert
-                awscli
-                coreutils
-                bash
-                # Add project root to paths to copy dhall-configs and swagger dirs
-                self
-                nammayatri-in-opt
-              ];
-              name = "beckn-root";
-              pathsToLink = [
-                "/Backend/dhall-configs"
-                "/Backend/swagger"
-                "/bin"
-                "/opt"
-              ];
-            };
-            config = {
-              Env = [
-                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-                # Ref: https://hackage.haskell.org/package/x509-system-1.6.7/docs/src/System.X509.Unix.html#getSystemCertificateStore
-                "SYSTEM_CERTIFICATE_PATH=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
-              Cmd = [ "${self'.packages.nammayatri}/bin/rider-app-exe" ];
-            };
+        dockerImage = pkgs.dockerTools.buildImage {
+          name = imageName;
+          created = "now";
+          tag = imageTag;
+          copyToRoot = pkgs.buildEnv {
+            paths = with pkgs; [
+              cacert
+              awscli
+              coreutils
+              bash
+              self'.packages.nammayatri-dist
+            ];
+            name = "beckn-root";
+            pathsToLink = [
+              "/bin"
+              "/opt"
+            ];
           };
+          config = {
+            Env = [
+              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              # Ref: https://hackage.haskell.org/package/x509-system-1.6.7/docs/src/System.X509.Unix.html#getSystemCertificateStore
+              "SYSTEM_CERTIFICATE_PATH=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            ];
+            Cmd = [ "${self'.packages.nammayatri}/bin/rider-app-exe" ];
+          };
+        };
       };
     };
   };


### PR DESCRIPTION
After this change, in the docker image:

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/3998/232550739-aee52fc1-f764-46ae-8d2e-ffcde09570c1.png">

(Diff is huge, because I had to refactor a few things; `nammayatri-dist` is the only relevant change)