### PR TITLE
vscode: Disable autoformatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
-  "editor.formatOnType": true,
-  "editor.formatOnSave": true,
+  // Disabled until https://github.com/nammayatri/nammayatri/issues/649
+  "editor.formatOnType": false,
+  "editor.formatOnSave": false,
   "haskell.formattingProvider": "ormolu",
   "haskell.manageHLS": "PATH"
 }


### PR DESCRIPTION
Until https://github.com/nammayatri/nammayatri/issues/649

Because there is an issue with record-dot-preprocessor recognition by this old ormolu.
