### PR TITLE
Backend/ProdHotPush: removed unnecessary findall

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/dynamic-offer-driver-drainer.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/dynamic-offer-driver-drainer.cabal
@@ -85,6 +85,7 @@ library
     , beam-postgres
     , bytestring
     , casing
+    , cereal
     , connection
     , containers
     , directory
@@ -169,6 +170,7 @@ executable dynamic-offer-driver-drainer-exe
     , beam-postgres
     , bytestring
     , casing
+    , cereal
     , connection
     , containers
     , directory

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/package.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/package.yaml
@@ -57,6 +57,7 @@ dependencies:
   - beam-postgres
   - bytestring
   - casing
+  - cereal
   - connection
   - containers
   - directory
@@ -92,6 +93,7 @@ dependencies:
   - warp
   - warp-tls
   - hw-kafka-client
+  - cereal
 
 ghc-options:
   - -fwrite-ide-info

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Constants.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Constants.hs
@@ -192,3 +192,6 @@ threadPerPodCount = "THREAD_PER_POD_COUNT"
 
 pushToKafkaEnvKey :: String
 pushToKafkaEnvKey = "PUSH_TO_KAFKA"
+
+kafkaUpdateFailedStream :: String
+kafkaUpdateFailedStream = "driver-kafka-update-failed-stream"

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
@@ -1,31 +1,36 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module DBSync.Update where
 
 import Config.Env
+import qualified Constants as C
 import Data.Aeson as A
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy as LBS
 import Data.Either.Extra (mapLeft)
 import Data.Maybe (fromJust)
+import qualified Data.Serialize as Serialize
 import Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Database.Beam as B hiding (runUpdate)
 import EulerHS.CachedSqlDBQuery as CDB
-import EulerHS.KVConnector.DBSync
-import EulerHS.KVConnector.Types
-import EulerHS.KVConnector.Utils as EKU
+import EulerHS.KVConnector.Types as EKT
+import EulerHS.KVConnector.Utils as Utils
 import qualified EulerHS.Language as EL
 import EulerHS.Prelude hiding (id)
 import EulerHS.Types as ET
 import Kafka.Producer as KafkaProd
 import Kafka.Producer as Producer
+import qualified Kernel.Beam.Functions as BeamFunction
 import qualified Kernel.Beam.Types as KBT
 import Sequelize (Model, Set, Where)
 import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
+import Utils.Redis
 import Utils.Utils
 
 updateDB ::
@@ -46,132 +51,155 @@ updateDB ::
   [Set be table] ->
   Where be table ->
   ByteString ->
