### PR TITLE
backend/feat: #1361 on_status improving rebase

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -101,6 +101,7 @@ library
       App.Server
       Beckn.ACL.Cancel
       Beckn.ACL.Common
+      Beckn.ACL.Common.Order
       Beckn.ACL.Confirm
       Beckn.ACL.Init
       Beckn.ACL.OnConfirm

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Status.hs
@@ -53,8 +53,9 @@ status transporterId (SignatureAuthResult _ subscriber) req =
     internalEndPointHashMap <- asks (.internalEndPointHashMap)
 
     let context = req.context
+    onStatusMessage <- ACL.buildOnStatusMessage dStatusRes.info
     void $
       CallBAP.withCallback dStatusRes.transporter Context.STATUS OnStatus.onStatusAPI context context.bap_uri internalEndPointHashMap $
-        pure $ ACL.mkOnStatusMessage dStatusRes
+        pure onStatusMessage
 
     pure Ack

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Common/Order.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Common/Order.hs
@@ -1,0 +1,181 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Beckn.ACL.Common.Order
+  ( mkFulfillment,
+    buildDistanceTagGroup,
+    mkArrivalTimeTagGroup,
+    buildRideCompletedQuote,
+    mkRideCompletedPayment,
+  )
+where
+
+import qualified Beckn.ACL.Common as Common
+import qualified Beckn.Types.Core.Taxi.Common.BreakupItem as Breakup
+import qualified Beckn.Types.Core.Taxi.Common.FulfillmentInfo as RideFulfillment
+import qualified Beckn.Types.Core.Taxi.Common.Payment as Payment
+import qualified Beckn.Types.Core.Taxi.Common.RideCompletedQuote as Quote
+import qualified Beckn.Types.Core.Taxi.Common.Tags as Tags
+import qualified Domain.Types.Booking as DRB
+import qualified Domain.Types.FareParameters as DFParams
+import qualified Domain.Types.Merchant.MerchantPaymentMethod as DMPM
+import qualified Domain.Types.Person as SP
+import Domain.Types.Ride as DRide
+import qualified Domain.Types.Vehicle as SVeh
+import Kernel.Prelude
+import Kernel.Types.Common
+import Kernel.Utils.Common
+import qualified SharedLogic.FareCalculator as Fare
+import Tools.Error
+
+-- Identical for on_update and on_status
+mkFulfillment ::
+  (EsqDBFlow m r, EncFlow m r) =>
+  Maybe SP.Person ->
+  DRide.Ride ->
+  DRB.Booking ->
+  Maybe SVeh.Vehicle ->
+  Maybe Text ->
+  Maybe Tags.TagGroups ->
+  Bool ->
+  m RideFulfillment.FulfillmentInfo
+mkFulfillment mbDriver ride booking mbVehicle mbImage tags isDriverBirthDay = do
+  agent <-
+    forM mbDriver $ \driver -> do
+      let agentTags =
+            [ Tags.TagGroup
+                { display = False,
+                  code = "driver_details",
+                  name = "Driver Details",
+                  list =
+                    [ Tags.Tag (Just False) (Just "registered_at") (Just "Registered At") (Just $ show driver.createdAt),
+                      Tags.Tag (Just False) (Just "rating") (Just "rating") (show <$> driver.rating),
+                      Tags.Tag (Just False) (Just "is_driver_birthday") (Just "Is Driver BirthDay") (Just $ show isDriverBirthDay)
+                    ]
+                }
+            ]
+      mobileNumber <- SP.getPersonNumber driver >>= fromMaybeM (InternalError "Driver mobile number is not present.")
+      name <- SP.getPersonFullName driver & fromMaybeM (PersonFieldNotPresent "firstName")
+      pure $
+        RideFulfillment.Agent
+          { name = name,
+            rateable = True,
+            phone = Just mobileNumber,
+            image = mbImage,
+            tags = Just $ Tags.TG agentTags
+          }
+  let veh =
+        mbVehicle <&> \vehicle ->
+          RideFulfillment.Vehicle
+            { model = vehicle.model,
+              variant = show vehicle.variant,
+              color = vehicle.color,
+              registration = vehicle.registrationNo
+            }
+  let authorization =
+        RideFulfillment.Authorization
+          { _type = "OTP",
+            token = ride.otp
+          }
+  pure $
+    RideFulfillment.FulfillmentInfo
+      { id = ride.id.getId,
+        start =
+          RideFulfillment.StartInfo
+            { authorization =
+                case booking.bookingType of
+                  DRB.SpecialZoneBooking -> Just authorization
+                  DRB.NormalBooking -> Just authorization, -- TODO :: Remove authorization for NormalBooking once Customer side code is decoupled.
+              location =
+                RideFulfillment.Location
+                  { gps = RideFulfillment.Gps {lat = booking.fromLocation.lat, lon = booking.fromLocation.lon}
+                  },
+              time = ride.tripStartTime <&> \tripStartTime -> RideFulfillment.TimeTimestamp {timestamp = tripStartTime}
+            },
+        end =
+          RideFulfillment.EndInfo
+            { location =
+                RideFulfillment.Location
+                  { gps = RideFulfillment.Gps {lat = booking.toLocation.lat, lon = booking.toLocation.lon} -- assuming locations will always be in correct order in list
+                  },
+              time = ride.tripEndTime <&> \tripEndTime -> RideFulfillment.TimeTimestamp {timestamp = tripEndTime}
+            },
+        agent,
+        _type = if booking.bookingType == DRB.NormalBooking then RideFulfillment.RIDE else RideFulfillment.RIDE_OTP,
+        vehicle = veh,
+        ..
+      }
+
+buildDistanceTagGroup :: MonadFlow m => DRide.Ride -> m [Tags.TagGroup]
+buildDistanceTagGroup ride = do
+  chargeableDistance :: HighPrecMeters <-
+    realToFrac <$> ride.chargeableDistance
+      & fromMaybeM (InternalError "Ride chargeable distance is not present.")
+  let traveledDistance :: HighPrecMeters = ride.traveledDistance
+  pure
+    [ Tags.TagGroup
+        { display = False,
+          code = "ride_distance_details",
+          name = "Ride Distance Details",
+          list =
+            [ Tags.Tag (Just False) (Just "chargeable_distance") (Just "Chargeable Distance") (Just $ show chargeableDistance),
+              Tags.Tag (Just False) (Just "traveled_distance") (Just "Traveled Distance") (Just $ show traveledDistance)
+            ]
+        }
+    ]
+
+mkArrivalTimeTagGroup :: Maybe UTCTime -> [Tags.TagGroup]
+mkArrivalTimeTagGroup arrivalTime =
+  [ Tags.TagGroup
+      { display = False,
+        code = "driver_arrived_info",
+        name = "Driver Arrived Info",
+        list = [Tags.Tag (Just False) (Just "arrival_time") (Just "Chargeable Distance") (show <$> arrivalTime) | isJust arrivalTime]
+      }
+  ]
+
+currency :: Text
+currency = "INR"
+
+buildRideCompletedQuote :: MonadFlow m => DRide.Ride -> DFParams.FareParameters -> m Quote.RideCompletedQuote
+buildRideCompletedQuote ride fareParams = do
+  fare <- realToFrac <$> ride.fare & fromMaybeM (InternalError "Ride fare is not present.")
+  let price =
+        Quote.QuotePrice
+          { currency,
+            value = fare,
+            computed_value = fare
+          }
+      breakup =
+        Fare.mkBreakupList (Breakup.BreakupItemPrice currency . fromIntegral) Breakup.BreakupItem fareParams
+          & filter (Common.filterRequiredBreakups $ DFParams.getFareParametersType fareParams) -- TODO: Remove after roll out
+  pure
+    Quote.RideCompletedQuote
+      { price,
+        breakup
+      }
+
+mkRideCompletedPayment :: Maybe DMPM.PaymentMethodInfo -> Maybe Text -> Payment.Payment
+mkRideCompletedPayment paymentMethodInfo paymentUrl = do
+  Payment.Payment
+    { _type = maybe Payment.ON_FULFILLMENT (Common.castDPaymentType . (.paymentType)) paymentMethodInfo,
+      params =
+        Payment.PaymentParams
+          { collected_by = maybe Payment.BPP (Common.castDPaymentCollector . (.collectedBy)) paymentMethodInfo,
+            instrument = Nothing,
+            currency,
+            amount = Nothing
+          },
+      uri = paymentUrl
+    }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnInit.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnInit.hs
@@ -20,20 +20,19 @@ import Domain.Action.Beckn.Init as DInit
 import qualified Domain.Types.Booking as DRB
 import qualified Domain.Types.FareParameters as DFParams
 import qualified Domain.Types.Location as DL
-import qualified Domain.Types.Vehicle.Variant as VehVar
 import Kernel.Prelude
 import SharedLogic.FareCalculator
 
 mkOnInitMessage :: DInit.InitRes -> OnInit.OnInitMessage
 mkOnInitMessage res = do
   let rb = res.booking
-      vehicleVariant = castVehicleVariant res.booking.vehicleVariant
+      vehicleVariant = Common.castVariant res.booking.vehicleVariant
       itemId = Common.mkItemId res.transporter.shortId.getShortId res.booking.vehicleVariant
       fareDecimalValue = fromIntegral rb.estimatedFare
       currency = "INR"
       breakup_ =
         mkBreakupList (OnInit.BreakupItemPrice currency . fromIntegral) OnInit.BreakupItem rb.fareParams
-          & filter (filterRequiredBreakups $ DFParams.getFareParametersType rb.fareParams) -- TODO: Remove after roll out
+          & filter (Common.filterRequiredBreakups $ DFParams.getFareParametersType rb.fareParams) -- TODO: Remove after roll out
   OnInit.OnInitMessage
     { order =
         OnInit.Order
@@ -132,37 +131,6 @@ mkOnInitMessage res = do
     }
   where
     castAddress DL.LocationAddress {..} = OnInit.Address {area_code = areaCode, locality = area, ward = Nothing, ..}
-    castVehicleVariant = \case
-      VehVar.SEDAN -> OnInit.SEDAN
-      VehVar.SUV -> OnInit.SUV
-      VehVar.HATCHBACK -> OnInit.HATCHBACK
-      VehVar.AUTO_RICKSHAW -> OnInit.AUTO_RICKSHAW
-      VehVar.TAXI -> OnInit.TAXI
-      VehVar.TAXI_PLUS -> OnInit.TAXI_PLUS
     buildFulfillmentType = \case
       DRB.NormalBooking -> OnInit.RIDE
       DRB.SpecialZoneBooking -> OnInit.RIDE_OTP
-    filterRequiredBreakups fParamsType breakup = do
-      case fParamsType of
-        DFParams.Progressive ->
-          breakup.title == "BASE_FARE"
-            || breakup.title == "SERVICE_CHARGE"
-            || breakup.title == "DEAD_KILOMETER_FARE"
-            || breakup.title == "EXTRA_DISTANCE_FARE"
-            || breakup.title == "DRIVER_SELECTED_FARE"
-            || breakup.title == "CUSTOMER_SELECTED_FARE"
-            || breakup.title == "TOTAL_FARE"
-            || breakup.title == "WAITING_OR_PICKUP_CHARGES"
-            || breakup.title == "EXTRA_TIME_FARE"
-        DFParams.Slab ->
-          breakup.title == "BASE_FARE"
-            || breakup.title == "SERVICE_CHARGE"
-            || breakup.title == "WAITING_OR_PICKUP_CHARGES"
-            || breakup.title == "PLATFORM_FEE"
-            || breakup.title == "SGST"
-            || breakup.title == "CGST"
-            || breakup.title == "FIXED_GOVERNMENT_RATE"
-            || breakup.title == "CUSTOMER_SELECTED_FARE"
-            || breakup.title == "TOTAL_FARE"
-            || breakup.title == "NIGHT_SHIFT_CHARGE"
-            || breakup.title == "EXTRA_TIME_FARE"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnSelect.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnSelect.hs
@@ -165,7 +165,7 @@ mkQuote driverQuote now = do
   let currency = "INR"
       breakup_ =
         mkBreakupList (OS.Price currency . fromIntegral) OS.PriceBreakup driverQuote.fareParams
