### PR TITLE
backend/fix: dont error out when finding updated object from redis fails

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
@@ -194,7 +194,9 @@ runUpdateCommands (cmd, val) dbStreamKey = do
                 res''
             Left _ -> do
               _ <- addValueToErrorQueue C.kafkaUpdateFailedStream [("UpdateCommand", value)]
-              pure $ Left (UnexpectedError "Kafka Error", id)
+              EL.logError ("ERROR:" :: Text) ("Could not find the key in redis to get the updated object" :: Text)
+              void $ publishDBSyncMetric Event.KafkaUpdateMissing
+              pure $ Right id
 
     -- Updates entry in DB if KAFKA_PUSH key is set to false. Else Updates in both.
     runUpdateInKafkaAndDb id value dbStreamKey' setClause tag whereClause model dbConf = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Event/Event.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Event/Event.hs
@@ -20,6 +20,7 @@ mkDBSyncMetric = do
       DrainerQueryExecutes action count -> add (metrics </> #driver_drainer_query_executes) count action
       QueryDrainLatency action latency -> observe (metrics </> #driver_query_drain_latency) latency action
       DrainerStopStatus status -> setGauge (metrics </> #driver_drainer_stop_status) status
+      KafkaUpdateMissing -> inc (metrics </> #driver_kafka_update_missing)
       KafkaPushFailure -> inc (metrics </> #driver_kafka_push_failure)
   where
     collectionDBSyncMetric =
@@ -31,5 +32,6 @@ mkDBSyncMetric = do
         .> driver_drainer_query_executes
         .> driver_query_drain_latency
         .> driver_drainer_stop_status
+        .> driver_kafka_update_missing
         .> driver_kafka_push_failure
         .> MNil

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Types/Event.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Types/Event.hs
@@ -33,4 +33,5 @@ data DBSyncMetric
   | QueryDrainLatency Action Latency
   | DrainerQueryExecutes Action Word
   | DrainerStopStatus Status
+  | KafkaUpdateMissing
   | KafkaPushFailure

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Utils/Event.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Utils/Event.hs
@@ -59,3 +59,8 @@ driver_kafka_push_failure :: PromRep 'Counter "driver_kafka_push_failure" '[]
 driver_kafka_push_failure =
   counter #driver_kafka_push_failure
     .& build
+
+driver_kafka_update_missing :: PromRep 'Counter "driver_kafka_update_missing" '[]
+driver_kafka_update_missing =
+  counter #driver_kafka_update_missing
+    .& build

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
@@ -155,8 +155,10 @@ runUpdateCommands (cmd, val) streamKey = do
                 (\_ -> pure $ Right id)
                 res''
             Left _ -> do
+              EL.logError ("ERROR:" :: Text) ("Could not find the key in redis to get the updated object" :: Text)
+              void $ publishDBSyncMetric Event.KafkaUpdateMissing
               _ <- addValueToErrorQueue C.kafkaUpdateFailedStream [("UpdateCommand", value)]
-              pure $ Left (UnexpectedError "Kafka Error", id)
+              pure $ Right id
 
     -- Updates entry in DB if KAFKA_PUSH key is set to false. Else Updates in both.
     runUpdateInKafkaAndDb id value dbStreamKey' setClause tag whereClause model dbConf = do

--- a/Backend/app/rider-platform/rider-app-drainer/src/Event/Event.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Event/Event.hs
@@ -20,6 +20,7 @@ mkDBSyncMetric = do
       DrainerQueryExecutes action count -> add (metrics </> #drainer_query_executes) count action
       QueryDrainLatency action latency -> observe (metrics </> #query_drain_latency) latency action
       DrainerStopStatus status -> setGauge (metrics </> #drainer_stop_status) status
+      KafkaUpdateMissing -> inc (metrics </> #rider_kafka_update_missing)
       KafkaPushFailure -> inc (metrics </> #rider_kafka_push_failure)
   where
     collectionDBSyncMetric =
@@ -31,5 +32,6 @@ mkDBSyncMetric = do
         .> drainer_query_executes
         .> query_drain_latency
         .> drainer_stop_status
+        .> rider_kafka_update_missing
         .> rider_kafka_push_failure
         .> MNil

--- a/Backend/app/rider-platform/rider-app-drainer/src/Types/Event.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Types/Event.hs
@@ -33,4 +33,5 @@ data DBSyncMetric
   | DrainerQueryExecutes Action Word
   | QueryDrainLatency Action Latency
   | DrainerStopStatus Status
+  | KafkaUpdateMissing
   | KafkaPushFailure

--- a/Backend/app/rider-platform/rider-app-drainer/src/Utils/Event.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Utils/Event.hs
@@ -59,3 +59,8 @@ rider_kafka_push_failure :: PromRep 'Counter "rider_kafka_push_failure" '[]
 rider_kafka_push_failure =
   counter #rider_kafka_push_failure
     .& build
+
+rider_kafka_update_missing :: PromRep 'Counter "rider_kafka_update_missing" '[]
+rider_kafka_update_missing =
+  counter #rider_kafka_update_missing
+    .& build


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Cherry picked changes from https://github.com/nammayatri/nammayatri/pull/3277

