### PR TITLE
backend/euler: flake update for inMemcache fix for saving redis storage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -598,11 +598,11 @@
         "tinylog": "tinylog"
       },
       "locked": {
-        "lastModified": 1699954198,
-        "narHash": "sha256-o7t0pQtXBo+pEXk7lJ7J2Z07HEWFvlTwy7ZPoPn4Ptw=",
+        "lastModified": 1701939462,
+        "narHash": "sha256-ZVrFeWGmj0zVpEn/iZncsDcDO4K4yzDz3h2K64aelLM=",
         "owner": "juspay",
         "repo": "euler-hs",
-        "rev": "9492f18e5a36e163c3c55965254fe97f4524f7ac",
+        "rev": "61ef36ab8bab51c59f5a62129ec2fb857db3d0c9",
         "type": "github"
       },
       "original": {
@@ -2973,11 +2973,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1701852430,
-        "narHash": "sha256-vZEhsJQQG91pymWzZ5rdt5FetFPuBrQo9+DfS+QGwkw=",
+        "lastModified": 1701939635,
+        "narHash": "sha256-tjBUeyluauEYvB6iu4neBtCa9dRhO9JJMy5yzDHVWcQ=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "8f8df4278032b39263e2fefb416220fa12e39914",
+        "rev": "dbc354dc43898f4935cf201114f2a44c96816290",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
this contain the change in euler-hs which will avoid pushing inMemCache data to redis

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
