### PR TITLE
frontend/feat/enable-aadhaar-popup

### DIFF
--- a/Frontend/ui-driver/src/Screens/HomeScreen/ComponentConfig.purs
+++ b/Frontend/ui-driver/src/Screens/HomeScreen/ComponentConfig.purs
@@ -183,7 +183,8 @@ linkAadhaarPopupConfig state = let
     option2 {
       visibility = false
     },
-    backgroundClickable = false,
+    backgroundClickable = true,
+    dismissPopup = true,
     cornerRadius = (PTD.Corners 15.0 true true true true),
     coverImageConfig {
       imageUrl = "ny_ic_aadhaar_logo,https://assets.juspay.in/nammayatri/images/driver/ny_ic_aadhaar_logo.png"

--- a/Frontend/ui-driver/src/Screens/HomeScreen/Controller.purs
+++ b/Frontend/ui-driver/src/Screens/HomeScreen/Controller.purs
@@ -278,9 +278,10 @@ eval BackPressed state = do
                   else if state.data.paymentState.showRateCard then
                     continue state { data { paymentState{ showRateCard = false } } }
                       else if state.props.endRidePopUp then continue state{props {endRidePopUp = false}}
-                        else do
-                          _ <- pure $ minimizeApp ""
-                          continue state
+                        else if (state.props.showlinkAadhaarPopup && state.props.showAadharPopUp) then continue state {props{showAadharPopUp = false}}
+                          else do
+                            _ <- pure $ minimizeApp ""
+                            continue state
 
 eval TriggerMaps state = continueWithCmd state[ do
   _ <- pure $ openNavigation 0.0 0.0 state.data.activeRide.dest_lat state.data.activeRide.dest_lon
@@ -629,6 +630,8 @@ eval RemovePaymentBanner state = if state.data.paymentState.blockedDueToPayment 
                                                   continue state else continue state {data { paymentState {paymentStatusBanner = false}}}
 eval (LinkAadhaarPopupAC PopUpModal.OnButton1Click) state = exit $ AadhaarVerificationFlow state
 
+eval (LinkAadhaarPopupAC PopUpModal.DismissPopup) state = continue state {props{showAadharPopUp = false}}
+
 eval RemoveGenderBanner state = do
   _ <- pure $ setValueToLocalStore IS_BANNER_ACTIVE "False"
   continue state { props = state.props{showGenderBanner = false}}
@@ -642,7 +645,7 @@ eval (PaymentStatusAction status) state =
                   bannerTitle = getString YOUR_PREVIOUS_PAYMENT_IS_PENDING,
                   bannerTitleColor = Color.dustyRed,
                   banneActionText = getString CONTACT_SUPPORT,
-                  bannerImage = "ny_ic_payment_falied_banner," }}}
+                  bannerImage = "ny_ic_payment_failed_banner," }}}
 
 eval _ state = continue state
 

--- a/Frontend/ui-driver/src/Screens/HomeScreen/ScreenData.purs
+++ b/Frontend/ui-driver/src/Screens/HomeScreen/ScreenData.purs
@@ -133,6 +133,7 @@ initData = {
         showBonusInfo : false,
         timerRefresh : true,
         showlinkAadhaarPopup : false,
-        isChatOpened : false
+        isChatOpened : false,
+        showAadharPopUp : true
     }
 }

--- a/Frontend/ui-driver/src/Screens/HomeScreen/View.purs
+++ b/Frontend/ui-driver/src/Screens/HomeScreen/View.purs
@@ -213,6 +213,7 @@ view push state =
       , if state.props.silentPopUpView then popupModelSilentAsk push state else dummyTextView
       , if state.data.activeRide.waitTimeInfo then waitTimeInfoPopUp push state else dummyTextView
       , if state.data.paymentState.showRateCard then rateCardView push state else dummyTextView
+      , if (state.props.showlinkAadhaarPopup && state.props.showAadharPopUp) then linkAadhaarPopup push state else dummyTextView
   ]
 
 driverMapsHeaderView :: forall w . (Action -> Effect Unit) -> HomeScreenState -> PrestoDOM (Effect Unit) w

--- a/Frontend/ui-driver/src/Screens/Types.purs
+++ b/Frontend/ui-driver/src/Screens/Types.purs
@@ -874,7 +874,8 @@ type HomeScreenProps =  {
   showBonusInfo :: Boolean,
   timerRefresh :: Boolean,
   showlinkAadhaarPopup :: Boolean,
-  isChatOpened :: Boolean
+  isChatOpened :: Boolean,
+  showAadharPopUp :: Boolean
  }
 
 data DriverStatus = Online | Offline | Silent


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Enabled Aadhaar pop up for yatri-saathi.
If user clicks outside the pop-up or phone backpress then the pop-up will disappear and after a ride the pop-up will come again.

This will happen until we get correct aadhaar verification success from backend.


https://drive.google.com/file/d/1I6ZQuULdFHpmb5C1SG8x2ETRkYHYH13o/view?usp=sharing