-          & filter filterRequiredBreakups
+          & filter filterRequiredBreakups'
   let nominalDifferenceTime = diffUTCTime driverQuote.validTill now
   OS.Quote
     { price = mkPrice driverQuote,
@@ -173,7 +173,7 @@ mkQuote driverQuote now = do
       breakup = breakup_
     }
   where
-    filterRequiredBreakups breakup =
+    filterRequiredBreakups' breakup =
       breakup.title == "BASE_FARE"
         || breakup.title == "SERVICE_CHARGE"
         || breakup.title == "DEAD_KILOMETER_FARE"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnUpdate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnUpdate.hs
@@ -20,7 +20,7 @@ module Beckn.ACL.OnUpdate
 where
 
 import qualified Beckn.ACL.Common as Common
-import qualified Beckn.Types.Core.Taxi.Common.FulfillmentInfo as RideFulfillment
+import qualified Beckn.ACL.Common.Order as Common
 import qualified Beckn.Types.Core.Taxi.Common.Tags as Tags
 import qualified Beckn.Types.Core.Taxi.OnUpdate as OnUpdate
 import qualified Beckn.Types.Core.Taxi.OnUpdate.OnUpdateEvent.BookingCancelledEvent as BookingCancelledOU
@@ -35,7 +35,6 @@ import qualified Beckn.Types.Core.Taxi.OnUpdate.OnUpdateEvent.SafetyAlertEvent a
 import qualified Domain.Types.Booking as DRB
 import qualified Domain.Types.BookingCancellationReason as SBCR
 import qualified Domain.Types.Estimate as DEst
-import qualified Domain.Types.FareParameters as DFParams
 import qualified Domain.Types.FareParameters as Fare
 import qualified Domain.Types.Merchant.MerchantPaymentMethod as DMPM
 import qualified Domain.Types.Person as SP
@@ -44,9 +43,6 @@ import qualified Domain.Types.Vehicle as SVeh
 import Kernel.Prelude
 import Kernel.Types.Common
 import Kernel.Types.Id
-import Kernel.Utils.Common
-import SharedLogic.FareCalculator
-import Tools.Error
 
 data OnUpdateBuildReq
   = RideAssignedBuildReq
@@ -103,87 +99,12 @@ data OnUpdateBuildReq
         reason :: Text
       }
 
-mkFullfillment ::
-  (EsqDBFlow m r, EncFlow m r) =>
-  Maybe SP.Person ->
-  DRide.Ride ->
-  DRB.Booking ->
-  Maybe SVeh.Vehicle ->
-  Maybe Text ->
-  Maybe Tags.TagGroups ->
-  Bool ->
-  m RideFulfillment.FulfillmentInfo
-mkFullfillment mbDriver ride booking mbVehicle mbImage tags isDriverBirthDay = do
-  agent <-
-    forM mbDriver $ \driver -> do
-      let agentTags =
-            [ Tags.TagGroup
-                { display = False,
-                  code = "driver_details",
-                  name = "Driver Details",
-                  list =
-                    [ Tags.Tag (Just False) (Just "registered_at") (Just "Registered At") (Just $ show driver.createdAt),
-                      Tags.Tag (Just False) (Just "rating") (Just "rating") (show <$> driver.rating),
-                      Tags.Tag (Just False) (Just "is_driver_birthday") (Just "Is Driver BirthDay") (Just $ show isDriverBirthDay)
-                    ]
-                }
-            ]
-      mobileNumber <- SP.getPersonNumber driver >>= fromMaybeM (InternalError "Driver mobile number is not present.")
-      name <- SP.getPersonFullName driver & fromMaybeM (PersonFieldNotPresent "firstName")
-      pure $
-        RideAssignedOU.Agent
-          { name = name,
-            rateable = True,
-            phone = Just mobileNumber,
-            image = mbImage,
-            tags = Just $ Tags.TG agentTags
-          }
-  let veh =
-        mbVehicle <&> \vehicle ->
-          RideAssignedOU.Vehicle
-            { model = vehicle.model,
-              variant = show vehicle.variant,
-              color = vehicle.color,
-              registration = vehicle.registrationNo
-            }
-  let authorization =
-        RideAssignedOU.Authorization
-          { _type = "OTP",
-            token = ride.otp
-          }
-  pure $
-    RideAssignedOU.FulfillmentInfo
-      { id = ride.id.getId,
-        start =
-          RideAssignedOU.StartInfo
-            { authorization =
-                case booking.bookingType of
-                  DRB.SpecialZoneBooking -> Just authorization
-                  DRB.NormalBooking -> Just authorization, -- TODO :: Remove authorization for NormalBooking once Customer side code is decoupled.
-              location =
-                RideAssignedOU.Location
-                  { gps = RideAssignedOU.Gps {lat = booking.fromLocation.lat, lon = booking.fromLocation.lon}
-                  }
-            },
-        end =
-          RideAssignedOU.EndInfo
-            { location =
-                RideAssignedOU.Location
-                  { gps = RideAssignedOU.Gps {lat = booking.toLocation.lat, lon = booking.toLocation.lon} -- assuming locations will always be in correct order in list
-                  }
-            },
-        agent,
-        _type = if booking.bookingType == DRB.NormalBooking then RideAssignedOU.RIDE else RideAssignedOU.RIDE_OTP,
-        vehicle = veh,
-        ..
-      }
-
 buildOnUpdateMessage ::
   (EsqDBFlow m r, EncFlow m r) =>
   OnUpdateBuildReq ->
   m OnUpdate.OnUpdateMessage
 buildOnUpdateMessage RideAssignedBuildReq {..} = do
-  fulfillment <- mkFullfillment (Just driver) ride booking (Just vehicle) image Nothing isDriverBirthDay
+  fulfillment <- Common.mkFulfillment (Just driver) ride booking (Just vehicle) image Nothing isDriverBirthDay
   return $
     OnUpdate.OnUpdateMessage
       { order =
@@ -196,7 +117,7 @@ buildOnUpdateMessage RideAssignedBuildReq {..} = do
         update_target = "order.fufillment.state.code, order.fulfillment.agent, order.fulfillment.vehicle" <> ", order.fulfillment.start.authorization" -- TODO :: Remove authorization for NormalBooking once Customer side code is decoupled.
       }
 buildOnUpdateMessage RideStartedBuildReq {..} = do
-  fulfillment <- mkFullfillment (Just driver) ride booking (Just vehicle) Nothing Nothing False
+  fulfillment <- Common.mkFulfillment (Just driver) ride booking (Just vehicle) Nothing Nothing False
   return $
     OnUpdate.OnUpdateMessage
       { order =
@@ -208,88 +129,21 @@ buildOnUpdateMessage RideStartedBuildReq {..} = do
         update_target = "order.fufillment.state.code"
       }
 buildOnUpdateMessage req@RideCompletedBuildReq {} = do
-  chargeableDistance :: HighPrecMeters <-
-    realToFrac <$> req.ride.chargeableDistance
-      & fromMaybeM (InternalError "Ride chargeable distance is not present.")
-  let traveledDistance :: HighPrecMeters = req.ride.traveledDistance
-  let tagGroups =
-        [ Tags.TagGroup
-            { display = False,
-              code = "ride_distance_details",
-              name = "Ride Distance Details",
-              list =
-                [ Tags.Tag (Just False) (Just "chargeable_distance") (Just "Chargeable Distance") (Just $ show chargeableDistance),
-                  Tags.Tag (Just False) (Just "traveled_distance") (Just "Traveled Distance") (Just $ show traveledDistance)
-                ]
-            }
-        ]
-  fulfillment <- mkFullfillment (Just req.driver) req.ride req.booking (Just req.vehicle) Nothing (Just $ Tags.TG tagGroups) False
-  fare <- realToFrac <$> req.ride.fare & fromMaybeM (InternalError "Ride fare is not present.")
-  let currency = "INR"
-      price =
-        RideCompletedOU.QuotePrice
-          { currency,
-            value = fare,
-            computed_value = fare
-          }
-      breakup =
-        mkBreakupList (OnUpdate.BreakupPrice currency . fromIntegral) OnUpdate.BreakupItem req.fareParams
-          & filter (filterRequiredBreakups $ DFParams.getFareParametersType req.fareParams) -- TODO: Remove after roll out
+  distanceTagGroup <- Common.buildDistanceTagGroup req.ride
+  fulfillment <- Common.mkFulfillment (Just req.driver) req.ride req.booking (Just req.vehicle) Nothing (Just $ Tags.TG distanceTagGroup) False
+  quote <- Common.buildRideCompletedQuote req.ride req.fareParams
   return $
     OnUpdate.OnUpdateMessage
       { order =
           OnUpdate.RideCompleted
             RideCompletedOU.RideCompletedEvent
               { id = req.booking.id.getId,
-                quote =
-                  RideCompletedOU.RideCompletedQuote
-                    { price,
-                      breakup
-                    },
-                payment =
-                  Just
-                    OnUpdate.Payment
-                      { _type = maybe OnUpdate.ON_FULFILLMENT (Common.castDPaymentType . (.paymentType)) req.paymentMethodInfo,
-                        params =
-                          OnUpdate.PaymentParams
-                            { collected_by = maybe OnUpdate.BPP (Common.castDPaymentCollector . (.collectedBy)) req.paymentMethodInfo,
-                              instrument = Nothing,
-                              currency = "INR",
-                              amount = Nothing
-                            },
-                        uri = req.paymentUrl
-                      },
+                quote,
+                payment = Just $ Common.mkRideCompletedPayment req.paymentMethodInfo req.paymentUrl,
                 fulfillment = fulfillment
               },
         update_target = "order.payment, order.quote, order.fulfillment.tags, order.fulfillment.state.tags"
       }
-  where
-    filterRequiredBreakups fParamsType breakup = do
-      case fParamsType of
-        DFParams.Progressive ->
-          breakup.title == "BASE_FARE"
-            || breakup.title == "SERVICE_CHARGE"
-            || breakup.title == "DEAD_KILOMETER_FARE"
-            || breakup.title == "EXTRA_DISTANCE_FARE"
-            || breakup.title == "DRIVER_SELECTED_FARE"
-            || breakup.title == "CUSTOMER_SELECTED_FARE"
-            || breakup.title == "TOTAL_FARE"
-            || breakup.title == "WAITING_OR_PICKUP_CHARGES"
-            || breakup.title == "EXTRA_TIME_FARE"
-            || breakup.title == "CUSTOMER_CANCELLATION_DUES"
-        DFParams.Slab ->
-          breakup.title == "BASE_FARE"
-            || breakup.title == "SERVICE_CHARGE"
-            || breakup.title == "WAITING_OR_PICKUP_CHARGES"
-            || breakup.title == "PLATFORM_FEE"
-            || breakup.title == "SGST"
-            || breakup.title == "CGST"
-            || breakup.title == "FIXED_GOVERNMENT_RATE"
-            || breakup.title == "TOTAL_FARE"
-            || breakup.title == "CUSTOMER_SELECTED_FARE"
-            || breakup.title == "NIGHT_SHIFT_CHARGE"
-            || breakup.title == "EXTRA_TIME_FARE"
-            || breakup.title == "CUSTOMER_CANCELLATION_DUES"
 buildOnUpdateMessage BookingCancelledBuildReq {..} = do
   return $
     OnUpdate.OnUpdateMessage
@@ -298,20 +152,13 @@ buildOnUpdateMessage BookingCancelledBuildReq {..} = do
             BookingCancelledOU.BookingCancelledEvent
               { id = booking.id.getId,
                 state = "CANCELLED",
-                cancellation_reason = castCancellationSource cancellationSource
+                cancellation_reason = Common.castCancellationSource cancellationSource
               },
         update_target = "state,fufillment.state.code"
       }
 buildOnUpdateMessage DriverArrivedBuildReq {..} = do
