### PR TITLE
frontend/feat: enable firebase remote configs for splash screen and force udpate

### DIFF
--- a/Frontend/android-native/mobility-app/src/main/java/in/juspay/mobility/app/RemoteConfigs/MobilityRemoteConfigs.java
+++ b/Frontend/android-native/mobility-app/src/main/java/in/juspay/mobility/app/RemoteConfigs/MobilityRemoteConfigs.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2022-23, Juspay India Pvt Ltd
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+ *  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+ *  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+ *  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package in.juspay.mobility.app.RemoteConfigs;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.remoteconfig.ConfigUpdate;
+import com.google.firebase.remoteconfig.ConfigUpdateListener;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigException;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
+
+import in.juspay.mobility.app.R;
+
+public class MobilityRemoteConfigs {
+
+    private String LOG_TAG = "MobilityRemoteConfigs";
+
+    private FirebaseRemoteConfig mFirebaseRemoteConfig;
+    private FirebaseRemoteConfigSettings configSettings;
+
+    public MobilityRemoteConfigs() {
+        mFirebaseRemoteConfig = FirebaseRemoteConfig.getInstance();
+        configSettings = new FirebaseRemoteConfigSettings.Builder()
+                .build();
+        mFirebaseRemoteConfig.setDefaultsAsync(R.xml.remote_config_defaults);
+        fetchRemoteConfigs();
+        realTimeConfigListner(); // TODO:: Remove before release
+        Log.d(LOG_TAG, "CONSTRUCTOR");
+    }
+
+    public boolean getBoolean(String key) {
+        return mFirebaseRemoteConfig.getBoolean(key);
+    }
+
+    public double getDouble(String key) {
+        return mFirebaseRemoteConfig.getDouble(key);
+    }
+
+    public long getLong(String key) {
+        return mFirebaseRemoteConfig.getLong(key);
+    }
+
+    public String getString(String key) {
+        return mFirebaseRemoteConfig.getString(key);
+    }
+
+    public void fetchRemoteConfigs() {
+        mFirebaseRemoteConfig.setConfigSettingsAsync(configSettings);
+        mFirebaseRemoteConfig
+                .fetchAndActivate()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        boolean updated = task.getResult();
+                        Log.d(LOG_TAG, "Config params updated: " + updated);
+                    } else {
+                        Log.d(LOG_TAG, "Config params failed: " + task.getException());
+                    }
+                });
+    }
+
+    public void realTimeConfigListner() {
+        mFirebaseRemoteConfig.addOnConfigUpdateListener(new ConfigUpdateListener() {
+            @Override
+            public void onUpdate(ConfigUpdate configUpdate) {
+                Log.d(LOG_TAG, "Updated keys: " + configUpdate.getUpdatedKeys());
+
+                mFirebaseRemoteConfig.activate().addOnCompleteListener(new OnCompleteListener() {
+                    @Override
+                    public void onComplete(@NonNull Task task) {
+                        Log.d(LOG_TAG, "Config params activate " + task);
+//                        displayWelcomeMessage();
+                    }
+                });
+            }
+            @Override
+            public void onError(FirebaseRemoteConfigException error) {
+                Log.w(LOG_TAG, "Config update error with code: " + error.getCode(), error);
+            }
+        });
+    }
+
+
+}

--- a/Frontend/android-native/mobility-app/src/main/res/xml/remote_config_defaults.xml
+++ b/Frontend/android-native/mobility-app/src/main/res/xml/remote_config_defaults.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<defaults>
+  <entry>
+    <key>forceUpdate</key>
+    <value>false</value>
+  </entry>
+  <entry>
+    <key>splash_screen</key>
+    <value>""</value>
+  </entry>
+</defaults>


### PR DESCRIPTION
To read more about Firebase Remote Config - https://firebase.google.com/docs/remote-config/get-started?platform=android

This can be used to have remote configs for Native part of application and can be extended to PS. Will be helpful for realtime update

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
