### PR TITLE
frontend/fix: 3525-disability banner storage updation issue fix

### DIFF
--- a/Frontend/ui-customer/src/Helpers/Storage/Flow/SearchStatus.purs
+++ b/Frontend/ui-customer/src/Helpers/Storage/Flow/SearchStatus.purs
@@ -39,7 +39,7 @@ updateFlowStatusStorage response = do
   -- (PersonStatsRes resp) <- Remote.getPersonStatsBT "" -- TODO:: Make this function async in non critical flow @ashkriti
   
   setValueToLocalStore DRIVER_ARRIVAL_ACTION "TRIGGER_DRIVER_ARRIVAL" --TODO:: How is this being used @rohit??
-  setValueToLocalStore DISABILITY_UPDATED $ show $ isNothing $ response ^. _hasDisability
+  setValueToLocalStore DISABILITY_UPDATED $ show $ isJust $ response ^. _hasDisability
   setValueToLocalStore REFERRAL_STATUS userRideStatus
   setValueToLocalStore HAS_TAKEN_FIRST_RIDE $ show $ response ^. _hasTakenRide
   setValueToLocalStore USER_NAME name


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

Issue - The banner to update the disability is showing up on Home Screen when user kills and reopens the application even if the value is updated. This is because of incorrect value updation in the flow.
