### PR TITLE
backend/refactor: remove partial fields

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Update.hs
@@ -46,9 +46,10 @@ update _ (SignatureAuthResult _ subscriber) req = withFlowHandlerBecknAPI $
   withTransactionIdLogTag req $ do
     logTagInfo "updateAPI" "Received update API call."
     dUpdateReq <- ACL.buildUpdateReq subscriber req
-    Redis.whenWithLockRedis (updateLockKey dUpdateReq.bookingId.getId) 60 $ do
+    let bookingId = DUpdate.getBookingId dUpdateReq
+    Redis.whenWithLockRedis (updateLockKey bookingId.getId) 60 $ do
       fork "update request processing" $
-        Redis.whenWithLockRedis (updateProcessingLockKey dUpdateReq.bookingId.getId) 60 $
+        Redis.whenWithLockRedis (updateProcessingLockKey bookingId.getId) 60 $
           DUpdate.handler dUpdateReq
     pure Ack
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Dashboard/Management/Overlay.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Dashboard/Management/Overlay.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module API.Dashboard.Management.Overlay where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Dashboard/RideBooking/Maps.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Dashboard/RideBooking/Maps.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module API.Dashboard.RideBooking.Maps where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnStatus.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnStatus.hs
@@ -54,7 +54,7 @@ buildOnStatusMessage ::
   (EsqDBFlow m r, EncFlow m r) =>
   DStatus.OnStatusBuildReq ->
   m OnStatus.OnStatusMessage
-buildOnStatusMessage (DStatus.NewBookingBuildReq {bookingId}) = do
+buildOnStatusMessage (DStatus.NewBookingBuildReq (DNewBookingBuildReq bookingId)) = do
   return $
     OnStatus.OnStatusMessage
       { order =
@@ -130,7 +130,7 @@ buildOnStatusMessage (DStatus.BookingCancelledReq Common.DBookingCancelledReq {.
                 fulfillment
               }
       }
-buildOnStatusMessage DStatus.BookingReallocationBuildReq {bookingReallocationInfo, bookingDetails} = do
+buildOnStatusMessage (DStatus.BookingReallocationBuildReq DStatus.DBookingReallocationBuildReq {bookingReallocationInfo, bookingDetails}) = do
   let DStatus.BookingCancelledInfo {cancellationSource} = bookingReallocationInfo
   let Common.BookingDetails {..} = bookingDetails
   let image = Nothing
@@ -207,7 +207,7 @@ mkOnStatusMessageV2 res mbFarePolicy bppConfig = do
       }
 
 tfOrder :: (MonadFlow m, EncFlow m r) => DStatus.OnStatusBuildReq -> Maybe FarePolicyD.FullFarePolicy -> DBC.BecknConfig -> m Spec.Order
