### PR TITLE
backend/enh: adds support for driver call to rider-exophone number

### DIFF
--- a/Backend/dev/migrations/rider-app/1250-add-idx-ride-driver-mobile-number-and-status.sql
+++ b/Backend/dev/migrations/rider-app/1250-add-idx-ride-driver-mobile-number-and-status.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY idx_ride_driver_mobile_number_and_status ON atlas_app.ride USING btree (driver_mobile_number, status);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
- Adds fetch for customer number when call is from driver on rider-app configured exophone number.
- Adds driver number based query on `ride` table.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->
1. Adds index on `ride` table for `driver_mobile_number` and `status`.
2. Adds custom redis caching for `rideId` on `driverMobileNumber`.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Issue: 
- In case of offus transactions, we share virtual numbers to bpp instead of original numbers, so when other bpp driver tries to connect our customer it will not be able to connect because our virtual number callbacks are configured to only lookup for driver number for the caller active ride.
Solution: 
- Adds fallback logic to find customer number when caller number linked rider is not found.
- Also adds queries on ride table to find active rides of a certain driver number.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested caching part locally, for calling will have to test in master.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