-  let tagGroups =
-        [ Tags.TagGroup
-            { display = False,
-              code = "driver_arrived_info",
-              name = "Driver Arrived Info",
-              list = [Tags.Tag (Just False) (Just "arrival_time") (Just "Chargeable Distance") (show <$> arrivalTime) | isJust arrivalTime]
-            }
-        ]
-  fulfillment <- mkFullfillment (Just driver) ride booking (Just vehicle) Nothing (Just $ Tags.TG tagGroups) False
+  let tagGroups = Common.mkArrivalTimeTagGroup arrivalTime
+  fulfillment <- Common.mkFulfillment (Just driver) ride booking (Just vehicle) Nothing (Just $ Tags.TG tagGroups) False
   return $
     OnUpdate.OnUpdateMessage
       { order =
@@ -328,10 +175,10 @@ buildOnUpdateMessage EstimateRepetitionBuildReq {..} = do
             { display = False,
               code = "previous_cancellation_reasons",
               name = "Previous Cancellation Reasons",
-              list = [Tags.Tag (Just False) (Just "cancellation_reason") (Just "Chargeable Distance") (Just . show $ castCancellationSource cancellationSource)]
+              list = [Tags.Tag (Just False) (Just "cancellation_reason") (Just "Chargeable Distance") (Just . show $ Common.castCancellationSource cancellationSource)]
             }
         ]
-  fulfillment <- mkFullfillment Nothing ride booking Nothing Nothing (Just $ Tags.TG tagGroups) False
+  fulfillment <- Common.mkFulfillment Nothing ride booking Nothing Nothing (Just $ Tags.TG tagGroups) False
   let item = EstimateRepetitionOU.Item {id = estimateId.getId}
   return $
     OnUpdate.OnUpdateMessage
@@ -353,7 +200,7 @@ buildOnUpdateMessage NewMessageBuildReq {..} = do
               list = [Tags.Tag (Just False) (Just "message") (Just "New Message") (Just message)]
             }
         ]
-  fulfillment <- mkFullfillment (Just driver) ride booking (Just vehicle) Nothing (Just $ Tags.TG tagGroups) False
+  fulfillment <- Common.mkFulfillment (Just driver) ride booking (Just vehicle) Nothing (Just $ Tags.TG tagGroups) False
   return $
     OnUpdate.OnUpdateMessage
       { update_target = "order.fufillment.state.code, order.fulfillment.tags",
@@ -373,7 +220,7 @@ buildOnUpdateMessage SafetyAlertBuildReq {..} = do
               list = [Tags.Tag (Just False) (Just code) (Just "Safety Alert Trigger") (Just reason)]
             }
         ]
-  fulfillment <- mkFullfillment Nothing ride booking Nothing Nothing (Just $ Tags.TG tagGroups) False
+  fulfillment <- Common.mkFullfillment Nothing ride booking Nothing Nothing (Just $ Tags.TG tagGroups) False
   return $
     OnUpdate.OnUpdateMessage
       { order =
@@ -384,11 +231,3 @@ buildOnUpdateMessage SafetyAlertBuildReq {..} = do
               },
         update_target = "order.fufillment.state.code, order.fulfillment.tags"
       }
-
-castCancellationSource :: SBCR.CancellationSource -> BookingCancelledOU.CancellationSource
-castCancellationSource = \case
-  SBCR.ByUser -> BookingCancelledOU.ByUser
-  SBCR.ByDriver -> BookingCancelledOU.ByDriver
-  SBCR.ByMerchant -> BookingCancelledOU.ByMerchant
-  SBCR.ByAllocator -> BookingCancelledOU.ByAllocator
-  SBCR.ByApplication -> BookingCancelledOU.ByApplication

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnUpdate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnUpdate.hs
@@ -220,7 +220,7 @@ buildOnUpdateMessage SafetyAlertBuildReq {..} = do
               list = [Tags.Tag (Just False) (Just code) (Just "Safety Alert Trigger") (Just reason)]
             }
         ]
