### PR TITLE
frontend/fix/#941: fixed confirm pickup missing stage for source chos…

### DIFF
--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/Controller.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/Controller.purs
@@ -1070,7 +1070,7 @@ eval (TagClick savedAddressType arrItem) state = tagClickEvent savedAddressType 
 eval (SearchLocationModelActionController (SearchLocationModelController.LocationListItemActionController (LocationListItemController.OnClick item))) state = do
   _ <- pure $ firebaseLogEvent "ny_user_location_list_item"
   let condition = state.props.isSource == Just true && item.locationItemType == Just RECENTS
-  locationSelected item{tag=if condition then "RECENT" else item.tag} true state{ props { sourceSelectedOnMap = if condition then true else state.props.sourceSelectedOnMap }}
+  locationSelected item{tag=if condition then "" else item.tag} true state{ props { sourceSelectedOnMap = if condition then false else state.props.sourceSelectedOnMap }}
 
 eval (ExitLocationSelected item addToRecents)state = exit $ LocationSelected item  addToRecents state
 

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/View.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/View.purs
@@ -137,7 +137,7 @@ screen initialState =
                 if ((getValueToLocalStore TRACKING_DRIVER) == "False") then do
                   _ <- removeMarker (getCurrentLocationMarker (getValueToLocalStore VERSION_NAME))
                   _ <- pure $ setValueToLocalStore TRACKING_ID (getNewTrackingId unit)
-                  void $ launchAff $ flowRunner $ driverLocationTracking push UpdateCurrentStage DriverArrivedAction UpdateETA 5000.0 (getValueToLocalStore TRACKING_ID) initialState "pickup" 0
+                  void $ launchAff $ flowRunner $ driverLocationTracking push UpdateCurrentStage DriverArrivedAction UpdateETA 3000.0 (getValueToLocalStore TRACKING_ID) initialState "pickup"
                 else pure unit
                 if(not initialState.props.chatcallbackInitiated) then do
                   _ <- storeCallBackMessageUpdated push initialState.data.driverInfoCardState.bppRideId "Customer" UpdateMessages
@@ -151,7 +151,7 @@ screen initialState =
                 if ((getValueToLocalStore TRACKING_DRIVER) == "False") then do
                   _ <- removeMarker (getCurrentLocationMarker (getValueToLocalStore VERSION_NAME))
                   _ <- pure $ setValueToLocalStore TRACKING_ID (getNewTrackingId unit)
-                  _ <- launchAff $ flowRunner $ driverLocationTracking push UpdateCurrentStage DriverArrivedAction UpdateETA 20000.0 (getValueToLocalStore TRACKING_ID) initialState "trip" 0
+                  _ <- launchAff $ flowRunner $ driverLocationTracking push UpdateCurrentStage DriverArrivedAction UpdateETA 20000.0 (getValueToLocalStore TRACKING_ID) initialState "trip"
                   pure unit
                 else
                   pure unit
@@ -1761,8 +1761,8 @@ getQuotesPolling pollingId action retryAction count duration push state = do
         _ <- pure $ updateLocalStage QuoteList
         doAff do liftEffect $ push $ action response
 
-driverLocationTracking :: forall action. (action -> Effect Unit) -> (String -> action) -> (String -> action) -> (Int -> Int -> action) -> Number -> String -> HomeScreenState -> String -> Int -> Flow GlobalState Unit
-driverLocationTracking push action driverArrivedAction updateState duration trackingId state routeState dynamicDuration = do
+driverLocationTracking :: forall action. (action -> Effect Unit) -> (String -> action) -> (String -> action) -> (Int -> Int -> action) -> Number -> String -> HomeScreenState -> String -> Flow GlobalState Unit
+driverLocationTracking push action driverArrivedAction updateState duration trackingId state routeState = do
   _ <- pure $ printLog "trackDriverLocation2_function" trackingId
   if (any (\stage -> isLocalStageOn stage) [ RideAccepted, RideStarted, ChatWithDriver]) && ((getValueToLocalStore TRACKING_ID) == trackingId) then do
     when (state.props.bookingId /= "") $ do
@@ -1786,7 +1786,7 @@ driverLocationTracking push action driverArrivedAction updateState duration trac
       _ <- doAff $ liftEffect $ animateCamera state.data.driverInfoCardState.sourceLat state.data.driverInfoCardState.sourceLng 17
       _ <- doAff $ liftEffect $ addMarker "ny_ic_src_marker" state.data.driverInfoCardState.sourceLat state.data.driverInfoCardState.sourceLng 160 (0.0) (0.0)
       void $ delay $ Milliseconds duration
-      driverLocationTracking push action driverArrivedAction updateState duration trackingId state routeState (dynamicDuration+1)
+      driverLocationTracking push action driverArrivedAction updateState duration trackingId state routeState
       else do 
         response <- getDriverLocation state.data.driverInfoCardState.rideId
         case response of
