### PR TITLE
frontend/fix: #2878 removed onFocus from PrimaryEditText

### DIFF
--- a/Frontend/ui-common/src/Components/PrimaryEditText/View.purs
+++ b/Frontend/ui-common/src/Components/PrimaryEditText/View.purs
@@ -104,11 +104,7 @@ editTextView push config =
   , gravity config.editText.gravity
   , letterSpacing config.editText.letterSpacing
   , alpha config.editText.alpha
-  , onFocus (\action -> do 
-    _ <- push action 
-    _ <- pure $ setText config.id config.editText.text
-    pure unit
-    ) $ FocusChanged
+  , onFocus push $ FocusChanged
   ] <> (FontStyle.getFontStyle config.editText.textStyle LanguageStyle)
     <> (case config.editText.pattern of 
         Just _pattern -> case config.type of 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
