### PR TITLE
frontend:#3525- made govt guidelines text city level configurable

### DIFF
--- a/Frontend/ui-customer/src/Helpers/Utils.purs
+++ b/Frontend/ui-customer/src/Helpers/Utils.purs
@@ -26,7 +26,7 @@ import Common.Types.App (EventPayload(..), GlobalPayload(..), LazyCheck(..), Pay
 import Components.LocationListItem.Controller (locationListStateObj)
 import Control.Monad.Except (runExcept)
 import Control.Monad.Free (resume)
-import Data.Array (cons, deleteAt, drop, filter, head, length, null, sortBy, sortWith, tail, (!!), reverse)
+import Data.Array (cons, deleteAt, drop, filter, head, length, null, sortBy, sortWith, tail, (!!), reverse, find)
 import Data.Array.NonEmpty (fromArray)
 import Data.Boolean (otherwise)
 import Data.Date (Date)
@@ -86,6 +86,7 @@ import Unsafe.Coerce (unsafeCoerce)
 import Data.Function.Uncurried (Fn1)
 import Styles.Colors as Color
 import Common.Styles.Colors as CommonColor
+import Data.Tuple (Tuple(..), fst, snd)
 
 foreign import shuffle :: forall a. Array a -> Array a
 
@@ -596,3 +597,33 @@ getTitleConfig vehicleVariant =
             text : text',
             color : color'
           }
+
+cityCodeMap :: Array (Tuple String String)
+cityCodeMap = 
+  [ Tuple "std:080" "bangalore"
+  , Tuple "std:033" "kolkata"
+  , Tuple "std:001" "paris"
+  , Tuple "std:484" "kochi"
+  , Tuple "std:011" "delhi"
+  , Tuple "std:040" "hyderabad"
+  , Tuple "std:022" "mumbai"
+  , Tuple "std:044" "chennai"
+  , Tuple "std:0422" "coimbatore"
+  , Tuple "std:0413" "pondicherry"
+  , Tuple "std:08342" "goa"
+  , Tuple "std:020" "pune"
+  , Tuple "std:0821" "mysore"
+  , Tuple "std:0816" "tumakuru"
+  ]
+
+getCityFromCode :: String -> String
+getCityFromCode code = 
+  let 
+    cityCodeTuple = find (\ tuple -> (fst tuple) == code) cityCodeMap
+  in maybe "" (\tuple -> snd tuple) cityCodeTuple
+
+getCodeFromCity :: String -> String
+getCodeFromCity city = 
+  let 
+    cityCodeTuple = find (\tuple -> (snd tuple) == (DS.toLower city)) cityCodeMap
+  in maybe "" (\tuple -> fst tuple) cityCodeTuple

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ComponentConfig.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ComponentConfig.purs
@@ -48,7 +48,7 @@ import Data.Array as DA
 import Data.Either (Either(..))
 import Data.Int (toNumber)
 import Data.Int as INT
-import Data.Maybe (Maybe(..), fromMaybe, isJust)
+import Data.Maybe (Maybe(..), fromMaybe, isJust, maybe)
 import Data.String as DS
 import Effect (Effect)
 import Engineering.Helpers.Commons as EHC
@@ -726,6 +726,8 @@ rateCardConfig :: ST.HomeScreenState -> RateCard.Config
 rateCardConfig state =
   let
     config' = RateCard.config
+    bangaloreCode = HU.getCodeFromCity "Bangalore"
+    fareInfoText = maybe (mkFareInfoText bangaloreCode) (\city -> mkFareInfoText city) state.props.city
     rateCardConfig' =
       config'
         { nightCharges = state.data.rateCard.nightCharges
@@ -752,7 +754,7 @@ rateCardConfig state =
           {key : "DRIVER_ADDITIONS", val : (getString DRIVER_ADDITIONS)},
           {key : "FARE_UPDATE_POLICY", val : (getString FARE_UPDATE_POLICY)},
           {key : "WAITING_CHARGES", val : getString WAITING_CHARGE }]
-        , fareInfoText = (getString $ FARE_INFO_TEXT "FARE_INFO_TEXT")
+        , fareInfoText = fareInfoText
         , additionalStrings = [
           {key : "DRIVER_ADDITIONS_OPTIONAL", val : (getString DRIVER_ADDITIONS_OPTIONAL)},
           {key : "THE_DRIVER_MAY_QUOTE_EXTRA_TO_COVER_FOR_TRAFFIC", val : (getString THE_DRIVER_MAY_QUOTE_EXTRA_TO_COVER_FOR_TRAFFIC)},
@@ -770,6 +772,14 @@ rateCardConfig state =
         }
   in
     rateCardConfig'
+  where 
+
+    mkFareInfoText :: String -> String
+    mkFareInfoText city = 
+      let city_array = map (\item -> HU.getCodeFromCity item) [ "Bangalore", "Tumakuru" , "Mysore"]
+      in (if DA.any ( _ == city) city_array 
+            then (getString $ FARE_INFO_TEXT "FARE_INFO_TEXT") 
+            else "")
 
 
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

Made Fare Info Text City level Configurable.