### PR TITLE
frontend/fix: #963 fixed try again popup after search expire in custo…

### DIFF
--- a/Frontend/ui-customer/src/Flow.purs
+++ b/Frontend/ui-customer/src/Flow.purs
@@ -643,6 +643,7 @@ homeScreenFlow = do
         homeScreenFlow
     GET_SELECT_LIST state -> do
       when (isLocalStageOn QuoteList) $ do
+        cancelEstimate state.props.estimateId
         updateFlowStatus SEARCH_CANCELLED
       homeScreenFlow
     CONFIRM_RIDE state -> do

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/Controller.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/Controller.purs
@@ -913,7 +913,9 @@ eval OpenSettings state = do
 eval (SearchExpireCountDown seconds id status timerID) state = do
   if status == "EXPIRED" then do
     _ <- pure $ clearTimer timerID
-    continue state { props { searchExpire = seconds } }
+    _ <- pure $ updateLocalStage QuoteList
+    let updatedState = if state.props.customerTip.enableTips then tipEnabledState state{props{isPopUp = TipsPopUp}} else state{props{isPopUp = ConfirmBack}}
+    exit $ GetSelectList updatedState { props { searchExpire = seconds , isSearchLocation = NoView, isSource = Nothing,currentStage = QuoteList} }
   else
     continue state { props { searchExpire = seconds } }
 


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Frontend changes- show ride expired and try again screen when search expires.

Issues: Currently when there is an on-going search, if the user closes the app and comes back after search expiry time also, UI is still showing the 'Finding Ride screen'. It should ideally tell the user that the search expired and show try again.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
