### PR TITLE
backend/fix: adds lock during otp ride create to fix duplicate ride creation

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
@@ -228,3 +228,6 @@ searchRequestKey sId = "Driver:Search:Request:" <> sId
 
 multipleRouteKey :: Text -> Text
 multipleRouteKey id = "multiple-routes-" <> id
+
+confirmLockKey :: Id DBooking.Booking -> Text
+confirmLockKey (Id id) = "Driver:Confirm:BookingId-" <> id


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Adds lock on `bookingId` before ride creation during ride otp driver assignment.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
- During ride otp flow, driver is assigned from dashboard and during this if that api is somehow triggered twice, then two rides are created for driver and rider with same `bookingId`. 
- In such cases, its tricky to figure which ride is picked up by UI, and in case if it picks wrong set of ride for customer and driver than ride becomes stuck for rider.
- To fix this, have added a lock before creating ride in ride otp flow.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested locally.

## Screenshot of test results
<!-- Provide screenshot of the test results -->
<img width="804" alt="image" src="https://github.com/nammayatri/nammayatri/assets/77069644/103398b1-3937-4a60-ae69-1c4b7e8d4167">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [x] I added integration tests for my changes where possible
- [x] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