-  fulfillment <- Common.mkFullfillment Nothing ride booking Nothing Nothing (Just $ Tags.TG tagGroups) False
+  fulfillment <- Common.mkFulfillment Nothing ride booking Nothing Nothing (Just $ Tags.TG tagGroups) False
   return $
     OnUpdate.OnUpdateMessage
       { order =

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Status.hs
@@ -11,23 +11,26 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
+{-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
 
 module Domain.Action.Beckn.Status
   ( handler,
     DStatusReq (..),
     DStatusRes (..),
+    OnStatusBuildReq (..),
   )
 where
 
 import qualified Domain.Types.Booking as DBooking
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.Ride as DRide
+import Environment
 import EulerHS.Prelude
 import Kernel.Beam.Functions as B
-import Kernel.Storage.Esqueleto as Esq
 import Kernel.Types.Error
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import qualified SharedLogic.SyncRide as SyncRide
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.Queries.Booking as QRB
 import qualified Storage.Queries.Ride as QRide
@@ -36,18 +39,35 @@ newtype DStatusReq = StatusReq
   { bookingId :: Id DBooking.Booking
   }
 
-data DStatusRes = StatusRes
+data DStatusRes = DStatusRes
   { transporter :: DM.Merchant,
-    bookingId :: Id DBooking.Booking,
-    bookingStatus :: DBooking.BookingStatus,
-    mbRide :: Maybe DRide.Ride
+    info :: OnStatusBuildReq
   }
 
+data OnStatusBuildReq
+  = NewBookingBuildReq
+      { bookingId :: Id DBooking.Booking
+      }
+  | RideAssignedBuildReq
+      { bookingId :: Id DBooking.Booking,
+        newRideInfo :: SyncRide.NewRideInfo
+      }
+  | RideStartedBuildReq
+      { newRideInfo :: SyncRide.NewRideInfo
+      }
+  | RideCompletedBuildReq
+      { newRideInfo :: SyncRide.NewRideInfo,
+        rideCompletedInfo :: SyncRide.RideCompletedInfo
+      }
+  | BookingCancelledBuildReq
+      { bookingCancelledInfo :: SyncRide.BookingCancelledInfo,
+        mbNewRideInfo :: Maybe SyncRide.NewRideInfo
+      }
+
 handler ::
-  (CacheFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r) =>
   Id DM.Merchant ->
   DStatusReq ->
-  m DStatusRes
+  Flow DStatusRes
 handler transporterId req = do
   transporter <-
     CQM.findById transporterId
@@ -56,11 +76,32 @@ handler transporterId req = do
   mbRide <- B.runInReplica $ QRide.findOneByBookingId booking.id
   let transporterId' = booking.providerId
   unless (transporterId' == transporterId) $ throwError AccessDenied
-
-  return $
-    StatusRes
-      { bookingId = booking.id,
-        bookingStatus = booking.status,
-        mbRide,
-        transporter
-      }
+  info <- case mbRide of
+    Just ride -> do
+      case ride.status of
+        DRide.NEW -> do
+          newRideInfo <- SyncRide.fetchNewRideInfo ride booking
+          pure $ RideAssignedBuildReq {bookingId = booking.id, newRideInfo = newRideInfo}
+        DRide.INPROGRESS -> do
+          newRideInfo <- SyncRide.fetchNewRideInfo ride booking
+          pure $ RideStartedBuildReq {newRideInfo}
+        DRide.COMPLETED -> do
+          newRideInfo <- SyncRide.fetchNewRideInfo ride booking
+          rideCompletedInfo <- SyncRide.fetchRideCompletedInfo ride booking
+          pure $ RideCompletedBuildReq {newRideInfo, rideCompletedInfo}
+        DRide.CANCELLED -> do
+          newRideInfo <- SyncRide.fetchNewRideInfo ride booking
+          bookingCancelledInfo <- SyncRide.fetchBookingCancelledInfo (Just ride) booking
+          pure $ BookingCancelledBuildReq {mbNewRideInfo = Just newRideInfo, bookingCancelledInfo}
+    Nothing -> do
+      case booking.status of
+        DBooking.NEW -> do
+          pure $ NewBookingBuildReq {bookingId = booking.id}
+        DBooking.TRIP_ASSIGNED -> do
+          throwError (RideNotFound $ "BookingId: " <> booking.id.getId)
+        DBooking.COMPLETED -> do
+          throwError (RideNotFound $ "BookingId: " <> booking.id.getId)
+        DBooking.CANCELLED -> do
+          bookingCancelledInfo <- SyncRide.fetchBookingCancelledInfo Nothing booking
+          pure $ BookingCancelledBuildReq {mbNewRideInfo = Nothing, bookingCancelledInfo}
+  pure DStatusRes {transporter, info}

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
@@ -260,7 +260,7 @@ otpRideCreate driver otpCode booking = do
   uBooking <- runInReplica $ QBooking.findById booking.id >>= fromMaybeM (BookingNotFound booking.id.getId) -- in replica db we can have outdated value
   Notify.notifyDriver booking.merchantOperatingCityId notificationType notificationTitle (message uBooking) driver.id driver.deviceToken
 
-  handle (errHandler uBooking transporter) $ BP.sendRideAssignedUpdateToBAP uBooking ride
+  handle (errHandler uBooking transporter) $ BP.sendRideAssignedUpdateToBAP uBooking ride driver vehicle
 
   DS.driverScoreEventHandler booking.merchantOperatingCityId DST.OnNewRideAssigned {merchantId = transporter.id, driverId = driver.id}
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SyncRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SyncRide.hs
@@ -18,6 +18,8 @@ module SharedLogic.SyncRide
     fetchRideCompletedInfo,
     BookingCancelledInfo (..),
     fetchBookingCancelledInfo,
+    BookingReallocationInfo,
+    fetchBookingReallocationInfo,
     NewRideInfo (..),
     fetchNewRideInfo,
   )
@@ -134,6 +136,13 @@ findCancellationSource (Just ride) = do
               <> "; Using ByMerchant as cancellation source"
           pure DBCReason.ByMerchant
 findCancellationSource Nothing = pure DBCReason.ByMerchant
+
+-- REALLOCATION --
+
+type BookingReallocationInfo = BookingCancelledInfo
+
+fetchBookingReallocationInfo :: Maybe DRide.Ride -> DB.Booking -> Flow BookingCancelledInfo
+fetchBookingReallocationInfo = fetchBookingCancelledInfo
 
 -- COMPLETED --
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/Common.hs
@@ -14,11 +14,13 @@
 
 module Beckn.ACL.Common where
 
+import qualified Beckn.Types.Core.Taxi.Common.CancellationSource as Common
 import qualified Beckn.Types.Core.Taxi.Common.Payment as Payment
 import qualified Beckn.Types.Core.Taxi.Common.Tags as Tags
 import qualified Beckn.Types.Core.Taxi.Common.Vehicle as Common
 import qualified Beckn.Types.Core.Taxi.Search as Search
 import qualified Domain.Action.UI.Search.Common as DSearchCommon
+import qualified Domain.Types.BookingCancellationReason as SBCR
 import qualified Domain.Types.Merchant.MerchantPaymentMethod as DMPM
 import qualified Domain.Types.VehicleVariant as Variant
 import Kernel.Prelude
@@ -101,3 +103,11 @@ getTag tagGroupCode tagCode (Tags.TG tagGroups) = do
   tagGroup <- find (\tagGroup -> tagGroup.code == tagGroupCode) tagGroups
   tag <- find (\tag -> tag.code == Just tagCode) tagGroup.list
   tag.value
+
+castCancellationSource :: Common.CancellationSource -> SBCR.CancellationSource
+castCancellationSource = \case
+  Common.ByUser -> SBCR.ByUser
+  Common.ByDriver -> SBCR.ByDriver
+  Common.ByMerchant -> SBCR.ByMerchant
+  Common.ByAllocator -> SBCR.ByAllocator
+  Common.ByApplication -> SBCR.ByApplication

--- a/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/OnStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/OnStatus.hs
@@ -14,44 +14,157 @@
 
 module Beckn.ACL.OnStatus (buildOnStatusReq) where
 
+import Beckn.ACL.Common (getTag)
+import qualified Beckn.ACL.Common as Common
 import qualified Beckn.Types.Core.Taxi.API.OnStatus as OnStatus
 import qualified Beckn.Types.Core.Taxi.OnStatus as OnStatus
+import Beckn.Types.Core.Taxi.OnStatus.Order.BookingCancelledOrder as OnStatusBookingCancelled
+import Beckn.Types.Core.Taxi.OnStatus.Order.RideAssignedOrder as OnStatusRideAssigned
+import Beckn.Types.Core.Taxi.OnStatus.Order.RideCompletedOrder as OnStatusRideCompleted
+import Beckn.Types.Core.Taxi.OnStatus.Order.RideStartedOrder as OnStatusRideStarted
+import qualified Data.Text as T
 import qualified Domain.Action.Beckn.OnStatus as DOnStatus
-import qualified Domain.Types.Booking as DBooking
-import qualified Domain.Types.Ride as DRide
 import Kernel.Prelude
 import Kernel.Product.Validation.Context
 import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Types.Id (Id (Id))
 import Kernel.Utils.Common
+import Tools.Error (GenericError (InvalidRequest))
 
 buildOnStatusReq ::
   ( HasFlowEnv m r '["coreVersion" ::: Text]
   ) =>
   OnStatus.OnStatusReq ->
-  m (Maybe DOnStatus.OnStatusReq)
+  m (Maybe DOnStatus.DOnStatusReq)
 buildOnStatusReq req = do
   validateContext Context.ON_STATUS req.context
   handleError req.contents $ \message ->
-    return $
-      DOnStatus.OnStatusReq
-        { bppBookingId = Id message.order.id,
-          bookingStatus = mapToDomainBookingStatus message.order.status,
-          mbRideInfo = mkRideInfo <$> message.order.fulfillment
-        }
+    parseOrder message.order
 
-mkRideInfo :: OnStatus.FulfillmentInfo -> DOnStatus.RideInfo
-mkRideInfo fulfillment =
-  DOnStatus.RideInfo
-    { bppRideId = Id fulfillment.id,
-      rideStatus = mapToDomainRideStatus fulfillment.status
-    }
+parseOrder :: (MonadFlow m) => OnStatus.Order -> m DOnStatus.DOnStatusReq
+parseOrder (OnStatus.NewBooking raOrder) = do
+  pure
+    DOnStatus.DOnStatusReq
+      { bppBookingId = Id raOrder.id,
+        rideDetails = DOnStatus.NewBookingDetails
+      }
+parseOrder (OnStatus.RideAssigned raOrder) = do
+  newRideInfo <- buildNewRideInfo raOrder.fulfillment
+  pure
+    DOnStatus.DOnStatusReq
+      { bppBookingId = Id raOrder.id,
+        rideDetails = DOnStatus.RideAssignedDetails {newRideInfo}
+      }
+parseOrder (OnStatus.RideStarted rsOrder) = do
+  newRideInfo <- buildNewRideInfo . mkRideAssignedFulfillment $ rsOrder.fulfillment
+  rideStartTime <- fromMaybeM (InvalidRequest "fulfillment.start.time is not present in RideStarted Order.") (rsOrder.fulfillment.start.time <&> (.timestamp))
+  tagsGroup <- fromMaybeM (InvalidRequest "agent tags is not present in DriverArrived Event.") rsOrder.fulfillment.tags
+  let driverArrivalTime =
+        readMaybe . T.unpack
+          =<< getTag "driver_arrived_info" "arrival_time" tagsGroup
+  let rideStartedInfo =
+        DOnStatus.RideStartedInfo
+          { rideStartTime,
+            driverArrivalTime
+          }
+  pure
+    DOnStatus.DOnStatusReq
+      { bppBookingId = Id rsOrder.id,
+        rideDetails = DOnStatus.RideStartedDetails {newRideInfo, rideStartedInfo}
+      }
+  where
+    mkRideAssignedFulfillment OnStatusRideStarted.FulfillmentInfo {..} = OnStatusRideAssigned.FulfillmentInfo {..}
+parseOrder (OnStatus.RideCompleted rcOrder) = do
+  tagsGroup <- fromMaybeM (InvalidRequest "agent tags is not present in RideCompleted Order.") rcOrder.fulfillment.tags
+  chargeableDistance :: HighPrecMeters <-
+    fromMaybeM (InvalidRequest "chargeable_distance is not present.") $
+      readMaybe . T.unpack
+        =<< getTag "ride_distance_details" "chargeable_distance" tagsGroup
+  traveledDistance :: HighPrecMeters <-
+    fromMaybeM (InvalidRequest "traveled_distance is not present.") $
+      readMaybe . T.unpack
+        =<< getTag "ride_distance_details" "traveled_distance" tagsGroup
+  let driverArrivalTime =
+        readMaybe . T.unpack
+          =<< getTag "driver_arrived_info" "arrival_time" tagsGroup
+  newRideInfo <- buildNewRideInfo . mkRideAssignedFulfillment $ rcOrder.fulfillment
+  rideStartTime <- fromMaybeM (InvalidRequest "fulfillment.start.time is not present in RideCompleted Order.") (rcOrder.fulfillment.start.time <&> (.timestamp))
+  rideEndTime <- fromMaybeM (InvalidRequest "fulfillment.end.time is not present in RideCompleted Order.") (rcOrder.fulfillment.end.time <&> (.timestamp))
+  let rideStartedInfo =
+        DOnStatus.RideStartedInfo
+          { rideStartTime,
+            driverArrivalTime
+          }
+  let rideCompletedInfo =
+        DOnStatus.RideCompletedInfo
+          { rideEndTime,
+            fare = roundToIntegral rcOrder.quote.price.value,
+            totalFare = roundToIntegral rcOrder.quote.price.computed_value,
+            fareBreakups = mkOnStatusFareBreakup <$> rcOrder.quote.breakup,
+            chargeableDistance,
+            traveledDistance,
+            paymentUrl = rcOrder.payment >>= (.uri)
+          }
+  pure
+    DOnStatus.DOnStatusReq
+      { bppBookingId = Id rcOrder.id,
+        rideDetails = DOnStatus.RideCompletedDetails {newRideInfo, rideStartedInfo, rideCompletedInfo}
+      }
+  where
+    mkRideAssignedFulfillment OnStatusRideCompleted.FulfillmentInfo {..} = OnStatusRideAssigned.FulfillmentInfo {..}
+    mkOnStatusFareBreakup breakup =
+      DOnStatus.OnStatusFareBreakup
+        { amount = realToFrac breakup.price.value,
+          description = breakup.title
+        }
+parseOrder (OnStatus.BookingCancelled bcOrder) = do
+  mbNewRideInfo <- forM bcOrder.fulfillment (buildNewRideInfo . mkRideAssignedFulfillment)
+  pure
+    DOnStatus.DOnStatusReq
+      { bppBookingId = Id bcOrder.id,
+        rideDetails =
+          DOnStatus.BookingCancelledDetails
+            { mbNewRideInfo,
+              cancellationSource = Common.castCancellationSource bcOrder.cancellation_reason
+            }
+      }
+  where
+    mkRideAssignedFulfillment OnStatusBookingCancelled.FulfillmentInfo {..} = OnStatusRideAssigned.FulfillmentInfo {..}
+
+buildNewRideInfo :: (MonadFlow m) => OnStatusRideAssigned.FulfillmentInfo -> m DOnStatus.NewRideInfo
+buildNewRideInfo fulfillment = do
+  vehicle <- fromMaybeM (InvalidRequest "vehicle is not present in RideAssigned Order.") $ fulfillment.vehicle
+  agent <- fromMaybeM (InvalidRequest "agent is not present in RideAssigned Order.") $ fulfillment.agent
+  agentPhone <- fromMaybeM (InvalidRequest "agent phoneNumber is not present in RideAssigned Order.") $ agent.phone
+  tagsGroup <- fromMaybeM (InvalidRequest "agent tags is not present in RideAssigned Order.") agent.tags
+  registeredAt :: UTCTime <-
+    fromMaybeM (InvalidRequest "registered_at is not present.") $
+      readMaybe . T.unpack
+        =<< getTag "driver_details" "registered_at" tagsGroup
+  let rating :: Maybe HighPrecMeters =
+        readMaybe . T.unpack
+          =<< getTag "driver_details" "rating" tagsGroup
+  authorization <- fromMaybeM (InvalidRequest "authorization is not present in RideAssigned Order.") $ fulfillment.start.authorization
+  pure
+    DOnStatus.NewRideInfo
+      { bppRideId = Id fulfillment.id,
+        otp = authorization.token,
+        driverName = agent.name,
+        driverMobileNumber = agentPhone,
+        driverMobileCountryCode = Just "+91", -----------TODO needs to be added in agent Tags------------
+        driverRating = realToFrac <$> rating,
+        driverImage = agent.image,
+        driverRegisteredAt = registeredAt,
+        vehicleNumber = vehicle.registration,
+        vehicleColor = vehicle.color,
+        vehicleModel = vehicle.model
+      }
 
 handleError ::
   (MonadFlow m) =>
   Either Error OnStatus.OnStatusMessage ->
-  (OnStatus.OnStatusMessage -> m DOnStatus.OnStatusReq) ->
-  m (Maybe DOnStatus.OnStatusReq)
+  (OnStatus.OnStatusMessage -> m DOnStatus.DOnStatusReq) ->
+  m (Maybe DOnStatus.DOnStatusReq)
 handleError etr action =
   case etr of
     Right msg -> do
@@ -59,16 +172,3 @@ handleError etr action =
     Left err -> do
       logTagError "on_status req" $ "on_status error: " <> show err
       pure Nothing
-
-mapToDomainBookingStatus :: OnStatus.BookingStatus -> DBooking.BookingStatus
-mapToDomainBookingStatus OnStatus.NEW_BOOKING = DBooking.NEW
-mapToDomainBookingStatus OnStatus.TRIP_ASSIGNED = DBooking.TRIP_ASSIGNED
-mapToDomainBookingStatus OnStatus.BOOKING_COMPLETED = DBooking.COMPLETED
-mapToDomainBookingStatus OnStatus.BOOKING_CANCELLED = DBooking.CANCELLED
-mapToDomainBookingStatus OnStatus.BOOKING_REALLOCATED = DBooking.REALLOCATED
-
-mapToDomainRideStatus :: OnStatus.RideStatus -> DRide.RideStatus
-mapToDomainRideStatus OnStatus.NEW = DRide.NEW
-mapToDomainRideStatus OnStatus.INPROGRESS = DRide.INPROGRESS
-mapToDomainRideStatus OnStatus.COMPLETED = DRide.COMPLETED
-mapToDomainRideStatus OnStatus.CANCELLED = DRide.CANCELLED

--- a/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/OnUpdate.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/OnUpdate.hs
@@ -15,11 +15,10 @@
 module Beckn.ACL.OnUpdate (buildOnUpdateReq) where
 
 import Beckn.ACL.Common (getTag)
+import qualified Beckn.ACL.Common as Common
 import qualified Beckn.Types.Core.Taxi.OnUpdate as OnUpdate
-import qualified Beckn.Types.Core.Taxi.OnUpdate.OnUpdateEvent.BookingCancelledEvent as OnUpdate
 import qualified Data.Text as T
 import qualified Domain.Action.Beckn.OnUpdate as DOnUpdate
-import qualified Domain.Types.BookingCancellationReason as SBCR
 import EulerHS.Prelude hiding (state)
 import Kernel.Prelude (roundToIntegral)
 import Kernel.Product.Validation.Context (validateContext)
@@ -125,14 +124,14 @@ parseEvent _ (OnUpdate.BookingCancelled tcEvent) = do
   return $
     DOnUpdate.BookingCancelledReq
       { bppBookingId = Id $ tcEvent.id,
-        cancellationSource = castCancellationSource tcEvent.cancellation_reason
+        cancellationSource = Common.castCancellationSource tcEvent.cancellation_reason
       }
 parseEvent _ (OnUpdate.BookingReallocation rbrEvent) = do
   return $
     DOnUpdate.BookingReallocationReq
       { bppBookingId = Id $ rbrEvent.id,
         bppRideId = Id rbrEvent.fulfillment.id,
-        reallocationSource = castCancellationSource rbrEvent.reallocation_reason
+        reallocationSource = Common.castCancellationSource rbrEvent.reallocation_reason
       }
 parseEvent _ (OnUpdate.DriverArrived daEvent) = do
   tagsGroup <- fromMaybeM (InvalidRequest "agent tags is not present in DriverArrived Event.") daEvent.fulfillment.tags
@@ -169,7 +168,7 @@ parseEvent transactionId (OnUpdate.EstimateRepetition erEvent) = do
         bppEstimateId = Id erEvent.item.id,
         bppBookingId = Id $ erEvent.id,
         bppRideId = Id erEvent.fulfillment.id,
-        cancellationSource = castCancellationSource cancellationReason
+        cancellationSource = Common.castCancellationSource cancellationReason
       }
 parseEvent _ (OnUpdate.SafetyAlert saEvent) = do
   tagsGroup <- fromMaybeM (InvalidRequest "agent tags is not present in SafetyAlert Event.") saEvent.fulfillment.tags
@@ -183,11 +182,3 @@ parseEvent _ (OnUpdate.SafetyAlert saEvent) = do
         reason = deviation,
         code = "deviation"
       }
