### PR TITLE
frontend/#6625/active booking already exists issue

### DIFF
--- a/Frontend/ui-common/src/Engineering/Helpers/Log.purs
+++ b/Frontend/ui-common/src/Engineering/Helpers/Log.purs
@@ -25,7 +25,7 @@ import Foreign.Class (class Encode, encode)
 import Foreign.Object (Object, empty, insert, lookup)
 import Tracker (trackActionObject, trackScreenEnd, trackScreen, trackScreenEvent)
 import Tracker.Types (Action(..), Level(..), Screen(..)) as Tracker
-import Prelude (Unit, pure, unit, ($), (<$>), (<<<), (/=), (&&),bind, not, show)
+import Prelude (Unit, pure, unit, ($), (<$>), (<<<), (/=), (&&),bind, not, show, (<>))
 import Effect.Unsafe (unsafePerformEffect)
 import Control.Applicative
 
@@ -131,3 +131,6 @@ logInfo key value =
 logWarn :: forall f a. Applicative f => Encode a => String -> a -> f Unit
 logWarn key value =
   logImpl Tracker.Warning key value -- warnings will not be shown in kibana
+
+logStatus :: forall f a. Applicative f => Encode a => String -> a -> f Unit
+logStatus key = logImpl Tracker.Info ("flow_status_" <> key)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
1. active booking already exists status from api error does not continue with the further flow but stuck at current screen, forcing users to reopen the app to update the status.
2. after preventing user interaction on screen at the same time when driver already accepted the ride, the rideBooking api still does not gives active ride details due to DB updates, so calling rideBooking api polling in such cases with confirming ride screen to get data when available and update respective screen.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
