### PR TITLE
Revert "jenkins: Remove intel mac from CI"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                 axes {
                     axis {
                         name 'SYSTEM'
-                        values 'x86_64-linux', 'aarch64-darwin' // 'aarch64-linux'
+                        values 'x86_64-linux', 'aarch64-darwin', 'x86_64-darwin' // 'aarch64-linux'
                     }
                 }
                 stages {


### PR DESCRIPTION
Reverts nammayatri/nammayatri#4992

We still support intel mac for this as an open source project, per @hemantmangla 