### PR TITLE
backend/feat: #3256 cron job end ride case

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/src/Dashboard/ProviderPlatform/Ride.hs
+++ b/Backend/app/dashboard/CommonAPIs/src/Dashboard/ProviderPlatform/Ride.hs
@@ -146,7 +146,7 @@ newtype MultipleRideEndReq = MultipleRideEndReq
 
 data MultipleRideEndItem = MultipleRideEndItem
   { rideId :: Id Ride,
-    point :: Maybe LatLong
+    point :: Maybe LatLong -- FIXME not used for distance calculation, remove when possible
   }
   deriving stock (Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)

--- a/Backend/app/mocks/google/src/API/Directions.hs
+++ b/Backend/app/mocks/google/src/API/Directions.hs
@@ -40,7 +40,7 @@ handler origin destination key _alternatives mode waypoints avoid = withFlowHand
     throwError $ NotImplemented $ "directions API is not implemented: mode: " <> show mode
   unless (isEmptyWaypoint waypoints) $
     throwError $ NotImplemented $ "directions API is not implemented: waypoints: " <> show waypoints
-  unless (isNothing avoid || avoid == Just "tolls") $
+  unless (isNothing avoid || avoid == Just "tolls" || avoid == Just "tolls|ferries") $
     throwError $ NotImplemented $ "directions API is not implemented: avoid: " <> show avoid
   case (origin, destination) of
     (GoogleMaps.Location origin', GoogleMaps.Location destination') -> do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Dashboard/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Dashboard/Ride.hs
@@ -107,12 +107,12 @@ multipleRideEnd merchantShortId req = withFlowHandlerAPI $ do
   respItems <- forM req.rides $ \reqItem -> do
     info <- handle Common.listItemErrHandler $ do
       let rideId = cast @Common.Ride @DRide.Ride reqItem.rideId
-      let dashboardReq =
-            EHandler.DashboardEndRideReq
+      let cronJobReq =
+            EHandler.CronJobEndRideReq
               { point = reqItem.point,
                 merchantId = merchant.id
               }
-      Success <- EHandler.dashboardEndRide shandle rideId dashboardReq
+      Success <- EHandler.cronJobEndRide shandle rideId cronJobReq
       pure Common.SuccessItem
     pure $ Common.MultipleRideSyncRespItem {rideId = reqItem.rideId, info}
   pure $ Common.MultipleRideSyncResp {list = respItems}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
The intended behavior is for calls to `endRide` from the `CronJob` 'stuck bookings cancel' to be routed via another request type 'CronJob' and not via the `dashboardRequest`. Under this case, we want fare recomputation to not be triggered and the `returnEstimatesAsFinalValues` to be called instead.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested locally


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
