### PR TITLE
backend/fix: fixes message_id in context for on_status callbacks

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Status.hs
@@ -55,7 +55,8 @@ status transporterId (SignatureAuthResult _ subscriber) reqV2 = withFlowHandlerB
     callbackUrl <- Utils.getContextBapUri context
     dStatusRes <- DStatus.handler transporterId dStatusReq
     internalEndPointHashMap <- asks (.internalEndPointHashMap)
-    onStautusReq <- ACL.buildOnStatusReqV2 dStatusRes.transporter dStatusRes.booking dStatusRes.info
+    msgId <- Utils.getMessageId context
+    onStautusReq <- ACL.buildOnStatusReqV2 dStatusRes.transporter dStatusRes.booking dStatusRes.info (Just msgId)
     Callback.withCallback dStatusRes.transporter "STATUS" OnStatus.onStatusAPIV2 callbackUrl internalEndPointHashMap (errHandler onStautusReq.onStatusReqContext) $
       pure onStautusReq
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnStatus.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnStatus.hs
@@ -159,9 +159,10 @@ buildOnStatusReqV2 ::
   DM.Merchant ->
   DRB.Booking ->
   DStatus.OnStatusBuildReq ->
+  Maybe Text ->
   m Spec.OnStatusReq
-buildOnStatusReqV2 merchant booking req = do
-  msgId <- generateGUID
+buildOnStatusReqV2 merchant booking req mbMessageId = do
+  msgId <- maybe generateGUID pure mbMessageId
   let bppId = getShortId $ merchant.subscriberId
       city = fromMaybe merchant.city booking.bapCity
       country = fromMaybe merchant.country booking.bapCountry

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
@@ -382,7 +382,7 @@ sendRideStartedUpdateToBAP booking ride tripStartLocation = do
   let bookingDetails = ACL.BookingDetails {..}
       rideStartedBuildReq = ACL.RideStartedReq ACL.DRideStartedReq {..}
   retryConfig <- asks (.longDurationRetryCfg)
-  rideStartedMsgV2 <- ACL.buildOnStatusReqV2 merchant booking rideStartedBuildReq
+  rideStartedMsgV2 <- ACL.buildOnStatusReqV2 merchant booking rideStartedBuildReq Nothing
   void $ callOnStatusV2 rideStartedMsgV2 retryConfig
 
 sendRideCompletedUpdateToBAP ::

--- a/Backend/dev/migrations/rider-app/1250-add-createdAt-updatedAt-to-tables.sql
+++ b/Backend/dev/migrations/rider-app/1250-add-createdAt-updatedAt-to-tables.sql
@@ -1,28 +1,28 @@
 --- Please run these queries while doing deployment
 
-ALTER TABLE atlas_app.black_list_org ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
-ALTER TABLE atlas_app.black_list_org ADD COLUMN updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.black_list_org ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.black_list_org ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.white_list_org ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
-ALTER TABLE atlas_app.white_list_org ADD COLUMN updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.white_list_org ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.white_list_org ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.trip_terms ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
-ALTER TABLE atlas_app.trip_terms ADD COLUMN updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.trip_terms ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.trip_terms ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.special_zone_quote ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
-ALTER TABLE atlas_app.special_zone_quote ADD COLUMN updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.special_zone_quote ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.special_zone_quote ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.quote ADD COLUMN updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.quote ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.person_disability ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.person_disability ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.special_zone_quote ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
-ALTER TABLE atlas_app.special_zone_quote ADD COLUMN updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.special_zone_quote ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.special_zone_quote ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.driver_offer ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.driver_offer ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.cancellation_reason ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
-ALTER TABLE atlas_app.cancellation_reason ADD COLUMN updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.cancellation_reason ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.cancellation_reason ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
 
-ALTER TABLE atlas_app.booking_cancellation_reason ADD COLUMN created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
-ALTER TABLE atlas_app.booking_cancellation_reason ADD COLUMN updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.booking_cancellation_reason ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;
+ALTER TABLE atlas_app.booking_cancellation_reason ADD COLUMN IF NOT EXISTS updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
- Either uses same `message_id` when `on_status` is triggered as a callback to bap `status` beckn api call else generates new UUID.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
- Ride Sync api are triggerred by cronjob to sync stuck rides, `on_status` api on bap side are used both during ride flow & cronjob. So to differentiate among which callback it is, we track them using `message_id`.
- But on bpp side we always generate new UUID for `on_status` callback regardless of how it was triggerred, so to fix it added a param to pass `message_id` during `on_status` if we have one else it will generate new.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Locally.

## Screenshot of test results
<!-- Provide screenshot of the test results -->
<img width="1051" alt="Tested Succesfully" src="https://github.com/nammayatri/nammayatri/assets/77069644/57f428e3-e30a-4ffa-ace0-a0eaba7c53f4">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [x] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