-
-castCancellationSource :: OnUpdate.CancellationSource -> SBCR.CancellationSource
-castCancellationSource = \case
-  OnUpdate.ByUser -> SBCR.ByUser
-  OnUpdate.ByDriver -> SBCR.ByDriver
-  OnUpdate.ByMerchant -> SBCR.ByMerchant
-  OnUpdate.ByAllocator -> SBCR.ByAllocator
-  OnUpdate.ByApplication -> SBCR.ByApplication

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnStatus.hs
@@ -11,42 +11,256 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
+{-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
 
 module Domain.Action.Beckn.OnStatus
   ( onStatus,
-    OnStatusReq (..),
-    RideInfo (..),
+    DOnStatusReq (..),
+    RideDetails (..),
+    OnStatusFareBreakup (..),
+    NewRideInfo (..),
+    RideStartedInfo (..),
+    RideCompletedInfo (..),
   )
 where
 
-import qualified Domain.Types.Booking as DBooking
+import qualified Domain.Types.Booking as DB
+import qualified Domain.Types.BookingCancellationReason as DBCR
+import qualified Domain.Types.FarePolicy.FareBreakup as DFareBreakup
+import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.Ride as DRide
 import EulerHS.Prelude hiding (id)
+import Kernel.Beam.Functions as B
 import Kernel.Types.Common hiding (id)
 import Kernel.Types.Error
 import Kernel.Types.Id (Id)
 import Kernel.Utils.Common
-import qualified Storage.Queries.Booking as QBooking
+import qualified Storage.Queries.Booking as QB
+import qualified Storage.Queries.BookingCancellationReason as QBCR
+import qualified Storage.Queries.FareBreakup as QFareBreakup
 import qualified Storage.Queries.Ride as QRide
 
-data OnStatusReq = OnStatusReq
-  { bppBookingId :: Id DBooking.BPPBooking,
-    bookingStatus :: DBooking.BookingStatus,
-    mbRideInfo :: Maybe RideInfo
+data DOnStatusReq = DOnStatusReq
+  { bppBookingId :: Id DB.BPPBooking,
+    rideDetails :: RideDetails
   }
 
--- we can receive more rideInfo in later PRs
-data RideInfo = RideInfo
+data NewRideInfo = NewRideInfo
   { bppRideId :: Id DRide.BPPRide,
-    rideStatus :: DRide.RideStatus
+    driverName :: Text,
+    driverImage :: Maybe Text,
+    driverMobileNumber :: Text,
+    driverMobileCountryCode :: Maybe Text,
+    driverRating :: Maybe Centesimal,
+    driverRegisteredAt :: UTCTime,
+    otp :: Text,
+    vehicleNumber :: Text,
+    vehicleColor :: Text,
+    vehicleModel :: Text
   }
 
-onStatus :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => OnStatusReq -> m ()
-onStatus OnStatusReq {..} = do
-  booking <- QBooking.findByBPPBookingId bppBookingId >>= fromMaybeM (BookingDoesNotExist $ "BppBookingId: " <> bppBookingId.getId)
-  case mbRideInfo of
-    Nothing -> QBooking.updateStatus booking.id bookingStatus
-    Just rideInfo -> do
-      ride <- QRide.findByBPPRideId rideInfo.bppRideId >>= fromMaybeM (RideDoesNotExist $ "BppRideId: " <> rideInfo.bppRideId.getId)
-      QBooking.updateStatus booking.id bookingStatus >> QRide.updateStatus ride.id rideInfo.rideStatus
-      QRide.updateStatus ride.id rideInfo.rideStatus
+data RideStartedInfo = RideStartedInfo
+  { rideStartTime :: UTCTime,
+    driverArrivalTime :: Maybe UTCTime
+  }
+
+data RideCompletedInfo = RideCompletedInfo
+  { rideEndTime :: UTCTime,
+    fare :: Money,
+    totalFare :: Money,
+    fareBreakups :: [OnStatusFareBreakup],
+    chargeableDistance :: HighPrecMeters,
+    traveledDistance :: HighPrecMeters,
+    paymentUrl :: Maybe Text
+  }
+
+data RideDetails
+  = NewBookingDetails
+  | RideAssignedDetails
+      { newRideInfo :: NewRideInfo
+      }
+  | RideStartedDetails
+      { newRideInfo :: NewRideInfo,
+        rideStartedInfo :: RideStartedInfo
+      }
+  | RideCompletedDetails
+      { newRideInfo :: NewRideInfo,
+        rideStartedInfo :: RideStartedInfo,
+        rideCompletedInfo :: RideCompletedInfo
+      }
+  | BookingCancelledDetails
+      { mbNewRideInfo :: Maybe NewRideInfo,
+        cancellationSource :: DBCR.CancellationSource
+      }
+
+-- the same as OnUpdateFareBreakup
+data OnStatusFareBreakup = OnStatusFareBreakup
+  { amount :: HighPrecMoney,
+    description :: Text
+  }
+
+data RideEntity
+  = UpdatedRide
+      { ride :: DRide.Ride,
+        rideOldStatus :: DRide.RideStatus
+      }
+  | RenewedRide
+      { ride :: DRide.Ride
+      }
+
+buildRideEntity :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => DB.Booking -> (DRide.Ride -> DRide.Ride) -> NewRideInfo -> m RideEntity
+buildRideEntity booking updRide newRideInfo = do
+  mbExistingRide <- B.runInReplica $ QRide.findByBPPRideId newRideInfo.bppRideId
+  case mbExistingRide of
+    Nothing -> do
+      newRide <- buildNewRide booking newRideInfo
+      pure $ RenewedRide (updRide newRide)
+    Just existingRide -> do
+      unless (existingRide.bookingId == booking.id) $ throwError (InvalidRequest "Invalid rideId")
+      pure $ UpdatedRide {ride = updRide existingRide, rideOldStatus = existingRide.status}
+
+rideBookingTransaction :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => DB.BookingStatus -> DRide.RideStatus -> DB.Booking -> RideEntity -> m ()
+rideBookingTransaction bookingNewStatus rideNewStatus booking rideEntity = do
+  unless (booking.status == bookingNewStatus) $ do
+    QB.updateStatus booking.id bookingNewStatus
+  case rideEntity of
+    UpdatedRide {ride, rideOldStatus} -> do
+      unless (rideOldStatus == rideNewStatus) $ do
+        QRide.updateMultiple ride.id ride
+    RenewedRide renewedRide -> do
+      QRide.create renewedRide
+
+isStatusChanged :: DB.BookingStatus -> DB.BookingStatus -> RideEntity -> Bool
+isStatusChanged bookingOldStatus bookingNewStatus rideEntity = do
+  let bookingStatusChanged = bookingOldStatus == bookingNewStatus
+  let rideStatusChanged = case rideEntity of
+        UpdatedRide {ride, rideOldStatus} -> rideOldStatus == ride.status
+        RenewedRide {} -> True
+  bookingStatusChanged || rideStatusChanged
+
+onStatus :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => DOnStatusReq -> m ()
+onStatus req = do
+  booking <- QB.findByBPPBookingId req.bppBookingId >>= fromMaybeM (BookingDoesNotExist $ "BppBookingId: " <> req.bppBookingId.getId)
+  case req.rideDetails of
+    NewBookingDetails -> do
+      mbExistingRide <- B.runInReplica $ QRide.findActiveByRBId booking.id
+      unless (booking.status == bookingNewStatus) $ do
+        QB.updateStatus booking.id bookingNewStatus
+      whenJust mbExistingRide \existingRide -> do
+        unless (existingRide.status == rideNewStatus) $ do
+          QRide.updateStatus existingRide.id rideNewStatus
+      where
+        bookingNewStatus = DB.NEW
+        rideNewStatus = DRide.CANCELLED
+    RideAssignedDetails {newRideInfo} -> do
+      rideEntity <- buildRideEntity booking updateNewRide newRideInfo
+      rideBookingTransaction bookingNewStatus rideNewStatus booking rideEntity
+      where
+        bookingNewStatus = DB.TRIP_ASSIGNED
+        rideNewStatus = DRide.NEW
+        updateNewRide newRide = newRide{status = rideNewStatus}
+    RideStartedDetails {newRideInfo, rideStartedInfo} -> do
+      rideEntity <- buildRideEntity booking updateRideStarted newRideInfo
+      rideBookingTransaction bookingNewStatus rideNewStatus booking rideEntity
+      where
+        bookingNewStatus = DB.TRIP_ASSIGNED
+        rideNewStatus = DRide.INPROGRESS
+        updateRideStarted newRide =
+          newRide{status = rideNewStatus,
+                  rideStartTime = Just rideStartedInfo.rideStartTime,
+                  driverArrivalTime = rideStartedInfo.driverArrivalTime
+                 }
+    RideCompletedDetails {newRideInfo, rideStartedInfo, rideCompletedInfo} -> do
+      rideEntity <- buildRideEntity booking updateRideCompleted newRideInfo
+      rideBookingTransaction bookingNewStatus rideNewStatus booking rideEntity
+      when (isStatusChanged booking.status bookingNewStatus rideEntity) $ do
+        breakups <- traverse (buildFareBreakup booking.id) rideCompletedInfo.fareBreakups
+        QFareBreakup.deleteAllByBookingId booking.id
+        QFareBreakup.createMany breakups
+        whenJust rideCompletedInfo.paymentUrl $ QB.updatePaymentUrl booking.id
+      where
+        bookingNewStatus = DB.COMPLETED
+        rideNewStatus = DRide.COMPLETED
+        updateRideCompleted newRide =
+          newRide{status = rideNewStatus,
+                  rideStartTime = Just rideStartedInfo.rideStartTime,
+                  driverArrivalTime = rideStartedInfo.driverArrivalTime,
+                  fare = Just rideCompletedInfo.fare,
+                  totalFare = Just rideCompletedInfo.totalFare,
+                  chargeableDistance = Just rideCompletedInfo.chargeableDistance,
+                  -- traveledDistance = Just rideCompletedInfo.traveledDistance, -- did not changed in on_update
+                  rideEndTime = Just rideCompletedInfo.rideEndTime
+                 }
+    BookingCancelledDetails {mbNewRideInfo, cancellationSource} -> do
+      mbRideEntity <- forM mbNewRideInfo (buildRideEntity booking updateRideCancelled)
+      let mbRideId = case mbRideEntity of
+            Just (UpdatedRide {ride}) -> Just ride.id
+            Just (RenewedRide {ride}) -> Just ride.id
+            Nothing -> Nothing
+      let bookingCancellationReason = mkBookingCancellationReason booking.id mbRideId cancellationSource booking.merchantId
+      whenJust mbRideEntity \rideEntity -> do
+        rideBookingTransaction bookingNewStatus rideNewStatus booking rideEntity
+      when (maybe (booking.status == bookingNewStatus) (isStatusChanged booking.status bookingNewStatus) mbRideEntity) $ do
+        unless (cancellationSource == DBCR.ByUser) $
+          QBCR.upsert bookingCancellationReason
+      where
+        bookingNewStatus = DB.CANCELLED
+        rideNewStatus = DRide.CANCELLED
+        updateRideCancelled newRide = newRide{status = rideNewStatus}
+
+buildNewRide :: MonadFlow m => DB.Booking -> NewRideInfo -> m DRide.Ride
+buildNewRide booking NewRideInfo {..} = do
+  id <- generateGUID
+  shortId <- generateShortId
+  now <- getCurrentTime
+  let fromLocation = booking.fromLocation
+      toLocation = case booking.bookingDetails of
+        DB.OneWayDetails details -> Just details.toLocation
+        DB.RentalDetails _ -> Nothing
+        DB.DriverOfferDetails details -> Just details.toLocation
+        DB.OneWaySpecialZoneDetails details -> Just details.toLocation
+  let createdAt = now
+      updatedAt = now
+      merchantId = Just booking.merchantId
+      merchantOperatingCityId = Just booking.merchantOperatingCityId
+      bookingId = booking.id
+      status = DRide.NEW
+      vehicleVariant = booking.vehicleVariant
+      trackingUrl = Nothing
+      fare = Nothing
+      totalFare = Nothing
+      chargeableDistance = Nothing
+      traveledDistance = Nothing
+      driverArrivalTime = Nothing
+      rideStartTime = Nothing
+      rideEndTime = Nothing
+      rideRating = Nothing
+  pure $ DRide.Ride {..}
+
+mkBookingCancellationReason ::
+  Id DB.Booking ->
+  Maybe (Id DRide.Ride) ->
+  DBCR.CancellationSource ->
+  Id DM.Merchant ->
+  DBCR.BookingCancellationReason
+mkBookingCancellationReason bookingId mbRideId cancellationSource merchantId = do
+  DBCR.BookingCancellationReason
+    { bookingId = bookingId,
+      rideId = mbRideId,
+      merchantId = Just merchantId,
+      source = cancellationSource,
+      reasonCode = Nothing,
+      reasonStage = Nothing,
+      additionalInfo = Nothing,
+      driverCancellationLocation = Nothing,
+      driverDistToPickup = Nothing
+    }
+
+buildFareBreakup :: MonadGuid m => Id DB.Booking -> OnStatusFareBreakup -> m DFareBreakup.FareBreakup
+buildFareBreakup bookingId OnStatusFareBreakup {..} = do
+  guid <- generateGUID
+  pure
+    DFareBreakup.FareBreakup
+      { id = guid,
+        ..
+      }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Booking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Booking.hs
@@ -155,3 +155,7 @@ bookingSync merchant merchantOpCityId reqBookingId = do
       let cancellationReason = mkBookingCancellationReason merchant.id Common.syncBookingCodeWithNoRide Nothing bookingId
       QBooking.updateStatus bookingId DBooking.CANCELLED
       QBCR.upsert cancellationReason
+      let updBooking = booking{status = DBooking.CANCELLED}
+      let dStatusReq = DStatusReq {booking = updBooking, merchant, city}
+      becknStatusReq <- buildStatusReq dStatusReq
+      void $ withShortRetry $ CallBPP.callStatus booking.providerUrl becknStatusReq

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/FareBreakup.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/FareBreakup.hs
@@ -34,6 +34,9 @@ createMany = traverse_ create
 findAllByBookingId :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Id Booking -> m [FareBreakup]
 findAllByBookingId bookingId = findAllWithKV [Se.Is BeamFB.bookingId $ Se.Eq $ getId bookingId]
 
+deleteAllByBookingId :: MonadFlow m => Id Booking -> m ()
+deleteAllByBookingId bookingId = deleteWithKV [Se.Is BeamFB.bookingId $ Se.Eq $ getId bookingId]
+
 instance FromTType' BeamFB.FareBreakup FareBreakup where
   fromTType' BeamFB.FareBreakupT {..} = do
     pure $

--- a/Backend/dev/migrations/mock-registry/0000-init.sql
+++ b/Backend/dev/migrations/mock-registry/0000-init.sql
@@ -1,0 +1,2 @@
+-- duplicated from seed, app is not running without migration
+ALTER TABLE atlas_registry.subscriber OWNER TO atlas_registry_user;

--- a/Backend/dev/rest-client/dynamic-offer-driver-app/auto-flow.http
+++ b/Backend/dev/rest-client/dynamic-offer-driver-app/auto-flow.http
@@ -1,6 +1,11 @@
-@token1 = 503d9b3b-18ef-4101-a68c-0bac45e3406e
-@token2 = 47f98c05-2859-484a-9f23-155af76d5f9b
+@token1 = {{driver-offer-bpp-auto-token1}}
+@token2 = {{driver-offer-bpp-auto-token2}}
+
+@driverId = favorit-auto1-0000000000000000000000
 @driver-offer-bpp-host = http://localhost:8016
+@location-tracking-service-host = http://localhost:8081
+@merchantId = favorit0-0000-0000-0000-00000favorit
+
 
 @app-host = http://localhost:8013/v2
 @app-token = 851a466b-33cd-461d-87ab-0c4e081efbb4
@@ -15,9 +20,25 @@ GET {{app-host}}
 
 ###
 
+@adminToken = favorit-admin-0000000000000000-token
+
+# @name updateVehicle
+
+POST {{driver-offer-bpp-host}}/ui/org/vehicle/{{driverId}}
+content-type: application/json
+token: {{adminToken}}
+
+{
+    "variant" : "AUTO_RICKSHAW"
+}
+
+###
 # @name updateInitial
-POST http://localhost:8081/ui/driver/location
+POST {{location-tracking-service-host}}/ui/driver/location
 token: {{token1}}
+mId: {{merchantId}}
+vt: AUTO_RICKSHAW
+dm: ONLINE
 content-type: application/json
 dm: ONLINE
 mid: favorit0-0000-0000-0000-00000favorit
@@ -30,7 +51,7 @@ vt: SUV
             "lon": 75.919028
 
         },
-        "ts": "2023-11-10T08:58:00+0000",
+        "ts": "{{$localDatetime iso8601}}",
         "acc": 0
     }
 ]
