### PR TITLE
backend/feat#797-adding-config-time-to-driver-pool

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/src/Dashboard/ProviderPlatform/Merchant.hs
+++ b/Backend/app/dashboard/CommonAPIs/src/Dashboard/ProviderPlatform/Merchant.hs
@@ -173,7 +173,9 @@ data DriverPoolConfigUpdateReq = DriverPoolConfigUpdateReq
     maxNumberOfBatches :: Maybe (MandatoryValue Int),
     maxParallelSearchRequests :: Maybe (MandatoryValue Int),
     poolSortingType :: Maybe (MandatoryValue PoolSortingType),
-    singleBatchProcessTime :: Maybe (MandatoryValue Seconds)
+    singleBatchProcessTime :: Maybe (MandatoryValue Seconds),
+    configStartTime :: Maybe (OptionalValue Hours),
+    configEndTime :: Maybe (OptionalValue Hours)
   }
   deriving stock (Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -199,7 +201,9 @@ validateDriverPoolConfigUpdateReq DriverPoolConfigUpdateReq {..} =
       validateField "driverBatchSize" driverBatchSize $ InMaybe $ InValue $ Min @Int 1,
       validateField "maxNumberOfBatches" maxNumberOfBatches $ InMaybe $ InValue $ Min @Int 1,
       validateField "maxParallelSearchRequests" maxParallelSearchRequests $ InMaybe $ InValue $ Min @Int 1,
-      validateField "singleBatchProcessTime" singleBatchProcessTime $ InMaybe $ InValue $ Min @Seconds 1
+      validateField "singleBatchProcessTime" singleBatchProcessTime $ InMaybe $ InValue $ Min @Seconds 1,
+      validateField "configStartTime" configStartTime $ InMaybe $ InValue $ Min @Hours 1,
+      validateField "configEndTime" configEndTime $ InMaybe $ InValue $ Min @Hours 1
     ]
 
 ---------------------------------------------------------
@@ -229,7 +233,9 @@ data DriverPoolConfigCreateReq = DriverPoolConfigCreateReq
     singleBatchProcessTime :: Seconds,
     radiusShrinkValueForDriversOnRide :: Int,
     driverToDestinationDistanceThreshold :: Meters,
-    driverToDestinationDuration :: Seconds
+    driverToDestinationDuration :: Seconds,
+    configStartTime :: Maybe Hours,
+    configEndTime :: Maybe Hours
   }
   deriving stock (Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -254,7 +260,9 @@ validateDriverPoolConfigCreateReq DriverPoolConfigCreateReq {..} =
       validateField "singleBatchProcessTime" singleBatchProcessTime $ Min @Seconds 1,
       validateField "radiusShrinkValueForDriversOnRide" radiusShrinkValueForDriversOnRide $ Min @Int 1,
       validateField "driverToDestinationDistanceThreshold" driverToDestinationDistanceThreshold $ Min @Meters 1,
-      validateField "driverToDestinationDuration" driverToDestinationDuration $ Min @Seconds 1
+      validateField "driverToDestinationDuration" driverToDestinationDuration $ Min @Seconds 1,
+      validateField "configStartTime" configStartTime $ InMaybe $ Min @Hours 1,
+      validateField "configEndTime" configEndTime $ InMaybe $ Min @Hours 1
     ]
 
 ---------------------------------------------------------

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Merchant.hs
@@ -178,7 +178,9 @@ driverPoolConfigUpdate merchantShortId tripDistance req = do
                maxNumberOfBatches = maybe config.maxNumberOfBatches (.value) req.maxNumberOfBatches,
                maxParallelSearchRequests = maybe config.maxParallelSearchRequests (.value) req.maxParallelSearchRequests,
                poolSortingType = maybe config.poolSortingType (castPoolSortingType . (.value)) req.poolSortingType,
-               singleBatchProcessTime = maybe config.singleBatchProcessTime (.value) req.singleBatchProcessTime
+               singleBatchProcessTime = maybe config.singleBatchProcessTime (.value) req.singleBatchProcessTime,
+               configStartTime = maybe config.configStartTime (.value) req.configStartTime,
+               configEndTime = maybe config.configEndTime (.value) req.configEndTime
               }
   Esq.runTransaction $ do
     CQDPC.update updConfig

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/DriverPoolConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/DriverPoolConfig.hs
@@ -41,6 +41,8 @@ data DriverPoolConfigD u = DriverPoolConfig
     radiusShrinkValueForDriversOnRide :: Int,
     driverToDestinationDistanceThreshold :: Meters,
     driverToDestinationDuration :: Seconds,
+    configStartTime :: Maybe Hours,
+    configEndTime :: Maybe Hours,
     createdAt :: UTCTime,
     updatedAt :: UTCTime
   }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Merchant/DriverPoolConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Merchant/DriverPoolConfig.hs
@@ -67,6 +67,8 @@ update config = do
         DriverPoolConfigMaxParallelSearchRequests =. val config.maxParallelSearchRequests,
         DriverPoolConfigPoolSortingType =. val config.poolSortingType,
         DriverPoolConfigSingleBatchProcessTime =. val config.singleBatchProcessTime,
+        DriverPoolConfigConfigStartTime =. val config.configStartTime,
+        DriverPoolConfigConfigEndTime =. val config.configEndTime,
         DriverPoolConfigUpdatedAt =. val now
       ]
     where_ $ tbl ^. DriverPoolConfigTId ==. val (toKey (config.merchantId, config.tripDistance))

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Tabular/Merchant/DriverPoolConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Tabular/Merchant/DriverPoolConfig.hs
@@ -24,7 +24,7 @@ import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.Merchant.DriverPoolConfig as Domain
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto
-import Kernel.Types.Common (Meters, Seconds)
+import Kernel.Types.Common (Hours, Meters, Seconds)
 import Kernel.Types.Id
 import SharedLogic.Allocator.Jobs.SendSearchRequestToDrivers.Handle.Internal.DriverPool.Config (PoolSortingType)
 import Storage.Tabular.Merchant (MerchantTId)
@@ -53,6 +53,8 @@ mkPersist
       radiusShrinkValueForDriversOnRide Int
       driverToDestinationDistanceThreshold Meters
       driverToDestinationDuration Seconds
+      configStartTime Hours Maybe
+      configEndTime Hours Maybe
       createdAt UTCTime
       updatedAt UTCTime
       Primary merchantId tripDistance

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0157-add-config-time-to-driver-pool.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0157-add-config-time-to-driver-pool.sql
@@ -1,0 +1,9 @@
+ALTER TABLE
+    atlas_driver_offer_bpp.driver_pool_config
+ADD
+    COLUMN config_start_time integer;
+
+ALTER TABLE
+    atlas_driver_offer_bpp.driver_pool_config
+ADD
+    COLUMN config_end_time integer;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Adding config start time and end time to driver pool config, so that we will be able to use configs based on peak hours.


### Additional Changes

- [x] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
This will help in differentiating factors like pickup-distance, ride distance, etc

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
