### PR TITLE
backend/feat: #655-Adding-door-at-bpp-location

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnConfirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnConfirm.hs
@@ -94,7 +94,7 @@ mklocation loc =
       address = castAddress loc.address
     }
   where
-    castAddress DBL.LocationAddress {..} = OnConfirm.Address {area_code = areaCode, locality = area, ward = Nothing, door = Nothing, ..}
+    castAddress DBL.LocationAddress {..} = OnConfirm.Address {area_code = areaCode, locality = area, ward = Nothing, ..}
 
 mkFulfillmentInfo :: DBL.BookingLocation -> DBL.BookingLocation -> UTCTime -> OnConfirm.FulfillmentInfo
 mkFulfillmentInfo fromLoc toLoc startTime =

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -212,6 +212,7 @@ handler merchantId sReq = do
       pure
         DLoc.SearchReqLocation
           { street = Nothing,
+            door = Nothing,
             city = Nothing,
             state = Nothing,
             country = Nothing,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Select.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Select.hs
@@ -182,6 +182,7 @@ buildSearchReqLocation merchantId sessionToken address customerLanguage latLong@
           Address
             { areaCode = loc.area_code,
               street = loc.street,
+              door = loc.door,
               city = loc.city,
               state = loc.state,
               country = loc.country,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Booking/BookingLocation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Booking/BookingLocation.hs
@@ -33,6 +33,7 @@ data BookingLocation = BookingLocation
 
 data LocationAddress = LocationAddress
   { street :: Maybe Text,
+    door :: Maybe Text,
     city :: Maybe Text,
     state :: Maybe Text,
     country :: Maybe Text,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/SearchRequest/SearchReqLocation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/SearchRequest/SearchReqLocation.hs
@@ -24,6 +24,7 @@ data SearchReqLocation = SearchReqLocation
     lat :: Double,
     lon :: Double,
     street :: Maybe Text,
+    door :: Maybe Text,
     city :: Maybe Text,
     state :: Maybe Text,
     country :: Maybe Text,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/GoogleMaps.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/GoogleMaps.hs
@@ -26,6 +26,7 @@ import Kernel.Types.App (MonadFlow)
 
 data Address = Address
   { street :: Maybe Text,
+    door :: Maybe Text,
     city :: Maybe Text,
     state :: Maybe Text,
     country :: Maybe Text,
@@ -44,6 +45,7 @@ mkLocation placeNameResp = do
     Address
       { areaCode = getField ["postal_code"] hashMap,
         street = getField ["route", "street_address"] hashMap,
+        door = Nothing,
         city = getField ["locality"] hashMap,
         state = getField ["administrative_area_level_1"] hashMap,
         country = getField ["country"] hashMap,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Tabular/Booking/BookingLocation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Tabular/Booking/BookingLocation.hs
@@ -33,6 +33,7 @@ mkPersist
       lat Double
       lon Double
       street Text Maybe
+      door Text Maybe
       city Text Maybe
       state Text Maybe
       country Text Maybe

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Tabular/SearchRequest/SearchReqLocation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Tabular/SearchRequest/SearchReqLocation.hs
@@ -33,6 +33,7 @@ mkPersist
       lat Double
       lon Double
       street Text Maybe
+      door Text Maybe
       city Text Maybe
       state Text Maybe
       country Text Maybe

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0154-add-door-in-location.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0154-add-door-in-location.sql
@@ -1,0 +1,9 @@
+ALTER TABLE
+    atlas_driver_offer_bpp.search_request_location
+ADD
+    COLUMN door character varying(255);
+
+ALTER TABLE
+    atlas_driver_offer_bpp.booking_location
+ADD
+    COLUMN door character varying(255);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In BPP full address, door part of the address is missing in bookingLocation and SearchReqLocation at BPP end.
We would pass "door" via beckn protocol to BPP end, and while creating full address it would be appended to full address.

### Additional Changes

- [x] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
To make address consistent at BAP and BPP sides


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