@@ -38,34 +59,9 @@ vt: SUV
 ###
 
 # @name setActive
-POST {{driver-offer-bpp-host}}/ui/driver/setActivity?active=true
+POST {{driver-offer-bpp-host}}/ui/driver/setActivity?active=true&mode="ONLINE"
 content-type: application/json
 token: {{token1}}
-
-###
-
-# @name createDriver
-POST {{driver-offer-bpp-host}}/ui/org/driver
-content-type: application/json
-token: ea37f941-427a-4085-a7d0-96240f166672
-
-{
-  "person" : {
-    "firstName": "Jonh",
-    "middleName": " Maybeext",
-    "lastName": "Maybext",
-    "mobileNumber": "9602580675",
-    "mobileCountryCode": "+7"
-  },
-  "vehicle" : {
-    "category": "CAR",
-    "model": "Ford",
-    "variant": "SEDAN",
-    "color": "White",
-    "registrationNo": "6001",
-    "capacity": 120
-  }
-}
 
 ###
 
@@ -233,8 +229,11 @@ content-type: application/json
 # location updates taken from karnatakaLocationUpdates, so mock-google could handle it
 
 # @name update1
-POST {{driver-offer-bpp-host}}/ui/driver/location
+POST {{location-tracking-service-host}}/ui/driver/location
 token: {{token1}}
