### PR TITLE
Backend/fix/white listing logic

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -126,6 +126,7 @@ data NearestDriverInfo = NearestDriverInfo
     distanceToNearestDriver :: Meters,
     driverLatLongs :: NonEmpty LatLong
   }
+  deriving (Generic, Show)
 
 getDistanceAndDuration :: Id DM.Merchant -> Id DMOC.MerchantOperatingCity -> LatLong -> LatLong -> Maybe Meters -> Maybe Seconds -> Flow (Meters, Seconds)
 getDistanceAndDuration _ _ _ _ (Just distance) (Just duration) = return (distance, duration)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Track.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Track.hs
@@ -47,6 +47,7 @@ data DTrackRes = TrackRes
     driverLocation :: Maybe DriverLocation,
     isValueAddNP :: Bool
   }
+  deriving (Generic, Show)
 
 track ::
   (CacheFlow m r, EsqDBFlow m r, HasFlowEnv m r '["ltsCfg" ::: LocationTrackingeServiceConfig]) =>
@@ -67,7 +68,9 @@ track transporterId req = do
     if not isValueAddNP
       then do
         driverLocations <- LF.driversLocation [ride.driverId]
-        return $ listToMaybe $ sortBy (comparing (Down . (.coordinatesCalculatedAt))) driverLocations
+        let resLoc = listToMaybe $ sortBy (comparing (Down . (.coordinatesCalculatedAt))) driverLocations
+        logTagDebug ("rideId:-" <> show ride.id) $ "track driverLocation:-" <> show resLoc
+        return resLoc
       else return Nothing
   return $
     TrackRes

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnTrack.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnTrack.hs
@@ -63,7 +63,8 @@ onTrack ValidatedOnTrackReq {..} = do
         void $ QRide.updateTrackingUrl ride.id trackUrl'
     else do
       whenJust trackingLocation $ \trackingLocation' -> do
-        void $ Hedis.setExp (Common.mkRideTrackingRedisKey ride.id.getId) trackingLocation' 10
+        logDebug $ "Updating tracking location for ride:" <> show ride.id <> " to " <> show trackingLocation'
+        void $ Hedis.setExp (Common.mkRideTrackingRedisKey ride.id.getId) trackingLocation' 60
 
 validateRequest :: (CacheFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r) => OnTrackReq -> m ValidatedOnTrackReq
 validateRequest OnTrackReq {..} = do

--- a/flake.lock
+++ b/flake.lock
@@ -3818,11 +3818,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1712765841,
-        "narHash": "sha256-MaU+3Ut3sXlFoU14xQFEOMUf06vC/DI2eNhiSs2SMm8=",
+        "lastModified": 1712954164,
+        "narHash": "sha256-h0dN+22guRolVIEH+qsRP1Nm1QJlhqz5PKBA7TzE+fA=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "1cdbef10e52398e29957f4679fe3f8c1eab10a66",
+        "rev": "47e8c462d7e68f3e451c0df7492ecad47d8dcc90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
1. Moved white-list & black-list checks out of caching part of `registryLookup`.
2. Made`on_search` quotes `[]` for non value-add-np transactions.
3. Moved `rating` api call of BAP to BPP, in forked thread to not propagate failure cases. 

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
1. Currently, whitelisting logic checks were inside caching part, because of which if once a network participant is whitelisted, it will get cached and even if we remove them from whitelist table, their requests will still reach our server. So moved the checks outside of caching part.
2. `on_search` were not being sent for non value-add-np when `quotes` were non-empty, so made them always `[]` when its a non value-add-np transaction.
3. Currently if `rating` api call failed on BPP end, it will propagate to UI call, which will result for stuck UI screen. So moved the call to forked thread as its non-critical.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested locally.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
