### PR TITLE
backend/fix/reverted O0 flag for scheduler

### DIFF
--- a/Backend/app/scheduler-example/package.yaml
+++ b/Backend/app/scheduler-example/package.yaml
@@ -93,7 +93,7 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
-          - -O0
+          - -O1
           - -funfolding-use-threshold20
           - -fno-cse
           - -fmax-simplifier-iterations1
@@ -118,7 +118,7 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
-          - -O0
+          - -O1
           - -funfolding-use-threshold20
           - -fno-cse
           - -fmax-simplifier-iterations1
@@ -144,7 +144,7 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
-          - -O0
+          - -O1
           - -funfolding-use-threshold20
           - -fno-cse
           - -fmax-simplifier-iterations1

--- a/Backend/app/scheduler-example/scheduler-example.cabal
+++ b/Backend/app/scheduler-example/scheduler-example.cabal
@@ -95,7 +95,7 @@ library
   if os(darwin)
     ghc-options: -fwhole-archive-hs-libs
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -O1 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -161,7 +161,7 @@ executable scheduler-example-app-exe
   if os(darwin)
     ghc-options: -fwhole-archive-hs-libs
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -O1 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -228,6 +228,6 @@ executable scheduler-example-scheduler-exe
   if os(darwin)
     ghc-options: -fwhole-archive-hs-libs
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -O1 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/scheduler/package.yaml
+++ b/Backend/lib/scheduler/package.yaml
@@ -112,7 +112,7 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
-          - -O0
+          - -O1
           - -funfolding-use-threshold20
           - -fno-cse
           - -fmax-simplifier-iterations1

--- a/Backend/lib/scheduler/scheduler.cabal
+++ b/Backend/lib/scheduler/scheduler.cabal
@@ -111,6 +111,6 @@ library
   if os(darwin)
     ghc-options: -fwhole-archive-hs-libs
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -O1 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
When building `scheduler` and `scheduler-example` with -O0 flags, it was causing disk to run out of space when trying to run backend on local. This issue does not occur when building `scheduler` and `scheduler-example` with -O1 flag. Therefore reverted the flags in case of `scheduler` and `scheduler-example`.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
