### PR TITLE
backend: Upgrade haskell-flake

### DIFF
--- a/.envrc.backend
+++ b/.envrc.backend
@@ -3,4 +3,4 @@ nix_direnv_watch_file \
     Backend/cabal.project \
     Backend/*.nix \
     Backend/nix/*.nix
-use flake .#backend --trace-verbose
+use flake .#backend --trace-verbose --show-trace

--- a/flake.lock
+++ b/flake.lock
@@ -349,11 +349,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1705651666,
-        "narHash": "sha256-BxNVuiCHrg4YiVJxOlHIfuEHIFkJZ0J+OBKa5d5CWLw=",
+        "lastModified": 1710791416,
+        "narHash": "sha256-a+BaHFhcAsNJlry9tbaWA9x/Qi1VOE8LwymCb954Gvs=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "fb176c0039b92ee459c09ab6fd3bee2ae73fae8c",
+        "rev": "58942765565ddc750934ab7f203971c8c16e979e",
         "type": "github"
       },
       "original": {
@@ -1636,11 +1636,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1705067885,
-        "narHash": "sha256-al2JqNIkXfLiVreqSJWly64Z6YVNphWBh4m3IxGIdYI=",
+        "lastModified": 1710675764,
+        "narHash": "sha256-ZpBoh1dVLTxC3wccOnsji7u/Ceuwh2raQn/Vq6BBYwo=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "8a526aaf98cde6af6b2d1d368e9acb460ee34547",
+        "rev": "ef955d7d239d7f82f343b569a4cf2c7c1a4df1f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Attempt to fix an `infinite recursion encountered` error in direnv (but doesn't happen in `nix develop .#backend` invocation), that came as a result of merging #5162 (see how `cac_client` is pulled from final package set and fed back into input packages), by upgrading `haskell-flake` (via common) to bring in https://github.com/srid/haskell-flake/pull/271

