### PR TITLE
frontend/fix: #1876 updated loader animaton and unserviceability pop up

### DIFF
--- a/Frontend/ui-common/src/Components/PrimaryButton/View.purs
+++ b/Frontend/ui-common/src/Components/PrimaryButton/View.purs
@@ -35,7 +35,7 @@ view push config =
   , margin config.margin
   , onClick (\action -> do
               _ <- pure $ toggleBtnLoader config.id true
-              _ <- pure $ startLottieProcess "primary_button_loader" (getNewIDWithTag config.id) true 0.6 "CENTER_CROP"
+              _ <- pure $ startLottieProcess "primary_button_loader" (getNewIDWithTag config.id) true 0.6 if os == "IOS" then "DEFAULT" else "CENTER_CROP"
               push action
               ) (const OnClick)
   , orientation HORIZONTAL

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ComponentConfig.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ComponentConfig.purs
@@ -621,7 +621,7 @@ sourceUnserviceableConfig state =
     config = ErrorModal.config
     errorModalConfig' =
       config
-        { height = MATCH_PARENT
+        { height = if (HU.getMerchant FunctionCall == HU.NAMMAYATRI) then MATCH_PARENT else WRAP_CONTENT
         , background = Color.white900
         , stroke = ("1," <> Color.borderGreyColor)
         , corners = (Corners 20.0 true true false false)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

- Change has been added to not block the user because of unserviceability for Yatri Sathi and Yatri 
- Updated the primary_button_loader animation in IOS so accordingly , changes have been added for the same