### PR TITLE
backend/fix: race condition of multiple booking creation

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnSelect.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnSelect.hs
@@ -110,9 +110,9 @@ onSelect OnSelectValidatedReq {..} = do
       let lowestFareQuote = selectLowestFareQuote quotes
       case lowestFareQuote of
         Just autoAssignQuote -> do
-          isLockAcquired <- SConfirm.tryInitTriggerLock person.id
+          isLockAcquired <- SConfirm.tryInitTriggerLock autoAssignQuote.requestId
           when isLockAcquired $ do
-            let dConfirmReq = SConfirm.DConfirmReq {personId = person.id, quoteId = autoAssignQuote.id, paymentMethodId = searchRequest.selectedPaymentMethodId}
+            let dConfirmReq = SConfirm.DConfirmReq {personId = person.id, quote = autoAssignQuote, paymentMethodId = searchRequest.selectedPaymentMethodId}
             dConfirmRes <- SConfirm.confirm dConfirmReq
             becknInitReq <- ACL.buildInitReqV2 dConfirmRes
             handle (errHandler dConfirmRes.booking) $

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Confirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Confirm.hs
@@ -51,7 +51,11 @@ confirm ::
   Id DQuote.Quote ->
   Maybe (Id DMPM.MerchantPaymentMethod) ->
   m SConfirm.DConfirmRes
-confirm personId quoteId paymentMethodId = SConfirm.confirm SConfirm.DConfirmReq {..}
+confirm personId quoteId paymentMethodId = do
+  isLockAcquired <- SConfirm.tryInitTriggerLock personId
+  unless isLockAcquired $ do
+    throwError . InvalidRequest $ "Lock on personId:-" <> personId.getId <> " to create booking already acquired, can't create booking for quoteId:-" <> quoteId.getId
+  SConfirm.confirm SConfirm.DConfirmReq {..}
 
 -- cancel booking when QUOTE_EXPIRED on bpp side, or other EXTERNAL_API_CALL_ERROR catched
 cancelBooking :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r) => DRB.Booking -> m ()

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Confirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Confirm.hs
@@ -49,14 +49,13 @@ import qualified Storage.CachedQueries.ValueAddNP as CQVAN
 import qualified Storage.Queries.Booking as QRideB
 import qualified Storage.Queries.Estimate as QEstimate
 import qualified Storage.Queries.Person as QPerson
-import qualified Storage.Queries.Quote as QQuote
 import qualified Storage.Queries.SearchRequest as QSReq
 import Tools.Error
 import Tools.Event
 
 data DConfirmReq = DConfirmReq
   { personId :: Id DP.Person,
-    quoteId :: Id DQuote.Quote,
+    quote :: DQuote.Quote,
     paymentMethodId :: Maybe (Id DMPM.MerchantPaymentMethod)
   }
 
@@ -87,9 +86,9 @@ data ConfirmQuoteDetails
   | ConfirmOneWaySpecialZoneDetails Text
   deriving (Show, Generic)
 
-tryInitTriggerLock :: (Redis.HedisFlow m r) => Id DP.Person -> m Bool
-tryInitTriggerLock personId = do
-  let initTriggerLockKey = "Customer:Init:Trigger:PersonId:-" <> personId.getId
+tryInitTriggerLock :: (Redis.HedisFlow m r) => Id DSReq.SearchRequest -> m Bool
+tryInitTriggerLock searchRequestId = do
+  let initTriggerLockKey = "Customer:Init:Trigger:SearchRequestId:-" <> searchRequestId.getId
       lockExpiryTime = 10 -- Note: this value should be decided based on the delay between consecutive quotes in on_select api & also considering reallocation.
   Redis.tryLockRedis initTriggerLockKey lockExpiryTime
 
@@ -106,7 +105,6 @@ confirm ::
   DConfirmReq ->
   m DConfirmRes
 confirm DConfirmReq {..} = do
-  quote <- QQuote.findById quoteId >>= fromMaybeM (QuoteDoesNotExist quoteId.getId)
   now <- getCurrentTime
   when (quote.validTill < now) $ throwError (InvalidRequest $ "Quote expired " <> show quote.id) -- init validation check
   fulfillmentId <-

--- a/Backend/dhall-configs/dev/secrets/rider-app.dhall
+++ b/Backend/dhall-configs/dev/secrets/rider-app.dhall
@@ -6,4 +6,6 @@
     "How wonderful it is that nobody need wait a single moment before starting to improve the world"
 , dashboardToken = "some-secret-dashboard-token-for-rider-app"
 , internalAPIKey = "test-bap-api-key"
+, clickHouseUsername = "default"
+, clickHousePassword = ""
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Before creating a booking in `on_select`, after above change we will first try to acquire lock on the basis of `personId`, to avoid multiple booking creation for same person.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Fixes race condition of multiple booking creation for same person at same time when consecutive `on_select` callbacks are received. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested locally.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