+mId: {{merchantId}}
+vt: AUTO_RICKSHAW
+dm: ONLINE
 content-type: application/json
 
 [
@@ -276,8 +275,11 @@ content-type: application/json
 ###
 
 # @name update2
-POST {{driver-offer-bpp-host}}/ui/driver/location
+POST {{location-tracking-service-host}}/ui/driver/location
 token: {{token1}}
+mId: {{merchantId}}
+vt: AUTO_RICKSHAW
+dm: ONLINE
 content-type: application/json
 
 [

--- a/Backend/dev/rest-client/dynamic-offer-driver-app/auto-flow.http
+++ b/Backend/dev/rest-client/dynamic-offer-driver-app/auto-flow.http
@@ -8,7 +8,6 @@
 
 
 @app-host = http://localhost:8013/v2
-@app-token = 851a466b-33cd-461d-87ab-0c4e081efbb4
 
 # @name healthcheck
 GET {{driver-offer-bpp-host}}/ui
@@ -40,9 +39,6 @@ mId: {{merchantId}}
 vt: AUTO_RICKSHAW
 dm: ONLINE
 content-type: application/json
-dm: ONLINE
-mid: favorit0-0000-0000-0000-00000favorit
-vt: SUV
 
 [
     {

--- a/Backend/lib/beckn-spec/beckn-spec.cabal
+++ b/Backend/lib/beckn-spec/beckn-spec.cabal
@@ -99,6 +99,7 @@ library
       Beckn.Types.Core.Taxi.Common.Price
       Beckn.Types.Core.Taxi.Common.Provider
       Beckn.Types.Core.Taxi.Common.Quote
+      Beckn.Types.Core.Taxi.Common.RideCompletedQuote
       Beckn.Types.Core.Taxi.Common.StartInfo
       Beckn.Types.Core.Taxi.Common.StopInfo
       Beckn.Types.Core.Taxi.Common.Tags
@@ -149,8 +150,13 @@ library
       Beckn.Types.Core.Taxi.OnSelect.StartInfo
       Beckn.Types.Core.Taxi.OnSelect.StopInfo
       Beckn.Types.Core.Taxi.OnStatus
-      Beckn.Types.Core.Taxi.OnStatus.Fulfillment
       Beckn.Types.Core.Taxi.OnStatus.Order
+      Beckn.Types.Core.Taxi.OnStatus.Order.BookingCancelledOrder
+      Beckn.Types.Core.Taxi.OnStatus.Order.NewBookingOrder
+      Beckn.Types.Core.Taxi.OnStatus.Order.OrderState
+      Beckn.Types.Core.Taxi.OnStatus.Order.RideAssignedOrder
+      Beckn.Types.Core.Taxi.OnStatus.Order.RideCompletedOrder
+      Beckn.Types.Core.Taxi.OnStatus.Order.RideStartedOrder
       Beckn.Types.Core.Taxi.OnTrack
       Beckn.Types.Core.Taxi.OnTrack.Tracking
       Beckn.Types.Core.Taxi.OnUpdate

--- a/Backend/lib/beckn-spec/beckn-spec.cabal
+++ b/Backend/lib/beckn-spec/beckn-spec.cabal
@@ -152,6 +152,7 @@ library
       Beckn.Types.Core.Taxi.OnStatus
       Beckn.Types.Core.Taxi.OnStatus.Order
       Beckn.Types.Core.Taxi.OnStatus.Order.BookingCancelledOrder
+      Beckn.Types.Core.Taxi.OnStatus.Order.BookingReallocationOrder
       Beckn.Types.Core.Taxi.OnStatus.Order.NewBookingOrder
       Beckn.Types.Core.Taxi.OnStatus.Order.OrderState
       Beckn.Types.Core.Taxi.OnStatus.Order.RideAssignedOrder

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Common/Authorization.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Common/Authorization.hs
@@ -1,3 +1,17 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
 module Beckn.Types.Core.Taxi.Common.Authorization where
 
 import Data.OpenApi hiding (Example, example, name, tags)

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Common/FulfillmentInfo.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Common/FulfillmentInfo.hs
@@ -20,18 +20,26 @@ where
 import Beckn.Types.Core.Taxi.Common.Agent as Reexport
 import Beckn.Types.Core.Taxi.Common.Gps as Reexport
 import qualified Beckn.Types.Core.Taxi.Common.Tags as T
+import Beckn.Types.Core.Taxi.Common.TimeTimestamp as Reexport
 import Data.Aeson (omitNothingFields)
 import Data.Aeson.Types (Options)
 import Data.OpenApi hiding (tags)
 import Kernel.Prelude
-import Kernel.Utils.JSON (stripPrefixUnderscoreIfAny)
+import Kernel.Utils.JSON (removeNullFields, stripPrefixUnderscoreIfAny)
 import Kernel.Utils.Schema (genericDeclareUnNamedSchema)
 
 data StartInfo = StartInfo
   { authorization :: Maybe Authorization,
-    location :: Location
+    location :: Location,
+    time :: Maybe TimeTimestamp
   }
-  deriving (Generic, Show, FromJSON, ToJSON)
+  deriving (Generic, Show)
+
+instance ToJSON StartInfo where
+  toJSON = genericToJSON removeNullFields
+
+instance FromJSON StartInfo where
+  parseJSON = genericParseJSON removeNullFields
 
 instance ToSchema StartInfo where
   declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions
@@ -77,10 +85,17 @@ instance ToJSON FulfillmentInfo where
 instance ToSchema FulfillmentInfo where
   declareNamedSchema = genericDeclareUnNamedSchema $ fromAesonOptions stripPrefixUnderscoreAndRemoveNullFields
 
-newtype EndInfo = EndInfo
-  { location :: Location
+data EndInfo = EndInfo
+  { location :: Location,
+    time :: Maybe TimeTimestamp
   }
-  deriving (Generic, Show, FromJSON, ToJSON)
+  deriving (Generic, Show)
+
+instance ToJSON EndInfo where
+  toJSON = genericToJSON removeNullFields
+
+instance FromJSON EndInfo where
+  parseJSON = genericParseJSON removeNullFields
 
 instance ToSchema EndInfo where
   declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Common/RideCompletedQuote.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/Common/RideCompletedQuote.hs
@@ -12,24 +12,34 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
-module Beckn.Types.Core.Taxi.OnStatus.Fulfillment where
+module Beckn.Types.Core.Taxi.Common.RideCompletedQuote
+  ( module Beckn.Types.Core.Taxi.Common.RideCompletedQuote,
+    module Reexport,
+  )
+where
 
-import Data.OpenApi (ToSchema (..), defaultSchemaOptions)
+import Beckn.Types.Core.Taxi.Common.BreakupItem as Reexport
+import Beckn.Types.Core.Taxi.Common.DecimalValue as Reexport
+import Data.Aeson as A
+import Data.OpenApi hiding (Example, example, title, value)
 import EulerHS.Prelude hiding (id)
-import Kernel.Utils.Schema (genericDeclareUnNamedSchema)
+import Kernel.Utils.Schema
 
-data FulfillmentInfo = FulfillmentInfo
-  { id :: Text, -- BPP ride id
-    status :: RideStatus
+data RideCompletedQuote = RideCompletedQuote
+  { price :: QuotePrice,
+    breakup :: [BreakupItem]
   }
   deriving (Generic, FromJSON, ToJSON, Show)
 
-instance ToSchema FulfillmentInfo where
+instance ToSchema RideCompletedQuote where
   declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions
 
-data RideStatus
-  = NEW
-  | INPROGRESS
-  | COMPLETED
-  | CANCELLED
-  deriving (Generic, FromJSON, ToJSON, Show, ToSchema)
+data QuotePrice = QuotePrice
+  { currency :: Text,
+    value :: DecimalValue,
+    computed_value :: DecimalValue
+  }
+  deriving (Generic, FromJSON, ToJSON, Show)
+
+instance ToSchema QuotePrice where
+  declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order.hs
@@ -12,58 +12,34 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
-module Beckn.Types.Core.Taxi.OnStatus.Order (Order (..), BookingStatus (..)) where
+module Beckn.Types.Core.Taxi.OnStatus.Order (Order (..)) where
 
-import Beckn.Types.Core.Taxi.OnStatus.Fulfillment (FulfillmentInfo)
+import Beckn.Types.Core.Taxi.OnStatus.Order.BookingCancelledOrder
+import Beckn.Types.Core.Taxi.OnStatus.Order.NewBookingOrder
+import Beckn.Types.Core.Taxi.OnStatus.Order.RideAssignedOrder
+import Beckn.Types.Core.Taxi.OnStatus.Order.RideCompletedOrder
+import Beckn.Types.Core.Taxi.OnStatus.Order.RideStartedOrder
 import Data.Aeson
 import Data.OpenApi
 import EulerHS.Prelude hiding (id)
+import qualified Kernel.Utils.JSON as J
 import Kernel.Utils.Schema (genericDeclareUnNamedSchema)
+import qualified Kernel.Utils.Schema as S
 
-data Order = Order
-  { id :: Text, -- BPP booking id
-    status :: BookingStatus,
-    fulfillment :: Maybe FulfillmentInfo
-  }
-  deriving (Generic, FromJSON, ToJSON, Show)
-
-instance ToSchema Order where
-  declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions
-
-data BookingStatus
-  = NEW_BOOKING
-  | TRIP_ASSIGNED
-  | BOOKING_COMPLETED
-  | BOOKING_CANCELLED
-  | BOOKING_REALLOCATED
+data Order
+  = NewBooking NewBookingOrder
+  | RideAssigned RideAssignedOrder
+  | RideStarted RideStartedOrder
+  | RideCompleted RideCompletedOrder
+  | BookingCancelled BookingCancelledOrder
+  | BookingReallocated BookingReallocatedOrder
   deriving (Generic, Show)
 
-instance ToJSON BookingStatus where
-  toJSON = genericToJSON bookingStatusOptions
+instance ToJSON Order where
+  toJSON = genericToJSON J.untaggedValue
 
-instance FromJSON BookingStatus where
-  parseJSON = genericParseJSON bookingStatusOptions
+instance FromJSON Order where
+  parseJSON = genericParseJSON J.untaggedValue
 
-instance ToSchema BookingStatus where
-  declareNamedSchema = genericDeclareNamedSchema bookingStatusSchemaOptions
-
-bookingStatusOptions :: Options
-bookingStatusOptions =
-  defaultOptions
-    { constructorTagModifier = modifier
-    }
-
-bookingStatusSchemaOptions :: SchemaOptions
-bookingStatusSchemaOptions =
-  defaultSchemaOptions
-    { constructorTagModifier = modifier
-    }
-
-modifier :: String -> String
-modifier = \case
-  "NEW_BOOKING" -> "NEW"
-  "TRIP_ASSIGNED" -> "TRIP_ASSIGNED"
-  "BOOKING_COMPLETED" -> "COMPLETED"
-  "BOOKING_CANCELLED" -> "CANCELLED"
-  "BOOKING_REALLOCATED" -> "REALLOCATED"
-  x -> x
+instance ToSchema Order where
+  declareNamedSchema = genericDeclareUnNamedSchema S.untaggedValue

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order.hs
@@ -15,6 +15,7 @@
 module Beckn.Types.Core.Taxi.OnStatus.Order (Order (..)) where
 
 import Beckn.Types.Core.Taxi.OnStatus.Order.BookingCancelledOrder
+import Beckn.Types.Core.Taxi.OnStatus.Order.BookingReallocationOrder
 import Beckn.Types.Core.Taxi.OnStatus.Order.NewBookingOrder
 import Beckn.Types.Core.Taxi.OnStatus.Order.RideAssignedOrder
 import Beckn.Types.Core.Taxi.OnStatus.Order.RideCompletedOrder
@@ -32,7 +33,7 @@ data Order
   | RideStarted RideStartedOrder
   | RideCompleted RideCompletedOrder
   | BookingCancelled BookingCancelledOrder
-  | BookingReallocated BookingReallocatedOrder
+  | BookingReallocation BookingReallocationOrder
   deriving (Generic, Show)
 
 instance ToJSON Order where

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/BookingCancelledOrder.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/BookingCancelledOrder.hs
@@ -1,0 +1,56 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Beckn.Types.Core.Taxi.OnStatus.Order.BookingCancelledOrder
+  ( module Beckn.Types.Core.Taxi.OnStatus.Order.BookingCancelledOrder,
+    module Reexport,
+  )
+where
+
+import Beckn.Types.Core.Taxi.Common.Agent as Reexport
+import Beckn.Types.Core.Taxi.Common.CancellationSource as Reexport
+import Beckn.Types.Core.Taxi.Common.FulfillmentInfo as Reexport
+import Beckn.Types.Core.Taxi.OnStatus.Order.OrderState (RideBookingCancelledOrderCode (RIDE_BOOKING_CANCELLED))
+import Data.Aeson as A
+import Data.OpenApi hiding (Example, example, name)
+import Kernel.Prelude
+import Kernel.Utils.Schema
+
+data BookingCancelledOrder = BookingCancelledOrder
+  { id :: Text,
+    state :: RideBookingCancelledOrderCode,
+    cancellation_reason :: CancellationSource,
+    fulfillment :: Maybe FulfillmentInfo
+  }
+  deriving (Generic, Show)
+
+orderState :: RideBookingCancelledOrderCode
+orderState = RIDE_BOOKING_CANCELLED
+
+instance ToSchema BookingCancelledOrder where
+  declareNamedSchema = genericDeclareUnNamedSchema $ fromAesonOptions bookingCancelledOrderJSONOptions
+
+instance FromJSON BookingCancelledOrder where
+  parseJSON = genericParseJSON bookingCancelledOrderJSONOptions
+
+instance ToJSON BookingCancelledOrder where
+  toJSON = genericToJSON bookingCancelledOrderJSONOptions
+
+bookingCancelledOrderJSONOptions :: A.Options
+bookingCancelledOrderJSONOptions =
+  defaultOptions
+    { fieldLabelModifier = \case
+        "cancellation_reason" -> "./komn/cancellation_reason"
+        a -> a
+    }

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/BookingReallocationOrder.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/BookingReallocationOrder.hs
@@ -1,0 +1,56 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Beckn.Types.Core.Taxi.OnStatus.Order.BookingReallocationOrder
+  ( module Beckn.Types.Core.Taxi.OnStatus.Order.BookingReallocationOrder,
+    module Reexport,
+  )
+where
+
+import Beckn.Types.Core.Taxi.Common.Agent as Reexport
+import Beckn.Types.Core.Taxi.Common.CancellationSource as Reexport
+import Beckn.Types.Core.Taxi.Common.FulfillmentInfo as Reexport
+import Beckn.Types.Core.Taxi.OnStatus.Order.OrderState (RideBookingReallocationOrderCode (RIDE_BOOKING_REALLOCATION))
+import Data.Aeson as A
+import Data.OpenApi hiding (Example, example, name)
+import Kernel.Prelude
+import Kernel.Utils.Schema
+
+data BookingReallocationOrder = BookingReallocationOrder
+  { id :: Text,
+    state :: RideBookingReallocationOrderCode,
+    fulfillment :: FulfillmentInfo,
+    reallocation_reason :: CancellationSource
+  }
+  deriving (Generic, Show)
+
+orderState :: RideBookingReallocationOrderCode
+orderState = RIDE_BOOKING_REALLOCATION
+
+instance ToSchema BookingReallocationOrder where
+  declareNamedSchema = genericDeclareUnNamedSchema $ fromAesonOptions bookingCancelledOrderJSONOptions
+
+instance FromJSON BookingReallocationOrder where
+  parseJSON = genericParseJSON bookingCancelledOrderJSONOptions
+
+instance ToJSON BookingReallocationOrder where
+  toJSON = genericToJSON bookingCancelledOrderJSONOptions
+
+bookingCancelledOrderJSONOptions :: A.Options
+bookingCancelledOrderJSONOptions =
+  defaultOptions
+    { fieldLabelModifier = \case
+        "reallocation_reason" -> "./komn/reallocation_reason"
+        a -> a
+    }

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/NewBookingOrder.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/NewBookingOrder.hs
@@ -12,16 +12,19 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
-module Beckn.Types.Core.Taxi.OnStatus
-  ( module Beckn.Types.Core.Taxi.OnStatus,
-    module Reexport,
+module Beckn.Types.Core.Taxi.OnStatus.Order.NewBookingOrder
+  ( module Beckn.Types.Core.Taxi.OnStatus.Order.NewBookingOrder,
   )
 where
 
-import Beckn.Types.Core.Taxi.OnStatus.Order as Reexport
+import Beckn.Types.Core.Taxi.OnStatus.Order.OrderState (NewBookingOrderCode (NEW_BOOKING))
 import Kernel.Prelude
 
-newtype OnStatusMessage = OnStatusMessage
-  { order :: Order
+data NewBookingOrder = NewBookingOrder
+  { id :: Text,
+    state :: NewBookingOrderCode
   }
-  deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
+orderState :: NewBookingOrderCode
+orderState = NEW_BOOKING

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/OrderState.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/OrderState.hs
@@ -1,0 +1,79 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Beckn.Types.Core.Taxi.OnStatus.Order.OrderState where
+
+import Data.Aeson.Types
+import Data.OpenApi
+import Kernel.Prelude
+
+-- In on_status API used order code instead of fulfillment code, because sometimes fulfillment is not present
+-- Created separate types, because each order type should have single possible value for correct parsing
+-- Constructors should be unique.
+
+data NewBookingOrderCode = NEW_BOOKING
+  deriving (Show, Generic, ToSchema)
+
+data RideAssignedOrderCode = RIDE_ASSIGNED
+  deriving (Show, Generic, ToSchema)
+
+data RideStartedOrderCode = RIDE_STARTED
+  deriving (Show, Generic, ToSchema)
+
+data RideCompletedOrderCode = RIDE_COMPLETED
+  deriving (Show, Generic, ToSchema)
+
+data RideBookingCancelledOrderCode = RIDE_BOOKING_CANCELLED
+  deriving (Show, Generic, ToSchema)
+
+-- Generic instances for type with single value will not work
+instance FromJSON NewBookingOrderCode where
+  parseJSON (String "NEW_BOOKING") = pure NEW_BOOKING
+  parseJSON (String _) = parseFail "Expected \"NEW_BOOKING\""
+  parseJSON e = typeMismatch "String" e
+
+instance ToJSON NewBookingOrderCode where
+  toJSON = String . show
+
+instance FromJSON RideAssignedOrderCode where
+  parseJSON (String "RIDE_ASSIGNED") = pure RIDE_ASSIGNED
+  parseJSON (String _) = parseFail "Expected \"RIDE_ASSIGNED\""
+  parseJSON e = typeMismatch "String" e
+
+instance ToJSON RideAssignedOrderCode where
+  toJSON = String . show
+
+instance FromJSON RideStartedOrderCode where
+  parseJSON (String "RIDE_STARTED") = pure RIDE_STARTED
+  parseJSON (String _) = parseFail "Expected \"RIDE_STARTED\""
+  parseJSON e = typeMismatch "String" e
+
+instance ToJSON RideStartedOrderCode where
+  toJSON = String . show
+
+instance FromJSON RideCompletedOrderCode where
+  parseJSON (String "RIDE_COMPLETED") = pure RIDE_COMPLETED
+  parseJSON (String _) = parseFail "Expected \"RIDE_COMPLETED\""
+  parseJSON e = typeMismatch "String" e
+
+instance ToJSON RideCompletedOrderCode where
+  toJSON = String . show
+
+instance FromJSON RideBookingCancelledOrderCode where
+  parseJSON (String "RIDE_BOOKING_CANCELLED") = pure RIDE_BOOKING_CANCELLED
+  parseJSON (String _) = parseFail "Expected \"RIDE_BOOKING_CANCELLED\""
+  parseJSON e = typeMismatch "String" e
+
+instance ToJSON RideBookingCancelledOrderCode where
+  toJSON = String . show

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/OrderState.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/OrderState.hs
@@ -37,6 +37,9 @@ data RideCompletedOrderCode = RIDE_COMPLETED
 data RideBookingCancelledOrderCode = RIDE_BOOKING_CANCELLED
   deriving (Show, Generic, ToSchema)
 
+data RideBookingReallocationOrderCode = RIDE_BOOKING_REALLOCATION
+  deriving (Show, Generic, ToSchema)
+
 -- Generic instances for type with single value will not work
 instance FromJSON NewBookingOrderCode where
   parseJSON (String "NEW_BOOKING") = pure NEW_BOOKING
@@ -76,4 +79,12 @@ instance FromJSON RideBookingCancelledOrderCode where
   parseJSON e = typeMismatch "String" e
 
 instance ToJSON RideBookingCancelledOrderCode where
+  toJSON = String . show
+
+instance FromJSON RideBookingReallocationOrderCode where
+  parseJSON (String "RIDE_BOOKING_REALLOCATION") = pure RIDE_BOOKING_REALLOCATION
+  parseJSON (String _) = parseFail "Expected \"RIDE_BOOKING_REALLOCATION\""
+  parseJSON e = typeMismatch "String" e
+
+instance ToJSON RideBookingReallocationOrderCode where
   toJSON = String . show

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/RideAssignedOrder.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/RideAssignedOrder.hs
@@ -12,16 +12,25 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
-module Beckn.Types.Core.Taxi.OnStatus
-  ( module Beckn.Types.Core.Taxi.OnStatus,
+module Beckn.Types.Core.Taxi.OnStatus.Order.RideAssignedOrder
+  ( module Beckn.Types.Core.Taxi.OnStatus.Order.RideAssignedOrder,
     module Reexport,
   )
 where
 
-import Beckn.Types.Core.Taxi.OnStatus.Order as Reexport
+import Beckn.Types.Core.Taxi.Common.Agent as Reexport
+import Beckn.Types.Core.Taxi.Common.FulfillmentInfo as Reexport
+import Beckn.Types.Core.Taxi.OnStatus.Order.OrderState (RideAssignedOrderCode (RIDE_ASSIGNED))
+import Data.Aeson as A
+import Data.OpenApi hiding (Example, example, name, tags)
 import Kernel.Prelude
 
-newtype OnStatusMessage = OnStatusMessage
-  { order :: Order
+data RideAssignedOrder = RideAssignedOrder
+  { id :: Text,
+    state :: RideAssignedOrderCode,
+    fulfillment :: FulfillmentInfo
   }
-  deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
+orderState :: RideAssignedOrderCode
+orderState = RIDE_ASSIGNED

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/RideCompletedOrder.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/RideCompletedOrder.hs
@@ -1,0 +1,41 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Beckn.Types.Core.Taxi.OnStatus.Order.RideCompletedOrder
+  ( module Beckn.Types.Core.Taxi.OnStatus.Order.RideCompletedOrder,
+    module Reexport,
+  )
+where
+
+import Beckn.Types.Core.Taxi.Common.Agent as Reexport
+import Beckn.Types.Core.Taxi.Common.FulfillmentInfo as Reexport
+import Beckn.Types.Core.Taxi.Common.Payment as Reexport
+import Beckn.Types.Core.Taxi.Common.RideCompletedQuote as Reexport
+import Beckn.Types.Core.Taxi.OnStatus.Order.OrderState (RideCompletedOrderCode (RIDE_COMPLETED))
+import Data.Aeson as A
+import Data.OpenApi hiding (Example, example, title, value)
+import EulerHS.Prelude hiding (id, state)
+import Kernel.Prelude
+
+data RideCompletedOrder = RideCompletedOrder
+  { id :: Text,
+    state :: RideCompletedOrderCode,
+    quote :: RideCompletedQuote,
+    fulfillment :: FulfillmentInfo,
+    payment :: Maybe Payment
+  }
+  deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
+
+orderState :: RideCompletedOrderCode
+orderState = RIDE_COMPLETED

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/RideStartedOrder.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnStatus/Order/RideStartedOrder.hs
@@ -12,16 +12,26 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
-module Beckn.Types.Core.Taxi.OnStatus
-  ( module Beckn.Types.Core.Taxi.OnStatus,
+module Beckn.Types.Core.Taxi.OnStatus.Order.RideStartedOrder
+  ( module Beckn.Types.Core.Taxi.OnStatus.Order.RideStartedOrder,
     module Reexport,
   )
 where
 
-import Beckn.Types.Core.Taxi.OnStatus.Order as Reexport
+import Beckn.Types.Core.Taxi.Common.Agent as Reexport
+import Beckn.Types.Core.Taxi.Common.FulfillmentInfo as Reexport
+import Beckn.Types.Core.Taxi.OnStatus.Order.OrderState (RideStartedOrderCode (RIDE_STARTED))
+import Data.Aeson as A
+import Data.OpenApi hiding (Example, example)
+import EulerHS.Prelude hiding (id, state)
 import Kernel.Prelude
 
-newtype OnStatusMessage = OnStatusMessage
-  { order :: Order
+data RideStartedOrder = RideStartedOrder
+  { id :: Text,
+    state :: RideStartedOrderCode,
+    fulfillment :: FulfillmentInfo
   }
-  deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
+orderState :: RideStartedOrderCode
+orderState = RIDE_STARTED

--- a/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnUpdate/OnUpdateEvent/RideCompletedEvent.hs
+++ b/Backend/lib/beckn-spec/src/Beckn/Types/Core/Taxi/OnUpdate/OnUpdateEvent/RideCompletedEvent.hs
@@ -22,14 +22,13 @@ where
 import Beckn.Types.Core.Taxi.Common.DecimalValue as Reexport
 import Beckn.Types.Core.Taxi.Common.FulfillmentInfo
 import Beckn.Types.Core.Taxi.Common.Payment as Reexport
+import Beckn.Types.Core.Taxi.Common.RideCompletedQuote as Reexport
 import Beckn.Types.Core.Taxi.OnUpdate.OnUpdateEvent.OnUpdateEventType (OnUpdateEventType (RIDE_COMPLETED))
 import qualified Control.Lens as L
 import Data.Aeson as A
 import Data.OpenApi hiding (Example, example, tags, title, value)
 import EulerHS.Prelude hiding (fromList, id)
 import GHC.Exts (fromList)
-import Kernel.Utils.GenericPretty (PrettyShow)
-import Kernel.Utils.Schema
 
 data RideCompletedEvent = RideCompletedEvent
   { id :: Text,
@@ -105,45 +104,3 @@ instance ToSchema RideCompletedEvent where
                    "fulfillment",
                    "payment"
                  ]
-
-data RideCompletedQuote = RideCompletedQuote
-  { price :: QuotePrice,
-    breakup :: [BreakupItem]
-  }
-  deriving (Generic, FromJSON, ToJSON, Show)
-
-instance ToSchema RideCompletedQuote where
-  declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions
-
-data QuotePrice = QuotePrice
-  { currency :: Text,
-    value :: DecimalValue,
-    computed_value :: DecimalValue
-  }
-  deriving (Generic, FromJSON, ToJSON, Show)
-
-instance ToSchema QuotePrice where
-  declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions
-
-data BreakupItem = BreakupItem
-  { title :: Text,
-    price :: BreakupPrice
-  }
-  deriving (Generic, FromJSON, ToJSON, Show, PrettyShow)
-
-instance ToSchema BreakupItem where
-  declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions
-
-data BreakupPrice = BreakupPrice
-  { currency :: Text,
-    value :: DecimalValue
-  }
-  deriving (Generic, FromJSON, ToJSON, Show, PrettyShow)
-
-instance ToSchema BreakupPrice where
-  declareNamedSchema = genericDeclareUnNamedSchema defaultSchemaOptions
-
-data DistanceRelatedTags = DistanceRelatedTags
-  { chargeable_distance :: DecimalValue,
-    traveled_distance :: DecimalValue
-  }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Earlier `on_status` api used for sync only `booking` and ride `statuses`. After this PR we can do via `on_status`:

- update the same bap `ride` fields as we update via `on_update` (when bpp `ride.status` is not the same as bap `ride.status`)
- create bap `ride` if it is not there
- create `cancellation_reason` and `fare_breakup`s on bap side

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [x] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested locally


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
