### PR TITLE
Improve nix build performance

### DIFF
--- a/Backend/nix/default-overrides.nix
+++ b/Backend/nix/default-overrides.nix
@@ -1,0 +1,22 @@
+# TODO: Upstream this via https://github.com/srid/haskell-flake/issues/101#issuecomment-1526276493
+{ pkgs, lib, config, ... }:
+
+with pkgs.haskell.lib.compose;
+let
+  overrideLocalPackage = name: info:
+    [
+      # Haddocks are not used, so disable them to speed up builds.
+      dontHaddock
+      # Library profiling is enabled by default in nixpkgs. This makes
+      # cabal compile the modules twice. Disable it to speed up nix
+      # builds.
+      disableLibraryProfiling
+    ] ++ (lib.optionals (info.exes != { }) [
+      # Separate about binaries from library assets, so the closure size
+      # of `.#nammayatri` will be smaller.
+      enableSeparateBinOutput
+    ]);
+  defaultOverrides =
+    lib.mapAttrs overrideLocalPackage config.haskellProjects.default.outputs.packages;
+in
+defaultOverrides

--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1682560208,
-        "narHash": "sha256-xf0PHV2mjcS3BrB360PILL08f2aSh1WM6hG9J0dcoUg=",
+        "lastModified": 1682614792,
+        "narHash": "sha256-ZeGSQnCUdH+PjXIGOgBujUhxYB7QmmCKbdZnBXWaJZI=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "9bcce05a676cb6ce50f267ddb538e714caa73fd8",
+        "rev": "883db102547415ed135fc11dd677513169360df1",
         "type": "github"
       },
       "original": {
@@ -632,11 +632,11 @@
     },
     "haskell-flake_2": {
       "locked": {
-        "lastModified": 1682559531,
-        "narHash": "sha256-XxqGtAcmcf/5JPa0C4U+vQcmP5HWyJOiXM6NMgtV7ws=",
+        "lastModified": 1682614676,
+        "narHash": "sha256-Eu53z8fdtt8mfMRp+IskjclCT9LqvCViMOzvqO0Rz50=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "c949068c4a1ba0ef35b84e4c0da73b12ddd1bc16",
+        "rev": "11ab35533afaf0cacc5f3ed8032cb2482cedf8fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Major,

- [x] Fix double-nix-builds of Haskell packages due to use of `justStaticExecutables` https://github.com/srid/haskell-flake/pull/146 - resolves #687
- [x] Fix double-cabal-builds of library (if there is an executable) for some unknown reason
- [x] Disable haddock generation for all local packages
    - Haddock generation is fine for dependencies (we use hoogle), though.

Minor,

- [x] Remove redundant treefmt-nix check: https://github.com/numtide/treefmt-nix/pull/64