### PR TITLE
frontend/feat: added remote config for splash screen

### DIFF
--- a/Frontend/android-native/app/src/main/java/in/juspay/mobility/MainActivity.java
+++ b/Frontend/android-native/app/src/main/java/in/juspay/mobility/MainActivity.java
@@ -86,6 +86,7 @@ import in.juspay.mobility.app.InAppNotification;
 import in.juspay.mobility.app.LocationUpdateService;
 import in.juspay.mobility.app.MyFirebaseMessagingService;
 import in.juspay.mobility.app.NotificationUtils;
+import in.juspay.mobility.app.RemoteConfigs.MobilityRemoteConfigs;
 import in.juspay.mobility.app.RideRequestActivity;
 import in.juspay.mobility.app.TranslatorMLKit;
 import in.juspay.mobility.app.WidgetService;
@@ -399,7 +400,7 @@ public class MainActivity extends AppCompatActivity {
             if (!city.equals("__failed")) {
                 View splash = findViewById(R.id.splash);
                 LottieAnimationView splashLottie = splash.findViewById(R.id.splash_lottie);
-                setSplashAnimAndStart(splashLottie,city);
+                setSplashAnimAndStart(splashLottie,city.toLowerCase());
             }
         } catch (Exception e){
             Bundle bundle = new Bundle();
@@ -412,19 +413,17 @@ public class MainActivity extends AppCompatActivity {
 
     private void setSplashAnimAndStart (LottieAnimationView view ,String city) {
         ResourceHandler resourceHandler = new ResourceHandler(this);
-        String splashConfig = resourceHandler.getFromAssets("splash_config.json");
+        MobilityRemoteConfigs remoteConfigs = new MobilityRemoteConfigs();
+        String splashScreenTemp = remoteConfigs.getString("splash_screen_" + city);
         @Nullable
         String animationFile = null;
         try {
-            JSONObject config = new JSONObject(splashConfig);
-            if (config.has(city)) {
-                JSONObject cityConfig = config.getJSONObject(city);
-                String file = cityConfig.optString("file_name","");
-                if  (resourceHandler.isResourcePresent("raw",file) && !cityConfig.optBoolean("forceToRemote",false)) {
-                    animationFile = resourceHandler.getRawResource(file);
-                } else {
-                    animationFile = cityConfig.optString("url");
-                }
+            JSONObject cityConfig = new JSONObject(splashScreenTemp);
+            String file = cityConfig.optString("file_name","");
+            if  (resourceHandler.isResourcePresent("raw",file) && !cityConfig.optBoolean("force_remote",false)) {
+                animationFile = resourceHandler.getRawResource(file);
+            } else {
+                animationFile = cityConfig.optString("url");
             }
         } catch (Exception e) {
             Bundle bundle = new Bundle();

--- a/Frontend/android-native/mobility-app/src/main/res/xml/remote_config_defaults.xml
+++ b/Frontend/android-native/mobility-app/src/main/res/xml/remote_config_defaults.xml
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <defaults>
   <entry>
-    <key>forceUpdate</key>
-    <value>false</value>
+    <key>splash_screen_hyderabad</key>
+    <value>{"file_name":"splash_lottie_hyd","url":"https://assets.juspay.in/beckn/nammayatri/driver/lottie/splash_lottie_hyd.json","force_remote":true}</value>
   </entry>
   <entry>
-    <key>splash_screen</key>
-    <value>""</value>
+    <key>splash_screen_mysore</key>
+    <value>{"file_name":"splash_lottie_mys","url":"https://assets.juspay.in/beckn/nammayatri/driver/lottie/splash_lottie_mys.json","force_remote":true}</value>
+  </entry>
+  <entry>
+    <key>splash_screen_delhi</key>
+    <value>{"file_name":"splash_lottie_del","url":"https://assets.juspay.in/beckn/nammayatri/driver/lottie/splash_lottie_del.json","force_remote":true}</value>
+  </entry>
+  <entry>
+    <key>splash_screen_bangalore</key>
+    <value>{"file_name":"splash_lottie_blr","url":"https://assets.juspay.in/beckn/nammayatri/driver/lottie/splash_lottie_blr.json","force_remote":true}</value>
   </entry>
 </defaults>


### PR DESCRIPTION
Added remote config for splash screen to have links in remote

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
