### PR TITLE
Backend/fix: send setclause and Id in case of missing redis entry

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Environment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Environment.hs
@@ -125,7 +125,8 @@ data AppCfg = AppCfg
     schedulerType :: SchedulerType,
     jobInfoMapx :: M.Map AllocatorJobType Bool,
     ltsCfg :: LocationTrackingeServiceConfig,
-    enableLocationTrackingService :: Bool
+    enableLocationTrackingService :: Bool,
+    dontEnableForDb :: [Text]
   }
   deriving (Generic, FromDhall)
 
@@ -198,7 +199,8 @@ data AppEnv = AppEnv
     schedulerSetName :: Text,
     schedulerType :: SchedulerType,
     ltsCfg :: LocationTrackingeServiceConfig,
-    enableLocationTrackingService :: Bool
+    enableLocationTrackingService :: Bool,
+    dontEnableForDb :: [Text]
   }
   deriving (Generic)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
@@ -53,7 +53,7 @@ main = do
             )
           dbSyncMetric <- Event.mkDBSyncMetric
           threadPerPodCount <- Env.getThreadPerPodCount
-          let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools.producer
+          let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools.producer appCfg.dontEnableForDb
           spawnDrainerThread threadPerPodCount flowRt environment
           R.runFlow flowRt (runReaderT DBSync.startDBSync environment)
       )

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Create.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Create.hs
@@ -113,8 +113,9 @@ runCreateCommands cmds streamKey = do
           byteStream = map (\(_, bts, _, _) -> bts) object
           entryIds = map (\(_, _, entryId, _) -> entryId) object
           cmdsToErrorQueue = map ("command" :: String,) byteStream
+      Env {..} <- ask
       maxRetries <- EL.runIO getMaxRetries
-      if null object then pure [Right []] else runCreateWithRecursion dbConf model dbObjects cmdsToErrorQueue entryIds 0 maxRetries False
+      if null object || model `elem` _dontEnableDbTables then pure [Right []] else runCreateWithRecursion dbConf model dbObjects cmdsToErrorQueue entryIds 0 maxRetries False
     -- If KAFKA_PUSH is false then entry will be there in DB Else Create entry in Kafka only.
     runCreateInKafka dbConf streamKey' model object = do
       isPushToKafka' <- EL.runIO isPushToKafka

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Delete.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Delete.hs
@@ -115,7 +115,8 @@ runDeleteCommands (cmd, val) dbStreamKey = do
   where
     runDelete id value _ whereClause model dbConf = do
       maxRetries <- EL.runIO getMaxRetries
-      runDeleteWithRetries id value whereClause model dbConf 0 maxRetries
+      Env {..} <- ask
+      if model `elem` _dontEnableDbTables then pure $ Right id else runDeleteWithRetries id value whereClause model dbConf 0 maxRetries
     -- If KAFKA_PUSH is false then entry will be there in DB Else Delete entry in Kafka only.
     runDeleteInKafka id value dbstremKey whereClause model dbConf = do
       isPushToKafka' <- EL.runIO isPushToKafka

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Types/DBSync.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Types/DBSync.hs
@@ -31,7 +31,8 @@ import Types.Event as Event
 data Env = Env
   { _streamRedisInfo :: Text,
     _counterHandles :: Event.DBSyncCounterHandler,
-    _kafkaConnection :: Producer.KafkaProducer
+    _kafkaConnection :: Producer.KafkaProducer,
+    _dontEnableDbTables :: [Text]
   }
 
 type Flow = EL.ReaderFlow Env

--- a/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
@@ -50,7 +50,7 @@ main = do
             )
 
           dbSyncMetric <- Event.mkDBSyncMetric
-          let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools.producer
+          let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools.producer appCfg.dontEnableForDb
           threadPerPodCount <- Env.getThreadPerPodCount
           spawnDrainerThread threadPerPodCount flowRt environment
           R.runFlow flowRt (runReaderT DBSync.startDBSync environment)

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Create.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Create.hs
@@ -75,8 +75,9 @@ runCreateCommands cmds streamKey = do
           byteStream = map (\(_, bts, _, _) -> bts) object
           entryIds = map (\(_, _, entryId, _) -> entryId) object
           cmdsToErrorQueue = map ("command" :: String,) byteStream
