### PR TITLE
frontend/fix/#2319 : Display plan price to 2 decimal places.

### DIFF
--- a/Frontend/ui-driver/src/Screens/SubscriptionScreen/Controller.purs
+++ b/Frontend/ui-driver/src/Screens/SubscriptionScreen/Controller.purs
@@ -14,6 +14,7 @@ import Data.Lens ((^.))
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Maybe as Mb
 import Data.Number (fromString) as Number
+import Data.Number.Format (fixed, toStringWith)
 import Data.String (toLower)
 import Effect.Unsafe (unsafePerformEffect)
 import Engineering.Helpers.Commons (convertUTCtoISC)
@@ -312,7 +313,7 @@ getPlanPrice fares priceType = do
   case price DA.!! 0 of
     Mb.Just (PaymentBreakUp element) -> case (DI.fromNumber element.amount) of
                         Mb.Just value -> show value
-                        Mb.Nothing -> show element.amount
+                        Mb.Nothing ->  toStringWith (fixed 2) element.amount
     Mb.Nothing -> ""
 
 getAllFareFromArray :: Array PaymentBreakUp -> Array String -> Number


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Changed 3.5 to 3.50 in joinplan, myplan and manage plan view.



### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
