### PR TITLE
.envrc: Make find command work on macOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 nix_direnv_watch_file \
-    $(find Backend -name "*.cabal" -printf '%p ') \
+    $(find Backend -name "*.cabal" | tr '\n' ' ') \
     Backend/cabal.project \
     Backend/*.nix \
     Backend/nix/*.nix


### PR DESCRIPTION
Without this, direnv will not reload on `.cabal` file changes. It shows this error:

```
find: -printf: unknown primary or operator
```

See https://stackoverflow.com/a/32293551/55246