### PR TITLE
nix: Allow passing args to run-mobility-stack-*

### DIFF
--- a/Backend/nix/scripts.nix
+++ b/Backend/nix/scripts.nix
@@ -48,7 +48,7 @@ _:
           set -x
           cd ./Backend  # These processes expect $PWD to be backend, for reading dhall configs
           rm -f ./*.log # Clean up the log files
-          nix run .#run-mobility-stack-nix
+          nix run .#run-mobility-stack-nix -- "$@"
         '';
       };
 
@@ -62,7 +62,7 @@ _:
           cd ./Backend  # These processes expect $PWD to be backend, for reading dhall configs
           rm -f ./*.log # Clean up the log files
           cabal build all
-          nix run .#run-mobility-stack-dev
+          nix run .#run-mobility-stack-dev -- "$@"
         '';
       };
 


### PR DESCRIPTION
For eg., `, run-mobility-stack-dev -t=false` can be run to get interleaved output like this:

<img width="794" alt="image" src="https://github.com/nammayatri/nammayatri/assets/3998/6c563e7c-d9c0-4e45-9e14-76297caeb28e">

See https://github.com/F1bonacc1/process-compose#-tui-terminal-user-interface