### PR TITLE
backend/fix/ #600 added logs and omit +91 in heartbeat api

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Exophone.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Exophone.hs
@@ -57,10 +57,13 @@ findAllExophones = findAll $ from $ table @ExophoneT
 
 updateAffectedPhones :: [Text] -> SqlDB ()
 updateAffectedPhones primaryPhones = do
+  let indianMobileCode = val "+91"
   now <- getCurrentTime
   let primaryPhonesList = valList primaryPhones
   Esq.update $ \tbl -> do
-    let isPrimaryDown = tbl ^. ExophonePrimaryPhone `in_` primaryPhonesList
+    let isPrimaryDown =
+          tbl ^. ExophonePrimaryPhone `in_` primaryPhonesList
+            ||. (indianMobileCode ++. tbl ^. ExophonePrimaryPhone) `in_` primaryPhonesList
     set
       tbl
       [ ExophoneIsPrimaryDown =. isPrimaryDown,

--- a/Backend/app/provider-platform/static-offer-driver-app/Main/src/Storage/Queries/Exophone.hs
+++ b/Backend/app/provider-platform/static-offer-driver-app/Main/src/Storage/Queries/Exophone.hs
@@ -57,10 +57,13 @@ findAllExophones = findAll $ from $ table @ExophoneT
 
 updateAffectedPhones :: [Text] -> SqlDB ()
 updateAffectedPhones primaryPhones = do
+  let indianMobileCode = val "+91"
   now <- getCurrentTime
   let primaryPhonesList = valList primaryPhones
   Esq.update $ \tbl -> do
-    let isPrimaryDown = tbl ^. ExophonePrimaryPhone `in_` primaryPhonesList
+    let isPrimaryDown =
+          tbl ^. ExophonePrimaryPhone `in_` primaryPhonesList
+            ||. (indianMobileCode ++. tbl ^. ExophonePrimaryPhone) `in_` primaryPhonesList
     set
       tbl
       [ ExophoneIsPrimaryDown =. isPrimaryDown,

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Exophone.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Exophone.hs
@@ -57,10 +57,13 @@ findAllExophones = findAll $ from $ table @ExophoneT
 
 updateAffectedPhones :: [Text] -> SqlDB ()
 updateAffectedPhones primaryPhones = do
+  let indianMobileCode = val "+91"
   now <- getCurrentTime
   let primaryPhonesList = valList primaryPhones
   Esq.update $ \tbl -> do
-    let isPrimaryDown = tbl ^. ExophonePrimaryPhone `in_` primaryPhonesList
+    let isPrimaryDown =
+          tbl ^. ExophonePrimaryPhone `in_` primaryPhonesList
+            ||. (indianMobileCode ++. tbl ^. ExophonePrimaryPhone) `in_` primaryPhonesList
     set
       tbl
       [ ExophoneIsPrimaryDown =. isPrimaryDown,

--- a/Backend/dev/rest-client/dashboard/bpp-dashboard/exotel.http
+++ b/Backend/dev/rest-client/dashboard/bpp-dashboard/exotel.http
@@ -8,7 +8,7 @@ GET {{bpp-dashboard-host}}
 
 # @name exotelHeartbeatOK
 
-POST {{bpp-dashboard-host}}/exotel/heartbeat?exotelToken={{exotelToken}}
+POST {{bpp-dashboard-host}}/exotel/{{exotelToken}}/heartbeat
 content-type: application/json
 
 {
@@ -26,7 +26,7 @@ content-type: application/json
 
 # @name exotelHeartbeatWARNING
 
-POST {{bpp-dashboard-host}}/exotel/heartbeat?exotelToken={{exotelToken}}
+POST {{bpp-dashboard-host}}/exotel/{{exotelToken}}/heartbeat
 content-type: application/json
 
 {
@@ -60,7 +60,7 @@ content-type: application/json
 
 # @name exotelHeartbeatCRITICAL
 
-POST {{bpp-dashboard-host}}/exotel/heartbeat?exotelToken={{exotelToken}}
+POST {{bpp-dashboard-host}}/exotel/{{exotelToken}}/heartbeat
 content-type: application/json
 
 {

--- a/Backend/stack-hie.yaml.lock
+++ b/Backend/stack-hie.yaml.lock
@@ -5,496 +5,496 @@
 
 packages:
 - completed:
-    commit: ed02c5e23953f04ed9d833465c1b334b7c8b02fd
-    git: https://github.com/nammayatri/beckn-gateway.git
+    subdir: app/gateway
     name: beckn-gateway
+    version: 0.1.0.0
+    git: https://github.com/nammayatri/beckn-gateway.git
     pantry-tree:
-      sha256: 5b71ecceb950d51b14799b31884b62babc9727b4671fe5d23e62327d15d2d4d9
       size: 1093
-    subdir: app/gateway
-    version: 0.1.0.0
+      sha256: 5b71ecceb950d51b14799b31884b62babc9727b4671fe5d23e62327d15d2d4d9
+    commit: ed02c5e23953f04ed9d833465c1b334b7c8b02fd
   original:
-    commit: ed02c5e23953f04ed9d833465c1b334b7c8b02fd
-    git: https://github.com/nammayatri/beckn-gateway.git
     subdir: app/gateway
-- completed:
-    commit: ed02c5e23953f04ed9d833465c1b334b7c8b02fd
     git: https://github.com/nammayatri/beckn-gateway.git
+    commit: ed02c5e23953f04ed9d833465c1b334b7c8b02fd
+- completed:
+    subdir: app/mock-registry
     name: mock-registry
-    pantry-tree:
-      sha256: bc4bc7ccaa69a5b025c80ae12321adb80e1eec2f2b0f4ce502cae4fa4f455b5d
-      size: 712
-    subdir: app/mock-registry
     version: 0.1.0.0
-  original:
-    commit: ed02c5e23953f04ed9d833465c1b334b7c8b02fd
     git: https://github.com/nammayatri/beckn-gateway.git
+    pantry-tree:
+      size: 712
+      sha256: bc4bc7ccaa69a5b025c80ae12321adb80e1eec2f2b0f4ce502cae4fa4f455b5d
+    commit: ed02c5e23953f04ed9d833465c1b334b7c8b02fd
+  original:
     subdir: app/mock-registry
+    git: https://github.com/nammayatri/beckn-gateway.git
+    commit: ed02c5e23953f04ed9d833465c1b334b7c8b02fd
 - completed:
-    commit: 9d8ccf5da2bbe4f6aa5e4b3044618e2228b28069
-    git: https://github.com/nammayatri/shared-kernel.git
+    subdir: lib/mobility-core
     name: mobility-core
-    pantry-tree:
-      sha256: 63e7f69c1526967e52128f9841a4726db7bab5b7fca548720bdf6e218d6e7cb8
-      size: 18889
-    subdir: lib/mobility-core
     version: 0.1.0.0
-  original:
-    commit: 9d8ccf5da2bbe4f6aa5e4b3044618e2228b28069
     git: https://github.com/nammayatri/shared-kernel.git
+    pantry-tree:
+      size: 18889
+      sha256: 6d26fcd1e79e053dc7557cd12fe50173fe44b8bdab5685f2fed1ee4dd0d5fbc4
+    commit: fb8c213b92160f3f54d4034bc6f8d168cb1b7bae
+  original:
     subdir: lib/mobility-core
+    git: https://github.com/nammayatri/shared-kernel.git
+    commit: fb8c213b92160f3f54d4034bc6f8d168cb1b7bae
 - completed:
-    commit: 5eafcf35b7f2f5619f21dbafb55d98b1e57b1d39
-    git: https://github.com/piyushKumar-1/clickhouse-haskell.git
     name: clickhouse-haskell
-    pantry-tree:
-      sha256: 15eac0cbf78e7d674b11c8d6d260255eb38b362a442ef6a7820e8f65ff8a6b8e
-      size: 885
     version: 0.1.2.4
-  original:
-    commit: 5eafcf35b7f2f5619f21dbafb55d98b1e57b1d39
     git: https://github.com/piyushKumar-1/clickhouse-haskell.git
+    pantry-tree:
+      size: 885
+      sha256: 15eac0cbf78e7d674b11c8d6d260255eb38b362a442ef6a7820e8f65ff8a6b8e
+    commit: 5eafcf35b7f2f5619f21dbafb55d98b1e57b1d39
+  original:
+    git: https://github.com/piyushKumar-1/clickhouse-haskell.git
+    commit: 5eafcf35b7f2f5619f21dbafb55d98b1e57b1d39
 - completed:
-    commit: bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff
-    git: https://github.com/juspay/passetto
+    subdir: core
     name: passetto-core
+    version: 0.1.0
+    git: https://github.com/juspay/passetto
     pantry-tree:
-      sha256: d5a3a1e7110099da7f7b9109578d27dc423a00973ccb47b69c6eeb09212742dd
       size: 406
-    subdir: core
-    version: 0.1.0
+      sha256: d5a3a1e7110099da7f7b9109578d27dc423a00973ccb47b69c6eeb09212742dd
+    commit: bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff
   original:
-    commit: bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff
-    git: https://github.com/juspay/passetto
     subdir: core
-- completed:
-    commit: bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff
     git: https://github.com/juspay/passetto
+    commit: bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff
+- completed:
+    subdir: client
     name: passetto-client
-    pantry-tree:
-      sha256: 2d0789a50636d2bb58ed655ffbc83f66f8af89ef3bc098ff2a8fbc69f3964e8d
-      size: 770
-    subdir: client
     version: 0.1.0
-  original:
-    commit: bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff
     git: https://github.com/juspay/passetto
+    pantry-tree:
+      size: 770
+      sha256: 2d0789a50636d2bb58ed655ffbc83f66f8af89ef3bc098ff2a8fbc69f3964e8d
+    commit: bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff
+  original:
     subdir: client
+    git: https://github.com/juspay/passetto
+    commit: bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff
 - completed:
-    commit: 0fdda6ef43c1a6c9c7221d7c194c278e375b9936
-    git: https://github.com/juspay/euler-hs
     name: euler-hs
-    pantry-tree:
-      sha256: d6a415449098fb477b794e8355285dca5f69e61d77de62cb12599dbb9b0bf6b5
-      size: 7074
     version: 2.6.0.1
-  original:
-    commit: 0fdda6ef43c1a6c9c7221d7c194c278e375b9936
     git: https://github.com/juspay/euler-hs
+    pantry-tree:
+      size: 7074
+      sha256: d6a415449098fb477b794e8355285dca5f69e61d77de62cb12599dbb9b0bf6b5
+    commit: 0fdda6ef43c1a6c9c7221d7c194c278e375b9936
+  original:
+    git: https://github.com/juspay/euler-hs
+    commit: 0fdda6ef43c1a6c9c7221d7c194c278e375b9936
 - completed:
-    commit: 46ea0ea78e6d8d1a2b1a66e6f08078a37864ad80
-    git: https://github.com/juspay/hedis
     name: hedis
-    pantry-tree:
-      sha256: efe83ea607d47d7d8200c61a0dddabc5e7f292a2f451a98dec1326eb0903ef71
-      size: 2570
     version: 0.12.8.1
-  original:
-    commit: 46ea0ea78e6d8d1a2b1a66e6f08078a37864ad80
     git: https://github.com/juspay/hedis
+    pantry-tree:
+      size: 2570
+      sha256: efe83ea607d47d7d8200c61a0dddabc5e7f292a2f451a98dec1326eb0903ef71
+    commit: 46ea0ea78e6d8d1a2b1a66e6f08078a37864ad80
+  original:
+    git: https://github.com/juspay/hedis
+    commit: 46ea0ea78e6d8d1a2b1a66e6f08078a37864ad80
 - completed:
-    commit: 4c876ea2eae60bf3402d6f5c1ecb60a386fe3ace
-    git: https://github.com/juspay/beam-mysql
     name: beam-mysql
-    pantry-tree:
-      sha256: c612aef440faa9a9278858c8a52b952c20240555c3d7e84ac8bfc1e94eb35c61
-      size: 3064
     version: 1.2.1.0
-  original:
-    commit: 4c876ea2eae60bf3402d6f5c1ecb60a386fe3ace
     git: https://github.com/juspay/beam-mysql
+    pantry-tree:
+      size: 3064
+      sha256: c612aef440faa9a9278858c8a52b952c20240555c3d7e84ac8bfc1e94eb35c61
+    commit: 4c876ea2eae60bf3402d6f5c1ecb60a386fe3ace
+  original:
+    git: https://github.com/juspay/beam-mysql
+    commit: 4c876ea2eae60bf3402d6f5c1ecb60a386fe3ace
 - completed:
-    commit: 788022d65538db422b02ecc0be138b862d2e5cee
-    git: https://github.com/juspay/mysql-haskell
     name: mysql-haskell
-    pantry-tree:
-      sha256: 2306f63a061d6cf45264a4d08f7da14ab3c719d20c528480b41c54db31ceace8
-      size: 3863
     version: 0.8.4.2
-  original:
-    commit: 788022d65538db422b02ecc0be138b862d2e5cee
     git: https://github.com/juspay/mysql-haskell
+    pantry-tree:
+      size: 3863
+      sha256: 2306f63a061d6cf45264a4d08f7da14ab3c719d20c528480b41c54db31ceace8
+    commit: 788022d65538db422b02ecc0be138b862d2e5cee
+  original:
+    git: https://github.com/juspay/mysql-haskell
+    commit: 788022d65538db422b02ecc0be138b862d2e5cee
 - completed:
-    commit: 0a46db1139011736687cb50bbd3877d223bcb737
-    git: https://github.com/juspay/bytestring-lexing
     name: bytestring-lexing
-    pantry-tree:
-      sha256: d2ffa359a9def33fd7fdef6c55341753e5390fa92173e29f9cb047647710d7ef
-      size: 2693
     version: 0.5.0.6
-  original:
-    commit: 0a46db1139011736687cb50bbd3877d223bcb737
     git: https://github.com/juspay/bytestring-lexing
+    pantry-tree:
+      size: 2693
+      sha256: d2ffa359a9def33fd7fdef6c55341753e5390fa92173e29f9cb047647710d7ef
+    commit: 0a46db1139011736687cb50bbd3877d223bcb737
+  original:
+    git: https://github.com/juspay/bytestring-lexing
+    commit: 0a46db1139011736687cb50bbd3877d223bcb737
 - completed:
-    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
-    git: https://github.com/juspay/beam
+    subdir: beam-core
     name: beam-core
-    pantry-tree:
-      sha256: 365f420adf34642df7ffac56f80a578da48b3bebfac140748f3e163f83b4e37c
-      size: 2623
-    subdir: beam-core
     version: 0.9.0.0
-  original:
-    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
     git: https://github.com/juspay/beam
+    pantry-tree:
+      size: 2623
+      sha256: 365f420adf34642df7ffac56f80a578da48b3bebfac140748f3e163f83b4e37c
+    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
+  original:
     subdir: beam-core
-- completed:
-    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
     git: https://github.com/juspay/beam
+    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
+- completed:
+    subdir: beam-migrate
     name: beam-migrate
+    version: 0.5.0.0
+    git: https://github.com/juspay/beam
     pantry-tree:
-      sha256: 3ef904145e6e05e2f1cf6558e40f109f2751f08d2f8ce446f4e43ab70675936b
       size: 1825
-    subdir: beam-migrate
-    version: 0.5.0.0
+      sha256: 3ef904145e6e05e2f1cf6558e40f109f2751f08d2f8ce446f4e43ab70675936b
+    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
   original:
-    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
-    git: https://github.com/juspay/beam
     subdir: beam-migrate
-- completed:
-    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
     git: https://github.com/juspay/beam
+    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
+- completed:
+    subdir: beam-sqlite
     name: beam-sqlite
+    version: 0.5.0.0
+    git: https://github.com/juspay/beam
     pantry-tree:
-      sha256: d28565e631ed326b35719b4f0b1825dbdda0daed39618bff3506b70f45b9d2e8
       size: 859
-    subdir: beam-sqlite
-    version: 0.5.0.0
+      sha256: d28565e631ed326b35719b4f0b1825dbdda0daed39618bff3506b70f45b9d2e8
+    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
   original:
-    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
-    git: https://github.com/juspay/beam
     subdir: beam-sqlite
-- completed:
-    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
     git: https://github.com/juspay/beam
+    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
+- completed:
+    subdir: beam-postgres
     name: beam-postgres
-    pantry-tree:
-      sha256: 4d11e99a86be3ce5067479308bec2a541fa60a88ffbb1f95c316017646ed4c57
-      size: 2594
-    subdir: beam-postgres
     version: 0.5.0.0
-  original:
-    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
     git: https://github.com/juspay/beam
-    subdir: beam-postgres
-- completed:
-    commit: 3abc8fe10edde3fd1c9a776ede81d057dc590341
-    git: https://github.com/juspay/haskell-sequelize.git
-    name: sequelize
     pantry-tree:
-      sha256: cc5224453360f8399ab3c71b03c646d8b515d52f29b727e1e929e9ef441068f3
-      size: 543
-    version: 1.1.0.0
+      size: 2594
+      sha256: 4d11e99a86be3ce5067479308bec2a541fa60a88ffbb1f95c316017646ed4c57
+    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
   original:
-    commit: 3abc8fe10edde3fd1c9a776ede81d057dc590341
+    subdir: beam-postgres
+    git: https://github.com/juspay/beam
+    commit: 185ff060e63ab0b8a72775ee2742621dd6fefeb1
+- completed:
+    name: sequelize
+    version: 1.1.0.0
     git: https://github.com/juspay/haskell-sequelize.git
+    pantry-tree:
+      size: 543
+      sha256: cc5224453360f8399ab3c71b03c646d8b515d52f29b727e1e929e9ef441068f3
+    commit: 3abc8fe10edde3fd1c9a776ede81d057dc590341
+  original:
+    git: https://github.com/juspay/haskell-sequelize.git
+    commit: 3abc8fe10edde3fd1c9a776ede81d057dc590341
 - completed:
     hackage: generic-lens-1.1.0.0@sha256:caaab13ae4f2a68e43671d25fb56746ba14bc9d5d787d594a66c7f56eba3fa66,6412
     pantry-tree:
-      sha256: 33e1509b7d786d816a0974f08cfb6208a7d02c7d45937bec2c91586523b14440
       size: 4174
+      sha256: 33e1509b7d786d816a0974f08cfb6208a7d02c7d45937bec2c91586523b14440
   original:
     hackage: generic-lens-1.1.0.0
 - completed:
     hackage: servant-0.18.1@sha256:d322da8a5033203b3da510fdd41c949f61d25b7a2e3ab707035aef5484bbeb13,5273
     pantry-tree:
-      sha256: 59fe629e1b6e92571e1b54a7028c09abfff655077361bedc0689bcaca30c7240
       size: 2594
+      sha256: 59fe629e1b6e92571e1b54a7028c09abfff655077361bedc0689bcaca30c7240
   original:
     hackage: servant-0.18.1
 - completed:
     hackage: servant-mock-0.8.7@sha256:64cb3e52bbd51ab6cb25e3f412a99ea712c6c26f1efd117f01a8d1664df49c67,2306
     pantry-tree:
-      sha256: b263e932ec6b151e52987054ec0a4cd692fa787f856c79e51498302eb0d6c388
       size: 555
+      sha256: b263e932ec6b151e52987054ec0a4cd692fa787f856c79e51498302eb0d6c388
   original:
     hackage: servant-mock-0.8.7
 - completed:
     hackage: servant-server-0.18.1@sha256:f0824cfa57b23b6b698dbd93e11598c4c5355aaa26121f48c091f6e5f03623fc,5665
     pantry-tree:
-      sha256: afba7a901c86dfe0c65d18470bca144b371cbff13d4fb516247b200fbd62597b
       size: 2614
+      sha256: afba7a901c86dfe0c65d18470bca144b371cbff13d4fb516247b200fbd62597b
   original:
     hackage: servant-server-0.18.1
 - completed:
     hackage: servant-client-0.18.1@sha256:03d5628829331eaa72402e7c5cc059cff72cb91c34c5f10042fe09fd05454eb4,4745
     pantry-tree:
-      sha256: a8e23be4307bef89466b4dd60035980820566cf6142b74b29b120a60490dd851
       size: 1300
+      sha256: a8e23be4307bef89466b4dd60035980820566cf6142b74b29b120a60490dd851
   original:
     hackage: servant-client-0.18.1
 - completed:
     hackage: servant-client-core-0.18.1@sha256:a116901bf2aa8b6ff63b1c8e24b34c4fe7c505682e9862f314c5bcd2f9279312,3763
     pantry-tree:
-      sha256: 8a47f39a046ba959fc150c44a95cec46f41feec28970e11ec6397604e785d36f
       size: 1444
+      sha256: 8a47f39a046ba959fc150c44a95cec46f41feec28970e11ec6397604e785d36f
   original:
     hackage: servant-client-core-0.18.1
 - completed:
     hackage: servant-docs-0.11.7@sha256:ef9179713f99a3025cd300df7d2fe7f4895b0483c8fe4d3fb7550b6128bd460a,3282
     pantry-tree:
-      sha256: a86b3885b2f3a41266c2944647d520fdbe23469c4a69c2384579e65c567ed913
       size: 702
+      sha256: a86b3885b2f3a41266c2944647d520fdbe23469c4a69c2384579e65c567ed913
   original:
     hackage: servant-docs-0.11.7
 - completed:
     hackage: servant-foreign-0.15.2@sha256:b009c6731459477396908c8b5c1a712792bbfeda4813eb96c5110507b41946b4,2784
     pantry-tree:
-      sha256: c0dc5da3feeba2116a645ed7fef559e3704bd4bdef6e9e1e0f14682816345d77
       size: 590
+      sha256: c0dc5da3feeba2116a645ed7fef559e3704bd4bdef6e9e1e0f14682816345d77
   original:
     hackage: servant-foreign-0.15.2
 - completed:
     hackage: named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
     pantry-tree:
-      sha256: e0df5f146ecd48ef129dd74f868e8d2d754f0a11b36c5d0e56bd4b1947433c9f
       size: 426
+      sha256: e0df5f146ecd48ef129dd74f868e8d2d754f0a11b36c5d0e56bd4b1947433c9f
   original:
     hackage: named-0.3.0.1@sha256:2975d50c9c5d88095026ffc1303d2d9be52e5f588a8f8bcb7003a04b79f10a06,2312
 - completed:
     hackage: esqueleto-3.5.2.0@sha256:8519980763ccbfa4b89bc3382b4861971dee06092b6f911c9714d70ff5c598b6,4858
     pantry-tree:
-      sha256: 0fddcfc9721afb89556692da95dd1b493faacdab640ad52f30b8e40c27fbb2c9
       size: 2355
+      sha256: 0fddcfc9721afb89556692da95dd1b493faacdab640ad52f30b8e40c27fbb2c9
   original:
     hackage: esqueleto-3.5.2.0@sha256:8519980763ccbfa4b89bc3382b4861971dee06092b6f911c9714d70ff5c598b6,4858
 - completed:
     hackage: persistent-2.13.0.1@sha256:08a79866b9f19710109d7d7feee6b33087065041b3ffdb123380d723aa17b666,6232
     pantry-tree:
-      sha256: 5e537e8e3070cb463d2ae868d897f9adc29cb08d3790c59cb150af4e0885ff79
       size: 5098
+      sha256: 5e537e8e3070cb463d2ae868d897f9adc29cb08d3790c59cb150af4e0885ff79
   original:
     hackage: persistent-2.13.0.1@sha256:08a79866b9f19710109d7d7feee6b33087065041b3ffdb123380d723aa17b666,6232
 - completed:
     hackage: persistent-postgresql-2.13.0.0@sha256:52be384aa24859142549ed1eddaf84c4623de2bb522502d5aaa238364a22a7aa,3557
     pantry-tree:
-      sha256: 901e580f2a59f942533baec4cdd730ad1b343ac5e9deda266473724d177f0e9e
       size: 988
+      sha256: 901e580f2a59f942533baec4cdd730ad1b343ac5e9deda266473724d177f0e9e
   original:
     hackage: persistent-postgresql-2.13.0.0@sha256:52be384aa24859142549ed1eddaf84c4623de2bb522502d5aaa238364a22a7aa,3557
 - completed:
     hackage: lift-type-0.1.0.1@sha256:6e38e49bf086fd2203346417d96ad2e6c300d8d8f41d222780abdccc7a4e451b,1106
     pantry-tree:
-      sha256: 9de4bdc6ce32b78c28b4bce75b5b2e488bf0f875a136ae269a02df804eb94a1a
       size: 361
+      sha256: 9de4bdc6ce32b78c28b4bce75b5b2e488bf0f875a136ae269a02df804eb94a1a
   original:
     hackage: lift-type-0.1.0.1@sha256:6e38e49bf086fd2203346417d96ad2e6c300d8d8f41d222780abdccc7a4e451b,1106
 - completed:
     hackage: dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
     pantry-tree:
-      sha256: 5defa30010904d2ad05a036f3eaf83793506717c93cbeb599f40db1a3632cfc5
       size: 551
+      sha256: 5defa30010904d2ad05a036f3eaf83793506717c93cbeb599f40db1a3632cfc5
   original:
     hackage: dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
 - completed:
     hackage: dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
     pantry-tree:
-      sha256: 9cbfb32b5a8a782b7a1c941803fd517633cb699159b851c1d82267a9e9391b50
       size: 290
+      sha256: 9cbfb32b5a8a782b7a1c941803fd517633cb699159b851c1d82267a9e9391b50
   original:
     hackage: dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
 - completed:
     hackage: haskell-src-exts-1.21.1@sha256:11d18ec3f463185f81b7819376b532e3087f8192cffc629aac5c9eec88897b35,4541
     pantry-tree:
-      sha256: 487db8defe20a7c8bdf5b4a9a68ec616a4349bdb643f2dc7c9d71e1a6495c8c7
       size: 95170
+      sha256: 487db8defe20a7c8bdf5b4a9a68ec616a4349bdb643f2dc7c9d71e1a6495c8c7
   original:
     hackage: haskell-src-exts-1.21.1@sha256:11d18ec3f463185f81b7819376b532e3087f8192cffc629aac5c9eec88897b35,4541
 - completed:
     hackage: sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
     pantry-tree:
-      sha256: e58b9955e483d51ee0966f8ba4384305d871480e2a38b32ee0fcd4573d74cf95
       size: 1930
+      sha256: e58b9955e483d51ee0966f8ba4384305d871480e2a38b32ee0fcd4573d74cf95
   original:
     hackage: sqlite-simple-0.4.18.0@sha256:3ceea56375c0a3590c814e411a4eb86943f8d31b93b110ca159c90689b6b39e5,3002
 - completed:
     hackage: constraints-extras-0.3.0.2@sha256:bf6884be65958e9188ae3c9e5547abfd6d201df021bff8a4704c2c4fe1e1ae5b,1784
     pantry-tree:
-      sha256: b0bcc96d375ee11b1972a2e9e8e42039b3f420b0e1c46e9c70652470445a6505
       size: 594
+      sha256: b0bcc96d375ee11b1972a2e9e8e42039b3f420b0e1c46e9c70652470445a6505
   original:
     hackage: constraints-extras-0.3.0.2@sha256:bf6884be65958e9188ae3c9e5547abfd6d201df021bff8a4704c2c4fe1e1ae5b,1784
 - completed:
     hackage: direct-sqlite-2.3.26@sha256:04e835402f1508abca383182023e4e2b9b86297b8533afbd4e57d1a5652e0c23,3718
     pantry-tree:
-      sha256: 11874ab21e10c5b54cd1e02a037b677dc1e2ee9986f38c599612c56654dc01c3
       size: 770
+      sha256: 11874ab21e10c5b54cd1e02a037b677dc1e2ee9986f38c599612c56654dc01c3
   original:
     hackage: direct-sqlite-2.3.26@sha256:04e835402f1508abca383182023e4e2b9b86297b8533afbd4e57d1a5652e0c23,3718
 - completed:
     hackage: tcp-streams-1.0.1.1@sha256:35e9ecfa515797052f8c3c01834d2daebd5e93f3152c7fc98b32652bf6f0c052,2329
     pantry-tree:
-      sha256: 572071fca40a0b6c4cc950d10277a6f12e83cf4846882b6ef83fcccaa2c18c45
       size: 1004
+      sha256: 572071fca40a0b6c4cc950d10277a6f12e83cf4846882b6ef83fcccaa2c18c45
   original:
     hackage: tcp-streams-1.0.1.1@sha256:35e9ecfa515797052f8c3c01834d2daebd5e93f3152c7fc98b32652bf6f0c052,2329
 - completed:
     hackage: wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
     pantry-tree:
-      sha256: c99a12bfcbeacc5da8f166fbed1eb105a45f08be1a3a071fe9f903b386b14e1d
       size: 506
+      sha256: c99a12bfcbeacc5da8f166fbed1eb105a45f08be1a3a071fe9f903b386b14e1d
   original:
     hackage: wire-streams-0.1.1.0@sha256:08816c7fa53b20f52e5c465252c106d9de8e6d9580ec0b6d9f000a34c7bcefc8,2130
 - completed:
     hackage: mason-0.2.3@sha256:186ff6306c7d44dbf7b108b87f73a30d45c70cd5c87d6f2a88d300def5542fef,1226
     pantry-tree:
-      sha256: 4147c0fd201f849d018f9408e82b75b0313294bb9fff290673dd30729eedf948
       size: 574
+      sha256: 4147c0fd201f849d018f9408e82b75b0313294bb9fff290673dd30729eedf948
   original:
     hackage: mason-0.2.3@sha256:186ff6306c7d44dbf7b108b87f73a30d45c70cd5c87d6f2a88d300def5542fef,1226
 - completed:
     hackage: hex-text-0.1.0.0@sha256:52dc2cf5ce45f7d86ea5e56e2ac57820f788c10bbb3fe83f6d57e678a426305b,1072
     pantry-tree:
-      sha256: 84ce6d618602d39e89e28b1a9cc41f0def4786d7046ac0a742557b5ab5381466
       size: 314
+      sha256: 84ce6d618602d39e89e28b1a9cc41f0def4786d7046ac0a742557b5ab5381466
   original:
     hackage: hex-text-0.1.0.0@sha256:52dc2cf5ce45f7d86ea5e56e2ac57820f788c10bbb3fe83f6d57e678a426305b,1072
 - completed:
     hackage: postgresql-migration-0.2.1.3@sha256:7378629d0790630d54b299f34cc01bf4f3288031eb2060ededf80c1449264002,4990
     pantry-tree:
-      sha256: 718bcbb8a80e66efe74cfa03ee6c907abd2f935a21a96257798c500a9610028e
       size: 1146
+      sha256: 718bcbb8a80e66efe74cfa03ee6c907abd2f935a21a96257798c500a9610028e
   original:
     hackage: postgresql-migration-0.2.1.3@sha256:7378629d0790630d54b299f34cc01bf4f3288031eb2060ededf80c1449264002,4990
 - completed:
     hackage: prometheus-metrics-ghc-1.0.1.1@sha256:d378a7186a967140fe0e09d325fe5e3bfd7b77a1123934b40f81fdfed2eacbdc,1233
     pantry-tree:
-      sha256: 0732085a4148b269bbc15eeb7ab422e65ac287878a42a7388a7b6e140ec740e5
       size: 293
+      sha256: 0732085a4148b269bbc15eeb7ab422e65ac287878a42a7388a7b6e140ec740e5
   original:
     hackage: prometheus-metrics-ghc-1.0.1.1@sha256:d378a7186a967140fe0e09d325fe5e3bfd7b77a1123934b40f81fdfed2eacbdc,1233
 - completed:
     hackage: prometheus-proc-0.1.3.0@sha256:84f56e9c886be777d5afd14fc57fff156137a611f0db0fe080b97fc602103c23,1058
     pantry-tree:
-      sha256: c3150da9edb4578e64a02f095e677c9a1ef1323673faf5be887547fc68c543f0
       size: 282
+      sha256: c3150da9edb4578e64a02f095e677c9a1ef1323673faf5be887547fc68c543f0
   original:
     hackage: prometheus-proc-0.1.3.0@sha256:84f56e9c886be777d5afd14fc57fff156137a611f0db0fe080b97fc602103c23,1058
 - completed:
     hackage: random-strings-0.1.1.0@sha256:935a7a23dab45411960df77636a29b44ce42b89eeb15f2b1e809d771491fa677,2517
     pantry-tree:
-      sha256: 5a382966fdd8d5220b5791f3bff6db00d2ea29235e2716dadd52461b8a8beb97
       size: 663
+      sha256: 5a382966fdd8d5220b5791f3bff6db00d2ea29235e2716dadd52461b8a8beb97
   original:
     hackage: random-strings-0.1.1.0@sha256:935a7a23dab45411960df77636a29b44ce42b89eeb15f2b1e809d771491fa677,2517
 - completed:
     hackage: servant-multipart-0.12@sha256:aa81dd0478270ade4a21b75611d5bc9cce8107df2e89c37b9964a3421629825d,2761
     pantry-tree:
-      sha256: 51c4e9e8be3ee80689bb6df46aee484a4f434dbeb33f4379ed8d1741fe4631cd
       size: 386
+      sha256: 51c4e9e8be3ee80689bb6df46aee484a4f434dbeb33f4379ed8d1741fe4631cd
   original:
     hackage: servant-multipart-0.12@sha256:aa81dd0478270ade4a21b75611d5bc9cce8107df2e89c37b9964a3421629825d,2761
 - completed:
     hackage: wai-middleware-prometheus-1.0.0@sha256:1625792914fb2139f005685be8ce519111451cfb854816e430fbf54af46238b4,1314
     pantry-tree:
-      sha256: 6d64803c639ed4c7204ea6fab0536b97d3ee16cdecb9b4a883cd8e56d3c61402
       size: 307
+      sha256: 6d64803c639ed4c7204ea6fab0536b97d3ee16cdecb9b4a883cd8e56d3c61402
   original:
     hackage: wai-middleware-prometheus-1.0.0@sha256:1625792914fb2139f005685be8ce519111451cfb854816e430fbf54af46238b4,1314
 - completed:
     hackage: unix-memory-0.1.2@sha256:601231a46e84088103190a156c1919573237317e7d4f775cd555c54356e0e2c4,1269
     pantry-tree:
-      sha256: 50912d2ac162c8fab4243c9d73b8a2adb3bb609fbe13853bb8396c7e7b3b87e2
       size: 322
+      sha256: 50912d2ac162c8fab4243c9d73b8a2adb3bb609fbe13853bb8396c7e7b3b87e2
   original:
     hackage: unix-memory-0.1.2@sha256:601231a46e84088103190a156c1919573237317e7d4f775cd555c54356e0e2c4,1269
 - completed:
     hackage: record-dot-preprocessor-0.2.14@sha256:00967231260e798d9125437db6e1cf04b3b232a9c0193a629563c0e6752c8e7c,2538
     pantry-tree:
-      sha256: 9c7f2f8c0159a565b3fa9d16068f1281c1bd9827155d6e71faa57a7c4684b25a
       size: 1078
+      sha256: 9c7f2f8c0159a565b3fa9d16068f1281c1bd9827155d6e71faa57a7c4684b25a
   original:
     hackage: record-dot-preprocessor-0.2.14@sha256:00967231260e798d9125437db6e1cf04b3b232a9c0193a629563c0e6752c8e7c,2538
 - completed:
     hackage: kleene-0.1@sha256:751db2ef4fea28a1abc42e0cd18d82d900bbb33d1b4e86f72271426c501ba7af,2424
     pantry-tree:
-      sha256: fba5a28ee3c79fd980231deb3b2464828bd356513cf3bfee6851922581aaf158
       size: 1147
+      sha256: fba5a28ee3c79fd980231deb3b2464828bd356513cf3bfee6851922581aaf158
   original:
     hackage: kleene-0.1@sha256:751db2ef4fea28a1abc42e0cd18d82d900bbb33d1b4e86f72271426c501ba7af,2424
 - completed:
     hackage: servant-openapi3-2.0.1.2@sha256:7beb612b56d01536bc97c745fd0c064f483198199619b1856a5a3f0a3a0f6431,4886
     pantry-tree:
-      sha256: cf0ace24c9d7779da852f0424ad304969f2b57482e821db9821900e464b23cbe
       size: 1637
+      sha256: cf0ace24c9d7779da852f0424ad304969f2b57482e821db9821900e464b23cbe
   original:
     hackage: servant-openapi3-2.0.1.2@sha256:7beb612b56d01536bc97c745fd0c064f483198199619b1856a5a3f0a3a0f6431,4886
 - completed:
     hackage: openapi3-3.1.0@sha256:815236a5d92cc8b3bc3cbcbba5503bd39035ccaf517d21cd02f74795b9747ae5,4824
     pantry-tree:
-      sha256: b02f8fc5f43f4f1a0c18b25242669f45240ae0a160d484f92a190f49462acaf8
       size: 2191
+      sha256: b02f8fc5f43f4f1a0c18b25242669f45240ae0a160d484f92a190f49462acaf8
   original:
     hackage: openapi3-3.1.0@sha256:815236a5d92cc8b3bc3cbcbba5503bd39035ccaf517d21cd02f74795b9747ae5,4824
 - completed:
     hackage: hw-kafka-client-4.0.3@sha256:20e3614454d5afd2a6acfc0709b9bf00bd6ee9a9bc646c2e2e4ccec1d16831a1,4861
     pantry-tree:
-      sha256: 709ea6818b3b3beb8eed6f79ea76b8dc13cce9ae165870c17986d5de2d695447
       size: 2057
+      sha256: 709ea6818b3b3beb8eed6f79ea76b8dc13cce9ae165870c17986d5de2d695447
   original:
     hackage: hw-kafka-client-4.0.3@sha256:20e3614454d5afd2a6acfc0709b9bf00bd6ee9a9bc646c2e2e4ccec1d16831a1,4861
 - completed:
     hackage: constraints-0.11.2@sha256:d173efdf7a5d5515075635c686420211dccd9f85bc091a579ecc18b3f138a5fe,2324
     pantry-tree:
-      sha256: 6bd2134dba1371444d5e72064c89cacc37f4573c5036060b9ff5237734ca60f3
       size: 867
+      sha256: 6bd2134dba1371444d5e72064c89cacc37f4573c5036060b9ff5237734ca60f3
   original:
     hackage: constraints-0.11.2@sha256:d173efdf7a5d5515075635c686420211dccd9f85bc091a579ecc18b3f138a5fe,2324
 - completed:
     hackage: some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
     pantry-tree:
-      sha256: c882b6ebe8a0616f1ab3908f1620087ad5c6d8d82d1a72b99226f6487419bfe6
       size: 708
+      sha256: c882b6ebe8a0616f1ab3908f1620087ad5c6d8d82d1a72b99226f6487419bfe6
   original:
     hackage: some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
 - completed:
     hackage: haxl-2.3.0.0@sha256:4c9a7371a2c21df910628d582776cf52db72bcd6c808daa02823be0ab06f1eb9,3974
     pantry-tree:
-      sha256: 2da38564de7cda18d12923fef2fd279c7072a7dbd6ee13a4dfea7f347eb50c8c
       size: 3076
+      sha256: 2da38564de7cda18d12923fef2fd279c7072a7dbd6ee13a4dfea7f347eb50c8c
   original:
     hackage: haxl-2.3.0.0@sha256:4c9a7371a2c21df910628d582776cf52db72bcd6c808daa02823be0ab06f1eb9,3974
 - completed:
     hackage: tz-0.1.3.6@sha256:1b0c04d8d7f494888f166c66b72e7fcbc2269e57d1d17d48294ac4e19133a3ef,4631
     pantry-tree:
-      sha256: 76bcdabe2c4083a914a6ddc532b2b6f7209e368cac14a9dcbe445a8707e9552d
       size: 1179
+      sha256: 76bcdabe2c4083a914a6ddc532b2b6f7209e368cac14a9dcbe445a8707e9552d
   original:
     hackage: tz-0.1.3.6@sha256:1b0c04d8d7f494888f166c66b72e7fcbc2269e57d1d17d48294ac4e19133a3ef,4631
 - completed:
     hackage: unordered-containers-0.2.19.1@sha256:db11042bb0356c0adea277d0794743829125b4c99455af6af2bd5f7bd5e88a39,3797
     pantry-tree:
-      sha256: ac7a077274515b8afdf98138177b2fd2293c8bb346c5ec5caf2c5999da495112
       size: 1517
+      sha256: ac7a077274515b8afdf98138177b2fd2293c8bb346c5ec5caf2c5999da495112
   original:
     hackage: unordered-containers-0.2.19.1@sha256:db11042bb0356c0adea277d0794743829125b4c99455af6af2bd5f7bd5e88a39,3797
 - completed:
     hackage: c2hs-0.28.8@sha256:980c1a91c93e492d5412e904f2500b2ace34a421e8509529b6d98d89c51f9a2e,9208
     pantry-tree:
-      sha256: 37edecd4f2eace540e82d8abc8fb6f5916b9732880ad16a5aa34e0c9b3f77f57
       size: 17398
+      sha256: 37edecd4f2eace540e82d8abc8fb6f5916b9732880ad16a5aa34e0c9b3f77f57
   original:
     hackage: c2hs-0.28.8@sha256:980c1a91c93e492d5412e904f2500b2ace34a421e8509529b6d98d89c51f9a2e,9208
 - completed:
     hackage: language-c-0.9.0.1@sha256:7a1c57e8f9c29e94bcd5c748d99e4479a73bd8560cc0affd838f3b2d1bbc0384,4893
     pantry-tree:
-      sha256: 65cf3410da4684205319a8f2dd4cf22edf8b76b1423b62bdbb88a53663cb88ed
       size: 3496
+      sha256: 65cf3410da4684205319a8f2dd4cf22edf8b76b1423b62bdbb88a53663cb88ed
   original:
     hackage: language-c-0.9.0.1@sha256:7a1c57e8f9c29e94bcd5c748d99e4479a73bd8560cc0affd838f3b2d1bbc0384,4893
 snapshots:
 - completed:
-    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
     size: 534126
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
+    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
   original: lts-16.31


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Some changes need to be done.

1. We are logging only the status (OK or Warning etc) but we also need to log which exophones are down incase of WARNING or CRITICAL. Dashboard side just log status, but at bap/bpp side log both status and affectedNumbers
2. Exotel is sending Number with 0 at the start in incoming_affected field and +91 in the Phone_Number inside data field. Our system is not catching it, since the number stored in DB doesn't have 0.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested locally


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