@@ -1802,8 +1802,8 @@ driverLocationTracking push action driverArrivedAction updateState duration trac
               _ <- pure $ setValueToLocalStore TRACKING_DRIVER "True"
               _ <- pure $ removeAllPolylines ""
               _ <- liftFlow $ drawRoute (walkCoordinate srcLat srcLon dstLat dstLon) "DOT" "#323643" false markers.srcMarker markers.destMarker 8 "DRIVER_LOCATION_UPDATE" "" ""
-              void $ delay $ Milliseconds  (if dynamicDuration > 20 && routeState == "pickup" then duration + 1000.0 else if dynamicDuration > 40 && routeState == "pickup" then duration + 2000.0 else duration)
-              driverLocationTracking push action driverArrivedAction updateState duration trackingId state routeState (dynamicDuration+1)
+              void $ delay $ Milliseconds duration
+              driverLocationTracking push action driverArrivedAction updateState duration trackingId state routeState
               pure unit
             else if ((getValueToLocalStore TRACKING_DRIVER) == "False" || not (isJust state.data.route)) then do
               _ <- pure $ setValueToLocalStore TRACKING_DRIVER "True"
@@ -1817,8 +1817,8 @@ driverLocationTracking push action driverArrivedAction updateState duration trac
                           newRoute = routes { points = Snapped (map (\item -> LatLong { lat: item.lat, lon: item.lng }) newPoints.points) }
                       liftFlow $ drawRoute newPoints "LineString" "#323643" true markers.srcMarker markers.destMarker 8 "DRIVER_LOCATION_UPDATE" "" (metersToKm routes.distance state)
                       _ <- doAff do liftEffect $ push $ updateState routes.duration routes.distance
-                      void $ delay $ Milliseconds (if dynamicDuration > 20 && routeState == "pickup" then duration + 1000.0 else if dynamicDuration > 40 && routeState == "pickup" then duration + 2000.0 else duration)
-                      driverLocationTracking push action driverArrivedAction updateState duration trackingId state { data { route = Just (Route newRoute), speed = routes.distance / routes.duration } } routeState (dynamicDuration+1)
+                      void $ delay $ Milliseconds duration
+                      driverLocationTracking push action driverArrivedAction updateState duration trackingId state { data { route = Just (Route newRoute), speed = routes.distance / routes.duration } } routeState
                     Nothing -> pure unit
                 Left err -> pure unit
             else do
@@ -1829,14 +1829,14 @@ driverLocationTracking push action driverArrivedAction updateState duration trac
                         let newPoints = { points : locationResp.points}
                         liftFlow $ updateRoute newPoints markers.destMarker (metersToKm locationResp.distance state)
                         _ <- doAff do liftEffect $ push $ updateState locationResp.eta locationResp.distance
-                        void $ delay $ Milliseconds (if dynamicDuration > 20 && routeState == "pickup" then duration + 1000.0 else if dynamicDuration > 40 && routeState == "pickup" then duration + 2000.0 else duration)
-                        driverLocationTracking push action driverArrivedAction updateState duration trackingId state routeState (dynamicDuration+1)
+                        void $ delay $ Milliseconds duration
+                        driverLocationTracking push action driverArrivedAction updateState duration trackingId state routeState
                       else do
-                        driverLocationTracking push action driverArrivedAction updateState duration trackingId state { data { route = Nothing } } routeState (dynamicDuration + 1)
-                Nothing -> driverLocationTracking push action driverArrivedAction updateState duration trackingId state { data { route = Nothing } } routeState (dynamicDuration + 1)
+                        driverLocationTracking push action driverArrivedAction updateState duration trackingId state { data { route = Nothing } } routeState
+                Nothing -> driverLocationTracking push action driverArrivedAction updateState duration trackingId state { data { route = Nothing } } routeState
           Left err -> do
-            void $ delay $ Milliseconds  (if dynamicDuration > 20 && routeState == "pickup" then duration + 1000.0 else if dynamicDuration > 40 && routeState == "pickup" then duration + 2000.0 else duration)
-            driverLocationTracking push action driverArrivedAction updateState duration trackingId state { data { route = Nothing } } routeState (dynamicDuration + 1)
+            void $ delay $ Milliseconds duration
+            driverLocationTracking push action driverArrivedAction updateState duration trackingId state { data { route = Nothing } } routeState
   else do
     pure unit
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Currently confirm pickup step is being skipped when source is selected from recent searches,
we should only skip confirm pickup step when source is selected from saved locations
Updating the driverLocationTracking polling for the customer every 3 seconds while the driver is coming to pickup the customer.

## Motivation and Context
https://github.com/nammayatri/nammayatri/issues/941

## How did you test it?
Tested Manually

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable

## Recording

https://github.com/nammayatri/nammayatri/assets/61149512/e38539fd-fcd4-4b2b-86fb-7209614e3191