-tfOrder (DStatus.NewBookingBuildReq {bookingId}) _ becknConfig =
+tfOrder (DStatus.NewBookingBuildReq DNewBookingBuildReq {bookingId}) _ becknConfig =
   pure
     Spec.Order
       { orderId = Just bookingId.getId,
@@ -227,7 +227,7 @@ tfOrder (DStatus.RideAssignedReq req) mbFarePolicy becknConfig = Common.tfAssign
 tfOrder (DStatus.RideStartedReq req) mbFarePolicy becknConfig = Common.tfStartReqToOrder req mbFarePolicy becknConfig
 tfOrder (DStatus.RideCompletedReq req) mbFarePolicy becknConfig = Common.tfCompleteReqToOrder req mbFarePolicy becknConfig
 tfOrder (DStatus.BookingCancelledReq req) _ becknConfig = Common.tfCancelReqToOrder req becknConfig
-tfOrder (DStatus.BookingReallocationBuildReq {bookingReallocationInfo, bookingDetails}) _ becknConfig = do
+tfOrder (DStatus.BookingReallocationBuildReq DBookingReallocationBuildReq {bookingReallocationInfo, bookingDetails}) _ becknConfig = do
   let DStatus.BookingCancelledInfo {cancellationSource} = bookingReallocationInfo
   let Common.BookingDetails {driver, vehicle, booking, ride, isValueAddNP} = bookingDetails
   let image = Nothing

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Update.hs
@@ -44,29 +44,33 @@ buildUpdateReq subscriber req = do
 
 parseEvent :: Update.UpdateEvent -> DUpdate.DUpdateReq
 parseEvent (Update.PaymentCompleted pcEvent) = do
-  DUpdate.PaymentCompletedReq
-    { bookingId = Id pcEvent.id,
-      rideId = Id pcEvent.fulfillment.id,
-      paymentStatus = castPaymentStatus pcEvent.payment.status,
-      paymentMethodInfo = mkPaymentMethodInfo pcEvent.payment
-    }
+  DUpdate.UPaymentCompletedReq $
+    DUpdate.PaymentCompletedReq
+      { bookingId = Id pcEvent.id,
+        rideId = Id pcEvent.fulfillment.id,
+        paymentStatus = castPaymentStatus pcEvent.payment.status,
+        paymentMethodInfo = mkPaymentMethodInfo pcEvent.payment
+      }
 parseEvent (Update.EditLocation elEvent) = do
-  DUpdate.EditLocationReq
-    { bookingId = Id elEvent.id,
-      rideId = Id elEvent.fulfillment.id,
-      origin = elEvent.fulfillment.origin.location,
-      destination = elEvent.fulfillment.destination >>= (.location)
-    }
+  DUpdate.UEditLocationReq $
+    DUpdate.EditLocationReq
+      { bookingId = Id elEvent.id,
+        rideId = Id elEvent.fulfillment.id,
+        origin = elEvent.fulfillment.origin.location,
+        destination = elEvent.fulfillment.destination >>= (.location)
+      }
 parseEvent (Update.AddStop asEvent) = do
-  DUpdate.AddStopReq
-    { bookingId = Id asEvent.id,
-      stops = asEvent.fulfillment.stops
-    }
+  DUpdate.UAddStopReq $
+    DUpdate.AddStopReq
+      { bookingId = Id asEvent.id,
+        stops = asEvent.fulfillment.stops
+      }
 parseEvent (Update.EditStop esEvent) = do
-  DUpdate.EditStopReq
-    { bookingId = Id esEvent.id,
-      stops = esEvent.fulfillment.stops
-    }
+  DUpdate.UEditStopReq $
+    DUpdate.EditStopReq
+      { bookingId = Id esEvent.id,
+        stops = esEvent.fulfillment.stops
+      }
 
 mkPaymentMethodInfo :: Update.Payment -> DMPM.PaymentMethodInfo
 mkPaymentMethodInfo Update.Payment {..} =

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Status.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
 
 module Domain.Action.Beckn.Status
   ( handler,
@@ -77,7 +76,7 @@ handler transporterId req = do
             DBooking.REALLOCATED -> do
               bookingDetails <- SyncRide.fetchBookingDetails ride booking
               bookingReallocationInfo <- SyncRide.fetchBookingReallocationInfo (Just ride) booking
-              pure $ BookingReallocationBuildReq {bookingDetails, bookingReallocationInfo}
+              pure $ BookingReallocationBuildReq DBookingReallocationBuildReq {bookingDetails, bookingReallocationInfo}
             _ -> do
               bookingDetails <- SyncRide.fetchBookingDetails ride booking
               SyncRide.BookingCancelledInfo {..} <- SyncRide.fetchBookingCancelledInfo (Just ride)
@@ -85,7 +84,7 @@ handler transporterId req = do
     Nothing -> do
       case booking.status of
         DBooking.NEW -> do
-          pure $ NewBookingBuildReq {bookingId = booking.id}
+          pure $ NewBookingBuildReq (DNewBookingBuildReq booking.id)
         DBooking.TRIP_ASSIGNED -> do
           throwError (RideNotFound $ "BookingId: " <> booking.id.getId)
         DBooking.COMPLETED -> do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TypeApplications #-}
 
 module Domain.Action.UI.Ride.CancelRide.Internal (cancelRideImpl) where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TypeApplications #-}
 
 module Domain.Action.UI.Ride.EndRide.Internal
   ( endRideTransaction,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Beckn/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Beckn/Status.hs
@@ -23,13 +23,8 @@ import Kernel.Types.Id
 import SharedLogic.Beckn.Common as Common
 
 data OnStatusBuildReq
-  = NewBookingBuildReq
-      { bookingId :: Id DBooking.Booking
-      }
-  | BookingReallocationBuildReq
-      { bookingReallocationInfo :: BookingReallocationInfo,
-        bookingDetails :: Common.BookingDetails
-      }
+  = NewBookingBuildReq DNewBookingBuildReq
+  | BookingReallocationBuildReq DBookingReallocationBuildReq
   | RideAssignedReq Common.DRideAssignedReq
   | RideStartedReq Common.DRideStartedReq
   | RideCompletedReq Common.DRideCompletedReq
@@ -50,4 +45,13 @@ type BookingReallocationInfo = BookingCancelledInfo
 
 newtype BookingCancelledInfo = BookingCancelledInfo
   { cancellationSource :: DBCR.CancellationSource
+  }
+
+newtype DNewBookingBuildReq = DNewBookingBuildReq
+  { bookingId :: Id DBooking.Booking
+  }
+
+data DBookingReallocationBuildReq = DBookingReallocationBuildReq
+  { bookingReallocationInfo :: BookingReallocationInfo,
+    bookingDetails :: Common.BookingDetails
   }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/BlackListOrg.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/BlackListOrg.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+
 {-
  Copyright 2022-23, Juspay India Pvt Ltd
 
@@ -12,7 +13,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.BlackListOrg where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Booking.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Booking.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Booking where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/BookingCancellationReason.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/BookingCancellationReason.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.BookingCancellationReason where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/BusinessEvent.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/BusinessEvent.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.BusinessEvent where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Driver/GoHomeFeature/DriverGoHomeRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Driver/GoHomeFeature/DriverGoHomeRequest.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Driver.GoHomeFeature.DriverGoHomeRequest where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverFee.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.DriverFee where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverInformation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverInformation.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Domain.Types.DriverInformation where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverOnboarding/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverOnboarding/Error.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.DriverOnboarding.Error where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverOnboarding/Image.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverOnboarding/Image.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.DriverOnboarding.Image where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverQuote.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/DriverQuote.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.DriverQuote where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FareParameters.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FareParameters.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.FareParameters where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.FarePolicy (module Reexport, module Domain.Types.FarePolicy) where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy/FarePolicySlabsDetails/FarePolicySlabsDetailsSlab.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy/FarePolicySlabsDetails/FarePolicySlabsDetailsSlab.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.FarePolicy.FarePolicySlabsDetails.FarePolicySlabsDetailsSlab where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FareProduct.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FareProduct.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.FareProduct where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Feedback/FeedbackForm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Feedback/FeedbackForm.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Feedback.FeedbackForm where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Invoice.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Invoice.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Domain.Types.Invoice where
 
 import Data.Aeson

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/LeaderBoardConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/LeaderBoardConfig.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.LeaderBoardConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/LocationMapping.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/LocationMapping.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.LocationMapping where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Mandate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Mandate.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Mandate where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Maps/PlaceNameCache.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Maps/PlaceNameCache.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Maps.PlaceNameCache where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Merchant where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/LeaderBoardConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/LeaderBoardConfig.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Merchant.LeaderBoardConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/MerchantMessage.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/MerchantMessage.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Merchant.MerchantMessage where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/MerchantPaymentMethod.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/MerchantPaymentMethod.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
 
 module Domain.Types.Merchant.MerchantPaymentMethod where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/MerchantServiceConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/MerchantServiceConfig.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Merchant.MerchantServiceConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/OnboardingDocumentConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Merchant/OnboardingDocumentConfig.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Merchant.OnboardingDocumentConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Message/Message.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Message/Message.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Message.Message where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Message/MessageReport.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Message/MessageReport.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Domain.Types.Message.MessageReport where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/OnUpdate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/OnUpdate.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
 
 module Domain.Types.OnUpdate
   ( module Domain.Types.OnUpdate,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Person.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Person.hs
@@ -13,7 +13,6 @@
 -}
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 
 module Domain.Types.Person where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Plan.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Plan where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/RegistrationToken.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/RegistrationToken.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.RegistrationToken where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Ride.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Ride where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/SearchRequestForDriver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/SearchRequestForDriver.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.SearchRequestForDriver where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/SearchTry.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/SearchTry.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.SearchTry where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Vehicle.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Vehicle.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Vehicle (module Domain.Types.Vehicle, module Reexport) where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Vehicle/Variant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Vehicle/Variant.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.Vehicle.Variant where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/WhiteListOrg.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/WhiteListOrg.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+
 {-
  Copyright 2022-23, Juspay India Pvt Ltd
 
@@ -12,7 +13,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Domain.Types.WhiteListOrg where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator.hs
@@ -14,7 +14,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module SharedLogic.Allocator where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPool/Config.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPool/Config.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module SharedLogic.Allocator.Jobs.SendSearchRequestToDrivers.Handle.Internal.DriverPool.Config
   ( DriverPoolBatchesConfig (..),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/BlackListOrg.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/BlackListOrg.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.BlackListOrg where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Booking.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Booking.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Booking where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Booking/BookingLocation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Booking/BookingLocation.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Booking.BookingLocation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/BookingCancellationReason.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/BookingCancellationReason.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.BookingCancellationReason where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/BusinessEvent.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/BusinessEvent.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.BusinessEvent where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/CallStatus.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/CallStatus.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.CallStatus where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Driver/GoHomeFeature/DriverGoHomeRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Driver/GoHomeFeature/DriverGoHomeRequest.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Driver.GoHomeFeature.DriverGoHomeRequest where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Driver/GoHomeFeature/DriverHomeLocation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Driver/GoHomeFeature/DriverHomeLocation.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Driver.GoHomeFeature.DriverHomeLocation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverBlockReason.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverBlockReason.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverBlockReason where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverFee.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverFee where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverInformation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverInformation.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverInformation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/AadhaarOtpReq.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/AadhaarOtpReq.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverOnboarding.AadhaarOtpReq where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/AadhaarOtpVerify.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/AadhaarOtpVerify.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverOnboarding.AadhaarOtpVerify where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/AadhaarVerification.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/AadhaarVerification.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverOnboarding.AadhaarVerification where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/DriverLicense.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/DriverLicense.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverOnboarding.DriverLicense where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/DriverRCAssociation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/DriverRCAssociation.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverOnboarding.DriverRCAssociation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/Image.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/Image.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverOnboarding.Image where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/VehicleRegistrationCertificate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverOnboarding/VehicleRegistrationCertificate.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverOnboarding.VehicleRegistrationCertificate where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverPlan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverPlan.hs
@@ -14,8 +14,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverPlan where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverQuote.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverQuote.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverQuote where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverStats.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/DriverStats.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.DriverStats where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareParameters.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareParameters.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FareParameters where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareParameters/FareParametersProgressiveDetails.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareParameters/FareParametersProgressiveDetails.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FareParameters.FareParametersProgressiveDetails where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareParameters/FareParametersSlabDetails.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareParameters/FareParametersSlabDetails.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FareParameters.FareParametersSlabDetails where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FarePolicy where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/DriverExtraFeeBounds.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/DriverExtraFeeBounds.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FarePolicy.DriverExtraFeeBounds where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/FarePolicyProgressiveDetails.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/FarePolicyProgressiveDetails.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FarePolicy.FarePolicyProgressiveDetails where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/FarePolicyProgressiveDetails/FarePolicyProgressiveDetailsPerExtraKmRateSection.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/FarePolicyProgressiveDetails/FarePolicyProgressiveDetailsPerExtraKmRateSection.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FarePolicy.FarePolicyProgressiveDetails.FarePolicyProgressiveDetailsPerExtraKmRateSection where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/FarePolicySlabDetails/FarePolicySlabDetailsSlab.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/FarePolicySlabDetails/FarePolicySlabDetailsSlab.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FarePolicy.FarePolicySlabDetails.FarePolicySlabDetailsSlab where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/RestrictedExtraFare.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FarePolicy/RestrictedExtraFare.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FarePolicy.RestrictedExtraFare where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareProduct.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareProduct.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FareProduct where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Feedback/Feedback.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Feedback/Feedback.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Feedback.Feedback where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Feedback/FeedbackBadge.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Feedback/FeedbackBadge.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Feedback.FeedbackBadge where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Feedback/FeedbackForm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Feedback/FeedbackForm.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Feedback.FeedbackForm where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FleetDriverAssociation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FleetDriverAssociation.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.FleetDriverAssociation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Geometry.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Geometry.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Geometry (module Reexport) where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/GoHomeConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/GoHomeConfig.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.GoHomeConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Invoice.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Invoice.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Invoice where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/KioskLocation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/KioskLocation.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.KioskLocation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/KioskLocationTranslation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/KioskLocationTranslation.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.KioskLocationTranslation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Location.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Location.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Location where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/LocationMapping.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/LocationMapping.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.LocationMapping where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Mandate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Mandate.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Mandate where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Maps/PlaceNameCache.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Maps/PlaceNameCache.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wwarn=type-defaults #-}
 
 module Storage.Beam.Maps.PlaceNameCache where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/DriverIntelligentPoolConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/DriverIntelligentPoolConfig.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.DriverIntelligentPoolConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/LeaderBoardConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/LeaderBoardConfig.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.LeaderBoardConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantMessage.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantMessage.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.MerchantMessage where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantOperatingCity.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantOperatingCity.hs
@@ -7,8 +7,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
 module Storage.Beam.Merchant.MerchantOperatingCity where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantPaymentMethod.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantPaymentMethod.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.MerchantPaymentMethod where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantServiceConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantServiceConfig.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.MerchantServiceConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantServiceUsageConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/MerchantServiceUsageConfig.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.MerchantServiceUsageConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/OnboardingDocumentConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/OnboardingDocumentConfig.hs
@@ -12,8 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.OnboardingDocumentConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/Overlay.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/Overlay.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.Overlay where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Merchant/TransporterConfig.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Merchant.TransporterConfig where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Message/Message.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Message/Message.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Message.Message where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Message/MessageReport.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Message/MessageReport.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Message.MessageReport where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Message/MessageTranslation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Message/MessageTranslation.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Message.MessageTranslation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Notification.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Notification.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Storage.Beam.Notification where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Person.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Person.hs
@@ -13,7 +13,6 @@
 -}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Person where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Plan.hs
@@ -13,7 +13,6 @@
 -}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Plan where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Quote.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Quote.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Quote where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/RegistrationToken.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/RegistrationToken.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.RegistrationToken where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/RegistryMapFallback.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/RegistryMapFallback.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.RegistryMapFallback where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Ride/Table.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Ride/Table.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Ride.Table where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/RideDetails.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/RideDetails.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.RideDetails where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/RiderDetails.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/RiderDetails.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.RiderDetails where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchRequest.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wwarn=orphans #-}
 
 module Storage.Beam.SearchRequest where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchRequest/SearchReqLocation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchRequest/SearchReqLocation.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.SearchRequest.SearchReqLocation where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchRequestForDriver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchRequestForDriver.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.SearchRequestForDriver where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchTry.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/SearchTry.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wwarn=orphans #-}
 
 module Storage.Beam.SearchTry where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Vehicle.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/Vehicle.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.Vehicle where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/WhiteListOrg.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/WhiteListOrg.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.WhiteListOrg where
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
@@ -11,7 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Tools.Error (module Tools.Error) where
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/OnStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/OnStatus.hs
@@ -90,7 +90,7 @@ parseRideBookingReallocationOrder order messageId = do
   bookingDetails <- Common.parseBookingDetails order messageId
   reallocationSourceText <- order.orderCancellation >>= (.cancellationCancelledBy) & fromMaybeM (InvalidRequest "order.cancellation.,cancelled_by is not present in on_status BookingReallocationEvent request.")
   let reallocationSource = Utils.castCancellationSourceV2 reallocationSourceText
-  pure $ DOnStatus.BookingReallocationDetails {..}
+  pure $ DOnStatus.BookingReallocationDetails DOnStatus.BookingReallocationReq {..}
 
 handleErrorV2 ::
   (MonadFlow m) =>

--- a/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/OnUpdate.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/OnUpdate.hs
@@ -99,11 +99,12 @@ parseNewMessageEvent order = do
   tagGroups <- order.orderFulfillments >>= listToMaybe >>= (.fulfillmentTags) & fromMaybeM (InvalidRequest "fulfillment.tags is not present in NewMessage Event.")
   message <- Utils.getTagV2 Tag.DRIVER_NEW_MESSAGE Tag.MESSAGE (Just tagGroups) & fromMaybeM (InvalidRequest "driver_new_message tag is not present in NewMessage Event.")
   return $
-    DOnUpdate.NewMessageReq
-      { bppBookingId = Id bppBookingId,
-        bppRideId = Id bppRideId,
-        message = message
-      }
+    DOnUpdate.OUNewMessageReq $
+      DOnUpdate.NewMessageReq
+        { bppBookingId = Id bppBookingId,
+          bppRideId = Id bppRideId,
+          message = message
+        }
 
 parseEstimateRepetitionEvent :: (MonadFlow m) => Text -> Spec.Order -> m DOnUpdate.OnUpdateReq
 parseEstimateRepetitionEvent transactionId order = do
@@ -113,13 +114,14 @@ parseEstimateRepetitionEvent transactionId order = do
   tagGroups <- order.orderFulfillments >>= listToMaybe >>= (.fulfillmentTags) & fromMaybeM (InvalidRequest "fulfillment.tags is not present in EstimateRepetition Event.")
   cancellationSource <- Utils.getTagV2 Tag.PREVIOUS_CANCELLATION_REASONS Tag.CANCELLATION_REASON (Just tagGroups) & fromMaybeM (InvalidRequest "previous_cancellation_reasons tag is not present in EstimateRepetition Event.")
   return $
-    DOnUpdate.EstimateRepetitionReq
-      { searchRequestId = Id transactionId,
-        bppEstimateId = Id bppEstimateId,
-        bppBookingId = Id bppBookingId,
-        bppRideId = Id bppRideId,
-        cancellationSource = Utils.castCancellationSourceV2 cancellationSource
-      }
+    DOnUpdate.OUEstimateRepetitionReq
+      DOnUpdate.EstimateRepetitionReq
+        { searchRequestId = Id transactionId,
+          bppEstimateId = Id bppEstimateId,
+          bppBookingId = Id bppBookingId,
+          bppRideId = Id bppRideId,
+          cancellationSource = Utils.castCancellationSourceV2 cancellationSource
+        }
 
 parseSafetyAlertEvent :: (MonadFlow m) => Spec.Order -> m DOnUpdate.OnUpdateReq
 parseSafetyAlertEvent order = do
@@ -128,17 +130,19 @@ parseSafetyAlertEvent order = do
   tagGroups <- order.orderFulfillments >>= listToMaybe >>= (.fulfillmentTags) & fromMaybeM (InvalidRequest "fulfillment.tags is not present in SafetyAlert Event.")
   deviation <- Utils.getTagV2 Tag.SAFETY_ALERT Tag.DEVIATION (Just tagGroups) & fromMaybeM (InvalidRequest "safety_alert tag is not present in SafetyAlert Event.")
   return $
-    DOnUpdate.SafetyAlertReq
-      { bppBookingId = Id bppBookingId,
-        bppRideId = Id bppRideId,
-        reason = deviation,
-        code = "deviation"
-      }
+    DOnUpdate.OUSafetyAlertReq
+      DOnUpdate.SafetyAlertReq
+        { bppBookingId = Id bppBookingId,
+          bppRideId = Id bppRideId,
+          reason = deviation,
+          code = "deviation"
+        }
 
 parseStopArrivedEvent :: (MonadFlow m) => Spec.Order -> m DOnUpdate.OnUpdateReq
 parseStopArrivedEvent order = do
   bppRideId <- order.orderFulfillments >>= listToMaybe >>= (.fulfillmentId) & fromMaybeM (InvalidRequest "fulfillment_id is not present in StopArrived Event.")
   return $
-    DOnUpdate.StopArrivedReq
-      { bppRideId = Id bppRideId
-      }
+    DOnUpdate.OUStopArrivedReq $
+      DOnUpdate.StopArrivedReq
+        { bppRideId = Id bppRideId
+        }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs
@@ -86,26 +86,26 @@ processStop bookingId loc merchantId isEdit = do
   QRB.updateStop booking (Just location)
   bppBookingId <- booking.bppBookingId & fromMaybeM (BookingFieldNotPresent "bppBookingId")
   merchant <- CQMerchant.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
-  let dUpdateReq =
+  let details =
         if isEdit
           then
-            ACL.EditStopBuildReq
-              { bppId = booking.providerId,
-                bppUrl = booking.providerUrl,
-                transactionId = booking.transactionId,
-                stops = [mkDomainLocation location],
-                city = merchant.defaultCity, -- TODO: Correct during interoperability
-                ..
-              }
+            ACL.UEditStopBuildReqDetails $
+              ACL.EditStopBuildReqDetails
+                { stops = [mkDomainLocation location]
+                }
           else
-            ACL.AddStopBuildReq
-              { bppId = booking.providerId,
-                bppUrl = booking.providerUrl,
-                transactionId = booking.transactionId,
-                stops = [mkDomainLocation location],
-                city = merchant.defaultCity, -- TODO: Correct during interoperability
-                ..
-              }
+            ACL.UAddStopBuildReqDetails $
+              ACL.AddStopBuildReqDetails
+                { stops = [mkDomainLocation location]
+                }
+  let dUpdateReq =
+        ACL.UpdateBuildReq
+          { bppId = booking.providerId,
+            bppUrl = booking.providerUrl,
+            transactionId = booking.transactionId,
+            city = merchant.defaultCity, -- TODO: Correct during interoperability
+            ..
+          }
   becknUpdateReq <- ACL.buildUpdateReq dUpdateReq
   void . withShortRetry $ CallBPP.update booking.providerUrl becknUpdateReq
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Ride.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Ride.hs
@@ -232,14 +232,20 @@ editLocation rideId (_, merchantId) req = do
     let origin = Just $ mkDomainLocation pickup
     bppBookingId <- booking.bppBookingId & fromMaybeM (BookingFieldNotPresent "bppBookingId")
     let dUpdateReq =
-          ACL.EditLocationBuildReq
-            { bppRideId = ride.bppRideId,
+          ACL.UpdateBuildReq
+            { bppBookingId,
+              merchant,
               bppId = booking.providerId,
               bppUrl = booking.providerUrl,
               transactionId = booking.transactionId,
-              destination = Nothing,
               city = merchant.defaultCity, -- TODO: Correct during interoperability
-              ..
+              details =
+                ACL.UEditLocationBuildReqDetails $
+                  ACL.EditLocationBuildReqDetails
+                    { bppRideId = ride.bppRideId,
+                      origin,
+                      destination = Nothing
+                    }
             }
     becknUpdateReq <- ACL.buildUpdateReq dUpdateReq
     void . withShortRetry $ CallBPP.update booking.providerUrl becknUpdateReq

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Beam/AadhaarVerification/AadhaarOtpReq.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Beam/AadhaarVerification/AadhaarOtpReq.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.AadhaarVerification.AadhaarOtpReq where

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Beam/AadhaarVerification/AadhaarOtpVerify.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Beam/AadhaarVerification/AadhaarOtpVerify.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.AadhaarVerification.AadhaarOtpVerify where

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Beam/AadhaarVerification/AadhaarVerification.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Beam/AadhaarVerification/AadhaarVerification.hs
@@ -12,7 +12,6 @@
   the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.AadhaarVerification.AadhaarVerification where

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Beam/LocationMapping.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Beam/LocationMapping.hs
@@ -12,7 +12,6 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Storage.Beam.LocationMapping where


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
Remove partial fields


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
suppose we have type
`data Foo = Bar {bar :: Int, cat :: Int} | Baz {baz :: Text}`
then `bar` will be partial field, i.e.

- if record created with `Bar` constructor, then all is okay;

- if record created with `Baz` constructor, and then somewhere in code we try to reach this field, we get error in runtime, which is not appear in logs and hard to debug:

```
let foo = Baz {baz = "Baz"}
...
foo.bar -- error in runtime
```
So I think we should remove this partial fields from our code, adding extra layer of definitions:

```
data Foo = Bar Bar' | Baz Baz'
data Bar' = Bar' {bar :: Int, cat :: Int} 
newtype Baz' = Baz' {baz :: Text}

let foo = Baz $ Baz' {baz = "Baz"}
...
case foo of
  Bar bar -> Just bar.bar
  Baz baz -> Nothing
```
With this approach unsafe code can't be compiled
 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
