### PR TITLE
backend/fix: fixing the secondary key issue in KV by caching the driverId

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchRequestForDriver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchRequestForDriver.hs
@@ -19,6 +19,7 @@
 module Storage.Beam.SearchRequestForDriver where
 
 import qualified Data.Aeson as A
+import Data.ByteString
 import Data.Serialize
 import qualified Data.Time as Time
 import qualified Database.Beam as B
@@ -32,12 +33,20 @@ import qualified Domain.Types.DriverInformation as D
 import qualified Domain.Types.SearchRequestForDriver as Domain
 import qualified Domain.Types.Vehicle.Variant as Variant
 import EulerHS.KVConnector.Types (KVConnector (..), MeshMeta (..), primaryKey, secondaryKeys, tableName)
+import EulerHS.Types
 import GHC.Generics (Generic)
 import Kernel.Beam.Lib.UtilsTH
 import Kernel.Prelude hiding (Generic)
 import Kernel.Types.Common hiding (id)
 import Lib.Utils ()
 import Sequelize
+
+extractValue :: KVDBAnswer [ByteString] -> [ByteString]
+extractValue (Right value) = value
+extractValue _ = []
+
+searchReqestForDriverkey :: Text -> Text
+searchReqestForDriverkey prefix = "searchRequestForDriver_" <> prefix
 
 instance FromField Domain.DriverSearchRequestStatus where
   fromField = fromFieldEnum


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
For searchRequestForDriver  we can't use driverId as secondary key so using a new key to store only active searchRequestForDriver and then deleting the record in case we are marking as inactive

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
