### PR TITLE
frontend/frontend/showing confirm pickup when fav lies inside special zone, stats issue, IOS route label and driver pickup status text change

### DIFF
--- a/Frontend/ui-common/src/Engineering/Helpers/JBridge.js
+++ b/Frontend/ui-common/src/Engineering/Helpers/JBridge.js
@@ -618,10 +618,13 @@ export const parseAddress = function (json) {
 export const drawRoute = function (data, style, trackColor, isActual, sourceMarkerConfig, destMarkerConfig, polylineWidth, type, mapRouteConfig) {
   console.log("I AM HERE ------------------ IN DRAW ROUTE");
   try {
-    return window.JBridge.drawRoute(JSON.stringify(data), style, trackColor, isActual, JSON.stringify(sourceMarkerConfig), JSON.stringify(destMarkerConfig), polylineWidth, type, JSON.stringify(mapRouteConfig));
+    if (window.__OS == "IOS" || methodArgumentCount("drawRoute") == 11) {
+      return window.JBridge.drawRoute(JSON.stringify(data), style, trackColor, isActual, sourceMarkerConfig.pointerIcon, destMarkerConfig.pointerIcon, polylineWidth, type, sourceMarkerConfig.primaryText, destMarkerConfig.primaryText, JSON.stringify(mapRouteConfig));  
+    } else {
+      return window.JBridge.drawRoute(JSON.stringify(data), style, trackColor, isActual, JSON.stringify(sourceMarkerConfig), JSON.stringify(destMarkerConfig), polylineWidth, type, JSON.stringify(mapRouteConfig));
+    }
   } catch (err) {
     console.log("error in draw route", err);
-    return window.JBridge.drawRoute(JSON.stringify(data), style, trackColor, isActual, sourceMarkerConfig.pointerIcon, destMarkerConfig.pointerIcon, polylineWidth, type, sourceMarkerConfig.primaryText, destMarkerConfig.primaryText, JSON.stringify(mapRouteConfig));
   }
 }
 

--- a/Frontend/ui-customer/src/Components/DriverInfoCard/View.purs
+++ b/Frontend/ui-customer/src/Components/DriverInfoCard/View.purs
@@ -1271,5 +1271,5 @@ driverPickUpStatusText state eta =
   case state.props.zoneType of
     SPECIAL_PICKUP -> getString IS_AT_PICKUP_LOCATION
     _ -> case eta of
-          "--" -> "is " <> eta <> getString AWAY
-          _    -> if state.data.waitingTime == "--" then getString IS_ON_THE_WAY else getString IS_WAITING_AT_PICKUP
+          "--" -> if state.data.waitingTime == "--" then getString IS_ON_THE_WAY else getString IS_WAITING_AT_PICKUP
+          _    -> "is " <> eta <> getString AWAY

--- a/Frontend/ui-customer/src/ModifyScreenTypes.purs
+++ b/Frontend/ui-customer/src/ModifyScreenTypes.purs
@@ -22,7 +22,7 @@ import Engineering.Helpers.BackTrack (modifyState, getState)
 import Prelude (Unit, bind, ($))
 import Resources.Constants (encodeAddress, getAddressFromBooking)
 import Screens.HomeScreen.ScreenData (initData) as HomeScreen
-import Screens.Types (MyRidesScreenState, Stage(..), Trip(..))
+import Screens.Types (MyRidesScreenState, Stage(..), Trip(..), LocationSelectType(..))
 import Types.App (FlowBT, GlobalState(..), ScreenType(..))
 
 modifyScreenState :: ScreenType -> FlowBT String Unit
@@ -63,39 +63,6 @@ modifyScreenState st =
     MetroTicketStatusScreenStateType a -> modifyState (\(GlobalState state) -> GlobalState $ state {metroTicketStatusScreen = a state.metroTicketStatusScreen})
     GlobalFlowCacheType a -> modifyState (\(GlobalState state) -> GlobalState $ state {globalFlowCache = a state.globalFlowCache})
 
-updateRideDetails :: MyRidesScreenState -> FlowBT String Unit
-updateRideDetails state = do 
-  (GlobalState globalState) <- getState
-  modifyScreenState $ HomeScreenStateType 
-    (\homeScreen -> HomeScreen.initData{ 
-    data {
-      source =  state.data.selectedItem.source
-    , destination = state.data.selectedItem.destination
-    , locationList = homeScreen.data.locationList
-    , sourceAddress = getAddressFromBooking state.data.selectedItem.sourceLocation
-    , savedLocations = homeScreen.data.savedLocations
-    , destinationAddress = getAddressFromBooking state.data.selectedItem.destinationLocation 
-    , settingSideBar {
-        gender = globalState.homeScreen.data.settingSideBar.gender 
-      , email = globalState.homeScreen.data.settingSideBar.email
-      , hasCompletedSafetySetup = globalState.homeScreen.data.settingSideBar.hasCompletedSafetySetup
-    }
-    }
-    , props{
-      sourceSelectedOnMap = true
-    , sourceLat = state.data.selectedItem.sourceLocation^._lat
-    , sourceLong = state.data.selectedItem.sourceLocation^._lon
-    , destinationLat = state.data.selectedItem.destinationLocation^._lat
-    , destinationLong = state.data.selectedItem.destinationLocation^._lon
-    , currentStage = FindingEstimate
-    , rideRequestFlow = true
-    , isSpecialZone = state.data.selectedItem.isSpecialZone
-    , isBanner = globalState.homeScreen.props.isBanner
-    , sosBannerType = globalState.homeScreen.props.sosBannerType 
-    , followsRide = globalState.homeScreen.props.followsRide
-    , isSafetyCenterDisabled = globalState.homeScreen.props.isSafetyCenterDisabled
-    }
-    })
     
 updateRepeatRideDetails :: Trip -> FlowBT String Unit
 updateRepeatRideDetails state = do 
@@ -116,7 +83,7 @@ updateRepeatRideDetails state = do
     }
     }
     , props{
-      sourceSelectedOnMap = true
+      rideSearchProps { sourceSelectType = REPEAT_RIDE }
     , sourceLat = state.sourceLat
     , sourceLong = state.sourceLong
     , destinationLat = state.destLat

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ScreenData.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ScreenData.purs
@@ -20,7 +20,7 @@ import Components.LocationListItem.Controller (locationListStateObj)
 import Components.SettingSideBar.Controller (SettingSideBarState, Status(..))
 import Components.ChooseVehicle.Controller (SearchType(..)) as CV
 import Data.Maybe (Maybe(..))
-import Screens.Types (Contact, DriverInfoCard, HomeScreenState, LocationListItemState, PopupType(..), RatingCard(..), SearchLocationModelType(..), Stage(..), Address, EmergencyHelpModelState, ZoneType(..), SpecialTags, TipViewStage(..), SearchResultType(..), Trip(..), City(..), SheetState(..), BottomNavBarIcon(..), ReferralStatus(..))
+import Screens.Types (Contact, DriverInfoCard, HomeScreenState, LocationListItemState, PopupType(..), RatingCard(..), SearchLocationModelType(..), Stage(..), Address, EmergencyHelpModelState, ZoneType(..), SpecialTags, TipViewStage(..), SearchResultType(..), Trip(..), City(..), SheetState(..), BottomNavBarIcon(..), ReferralStatus(..), LocationSelectType(..))
 import Services.API (DriverOfferAPIEntity(..), QuoteAPIDetails(..), QuoteAPIEntity(..), PlaceName(..), LatLong(..), SpecialLocation(..), QuoteAPIContents(..), RideBookingRes(..), RideBookingAPIDetails(..), RideBookingDetails(..), FareRange(..), FareBreakupAPIEntity(..))
 import Prelude (($) ,negate)
 import Data.Array (head)
@@ -194,7 +194,6 @@ initData = {
     , isLocationTracking : false
     , isInApp : true
     , locateOnMap : false
-    , sourceSelectedOnMap : false
     , distance : 0
     , isSrcServiceable : true
     , isDestServiceable : true
@@ -304,6 +303,7 @@ initData = {
           , sourceManuallyMoved : false
           , destManuallyMoved : false
           , autoCompleteType : Nothing
+          , sourceSelectType : SEARCH
         }
     , selectedEstimateHeight : 0
     , isSafetyCenterDisabled : false

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/View.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/View.purs
@@ -349,7 +349,7 @@ view push state =
                     [ width MATCH_PARENT
                     , height MATCH_PARENT
                     , background Color.transparent
-                    , padding (PaddingBottom if os == "IOS" then 60 else 70)
+                    , padding $ PaddingBottom $ (if os == "IOS" then 60 else 70) + extraPadding
                     , gravity CENTER
                     , accessibility DISABLE
                     , orientation VERTICAL
@@ -386,7 +386,7 @@ view push state =
                     [ width MATCH_PARENT
                     , height MATCH_PARENT
                     , background Color.transparent
-                    , padding (PaddingBottom 95)
+                    , padding $ PaddingBottom $ 95 + extraPadding
                     , gravity CENTER
                     , accessibility DISABLE
                     , orientation VERTICAL
@@ -403,7 +403,7 @@ view push state =
                     [ width MATCH_PARENT
                     , height MATCH_PARENT
                     , background Color.transparent
-                    , padding (PaddingBottom 36)
+                    , padding $ PaddingBottom $ 36 + extraPadding
                     , gravity CENTER
                     , accessibility DISABLE
                     , orientation VERTICAL

--- a/Frontend/ui-customer/src/Screens/Types.purs
+++ b/Frontend/ui-customer/src/Screens/Types.purs
@@ -703,7 +703,6 @@ type HomeScreenStateProps =
   , isLocationTracking :: Boolean
   , isInApp :: Boolean
   , locateOnMap :: Boolean
-  , sourceSelectedOnMap :: Boolean
   , distance :: Int
   , isSrcServiceable :: Boolean
   , isDestServiceable :: Boolean
@@ -2184,6 +2183,7 @@ type RideSearchProps = {
   , sourceManuallyMoved :: Boolean
   , destManuallyMoved :: Boolean
   , autoCompleteType :: Maybe AutoCompleteReqType
+  , sourceSelectType :: LocationSelectType
 }
 
 data AutoCompleteReqType = PICKUP | DROP
@@ -2219,3 +2219,8 @@ type HotSpotData = {
     lat :: Number
   , lon :: Number
 }
+
+data LocationSelectType = SEARCH | MAP | FAVOURITE | REPEAT_RIDE | RETRY_SEARCH | SUGGESTION
+
+derive instance genericLocationSelectType :: Generic LocationSelectType _
+instance eqLocationSelectType :: Eq LocationSelectType where eq = genericEq

--- a/Frontend/ui-driver/src/Screens/HomeScreen/View.purs
+++ b/Frontend/ui-driver/src/Screens/HomeScreen/View.purs
@@ -945,7 +945,6 @@ statsModel push state =
               , height WRAP_CONTENT
               , text $ "₹" <> formatCurrencyWithCommas (show state.data.totalEarningsOfDay)
               , color Color.black800
-              , visibility $ boolToVisibility state.data.driverStats
               ] <> FontStyle.h2 TypoGraphy
             , imageView 
               [ width $ V 12
@@ -981,7 +980,6 @@ statsModel push state =
                               true -> getString COINS
                               false -> show state.data.coinBalance
                   , color Color.black700
-                  , visibility $ boolToVisibility state.data.driverStats
                   ] <> FontStyle.tags TypoGraphy
               ]
             , imageView 
@@ -1015,8 +1013,8 @@ expandedStatsModel push state =
       [ width MATCH_PARENT
       , height WRAP_CONTENT
       , gravity CENTER_VERTICAL
-      ][ commonTV push (getString TODAYS_EARNINGS_STR) Color.black700 FontStyle.tags LEFT 0 ToggleStatsModel true true
-      , commonTV push ("₹" <> formatCurrencyWithCommas (show state.data.totalEarningsOfDay)) Color.black800 FontStyle.h2 RIGHT 0 ToggleStatsModel false state.data.driverStats
+      ][ commonTV push (getString TODAYS_EARNINGS_STR) Color.black700 FontStyle.tags LEFT 0 ToggleStatsModel true
+      , commonTV push ("₹" <> formatCurrencyWithCommas (show state.data.totalEarningsOfDay)) Color.black800 FontStyle.h2 RIGHT 0 ToggleStatsModel false
       , imageView 
         [ width $ V 12
         , height $ V 12
@@ -1031,15 +1029,15 @@ expandedStatsModel push state =
       , height WRAP_CONTENT
       , margin $ MarginTop 10
       , gravity CENTER_VERTICAL
-      ][ commonTV push (getString TRIP_EARNINGS) Color.black700 FontStyle.body3 LEFT 0 NoAction true true
-        , commonTV push ("₹" <> formatCurrencyWithCommas (show (state.data.totalEarningsOfDay - state.data.bonusEarned))) Color.black800 FontStyle.subHeading1 RIGHT 0 NoAction false state.data.driverStats
+      ][ commonTV push (getString TRIP_EARNINGS) Color.black700 FontStyle.body3 LEFT 0 NoAction true
+        , commonTV push ("₹" <> formatCurrencyWithCommas (show (state.data.totalEarningsOfDay - state.data.bonusEarned))) Color.black800 FontStyle.subHeading1 RIGHT 0 NoAction false
       ]
     , linearLayout
       [ width MATCH_PARENT
       , height WRAP_CONTENT
       , gravity CENTER_VERTICAL
       , margin $ MarginTop 10
-      ][ commonTV push (getString BONUS_EARNED) Color.black700 FontStyle.body3 LEFT 0 NoAction false true
+      ][ commonTV push (getString BONUS_EARNED) Color.black700 FontStyle.body3 LEFT 0 NoAction false
         , imageView 
           [ width $ V 12
           , height $ V 12
@@ -1047,7 +1045,7 @@ expandedStatsModel push state =
           , imageWithFallback $ HU.fetchImage HU.FF_COMMON_ASSET "ny_ic_info_grey"
           , onClick push $ const $ ToggleBonusPopup
           ]
-        , commonTV push ("₹" <> formatCurrencyWithCommas (show state.data.bonusEarned)) Color.green900 FontStyle.subHeading1 RIGHT 0 NoAction true state.data.driverStats
+        , commonTV push ("₹" <> formatCurrencyWithCommas (show state.data.bonusEarned)) Color.green900 FontStyle.subHeading1 RIGHT 0 NoAction true
       ]
     , separatorView 10
     , linearLayout
@@ -1055,13 +1053,13 @@ expandedStatsModel push state =
       , height WRAP_CONTENT
       , margin $ MarginTop 10
       , gravity CENTER_VERTICAL
-      ][ commonTV push (show state.data.totalRidesOfDay <> " " <> getString TRIPS) Color.black700 FontStyle.tags LEFT 0 NoAction true state.data.driverStats
-        , commonTV push (getString VIEW_MORE) Color.blue900 FontStyle.body3 RIGHT 0 (GoToEarningsScreen false) false true
+      ][ commonTV push (show state.data.totalRidesOfDay <> " " <> getString TRIPS) Color.black700 FontStyle.tags LEFT 0 NoAction true
+        , commonTV push (getString VIEW_MORE) Color.blue900 FontStyle.body3 RIGHT 0 (GoToEarningsScreen false) false
       ]
   ]
 
-commonTV :: forall w .  (Action -> Effect Unit) -> String -> String -> (LazyCheck -> forall properties. (Array (Prop properties))) -> Gravity -> Int -> Action -> Boolean -> Boolean -> PrestoDOM (Effect Unit) w
-commonTV push text' color' theme gravity' marginTop action useWeight visible = 
+commonTV :: forall w .  (Action -> Effect Unit) -> String -> String -> (LazyCheck -> forall properties. (Array (Prop properties))) -> Gravity -> Int -> Action -> Boolean -> PrestoDOM (Effect Unit) w
+commonTV push text' color' theme gravity' marginTop action useWeight = 
   textView $
   [ width WRAP_CONTENT
   , height WRAP_CONTENT
@@ -1070,7 +1068,6 @@ commonTV push text' color' theme gravity' marginTop action useWeight visible =
   , gravity gravity'
   , margin $ MarginTop marginTop
   , onClick push $ const action
-  , visibility $ boolToVisibility visible
   ] <> theme TypoGraphy
     <> if useWeight then [weight 1.0] else []
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
1. showing confirm pickup if favourites is added from autoComplete response and lies inside any special zone
2. stats not visible post ride completion
3. IOS route label text was not correct
4. updated pickup status text in bottomsheet

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
