### PR TITLE
Backend/fix: send setclause and Id in case of missing redis entry

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
@@ -4,11 +4,11 @@
 module DBSync.Update where
 
 import Config.Env
-import qualified Constants as C
 import Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy as LBS
 import Data.Either.Extra (mapLeft)
+import qualified Data.HashMap.Strict as HM
 import Data.Maybe (fromJust)
 import qualified Data.Serialize as Serialize
 import Data.Text as T
@@ -29,7 +29,6 @@ import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
-import Utils.Redis
 import Utils.Utils
 
 updateDB ::
@@ -187,16 +186,23 @@ runUpdateCommands (cmd, val) dbStreamKey = do
               either
                 ( \_ -> do
                     void $ publishDBSyncMetric Event.KafkaPushFailure
-                    EL.logError ("ERROR:" :: Text) ("Kafka Update Error " :: Text)
-                    pure $ Left (UnexpectedError "Kafka Error", id)
+                    EL.logError ("ERROR:" :: Text) ("Kafka Driver Update Error " :: Text)
+                    pure $ Left (UnexpectedError "Kafka Driver Update Error", id)
                 )
                 (\_ -> pure $ Right id)
                 res''
             Left _ -> do
-              _ <- addValueToErrorQueue C.kafkaUpdateFailedStream [("UpdateCommand", value)]
-              EL.logError ("ERROR:" :: Text) ("Could not find the key in redis to get the updated object" :: Text)
-              void $ publishDBSyncMetric Event.KafkaUpdateMissing
-              pure $ Right id
+              let updatedJSON = getDbUpdateDataJson model $ updValToJSON $ jsonKeyValueUpdates setClause <> getPKeyandValuesList tag
+              Env {..} <- ask
+              res'' <- EL.runIO $ streamDriverDrainerUpdates _kafkaConnection updatedJSON dbStreamKey'
+              either
+                ( \_ -> do
+                    void $ publishDBSyncMetric Event.KafkaPushFailure
+                    EL.logError ("ERROR:" :: Text) ("Kafka Driver Update Error " :: Text)
+                    pure $ Left (UnexpectedError "Kafka Driver Update Error", id)
+                )
+                (\_ -> pure $ Right id)
+                res''
 
     -- Updates entry in DB if KAFKA_PUSH key is set to false. Else Updates in both.
     runUpdateInKafkaAndDb id value dbStreamKey' setClause tag whereClause model dbConf = do
@@ -249,3 +255,15 @@ getDbUpdateDataJson model a =
       "tag" .= T.pack (pascal (T.unpack model) <> "Object"),
       "type" .= ("UPDATE" :: Text)
     ]
+
+updValToJSON :: [(Text, A.Value)] -> A.Value
+updValToJSON keyValuePairs = A.Object $ HM.fromList keyValuePairs
+
+getPKeyandValuesList :: Text -> [(Text, A.Value)]
+getPKeyandValuesList pKeyAndValue = go (splitOn "_" pKeyTrimmed) []
+  where
+    go (tName : k : v : rest) acc = go (tName : rest) ((k, A.String v) : acc)
+    go _ acc = acc
+    pKeyTrimmed = case splitOn "{" pKeyAndValue of
+      [] -> ""
+      (x : _) -> x

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
@@ -4,11 +4,11 @@
 module DBSync.Update where
 
 import Config.Env
-import qualified Constants as C
 import Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy as LBS
 import Data.Either.Extra (mapLeft)
+import Data.HashMap.Strict as HM
 import Data.Maybe (fromJust)
 import qualified Data.Serialize as Serialize
 import Data.Text as T
@@ -29,7 +29,6 @@ import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
-import Utils.Redis
 import Utils.Utils
 
 updateDB ::
@@ -149,16 +148,23 @@ runUpdateCommands (cmd, val) streamKey = do
               either
                 ( \_ -> do
                     void $ publishDBSyncMetric Event.KafkaPushFailure
-                    EL.logError ("ERROR:" :: Text) ("Kafka Update Error " :: Text)
-                    pure $ Left (UnexpectedError "Kafka Error", id)
+                    EL.logError ("ERROR:" :: Text) ("Kafka Rider Update Error " :: Text)
+                    pure $ Left (UnexpectedError "Kafka Rider Update Error", id)
                 )
                 (\_ -> pure $ Right id)
                 res''
             Left _ -> do
-              EL.logError ("ERROR:" :: Text) ("Could not find the key in redis to get the updated object" :: Text)
-              void $ publishDBSyncMetric Event.KafkaUpdateMissing
-              _ <- addValueToErrorQueue C.kafkaUpdateFailedStream [("UpdateCommand", value)]
-              pure $ Right id
+              let updatedJSON = getDbUpdateDataJson model $ updValToJSON $ jsonKeyValueUpdates setClause <> getPKeyandValuesList tag
+              Env {..} <- ask
+              res'' <- EL.runIO $ streamRiderDrainerUpdates _kafkaConnection updatedJSON dbStreamKey'
+              either
+                ( \_ -> do
+                    void $ publishDBSyncMetric Event.KafkaPushFailure
+                    EL.logError ("ERROR:" :: Text) ("Kafka Rider Update Error " :: Text)
+                    pure $ Left (UnexpectedError "Kafka Rider Update Error", id)
+                )
+                (\_ -> pure $ Right id)
+                res''
 
     -- Updates entry in DB if KAFKA_PUSH key is set to false. Else Updates in both.
     runUpdateInKafkaAndDb id value dbStreamKey' setClause tag whereClause model dbConf = do
@@ -211,3 +217,15 @@ getDbUpdateDataJson model a =
       "tag" .= T.pack (pascal (T.unpack model) <> "Object"),
       "type" .= ("UPDATE" :: Text)
     ]
+
+updValToJSON :: [(Text, A.Value)] -> A.Value
+updValToJSON keyValuePairs = A.Object $ HM.fromList keyValuePairs
+
+getPKeyandValuesList :: Text -> [(Text, A.Value)]
+getPKeyandValuesList pKeyAndValue = go (splitOn "_" pKeyTrimmed) []
+  where
+    go (tName : k : v : rest) acc = go (tName : rest) ((k, A.String v) : acc)
+    go _ acc = acc
+    pKeyTrimmed = case splitOn "{" pKeyAndValue of
+      [] -> ""
+      (x : _) -> x


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In case of drainer stop and entry from the redis is evicted in that case in kafka we will be pushing primarkey and update clause entry object. 


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
