### PR TITLE
frontend/fix: #1413/ fixed resend OTP bug fixes.

### DIFF
--- a/Frontend/ui-common/src/Engineering/Helpers/JBridge.js
+++ b/Frontend/ui-common/src/Engineering/Helpers/JBridge.js
@@ -1441,11 +1441,13 @@ export const startTimerWithTime = function (time) {
     return function (interval) {
       return function (cb) {
         return function (action) {
-          var callback = callbackMapper.map(function (seconds,quoteID,status,timerID) {
-            cb(action(seconds)(quoteID)(status)(timerID))();
-          });
-          if (JBridge.startCountDownTimerWithTime)  {
-            return JBridge.startCountDownTimerWithTime(time, interval, qouteId, callback);}
+          return function () {
+            var callback = callbackMapper.map(function (seconds,quoteID,status,timerID) {
+              cb(action(seconds)(quoteID)(status)(timerID))();
+            });
+            if (JBridge.startCountDownTimerWithTime)  {
+              return JBridge.startCountDownTimerWithTime(time, interval, qouteId, callback);}
+          }
         }
       }
     }

--- a/Frontend/ui-customer/src/Flow.purs
+++ b/Frontend/ui-customer/src/Flow.purs
@@ -487,7 +487,7 @@ enterMobileNumberScreenFlow = do
             setValueToLocalStore MOBILE_NUMBER (state.data.mobileNumber)
             void $ pure $ setCleverTapUserData "Phone" ("+91" <> (getValueToLocalStore MOBILE_NUMBER))
             (TriggerOTPResp triggerOtpResp) <- Remote.triggerOTPBT (Remote.makeTriggerOTPReq state.data.mobileNumber)
-            modifyScreenState $ EnterMobileNumberScreenType (\enterMobileNumberScreen → enterMobileNumberScreen { data { tokenId = triggerOtpResp.authId, attempts = triggerOtpResp.attempts}, props {enterOTP = true,resendEnable = true}})
+            modifyScreenState $ EnterMobileNumberScreenType (\enterMobileNumberScreen → enterMobileNumberScreen { data { tokenId = triggerOtpResp.authId, attempts = triggerOtpResp.attempts}, props {enterOTP = true,resendEnable = false}})
             modifyScreenState $ HomeScreenStateType (\homeScreen → homeScreen{data{settingSideBar{number = state.data.mobileNumber}}})
             enterMobileNumberScreenFlow
     ResendOTP state -> do

--- a/Frontend/ui-customer/src/Flow.purs
+++ b/Frontend/ui-customer/src/Flow.purs
@@ -494,7 +494,9 @@ enterMobileNumberScreenFlow = do
             (ResendOTPResp resendResp) <- Remote.resendOTPBT state.data.tokenId
             modifyScreenState $ EnterMobileNumberScreenType (\enterMobileNumberScreen → enterMobileNumberScreen { data { tokenId = resendResp.authId, attempts = resendResp.attempts}})
             enterMobileNumberScreenFlow
-    GoBack state  ->  enterMobileNumberScreenFlow
+    GoBack state  ->  do
+            modifyScreenState $ EnterMobileNumberScreenType (\enterMobileNumberScreen → enterMobileNumberScreen { data {timer = 30 }, props {enterOTP = false,resendEnable = false}})
+            enterMobileNumberScreenFlow
     GoToWelcomeScreen state -> welcomeScreenFlow
 
 welcomeScreenFlow :: FlowBT String Unit

--- a/Frontend/ui-customer/src/Helpers/Utils.js
+++ b/Frontend/ui-customer/src/Helpers/Utils.js
@@ -269,6 +269,17 @@ export const clearWaitingTimer = function (id){
   }
 }
 
+export const clearCountDownTimer = function (id){
+  if(__OS == "IOS"){
+    if (window.JBridge.clearCountDownTimer) {
+      window.JBridge.clearCountDownTimer();
+    }
+  }
+  else {
+    clearInterval(parseInt(id));
+  }
+}
+
 function getTwoDigitsNumber(number) {
   return number >= 10 ? number : "0"+number.toString();
 }

--- a/Frontend/ui-customer/src/Helpers/Utils.purs
+++ b/Frontend/ui-customer/src/Helpers/Utils.purs
@@ -159,6 +159,7 @@ foreign import updateInputString :: String -> Unit
 foreign import debounceFunction :: forall action. Int -> (action -> Effect Unit) -> (String -> action) -> Effect Unit
 
 foreign import clearWaitingTimer :: String -> Unit
