### PR TITLE
Backend/fix/Removed extra DB entries in broadcast message

### DIFF
--- a/Backend/app/kafka-consumers/src/Consumer/BroadcastMessage/Processor.hs
+++ b/Backend/app/kafka-consumers/src/Consumer/BroadcastMessage/Processor.hs
@@ -24,25 +24,34 @@ import Environment
 import EulerHS.Prelude
 import qualified Kernel.External.Notification.FCM.Types as FCM
 import Kernel.Types.Id
+import Kernel.Types.Time
 import "dynamic-offer-driver-app" Storage.Queries.Message.MessageReport as MRQuery
 import "dynamic-offer-driver-app" Storage.Queries.Person as Person
 import "dynamic-offer-driver-app" Tools.Notifications (sendMessageToDriver)
 
 broadcastMessage :: Types.MessageDict -> Text -> Flow ()
 broadcastMessage messageDict driverId = do
-  -- mDriver <- Esq.runInReplica $ Person.findById (Id driverId)
   mDriver <- Person.findById (Id driverId)
-  status <-
-    case mDriver of
-      Just driver -> do
-        let message = maybe messageDict.defaultMessage (flip (HM.findWithDefault messageDict.defaultMessage) messageDict.translations . show) driver.language
-        -- Esq.runTransaction $ MRQuery.updateDeliveryStatusByMessageIdAndDriverId message.id (Id driverId) Types.Sending
-        _ <- MRQuery.updateDeliveryStatusByMessageIdAndDriverId message.id (Id driverId) Types.Sending
-        exep <- try @_ @SomeException (sendMessageToDriver driver.merchantId FCM.SHOW (Just FCM.HIGH) FCM.NEW_MESSAGE message.title message.shortDescription driver.id message.id driver.deviceToken)
-        return $
-          case exep of
-            Left _ -> Types.Failed
-            Right _ -> Types.Success
-      Nothing -> return Types.Failed
-  -- void $ Esq.runTransaction $ MRQuery.updateDeliveryStatusByMessageIdAndDriverId messageDict.defaultMessage.id (Id driverId) status
-  void $ MRQuery.updateDeliveryStatusByMessageIdAndDriverId messageDict.defaultMessage.id (Id driverId) status
+  whenJust mDriver $ \driver -> do
+    let message = maybe messageDict.defaultMessage (flip (HM.findWithDefault messageDict.defaultMessage) messageDict.translations . show) driver.language
+    exep <- try @_ @SomeException (sendMessageToDriver driver.merchantId FCM.SHOW (Just FCM.HIGH) FCM.NEW_MESSAGE message.title message.shortDescription driver.id message.id driver.deviceToken)
+    let dStatus = case exep of
+          Left _ -> Types.Failed
+          Right _ -> Types.Success
+    mkMessageReport dStatus driverId messageDict.defaultMessage.id
+  where
+    mkMessageReport status drvrId messageId = do
+      now <- getCurrentTime
+      let messageReport =
+            Types.MessageReport
+              { driverId = Id drvrId,
+                messageId,
+                deliveryStatus = status,
+                readStatus = False,
+                likeStatus = False,
+                messageDynamicFields = HM.empty,
+                reply = Nothing,
+                createdAt = now,
+                updatedAt = now
+              }
+      void $ try @_ @SomeException $ MRQuery.create messageReport

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Message.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Message.hs
@@ -206,8 +206,6 @@ sendMessage merchantShortId Common.SendMessageRequest {..} = do
   where
     addToKafka message driverId = do
       topicName <- asks (.broadcastMessageTopic)
-      now <- getCurrentTime
-      void $ try @_ @SomeException (MRQuery.create (mkMessageReport now driverId)) -- avoid extra DB call to check if driverId exists
       msg <- createMessageLanguageDict message
       produceMessage
         (topicName, Just (encodeUtf8 $ getId driverId))
@@ -228,19 +226,6 @@ sendMessage merchantShortId Common.SendMessageRequest {..} = do
 
     addTranslation Domain.RawMessage {..} trans =
       (show trans.language, Domain.RawMessage {title = trans.title, description = trans.description, shortDescription = trans.shortDescription, label = trans.label, ..})
-
-    mkMessageReport now driverId =
-      Domain.MessageReport
-        { driverId,
-          messageId = Id messageId,
-          deliveryStatus = Domain.Queued,
-          readStatus = False,
-          likeStatus = False,
-          messageDynamicFields = M.empty,
-          reply = Nothing,
-          createdAt = now,
-          updatedAt = now
-        }
 
 messageList :: ShortId DM.Merchant -> Maybe Int -> Maybe Int -> Flow Common.MessageListResponse
 messageList merchantShortId mbLimit mbOffset = do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
While sending alert message to all the drivers, we are creating a DB entry for every single driver to whom the notification is sent. This results in a large number of DB entries (50k+).
Changed it such that the DB entries are not made when the message is sent, but instead when the message is delivered to the driver.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
