### PR TITLE
Test docker image to contain expected contents

### DIFF
--- a/Backend/nix/docker.nix
+++ b/Backend/nix/docker.nix
@@ -36,6 +36,15 @@ in
             ];
             Cmd = [ "${self'.packages.nammayatri}/bin/rider-app-exe" ];
           };
+
+          # Test that the docker image contains contents we expected for
+          # production.
+          extraCommands = ''
+            # Executables are under /opt/app
+            ls opt/app/rider-app-exe
+            # Swagger configs are copied over
+            ls opt/app/swagger
+          '';
         };
       };
     };


### PR DESCRIPTION
This just looks for `/opt/app/rider-app-exe` and `/opt/app/swagger`. Later, we can expand it to do other file checks.