+      Env {..} <- ask
       maxRetries <- EL.runIO getMaxRetries
-      if null object then pure [Right []] else runCreateWithRecursion dbConf model dbObjects cmdsToErrorQueue entryIds 0 maxRetries False
+      if null object || model `elem` _dontEnableDbTables then pure [Right []] else runCreateWithRecursion dbConf model dbObjects cmdsToErrorQueue entryIds 0 maxRetries False
     -- If KAFKA_PUSH is false then entry will be there in DB Else Create entry in Kafka only.
     runCreateInKafka dbConf streamKey' model object = do
       isPushToKafka' <- EL.runIO isPushToKafka

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Delete.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Delete.hs
@@ -77,7 +77,8 @@ runDeleteCommands (cmd, val) dbStreamKey = do
   where
     runDelete id value _ whereClause model dbConf = do
       maxRetries <- EL.runIO getMaxRetries
-      runDeleteWithRetries id value whereClause model dbConf 0 maxRetries
+      Env {..} <- ask
+      if model `elem` _dontEnableDbTables then pure $ Right id else runDeleteWithRetries id value whereClause model dbConf 0 maxRetries
     -- If KAFKA_PUSH is false then entry will be there in DB Else Delete entry in Kafka only.
     runDeleteInKafka id value dbstremKey whereClause model dbConf = do
       isPushToKafka' <- EL.runIO isPushToKafka

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
@@ -4,11 +4,11 @@
 module DBSync.Update where
 
 import Config.Env
-import qualified Constants as C
 import Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy as LBS
 import Data.Either.Extra (mapLeft)
+import Data.HashMap.Strict as HM
 import Data.Maybe (fromJust)
 import qualified Data.Serialize as Serialize
 import Data.Text as T
@@ -29,7 +29,6 @@ import System.Timeout (timeout)
 import Text.Casing
 import Types.DBSync
 import Types.Event as Event
-import Utils.Redis
 import Utils.Utils
 
 updateDB ::
@@ -133,7 +132,8 @@ runUpdateCommands (cmd, val) streamKey = do
   where
     runUpdate id value _ setClause whereClause model dbConf = do
       maxRetries <- EL.runIO getMaxRetries
-      runUpdateWithRetries id value setClause whereClause model dbConf 0 maxRetries
+      Env {..} <- ask
+      if model `elem` _dontEnableDbTables then pure $ Right id else runUpdateWithRetries id value setClause whereClause model dbConf 0 maxRetries
     -- If KAFKA_PUSH is false then entry will be there in DB Else Updates entry in Kafka only.
     runUpdateInKafka id value dbStreamKey' setClause whereClause model dbConf tag = do
       isPushToKafka' <- EL.runIO isPushToKafka
@@ -149,16 +149,23 @@ runUpdateCommands (cmd, val) streamKey = do
               either
                 ( \_ -> do
                     void $ publishDBSyncMetric Event.KafkaPushFailure
-                    EL.logError ("ERROR:" :: Text) ("Kafka Update Error " :: Text)
-                    pure $ Left (UnexpectedError "Kafka Error", id)
+                    EL.logError ("ERROR:" :: Text) ("Kafka Rider Update Error " :: Text)
+                    pure $ Left (UnexpectedError "Kafka Rider Update Error", id)
                 )
                 (\_ -> pure $ Right id)
                 res''
             Left _ -> do
-              EL.logError ("ERROR:" :: Text) ("Could not find the key in redis to get the updated object" :: Text)
-              void $ publishDBSyncMetric Event.KafkaUpdateMissing
-              _ <- addValueToErrorQueue C.kafkaUpdateFailedStream [("UpdateCommand", value)]
-              pure $ Right id
+              let updatedJSON = getDbUpdateDataJson model $ updValToJSON $ jsonKeyValueUpdates setClause <> getPKeyandValuesList tag
+              Env {..} <- ask
+              res'' <- EL.runIO $ streamRiderDrainerUpdates _kafkaConnection updatedJSON dbStreamKey'
+              either
+                ( \_ -> do
+                    void $ publishDBSyncMetric Event.KafkaPushFailure
+                    EL.logError ("ERROR:" :: Text) ("Kafka Rider Update Error " :: Text)
+                    pure $ Left (UnexpectedError "Kafka Rider Update Error", id)
+                )
+                (\_ -> pure $ Right id)
+                res''
 
     -- Updates entry in DB if KAFKA_PUSH key is set to false. Else Updates in both.
     runUpdateInKafkaAndDb id value dbStreamKey' setClause tag whereClause model dbConf = do
