### PR TITLE
backend/fix/stopping the drainer in case kafka service fails

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Delete.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Delete.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-type-defaults #-}
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module DBSync.Delete where
@@ -20,6 +21,7 @@ import qualified Kafka.Producer as KafkaProd
 import qualified Kafka.Producer as Producer
 import qualified Kernel.Beam.Types as KBT
 import Sequelize
+import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
@@ -149,11 +151,15 @@ runDeleteCommands (cmd, val) dbStreamKey = do
 streamDriverDrainerDeletes :: ToJSON a => Producer.KafkaProducer -> a -> Text -> IO (Either Text ())
 streamDriverDrainerDeletes producer dbObject dbStreamKey = do
   let topicName = "driver-drainer"
-  res <- KafkaProd.produceMessage producer (message topicName dbObject)
-  case res of
-    Just err -> pure $ Left $ T.pack ("Kafka Error: " <> show err)
-    _ -> pure $ Right ()
+  void $ KafkaProd.produceMessage producer (message topicName dbObject)
+  flushResult <- timeout (5 * 60 * 1000000) $ prodPush producer
+  case flushResult of
+    Just _ -> do
+      pure $ Right ()
+    Nothing -> pure $ Left "KafkaProd.flushProducer timed out after 5 minutes"
   where
+    prodPush producer' = KafkaProd.flushProducer producer' >> pure True
+
     message topicName event =
       ProducerRecord
         { prTopic = TopicName topicName,

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-type-defaults #-}
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module DBSync.Update where
@@ -21,6 +22,7 @@ import Kafka.Producer as KafkaProd
 import Kafka.Producer as Producer
 import qualified Kernel.Beam.Types as KBT
 import Sequelize (Model, Set, Where)
+import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
@@ -186,11 +188,15 @@ runUpdateCommands (cmd, val) dbStreamKey = do
 streamDriverDrainerUpdates :: ToJSON a => Producer.KafkaProducer -> a -> Text -> IO (Either Text ())
 streamDriverDrainerUpdates producer dbObject dbStreamKey = do
   let topicName = "driver-drainer"
-  res <- KafkaProd.produceMessage producer (message topicName dbObject)
-  case res of
-    Just err -> pure $ Left $ T.pack ("Kafka Error: " <> show err)
-    _ -> pure $ Right ()
+  void $ KafkaProd.produceMessage producer (message topicName dbObject)
+  flushResult <- timeout (5 * 60 * 1000000) $ prodPush producer
+  case flushResult of
+    Just _ -> do
+      pure $ Right ()
+    Nothing -> pure $ Left "KafkaProd.flushProducer timed out after 5 minutes"
   where
+    prodPush producer' = KafkaProd.flushProducer producer' >> pure True
+
     message topicName event =
       ProducerRecord
         { prTopic = TopicName topicName,

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Create.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Create.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-type-defaults #-}
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module DBSync.Create where
@@ -15,6 +16,7 @@ import EulerHS.Types as ET
 import Kafka.Producer as KafkaProd
 import Kafka.Producer as Producer
 import qualified Kernel.Beam.Types as KBT
+import System.Timeout (timeout)
 import Types.DBSync
 import Types.Event as Event
 import Utils.Utils
@@ -129,9 +131,15 @@ runCreateCommands cmds streamKey = do
 streamDriverDrainerCreates :: ToJSON a => Producer.KafkaProducer -> [a] -> Text -> IO (Either Text ())
 streamDriverDrainerCreates producer dbObject streamKey = do
   let topicName = "rider-drainer"
-  result' <- mapM (KafkaProd.produceMessage producer . message topicName) dbObject
-  if any isJust result' then pure $ Left ("Kafka Error: " <> show result') else pure $ Right ()
+  mapM_ (KafkaProd.produceMessage producer . message topicName) dbObject
+  flushResult <- timeout (5 * 60 * 1000000) $ prodPush producer
+  case flushResult of
+    Just _ -> do
+      pure $ Right ()
+    Nothing -> pure $ Left "KafkaProd.flushProducer timed out after 5 minutes"
   where
+    prodPush producer' = KafkaProd.flushProducer producer' >> pure True
+
     message topicName event =
       ProducerRecord
         { prTopic = TopicName topicName,

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Delete.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Delete.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-type-defaults #-}
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module DBSync.Delete where
@@ -20,6 +21,7 @@ import qualified Kafka.Producer as KafkaProd
 import qualified Kafka.Producer as Producer
 import qualified Kernel.Beam.Types as KBT
 import Sequelize
+import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
@@ -112,11 +114,15 @@ runDeleteCommands (cmd, val) dbStreamKey = do
 streamDriverDrainerDeletes :: ToJSON a => Producer.KafkaProducer -> a -> Text -> IO (Either Text ())
 streamDriverDrainerDeletes producer dbObject dbStreamKey = do
   let topicName = "rider-drainer"
-  res <- KafkaProd.produceMessage producer (message topicName dbObject)
-  case res of
-    Just err -> pure $ Left $ T.pack ("Kafka Error: " <> show err)
-    _ -> pure $ Right ()
+  void $ KafkaProd.produceMessage producer (message topicName dbObject)
+  flushResult <- timeout (5 * 60 * 1000000) $ prodPush producer
+  case flushResult of
+    Just _ -> do
+      pure $ Right ()
+    Nothing -> pure $ Left "KafkaProd.flushProducer timed out after 5 minutes"
   where
+    prodPush producer' = KafkaProd.flushProducer producer' >> pure True
+
     message topicName event =
       ProducerRecord
         { prTopic = TopicName topicName,

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-type-defaults #-}
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module DBSync.Update where
@@ -21,6 +22,7 @@ import Kafka.Producer as KafkaProd
 import Kafka.Producer as Producer
 import qualified Kernel.Beam.Types as KBT
 import Sequelize (Model, Set, Where)
+import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
@@ -150,11 +152,15 @@ runUpdateCommands (cmd, val) streamKey = do
 streamDriverDrainerUpdates :: ToJSON a => Producer.KafkaProducer -> a -> Text -> IO (Either Text ())
 streamDriverDrainerUpdates producer dbObject dbStreamKey = do
   let topicName = "rider-drainer"
-  res <- KafkaProd.produceMessage producer (message topicName dbObject)
-  case res of
-    Just err -> pure $ Left $ T.pack ("Kafka Error: " <> show err)
-    _ -> pure $ Right ()
+  void $ KafkaProd.produceMessage producer (message topicName dbObject)
+  flushResult <- timeout (5 * 60 * 1000000) $ prodPush producer
+  case flushResult of
+    Just _ -> do
+      pure $ Right ()
+    Nothing -> pure $ Left "KafkaProd.flushProducer timed out after 5 minutes"
   where
+    prodPush producer' = KafkaProd.flushProducer producer' >> pure True
+
     message topicName event =
       ProducerRecord
         { prTopic = TopicName topicName,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Handling the kafka log pusher function to stop the drainer services in case Kafka service goes down.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
