### PR TITLE
frontend/fix/MakeFloatingIconRound

### DIFF
--- a/Frontend/android-native/app/src/main/res/layout/floating_widget_layout.xml
+++ b/Frontend/android-native/app/src/main/res/layout/floating_widget_layout.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/root_container"
     android:layout_width="match_parent"
-    android:layout_height="90dp"
+    android:layout_height="93dp"
     android:orientation="vertical"
 
     android:layout_margin="16dp">
@@ -106,11 +106,16 @@
                     android:layout_marginHorizontal="25dp"
                     android:indeterminate="false" />
 
-                <ImageView
+                <com.google.android.material.imageview.ShapeableImageView
                     android:layout_width="64dp"
                     android:layout_height="64dp"
-                    android:src="@drawable/ic_floating_widget"
-                    android:id="@+id/floating_logo" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:srcCompat="@drawable/ic_floating_widget"
+                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.App.CornerSize50"
+                    />
+
 
                 <LinearLayout
                     android:layout_width="wrap_content"

--- a/Frontend/android-native/app/src/main/res/values/styles.xml
+++ b/Frontend/android-native/app/src/main/res/values/styles.xml
@@ -12,5 +12,9 @@
 
     </style>
 
+    <style name="ShapeAppearanceOverlay.App.CornerSize50" parent="">
+        <item name="cornerSize">50%</item>
+    </style>
+
     <color name="white">#FDFDFD</color>
 </resources>


### PR DESCRIPTION
## Type of Change
made changes such that the floating icon becomes circular in shape.

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

Made the layout from 90dp to 93dp to avoid cropping from below

**WITH 90dp**
<img width="192" alt="Screenshot 2023-08-11 at 2 34 42 PM" src="https://github.com/nammayatri/nammayatri/assets/65895796/50e5f641-65b5-4be1-8e69-f9e65dc532b5">

## Screenshots from Android Studio
<img width="543" alt="Screenshot 2023-08-11 at 2 35 41 PM" src="https://github.com/nammayatri/nammayatri/assets/65895796/a2e1cbc2-8288-46c9-a8d0-acffea184dae">
<img width="537" alt="Screenshot 2023-08-11 at 2 39 42 PM" src="https://github.com/nammayatri/nammayatri/assets/65895796/544b5cee-347f-481d-9e6c-6edac3e4847a">
<img width="532" alt="Screenshot 2023-08-11 at 2 41 03 PM" src="https://github.com/nammayatri/nammayatri/assets/65895796/97d3259b-054b-458d-bf8b-18eed260bdc5">

## Screenshots from device
![1691746615719](https://github.com/nammayatri/nammayatri/assets/65895796/f6543d9c-1633-4b73-a0be-60003f4169b0)
![1691747117554](https://github.com/nammayatri/nammayatri/assets/65895796/f6355474-2371-4605-9edd-07c76f3c5f5a)
![1691747117558](https://github.com/nammayatri/nammayatri/assets/65895796/30c5daef-175a-4fee-bd61-189548e9874b)