@@ -211,3 +218,15 @@ getDbUpdateDataJson model a =
       "tag" .= T.pack (pascal (T.unpack model) <> "Object"),
       "type" .= ("UPDATE" :: Text)
     ]
+
+updValToJSON :: [(Text, A.Value)] -> A.Value
+updValToJSON keyValuePairs = A.Object $ HM.fromList keyValuePairs
+
+getPKeyandValuesList :: Text -> [(Text, A.Value)]
+getPKeyandValuesList pKeyAndValue = go (splitOn "_" pKeyTrimmed) []
+  where
+    go (tName : k : v : rest) acc = go (tName : rest) ((k, A.String v) : acc)
+    go _ acc = acc
+    pKeyTrimmed = case splitOn "{" pKeyAndValue of
+      [] -> ""
+      (x : _) -> x

--- a/Backend/app/rider-platform/rider-app-drainer/src/Types/DBSync.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Types/DBSync.hs
@@ -36,7 +36,8 @@ data DBSyncConfig = DBSyncConfig
 data Env = Env
   { _streamRedisInfo :: Text,
     _counterHandles :: Event.DBSyncCounterHandler,
-    _kafkaConnection :: Producer.KafkaProducer
+    _kafkaConnection :: Producer.KafkaProducer,
+    _dontEnableDbTables :: [Text]
   }
 
 type Flow = EL.ReaderFlow Env

--- a/Backend/app/rider-platform/rider-app/Main/src/Environment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Environment.hs
@@ -111,7 +111,8 @@ data AppCfg = AppCfg
     enableRedisLatencyLogging :: Bool,
     enablePrometheusMetricLogging :: Bool,
     eventStreamMap :: [EventStreamMap],
-    tables :: Tables
+    tables :: Tables,
+    dontEnableForDb :: [Text]
   }
   deriving (Generic, FromDhall)
 
@@ -168,7 +169,8 @@ data AppEnv = AppEnv
     enableRedisLatencyLogging :: Bool,
     enablePrometheusMetricLogging :: Bool,
     eventStreamMap :: [EventStreamMap],
-    eventRequestCounter :: EventCounterMetric
+    eventRequestCounter :: EventCounterMetric,
+    dontEnableForDb :: [Text]
   }
   deriving (Generic)
 

--- a/Backend/dhall-configs/dev/dynamic-offer-driver-app.dhall
+++ b/Backend/dhall-configs/dev/dynamic-offer-driver-app.dhall
@@ -141,6 +141,8 @@ let tables =
       , enableKVForRead = [] : List Text
       }
 
+let dontEnableForDb = [] : List Text
+
 let appBackendBapInternal =
       { name = "APP_BACKEND"
       , url = "http://localhost:8013/"
@@ -259,4 +261,5 @@ in  { esqDBCfg
     , schedulerType = common.schedulerType.DbBased
     , ltsCfg = LocationTrackingeServiceConfig
     , enableLocationTrackingService = False
+    , dontEnableForDb
     }

--- a/Backend/dhall-configs/dev/rider-app.dhall
+++ b/Backend/dhall-configs/dev/rider-app.dhall
@@ -153,6 +153,8 @@ let tables =
       , enableKVForRead = [] : List Text
       }
 
+let dontEnableForDb = [] : List Text
+
 in  { esqDBCfg
     , esqDBReplicaCfg
     , hedisCfg = hcfg
@@ -208,4 +210,5 @@ in  { esqDBCfg
     , enablePrometheusMetricLogging = True
     , eventStreamMap = eventStreamMappings
     , tables
+    , dontEnableForDb
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In case of drainer stop and entry from the redis is evicted in that case in kafka we will be pushing primarkey and update clause entry object.
Also Now can enable which tables to push in db or not.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