-  m (Either MeshError [A.Value])
-updateDB dbConf _ setClause whereClause bts = do
-  either (pure . Left) ((Right <$>) . mapM updateModel') . mapLeft MDBError
-    =<< runExceptT
-      ( do
-          updateObj <- ExceptT $ CDB.updateOne dbConf Nothing setClause whereClause
-          pure [updateObj]
-      )
-  where
-    updateModel' model = do
-      let val = (EKU.updateModel @be @table) model (EKU.jsonKeyValueUpdates setClause)
-      case val of
-        Right obj -> pure obj
-        Left err -> do
-          EL.logError (("Model Update failed: " :: Text) <> T.pack (show err)) (show [("command" :: String, bts)] :: Text)
-          pure A.Null
+  m (Either MeshError ())
+updateDB dbConf _ setClause whereClause _ =
+  do
+    either (pure . Left) (pure . Right) . mapLeft MDBError
+    =<< CDB.updateOneWoReturning dbConf Nothing setClause whereClause
+
+getUpdatedValue ::
+  forall beM be table m.
+  ( HasCallStack,
+    ET.BeamRuntime be beM,
+    ET.BeamRunner beM,
+    Model be table,
+    MeshMeta be table,
+    B.HasQBuilder be,
+    EL.MonadFlow m,
+    ToJSON (table Identity),
+    FromJSON (table Identity),
+    Serialize.Serialize (table Identity)
+  ) =>
+  Text ->
+  Where be table ->
+  m (Either MeshError (table Identity))
+getUpdatedValue tag _ = do
+  res <- EL.runKVDB BeamFunction.meshConfig.kvRedis $ EL.get $ fromString $ T.unpack tag
+  case res of
+    Right (Just r) -> do
+      let (decodeResult :: MeshResult [table Identity], isLive) = Utils.decodeToField $ BSL.fromChunks [r]
+       in case decodeResult of
+            Right [decodeRes] -> return $ Right decodeRes
+            Right _ -> return $ Left (UnexpectedError "Redis Error: No Data for the key")
+            Left _ -> return $ Left (UnexpectedError "Redis Error: Decode Failed")
+    _ -> return $ Left (UnexpectedError "Redis Error")
 
 runUpdateCommands :: (UpdateDBCommand, ByteString) -> Text -> Flow (Either (MeshError, EL.KVDBStreamEntryID) EL.KVDBStreamEntryID)
 runUpdateCommands (cmd, val) dbStreamKey = do
   let dbConf = fromJust <$> EL.getOption KBT.PsqlDbCfg
   case cmd of
-    UpdateDBCommand id _ _ _ _ (RegistrationTokenOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("RegistrationToken" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BapMetadataOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("BapMetadata" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BookingOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Booking" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BookingLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("BookingLocation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BookingCancellationReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("BookingCancellationReason" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BusinessEventOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("BusinessEvent" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (CallStatusOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("CallStatus" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (CancellationReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("CancellationReason" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverFlowStatusOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverFlowStatus" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverBlockReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverBlockReason" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverFeeOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverFee" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverInformationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverInformation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverLocation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (AadhaarOtpReqOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("AadhaarOtpReq" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (AadhaarOtpVerifyOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("AadhaarOtpVerify" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (AadhaarVerificationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("AadhaarVerification" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverLicenseOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverLicense" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverRCAssociationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverRCAssociation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (IdfyVerificationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("IdfyVerification" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (ImageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Image" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (OperatingCityOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("OperatingCity" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (VehicleRegistrationCertificateOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("VehicleRegistrationCertificate" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverQuoteOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverQuote" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverReferralOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverReferral" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverStatsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverStats" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (EstimateOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Estimate" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (ExophoneOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Exophone" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FareParametersOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FareParameters" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FareParametersProgressiveDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FareParametersProgressiveDetails" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FareParametersSlabDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FareParametersSlabDetails" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FarePolicyOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FarePolicy" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverExtraFeeBoundsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverExtraFeeBounds" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FarePolicyProgressiveDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FarePolicyProgressiveDetails" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FarePolicyProgressiveDetailsPerExtraKmRateSectionOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FarePolicyProgressiveDetailsPerExtraKmRateSection" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FarePolicySlabDetailsSlabOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FarePolicySlabDetailsSlab" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (RestrictedExtraFareOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("RestrictedExtraFare" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FareProductOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FareProduct" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (GeometryOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Geometry" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (CommentOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Comment" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (IssueCategoryOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("IssueCategory" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (IssueOptionOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("IssueOption" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (IssueReportOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("IssueReport" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (IssueTranslationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("IssueTranslation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (LeaderBoardConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("LeaderBoardConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (PlaceNameCacheOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("PlaceNameCache" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MediaFileOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MediaFile" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Merchant" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverIntelligentPoolConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverIntelligentPoolConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverPoolConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("DriverPoolConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantLeaderBoardConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MerchantLeaderBoardConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantMessageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MerchantMessage" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantPaymentMethodOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MerchantPaymentMethod" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantServiceConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MerchantServiceConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantServiceUsageConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MerchantServiceUsageConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantOnboardingDocumentConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MerchantOnboardingDocumentConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (TransporterConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("TransporterConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MessageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Message" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MessageReportOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MessageReport" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MessageTranslationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MessageTranslation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MetaDataOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("MetaData" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (OnboardingDocumentConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("OnboardingDocumentConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (PersonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Person" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (QuoteSpecialZoneOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("QuoteSpecialZone" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (RatingOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Rating" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (RideOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Ride" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (RideDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("RideDetails" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (RiderDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("RiderDetails" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SearchRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("SearchRequest" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SearchReqLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("SearchReqLocation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SearchRequestForDriverOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("SearchRequestForDriver" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SearchRequestSpecialZoneOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("SearchRequestSpecialZone" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SearchTryOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("SearchTry" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (VehicleOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Vehicle" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FeedbackFormOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FeedbackForm" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FeedbackOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("Feedback" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FeedbackBadgeOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("FeedbackBadge" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BecknRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses whereClause ("BecknRequest" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RegistrationTokenOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("RegistrationToken" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BapMetadataOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("BapMetadata" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BookingOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Booking" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BookingLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("BookingLocation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BookingCancellationReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("BookingCancellationReason" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BusinessEventOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("BusinessEvent" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (CallStatusOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("CallStatus" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (CancellationReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("CancellationReason" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverFlowStatusOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverFlowStatus" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverBlockReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverBlockReason" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverFeeOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverFee" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverInformationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverInformation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverLocation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (AadhaarOtpReqOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("AadhaarOtpReq" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (AadhaarOtpVerifyOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("AadhaarOtpVerify" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (AadhaarVerificationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("AadhaarVerification" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverLicenseOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverLicense" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverRCAssociationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverRCAssociation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (IdfyVerificationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("IdfyVerification" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (ImageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Image" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (OperatingCityOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("OperatingCity" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (VehicleRegistrationCertificateOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("VehicleRegistrationCertificate" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverQuoteOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverQuote" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverReferralOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverReferral" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverStatsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverStats" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (EstimateOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Estimate" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (ExophoneOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Exophone" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FareParametersOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FareParameters" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FareParametersProgressiveDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FareParametersProgressiveDetails" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FareParametersSlabDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FareParametersSlabDetails" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FarePolicyOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FarePolicy" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverExtraFeeBoundsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverExtraFeeBounds" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FarePolicyProgressiveDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FarePolicyProgressiveDetails" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FarePolicyProgressiveDetailsPerExtraKmRateSectionOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FarePolicyProgressiveDetailsPerExtraKmRateSection" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FarePolicySlabDetailsSlabOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FarePolicySlabDetailsSlab" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RestrictedExtraFareOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("RestrictedExtraFare" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FareProductOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FareProduct" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (GeometryOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Geometry" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (CommentOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Comment" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (IssueCategoryOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("IssueCategory" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (IssueOptionOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("IssueOption" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (IssueReportOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("IssueReport" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (IssueTranslationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("IssueTranslation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (LeaderBoardConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("LeaderBoardConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (PlaceNameCacheOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("PlaceNameCache" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MediaFileOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MediaFile" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Merchant" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverIntelligentPoolConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverIntelligentPoolConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverPoolConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("DriverPoolConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantLeaderBoardConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MerchantLeaderBoardConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantMessageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MerchantMessage" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantPaymentMethodOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MerchantPaymentMethod" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantServiceConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MerchantServiceConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantServiceUsageConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MerchantServiceUsageConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantOnboardingDocumentConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MerchantOnboardingDocumentConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (TransporterConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("TransporterConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MessageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Message" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MessageReportOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MessageReport" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MessageTranslationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MessageTranslation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MetaDataOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("MetaData" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (OnboardingDocumentConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("OnboardingDocumentConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (PersonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Person" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (QuoteSpecialZoneOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("QuoteSpecialZone" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RatingOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Rating" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RideOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Ride" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RideDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("RideDetails" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RiderDetailsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("RiderDetails" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SearchRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("SearchRequest" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SearchReqLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("SearchReqLocation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SearchRequestForDriverOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("SearchRequestForDriver" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SearchRequestSpecialZoneOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("SearchRequestSpecialZone" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SearchTryOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("SearchTry" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (VehicleOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Vehicle" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FeedbackFormOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FeedbackForm" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FeedbackOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("Feedback" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FeedbackBadgeOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val dbStreamKey setClauses tag whereClause ("FeedbackBadge" :: Text) =<< dbConf
+    UpdateDBCommand id _ _ _ _ (BecknRequestOptions _ setClauses whereClause) -> runUpdate id val dbStreamKey setClauses whereClause ("BecknRequest" :: Text) =<< dbConf
   where
     runUpdate id value _ setClause whereClause model dbConf = do
       maxRetries <- EL.runIO getMaxRetries
       runUpdateWithRetries id value setClause whereClause model dbConf 0 maxRetries
 
-    runUpdateInKafka id value dbStreamKey' setClause whereClause model dbConf = do
+    runUpdateInKafka id value dbStreamKey' setClause whereClause model dbConf tag = do
       isPushToKafka' <- EL.runIO isPushToKafka
       if not isPushToKafka'
         then runUpdate id value dbStreamKey' setClause whereClause model dbConf
         else do
-          let setAndWhere = getDbUpdateDataJson model (jsonKeyValueUpdates setClause) whereClause
-          Env {..} <- ask
-          res <- EL.runIO $ streamDriverDrainerUpdates _kafkaConnection setAndWhere dbStreamKey'
-          either
-            ( \_ -> do
-                void $ publishDBSyncMetric Event.KafkaPushFailure
-                EL.logError ("ERROR:" :: Text) ("Kafka Update Error " :: Text)
-                pure $ Left (UnexpectedError "Kafka Error", id)
-            )
-            (\_ -> pure $ Right id)
-            res
+          res <- getUpdatedValue tag whereClause
+          case res of
+            Right dataObj -> do
+              Env {..} <- ask
+              let updatedJSON = getDbUpdateDataJson model dataObj
+              res'' <- EL.runIO $ streamDriverDrainerUpdates _kafkaConnection updatedJSON dbStreamKey'
+              either
+                ( \_ -> do
+                    void $ publishDBSyncMetric Event.KafkaPushFailure
+                    EL.logError ("ERROR:" :: Text) ("Kafka Update Error " :: Text)
+                    pure $ Left (UnexpectedError "Kafka Error", id)
+                )
+                (\_ -> pure $ Right id)
+                res''
+            Left _ -> do
+              _ <- addValueToErrorQueue C.kafkaUpdateFailedStream [("UpdateCommand", value)]
+              pure $ Left (UnexpectedError "Kafka Error", id)
 
-    runUpdateInKafkaAndDb id value dbStreamKey' setClause whereClause model dbConf = do
+    -- Updates entry in DB if KAFKA_PUSH key is set to false. Else Updates in both.
+    runUpdateInKafkaAndDb id value dbStreamKey' setClause tag whereClause model dbConf = do
       isPushToKafka' <- EL.runIO isPushToKafka
       if not isPushToKafka'
         then runUpdate id value dbStreamKey' setClause whereClause model dbConf
         else do
-          res <- runUpdateInKafka id value dbStreamKey' setClause whereClause model dbConf
+          res <- runUpdateInKafka id value dbStreamKey' setClause whereClause model dbConf tag
           either (\_ -> pure $ Left (UnexpectedError "Kafka Error", id)) (\_ -> runUpdate id value dbStreamKey' setClause whereClause model dbConf) res
 
     runUpdateWithRetries id value setClause whereClause model dbConf retryIndex maxRetries = do
@@ -181,10 +209,10 @@ runUpdateCommands (cmd, val) dbStreamKey = do
           void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Update" model
           EL.runIO $ delay =<< getRetryDelay
           runUpdateWithRetries id value setClause whereClause model dbConf (retryIndex + 1) maxRetries
-        (Left x, _) -> do
+        (Left _, _) -> do
           void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Update" model
-          EL.logError (("Update failed: " :: Text) <> T.pack (show x)) (show [("command" :: String, value)] :: Text)
-          pure $ Left (x, id)
+          EL.logError (("Update failed for model: " <> show model) :: Text) (show [("command" :: String, value)] :: Text)
+          pure $ Left (UnexpectedError "Update failed for model", id)
         (Right _, _) -> do
           pure $ Right id
 
@@ -208,14 +236,11 @@ streamDriverDrainerUpdates producer dbObject dbStreamKey = do
           prValue = Just . LBS.toStrict $ encode event
         }
 
-getDbUpdateDataJson :: forall be table. (Model be table, MeshMeta be table) => Text -> [(Text, A.Value)] -> Where be table -> A.Value
-getDbUpdateDataJson model upd whereClause =
+getDbUpdateDataJson :: ToJSON a => Text -> a -> A.Value
+getDbUpdateDataJson model a =
   A.object
     [ "contents"
-        .= A.object
-          [ "set" .= A.object [k .= v | (k, v) <- upd],
-            "where" .= modelEncodeWhere whereClause
-          ],
-      "tag" .= T.pack (pascal (T.unpack model)),
+        .= A.toJSON a,
+      "tag" .= T.pack (pascal (T.unpack model) <> "Object"),
       "type" .= ("UPDATE" :: Text)
     ]

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Event/Event.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Event/Event.hs
@@ -21,7 +21,7 @@ mkDBSyncMetric = do
       DrainerQueryExecutes action count -> add (metrics </> #driver_drainer_query_executes) count action
       QueryDrainLatency action latency -> observe (metrics </> #driver_query_drain_latency) latency action
       DrainerStopStatus status -> setGauge (metrics </> #driver_drainer_stop_status) status
-      KafkaPushFailure -> inc (metrics </> #kafka_message_push_failure)
+      KafkaPushFailure -> inc (metrics </> #driver_kafka_push_failure)
 
 collectionDBSyncMetric =
   driver_peek_db_command_error
@@ -32,5 +32,5 @@ collectionDBSyncMetric =
     .> driver_drainer_query_executes
     .> driver_query_drain_latency
     .> driver_drainer_stop_status
-    .> kafka_message_push_failure
+    .> driver_kafka_push_failure
     .> MNil

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Utils/Event.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Utils/Event.hs
@@ -55,7 +55,7 @@ driver_drainer_stop_status =
   gauge #driver_drainer_stop_status
     .& build
 
-kafka_message_push_failure :: PromRep 'Counter "kafka_message_push_failure" '[]
-kafka_message_push_failure =
-  counter #kafka_message_push_failure
+driver_kafka_push_failure :: PromRep 'Counter "driver_kafka_push_failure" '[]
+driver_kafka_push_failure =
+  counter #driver_kafka_push_failure
     .& build

--- a/Backend/app/rider-platform/rider-app-drainer/package.yaml
+++ b/Backend/app/rider-platform/rider-app-drainer/package.yaml
@@ -92,6 +92,7 @@ dependencies:
   - warp
   - warp-tls
   - hw-kafka-client
+  - cereal
 
 ghc-options:
   - -fwrite-ide-info

--- a/Backend/app/rider-platform/rider-app-drainer/rider-app-drainer.cabal
+++ b/Backend/app/rider-platform/rider-app-drainer/rider-app-drainer.cabal
@@ -84,6 +84,7 @@ library
     , beam-postgres
     , bytestring
     , casing
+    , cereal
     , connection
     , containers
     , directory
@@ -168,6 +169,7 @@ executable rider-app-drainer-exe
     , beam-postgres
     , bytestring
     , casing
+    , cereal
     , connection
     , containers
     , directory

--- a/Backend/app/rider-platform/rider-app-drainer/src/Constants.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Constants.hs
@@ -62,3 +62,6 @@ threadPerPodCount = "THREAD_PER_POD_COUNT"
 
 pushToKafkaEnvKey :: String
 pushToKafkaEnvKey = "PUSH_TO_KAFKA"
+
+kafkaUpdateFailedStream :: String
+kafkaUpdateFailedStream = "rider-kafka-update-failed-stream"

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Create.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Create.hs
@@ -87,7 +87,7 @@ runCreateCommands cmds streamKey = do
               let dataObjects = map (\(_, _, _, dataObject) -> dataObject) object
                   entryIds = map (\(_, _, entryId', _) -> entryId') object
               Env {..} <- ask
-              res <- EL.runIO $ streamDriverDrainerCreates _kafkaConnection dataObjects streamKey'
+              res <- EL.runIO $ streamRiderDrainerCreates _kafkaConnection dataObjects streamKey'
               either
                 ( \_ -> do
                     EL.logError ("ERROR:" :: Text) ("Kafka Create Error " :: Text)
@@ -133,8 +133,8 @@ runCreateCommands cmds streamKey = do
           EL.logError ("Create failed: " :: Text) (show cmdsToErrorQueue <> "\n Error: " <> show x :: Text)
           pure [Left entryIds]
 
-streamDriverDrainerCreates :: ToJSON a => Producer.KafkaProducer -> [a] -> Text -> IO (Either Text ())
-streamDriverDrainerCreates producer dbObject streamKey = do
+streamRiderDrainerCreates :: ToJSON a => Producer.KafkaProducer -> [a] -> Text -> IO (Either Text ())
+streamRiderDrainerCreates producer dbObject streamKey = do
   let topicName = "rider-drainer"
   mapM_ (KafkaProd.produceMessage producer . message topicName) dbObject
   flushResult <- timeout (5 * 60 * 1000000) $ prodPush producer

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Delete.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Delete.hs
@@ -85,7 +85,7 @@ runDeleteCommands (cmd, val) dbStreamKey = do
         then runDelete id value dbstremKey whereClause model dbConf
         else do
           Env {..} <- ask
-          res <- EL.runIO $ streamDriverDrainerDeletes _kafkaConnection (getDbDeleteDataJson model whereClause) dbstremKey
+          res <- EL.runIO $ streamRiderDrainerDeletes _kafkaConnection (getDbDeleteDataJson model whereClause) dbstremKey
           either
             ( \_ -> do
                 void $ publishDBSyncMetric Event.KafkaPushFailure
@@ -118,8 +118,8 @@ runDeleteCommands (cmd, val) dbStreamKey = do
         (Right _, _) -> do
           pure $ Right id
 
-streamDriverDrainerDeletes :: ToJSON a => Producer.KafkaProducer -> a -> Text -> IO (Either Text ())
-streamDriverDrainerDeletes producer dbObject dbStreamKey = do
+streamRiderDrainerDeletes :: ToJSON a => Producer.KafkaProducer -> a -> Text -> IO (Either Text ())
+streamRiderDrainerDeletes producer dbObject dbStreamKey = do
   let topicName = "rider-drainer"
   void $ KafkaProd.produceMessage producer (message topicName dbObject)
   flushResult <- timeout (5 * 60 * 1000000) $ prodPush producer

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
@@ -1,31 +1,36 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module DBSync.Update where
 
 import Config.Env
+import qualified Constants as C
 import Data.Aeson as A
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy as LBS
 import Data.Either.Extra (mapLeft)
 import Data.Maybe (fromJust)
+import qualified Data.Serialize as Serialize
 import Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Database.Beam as B hiding (runUpdate)
 import EulerHS.CachedSqlDBQuery as CDB
-import EulerHS.KVConnector.DBSync
-import EulerHS.KVConnector.Types
-import EulerHS.KVConnector.Utils as EKU
+import EulerHS.KVConnector.Types as EKT
+import EulerHS.KVConnector.Utils as Utils
 import qualified EulerHS.Language as EL
 import EulerHS.Prelude hiding (id)
 import EulerHS.Types as ET
 import Kafka.Producer as KafkaProd
 import Kafka.Producer as Producer
+import qualified Kernel.Beam.Functions as BeamFunction
 import qualified Kernel.Beam.Types as KBT
 import Sequelize (Model, Set, Where)
 import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
+import Utils.Redis
 import Utils.Utils
 
 updateDB ::
@@ -46,101 +51,121 @@ updateDB ::
   [Set be table] ->
   Where be table ->
   ByteString ->
-  m (Either MeshError [A.Value])
-updateDB dbConf _ setClause whereClause bts = do
-  either (pure . Left) ((Right <$>) . mapM updateModel') . mapLeft MDBError
-    =<< runExceptT
-      ( do
-          updateObj <- ExceptT $ CDB.updateOne dbConf Nothing setClause whereClause
-          pure [updateObj]
-      )
-  where
-    updateModel' model = do
-      let val = (EKU.updateModel @be @table) model (EKU.jsonKeyValueUpdates setClause)
-      case val of
-        Right obj -> pure obj
-        Left err -> do
-          EL.logError (("Model Update failed: " :: Text) <> T.pack (show err)) (show [("command" :: String, bts)] :: Text)
-          pure A.Null
+  m (Either MeshError ())
+updateDB dbConf _ setClause whereClause _ =
+  do
+    either (pure . Left) (pure . Right) . mapLeft MDBError
+    =<< CDB.updateOneWoReturning dbConf Nothing setClause whereClause
+
+getUpdatedValue ::
+  forall beM be table m.
+  ( HasCallStack,
+    ET.BeamRuntime be beM,
+    ET.BeamRunner beM,
+    Model be table,
+    MeshMeta be table,
+    B.HasQBuilder be,
+    EL.MonadFlow m,
+    ToJSON (table Identity),
+    FromJSON (table Identity),
+    Serialize.Serialize (table Identity)
+  ) =>
+  Text ->
+  Where be table ->
+  m (Either MeshError (table Identity))
+getUpdatedValue tag _ = do
+  res <- EL.runKVDB BeamFunction.meshConfig.kvRedis $ EL.get $ fromString $ T.unpack tag
+  case res of
+    Right (Just r) -> do
+      let (decodeResult :: MeshResult [table Identity], isLive) = Utils.decodeToField $ BSL.fromChunks [r]
+       in case decodeResult of
+            Right [decodeRes] -> return $ Right decodeRes
+            Right _ -> return $ Left (UnexpectedError "Redis Error: No Data for the key")
+            Left _ -> return $ Left (UnexpectedError "Redis Error: Decode Failed")
+    _ -> return $ Left (UnexpectedError "Redis Error")
 
 runUpdateCommands :: (UpdateDBCommand, ByteString) -> Text -> Flow (Either (MeshError, EL.KVDBStreamEntryID) EL.KVDBStreamEntryID)
 runUpdateCommands (cmd, val) streamKey = do
   let dbConf = fromJust <$> EL.getOption KBT.PsqlDbCfg
   case cmd of
-    UpdateDBCommand id _ _ _ _ (AppInstallsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("AppInstalls" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BlackListOrgOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("BlackListOrg" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BookingOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Booking" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BookingLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("BookingLocation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BookingCancellationReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("BookingCancellationReason" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (CallbackRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("CallbackRequest" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (CallStatusOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("CallStatus" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (CancellationReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("CancellationReason" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DriverOfferOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("DriverOffer" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (EstimateOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Estimate" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (EstimateBreakupOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("EstimateBreakup" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (ExophoneOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Exophone" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FareBreakupOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("FareBreakup" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (GeometryOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Geometry" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (IssueOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Issue" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (DirectionsCacheOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("DirectionsCache" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (PlaceNameCacheOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("PlaceNameCache" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Merchant" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantMessageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("MerchantMessage" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantPaymentMethodOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("MerchantPaymentMethod" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantServiceConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("MerchantServiceConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantServiceUsageConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("MerchantServiceUsageConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (MerchantConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("MerchantConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (OnSearchEventOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("OnSearchEvent" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (PaymentOrderOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("PaymentOrder" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (PaymentTransactionOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("PaymentTransaction" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (PersonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Person" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (PersonDefaultEmergencyNumberOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("PersonDefaultEmergencyNumber" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (PersonFlowStatusOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("PersonFlowStatus" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (QuoteOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Quote" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (RegistrationTokenOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("RegistrationToken" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (RentalSlabOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("RentalSlab" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (RideOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Ride" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SavedReqLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("SavedReqLocation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SearchRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("SearchRequest" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SearchReqLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("SearchReqLocation" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SosOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Sos" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (SpecialZoneQuoteOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("SpecialZoneQuote" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (TripTermsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("TripTerms" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (WebengageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("Webengage" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (FeedbackFormOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("FeedbackForm" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (HotSpotConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("HotSpotConfig" :: Text) =<< dbConf
-    UpdateDBCommand id _ _ _ _ (BecknRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses whereClause ("BecknRequest" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (AppInstallsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("AppInstalls" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BlackListOrgOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("BlackListOrg" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BookingOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Booking" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BookingLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("BookingLocation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BookingCancellationReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("BookingCancellationReason" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (CallbackRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("CallbackRequest" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (CallStatusOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("CallStatus" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (CancellationReasonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("CancellationReason" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DriverOfferOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("DriverOffer" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (EstimateOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Estimate" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (EstimateBreakupOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("EstimateBreakup" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (ExophoneOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Exophone" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FareBreakupOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("FareBreakup" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (GeometryOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Geometry" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (IssueOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Issue" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (DirectionsCacheOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("DirectionsCache" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (PlaceNameCacheOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("PlaceNameCache" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Merchant" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantMessageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("MerchantMessage" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantPaymentMethodOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("MerchantPaymentMethod" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantServiceConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("MerchantServiceConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantServiceUsageConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("MerchantServiceUsageConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (MerchantConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("MerchantConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (OnSearchEventOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("OnSearchEvent" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (PaymentOrderOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("PaymentOrder" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (PaymentTransactionOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("PaymentTransaction" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (PersonOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Person" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (PersonDefaultEmergencyNumberOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("PersonDefaultEmergencyNumber" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (PersonFlowStatusOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("PersonFlowStatus" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (QuoteOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Quote" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RegistrationTokenOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("RegistrationToken" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RentalSlabOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("RentalSlab" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (RideOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Ride" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SavedReqLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("SavedReqLocation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SearchRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("SearchRequest" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SearchReqLocationOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("SearchReqLocation" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SosOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Sos" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (SpecialZoneQuoteOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("SpecialZoneQuote" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (TripTermsOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("TripTerms" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (WebengageOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("Webengage" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (FeedbackFormOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("FeedbackForm" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (HotSpotConfigOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("HotSpotConfig" :: Text) =<< dbConf
+    UpdateDBCommand id _ tag _ _ (BecknRequestOptions _ setClauses whereClause) -> runUpdateInKafkaAndDb id val streamKey setClauses tag whereClause ("BecknRequest" :: Text) =<< dbConf
   where
     runUpdate id value _ setClause whereClause model dbConf = do
       maxRetries <- EL.runIO getMaxRetries
       runUpdateWithRetries id value setClause whereClause model dbConf 0 maxRetries
-    -- If KAFKA_PUSH is false then entry will be there in DB Else Updates entry in Kafka only.
-    runUpdateInKafka id value streamKey' setClause whereClause model dbConf = do
+    runUpdateInKafka id value dbStreamKey' setClause whereClause model dbConf tag = do
       isPushToKafka' <- EL.runIO isPushToKafka
       if not isPushToKafka'
-        then runUpdate id value streamKey' setClause whereClause model dbConf
+        then runUpdate id value dbStreamKey' setClause whereClause model dbConf
         else do
-          let setAndWhere = getDbUpdateDataJson model (jsonKeyValueUpdates setClause) whereClause
-          Env {..} <- ask
-          res <- EL.runIO $ streamDriverDrainerUpdates _kafkaConnection setAndWhere streamKey'
-          either
-            ( \err -> do
-                void $ publishDBSyncMetric Event.KafkaPushFailure
-                EL.logError ("ERROR:" :: Text) ("Kafka Update Error " :: Text)
-                pure $ Left (UnexpectedError err, id)
-            )
-            (\_ -> pure $ Right id)
-            res
-    -- Updates entry in DB if KAFKA_PUSH key is set to false. Else Updates in both.
-    runUpdateInKafkaAndDb id value streamKey' setClause whereClause model dbConf = do
-      isPushToKafka' <- EL.runIO isPushToKafka
-      if not isPushToKafka'
-        then runUpdate id value streamKey' setClause whereClause model dbConf
-        else do
-          res <- runUpdateInKafka id value streamKey' setClause whereClause model dbConf
+          res <- getUpdatedValue tag whereClause
           case res of
-            Left (err, id') -> pure $ Left (err, id')
-            Right _ -> runUpdate id value streamKey' setClause whereClause model dbConf
+            Right dataObj -> do
+              Env {..} <- ask
+              let updatedJSON = getDbUpdateDataJson model dataObj
+              res'' <- EL.runIO $ streamRiderDrainerUpdates _kafkaConnection updatedJSON dbStreamKey'
+              either
+                ( \_ -> do
+                    void $ publishDBSyncMetric Event.KafkaPushFailure
+                    EL.logError ("ERROR:" :: Text) ("Kafka Update Error " :: Text)
+                    pure $ Left (UnexpectedError "Kafka Error", id)
+                )
+                (\_ -> pure $ Right id)
+                res''
+            Left _ -> do
+              _ <- addValueToErrorQueue C.kafkaUpdateFailedStream [("UpdateCommand", value)]
+              pure $ Left (UnexpectedError "Kafka Error", id)
+
+    -- Updates entry in DB if KAFKA_PUSH key is set to false. Else Updates in both.
+    runUpdateInKafkaAndDb id value dbStreamKey' setClause tag whereClause model dbConf = do
+      isPushToKafka' <- EL.runIO isPushToKafka
+      if not isPushToKafka'
+        then runUpdate id value dbStreamKey' setClause whereClause model dbConf
+        else do
+          res <- runUpdateInKafka id value dbStreamKey' setClause whereClause model dbConf tag
+          either (\_ -> pure $ Left (UnexpectedError "Kafka Error", id)) (\_ -> runUpdate id value dbStreamKey' setClause whereClause model dbConf) res
 
     runUpdateWithRetries id value setClause whereClause model dbConf retryIndex maxRetries = do
       res <- updateDB dbConf Nothing setClause whereClause value
@@ -149,15 +174,15 @@ runUpdateCommands (cmd, val) streamKey = do
           void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Update" model
           EL.runIO $ delay =<< getRetryDelay
           runUpdateWithRetries id value setClause whereClause model dbConf (retryIndex + 1) maxRetries
-        (Left x, _) -> do
+        (Left _, _) -> do
           void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Update" model
-          EL.logError (("Update failed: " :: Text) <> T.pack (show x)) (show [("command" :: String, value)] :: Text)
-          pure $ Left (x, id)
+          EL.logError (("Update failed for model: " :: Text) <> T.pack (show model)) (show [("command" :: String, value)] :: Text)
+          pure $ Left (UnexpectedError "Update failed for model", id)
         (Right _, _) -> do
           pure $ Right id
 
-streamDriverDrainerUpdates :: ToJSON a => Producer.KafkaProducer -> a -> Text -> IO (Either Text ())
-streamDriverDrainerUpdates producer dbObject dbStreamKey = do
+streamRiderDrainerUpdates :: ToJSON a => Producer.KafkaProducer -> a -> Text -> IO (Either Text ())
+streamRiderDrainerUpdates producer dbObject dbStreamKey = do
   let topicName = "rider-drainer"
   void $ KafkaProd.produceMessage producer (message topicName dbObject)
   flushResult <- timeout (5 * 60 * 1000000) $ prodPush producer
@@ -176,14 +201,11 @@ streamDriverDrainerUpdates producer dbObject dbStreamKey = do
           prValue = Just . LBS.toStrict $ encode event
         }
 
-getDbUpdateDataJson :: forall be table. (Model be table, MeshMeta be table) => Text -> [(Text, A.Value)] -> Where be table -> A.Value
-getDbUpdateDataJson model upd whereClause =
+getDbUpdateDataJson :: ToJSON a => Text -> a -> A.Value
+getDbUpdateDataJson model a =
   A.object
     [ "contents"
-        .= A.object
-          [ "set" .= A.object [k .= v | (k, v) <- upd],
-            "where" .= modelEncodeWhere whereClause
-          ],
+        .= A.toJSON a,
       "tag" .= T.pack (pascal (T.unpack model) <> "Object"),
       "type" .= ("UPDATE" :: Text)
     ]

--- a/Backend/app/rider-platform/rider-app-drainer/src/Event/Event.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Event/Event.hs
@@ -21,7 +21,7 @@ mkDBSyncMetric = do
       DrainerQueryExecutes action count -> add (metrics </> #drainer_query_executes) count action
       QueryDrainLatency action latency -> observe (metrics </> #query_drain_latency) latency action
       DrainerStopStatus status -> setGauge (metrics </> #drainer_stop_status) status
-      KafkaPushFailure -> inc (metrics </> #kafka_message_push_failure)
+      KafkaPushFailure -> inc (metrics </> #rider_kafka_push_failure)
 
 collectionDBSyncMetric =
   peek_db_command_error
@@ -32,5 +32,5 @@ collectionDBSyncMetric =
     .> drainer_query_executes
     .> query_drain_latency
     .> drainer_stop_status
-    .> kafka_message_push_failure
+    .> rider_kafka_push_failure
     .> MNil

--- a/Backend/app/rider-platform/rider-app-drainer/src/Utils/Event.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Utils/Event.hs
@@ -71,7 +71,7 @@ drainer_stop_status =
   gauge #drainer_stop_status
     .& build
 
-kafka_message_push_failure :: PromRep 'Counter "kafka_message_push_failure" '[]
-kafka_message_push_failure =
-  counter #kafka_message_push_failure
+rider_kafka_push_failure :: PromRep 'Counter "rider_kafka_push_failure" '[]
+rider_kafka_push_failure =
+  counter #rider_kafka_push_failure
     .& build


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
Following are the changes in the PR:
1. Removed findall from the UPDATE function which was unnecessary.
2. Pushing updated OBJECT to kafka instead of where clause and set clause
3. Updated object if found from redis; this means the drainer lag cannot be more than ttl, o.w data to clickhouse could go missing. For now, if object is not found in redis, we are pushing the set and where clause to a redis stream which can later be run
4. Updated the names of kafka failure metrics.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
