### PR TITLE
backend/nix: Avoid unnecessary rebuilds

### DIFF
--- a/Backend/default.nix
+++ b/Backend/default.nix
@@ -15,7 +15,15 @@
     ];
 
     haskellProjects.default = {
-      projectRoot = ./.;
+      projectRoot = builtins.toString (pkgs.lib.fileset.toSource {
+        root = ./.;
+        fileset = pkgs.lib.fileset.unions [
+          ./app
+          ./lib
+          ./test
+          ./cabal.project
+        ];
+      });
       imports = [
         inputs.beckn-gateway.haskellFlakeProjectModules.output
         # inputs.namma-dsl.haskellFlakeProjectModules.output


### PR DESCRIPTION
With this change, when non-Haskell-related files change, the Haskell nix packages won't be rebuilt.

cf. https://github.com/srid/haskell-flake/issues/269