+foreign import clearCountDownTimer :: String -> Unit
 foreign import contactPermission :: Unit -> Effect Unit
 foreign import performHapticFeedback :: Unit -> Effect Unit
 foreign import adjustViewWithKeyboard :: String -> Effect Unit

--- a/Frontend/ui-customer/src/Screens/OnBoardingFlow/EnterMobileNumberScreen/Controller.purs
+++ b/Frontend/ui-customer/src/Screens/OnBoardingFlow/EnterMobileNumberScreen/Controller.purs
@@ -23,8 +23,8 @@ import Data.Maybe (Maybe(..))
 import Data.String (length)
 import Data.String.CodeUnits (charAt)
 import Debug (spy)
-import Engineering.Helpers.Commons (getNewIDWithTag, os, clearTimer)
-import Helpers.Utils (setText')
+import Engineering.Helpers.Commons (getNewIDWithTag, os)
+import Helpers.Utils (setText', clearCountDownTimer)
 import JBridge (hideKeyboardOnNavigation, toast, toggleBtnLoader, minimizeApp, firebaseLogEvent)
 import Language.Strings (getString)
 import Language.Types (STR(..))
@@ -176,6 +176,7 @@ eval (AutoFill otp) state = updateAndExit
 eval (BackPressed flag) state = do
       _ <- pure $ printLog "state" state
       _ <- pure $ toggleBtnLoader "" false
+      _ <- pure $ clearCountDownTimer state.data.timerID
       let newState = state {props{enterOTP =  false,letterSpacing = PX 1.0},data{otp = ""}}
       _ <- pure $ hideKeyboardOnNavigation true
       if state.props.enterOTP then exit $ GoBack newState
@@ -187,8 +188,8 @@ eval (BackPressed flag) state = do
 eval (CountDown seconds id status timerID) state = do
         _ <- pure $ printLog "timer" $ show seconds
         if status == "EXPIRED" then do
-            _ <- pure $ clearTimer timerID
-            let newState = state{data{timer = 15, timerID = ""},props = state.props{resendEnable = true}}
+            _ <- pure $ clearCountDownTimer state.data.timerID
+            let newState = state{data{timer = 30, timerID = ""},props = state.props{resendEnable = true}}
             continue newState
         else
             continue $ state{data{timer = seconds, timerID=timerID},props = state.props{resendEnable = false}}

--- a/Frontend/ui-customer/src/Screens/OnBoardingFlow/EnterMobileNumberScreen/Controller.purs
+++ b/Frontend/ui-customer/src/Screens/OnBoardingFlow/EnterMobileNumberScreen/Controller.purs
@@ -185,13 +185,13 @@ eval (BackPressed flag) state = do
                 continue state
 
 eval (CountDown seconds id status timerID) state = do
-        _ <- pure $ printLog "timer" seconds
+        _ <- pure $ printLog "timer" $ show seconds
         if status == "EXPIRED" then do
             _ <- pure $ clearTimer timerID
-            let newState = state{data{timer = "", timerID = ""},props = state.props{resendEnable = true}}
+            let newState = state{data{timer = 15, timerID = ""},props = state.props{resendEnable = true}}
             continue newState
         else
-            continue $ state{data{timer = show seconds, timerID=timerID},props = state.props{resendEnable = false}}
+            continue $ state{data{timer = seconds, timerID=timerID},props = state.props{resendEnable = false}}
 eval (SetToken id )state = do
   _ <- pure $ spy "SetTokenSetToken" id
   _ <- pure $ setValueToLocalNativeStore FCM_TOKEN  id

--- a/Frontend/ui-customer/src/Screens/OnBoardingFlow/EnterMobileNumberScreen/ScreenData.purs
+++ b/Frontend/ui-customer/src/Screens/OnBoardingFlow/EnterMobileNumberScreen/ScreenData.purs
@@ -25,7 +25,7 @@ initData = {
     , tokenId : ""
     , attempts : 0
     , otp : ""
-    , timer : ""
+    , timer : 30
     , timerID : ""
     },
     props: {
@@ -34,7 +34,7 @@ initData = {
         btnActiveOTP :false,
         isValidMobileNumber : true,
         wrongOTP : false,
-        resendEnable : true,
+        resendEnable : false,
         capturedOtp : "",
         isReadingOTP : true,
         letterSpacing : PX 1.0,

--- a/Frontend/ui-customer/src/Screens/OnBoardingFlow/EnterMobileNumberScreen/View.purs
+++ b/Frontend/ui-customer/src/Screens/OnBoardingFlow/EnterMobileNumberScreen/View.purs
@@ -39,7 +39,7 @@ import JBridge as JB
 import Language.Strings (getString)
 import Language.Types (STR(..))
 import Log (printLog)
-import Prelude (Unit, bind, const, discard, not, pure, unit, when, ($), (&&), (/=), (<<<), (<>), (==), (>=))
+import Prelude (Unit, bind, const, discard, not, pure, show, unit, when, ($), (&&), (/=), (<<<), (<>), (==), (>=))
 import Presto.Core.Types.Language.Flow (doAff)
 import PrestoDOM (Gravity(..), Length(..), Margin(..), Orientation(..), Padding(..), PrestoDOM, Screen, Visibility(..), afterRender, alpha, background, clickable, color, fontStyle, frameLayout, gravity, height, lineHeight, linearLayout, margin, onBackPressed, onClick, orientation, padding, singleLine, text, textSize, textView, visibility, weight, width, textFromHtml)
 import PrestoDOM.Animation as PrestoAnim
@@ -60,8 +60,10 @@ screen initialState =
       _ <- JB.setFCMToken push $ SetToken
       if not initialState.props.enterOTP then JB.detectPhoneNumbers push $ SetPhoneNumber else pure unit
       if initialState.data.timerID == "" then pure unit else pure $ EHC.clearTimer initialState.data.timerID
-      if not initialState.props.resendEnable && initialState.data.attempts >= 0 then do
-          _ <- launchAff $ EHC.flowRunner defaultGlobalState $ runExceptT $ runBackT $ lift $ lift $ doAff do liftEffect $ EHC.countDown 15 "otp" push CountDown
+      if not initialState.props.resendEnable && initialState.data.attempts >= 0 && initialState.props.enterOTP then do
+          _ <- launchAff $ EHC.flowRunner defaultGlobalState $ runExceptT $ runBackT $ lift $ lift $ doAff do 
+            if (EHC.os == "IOS") then liftEffect $ JB.startTimerWithTime (show initialState.data.timer) "otp" "1" push CountDown
+            else  liftEffect $ EHC.countDown initialState.data.timer "otp" push CountDown
           pure unit
         else pure unit
       pure (pure unit)) ] <> if EHC.os == "IOS" then [] else [ startOtpReciever AutoFill ]
@@ -178,14 +180,11 @@ enterOTPView state lang push =
     ][PrestoAnim.animationSet
       [ Anim.translateYAnimFromTopWithAlpha translateYAnimConfig{ifAnim = state.props.enterOTP} --400 15 0 0 state.props.enterOTP PrestoAnim.Linear
       ] $ PrimaryEditText.view (push <<< OTPEditTextAction) (otpEditTextConfig state)
-    , PrestoAnim.animationSet
-      [ Anim.translateYAnimFromTopWithAlpha translateYAnimConfig{ifAnim = state.props.enterOTP} --400 15 0 0 state.props.enterOTP PrestoAnim.Linear
-      ] $ linearLayout
+    ,  linearLayout
       [ height WRAP_CONTENT
       , width WRAP_CONTENT
       , orientation HORIZONTAL
       , clickable state.props.resendEnable
-      , visibility if state.props.resendEnable then VISIBLE else GONE
       ][linearLayout
       [ width WRAP_CONTENT
       , height WRAP_CONTENT
@@ -209,42 +208,7 @@ enterOTPView state lang push =
       , textView
         [ width WRAP_CONTENT
         , height WRAP_CONTENT
-        , text if lang == "HI_IN" then ("  "<> state.data.timer <> "s  "<> getString IN) else ("  " <> getString IN <> "  "<> state.data.timer <> "  s")
-        , textSize FontSize.a_12
-        , lineHeight "22"
-        , fontStyle $ FontStyle.semiBold LanguageStyle
-        , color Color.blue900
-        , visibility if state.props.resendEnable then GONE else VISIBLE
-        ]]
-      ,linearLayout
-      [ height WRAP_CONTENT
-      , width WRAP_CONTENT
-      , orientation HORIZONTAL
-      , visibility if state.props.resendEnable then GONE else VISIBLE
-      ][linearLayout
-      [ width WRAP_CONTENT
-      , height WRAP_CONTENT
-      , orientation VERTICAL
-      , alpha if state.props.resendEnable then 1.0 else 0.5
-      ][  textView
-        [ width WRAP_CONTENT
-        , height WRAP_CONTENT
-        , text (getString RESEND)
-        , textSize FontSize.a_12
-        , fontStyle $FontStyle.semiBold LanguageStyle
-
-        , color Color.blue900
-        ]
-        , linearLayout
-          [ width MATCH_PARENT
-          , height (V 1)
-          , background Color.blue900
-          ][]
-      ]
-      , textView
-        [ width WRAP_CONTENT
-        , height WRAP_CONTENT
-        , text if lang == "HI_IN" then ("  "<> state.data.timer <> "s  "<> getString IN) else ("  " <> getString IN <> "  "<> state.data.timer <> "  s")
+        , text if lang == "HI_IN" then ("  "<> show state.data.timer <> "s  "<> getString IN) else ("  " <> getString IN <> "  "<> show state.data.timer <> "  s")
         , textSize FontSize.a_12
         , lineHeight "22"
         , fontStyle $ FontStyle.semiBold LanguageStyle

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/View.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/View.purs
@@ -60,7 +60,7 @@ import Engineering.Helpers.Commons (countDown, flowRunner, getNewIDWithTag, lift
 import Font.Size as FontSize
 import Font.Style as FontStyle
 import Helpers.Utils (Merchant(..), decodeErrorMessage, fetchAndUpdateCurrentLocation, getCurrentLocationMarker, getLocationName, getMerchant, getNewTrackingId, getPreviousVersion, parseFloat, storeCallBackCustomer, storeCallBackLocateOnMap, storeOnResumeCallback, toString, waitingCountdownTimer)
-import JBridge (addMarker, animateCamera, drawRoute, enableMyLocation, firebaseLogEvent, getCurrentPosition, getHeightFromPercent, isCoordOnPath, isInternetAvailable, removeAllPolylines, removeMarker, requestKeyboardShow, showMap, startLottieProcess, toast, updateRoute, getExtendedPath, generateSessionId, initialWebViewSetUp, stopChatListenerService, startChatListenerService, storeCallBackMessageUpdated, isMockLocation, storeCallBackOpenChatScreen)
+import JBridge (addMarker, animateCamera, drawRoute, enableMyLocation, firebaseLogEvent, getCurrentPosition, getHeightFromPercent, isCoordOnPath, isInternetAvailable, removeAllPolylines, removeMarker, requestKeyboardShow, showMap, startLottieProcess, toast, updateRoute, getExtendedPath, generateSessionId, initialWebViewSetUp, stopChatListenerService, startChatListenerService, startTimerWithTime, storeCallBackMessageUpdated, isMockLocation, storeCallBackOpenChatScreen)
 import Language.Strings (getString)
 import Language.Types (STR(..))
 import Log (printLog)
@@ -125,7 +125,7 @@ screen initialState =
               FindingQuotes -> do
                 when ((getValueToLocalStore FINDING_QUOTES_POLLING) == "false") $ do
                   _ <- pure $ setValueToLocalStore FINDING_QUOTES_POLLING "true"
-                  _ <- countDown initialState.props.searchExpire "" push SearchExpireCountDown
+                  _ <- if os == "IOS" then startTimerWithTime (show initialState.props.searchExpire) "" "1" push SearchExpireCountDown else countDown initialState.props.searchExpire "" push SearchExpireCountDown
                   _ <- pure $ setValueToLocalStore GOT_ONE_QUOTE "FALSE"
                   _ <- pure $ setValueToLocalStore TRACKING_ID (getNewTrackingId unit)
                   let pollingCount = ceil ((toNumber initialState.props.searchExpire)/((fromMaybe 0.0 (NUM.fromString (getValueToLocalStore TEST_POLLING_INTERVAL))) / 1000.0))

--- a/Frontend/ui-customer/src/Screens/Types.purs
+++ b/Frontend/ui-customer/src/Screens/Types.purs
@@ -183,7 +183,7 @@ type EnterMobileNumberScreenStateData = {
   , tokenId :: String
   , attempts :: Int
   , otp :: String
-  , timer :: String
+  , timer :: Int
   , timerID :: String
 }
 -- ################################################ AccountSetUpScreenState ##################################################


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
The enterOTP view contained same code repeated. The position of "resend" now remains fixed after timer runs out. 
Other changes are : 

- Speed of timer in iOS has been fixed.
- Resend will be disabled for the first 30 seconds. 


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
