### PR TITLE
nix: Build docker image on Linux only

### DIFF
--- a/Backend/nix/docker.nix
+++ b/Backend/nix/docker.nix
@@ -9,7 +9,7 @@ in
 {
   config = {
     perSystem = { self', pkgs, lib, ... }: {
-      packages = {
+      packages = lib.optionalAttrs pkgs.stdenv.isLinux {
         dockerImage = (pkgs.dockerTools.buildImage {
           name = imageName;
           created = "now";


### PR DESCRIPTION
cf. https://github.com/nammayatri/jenkins-config/issues/4

Almost 200G of nix store on macOS is taken by docker images alone.