### PR TITLE
A couple of improvements to run-mobility-stack

### DIFF
--- a/Backend/nix/run-mobility-stack.nix
+++ b/Backend/nix/run-mobility-stack.nix
@@ -20,7 +20,12 @@ _:
             driver-tracking-healthcheck-exe.command = self'.apps.driver-tracking-healthcheck-exe.program;
             dynamic-offer-driver-app-exe.command = self'.apps.dynamic-offer-driver-app-exe.program;
             image-api-helper-exe.command = self'.apps.image-api-helper-exe.program;
-            kafka-consumers-exe.command = self'.apps.kafka-consumers-exe.program;
+            kafka-consumers-exe = {
+              command = self'.apps.kafka-consumers-exe.program;
+              environment = [
+                "CONSUMER_TYPE=AVAILABILITY_TIME"
+              ];
+            };
             mock-fcm-exe.command = self'.apps.mock-fcm-exe.program;
             mock-google-exe.command = self'.apps.mock-google-exe.program;
             mock-idfy-exe.command = self'.apps.mock-idfy-exe.program;

--- a/Backend/nix/scripts.nix
+++ b/Backend/nix/scripts.nix
@@ -45,6 +45,7 @@ _:
         exec = ''
           set -x
           cd ./Backend  # These processes expect $PWD to be backend, for reading dhall configs
+          rm -f ./*.log # Clean up the log files
           nix run .#run-mobility-stack
         '';
       };


### PR DESCRIPTION
- Cleanup `./Backend/*.log` files before starting up
- Set `CONSUMER_TYPE` when launching kafka-consumers