### PR TITLE
backend/fix/validate-Past-booking-date-for-ticket-booking-service

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
@@ -141,7 +141,8 @@ getStatus (personId, merchantId, merchantOperatingCityId) orderId = do
             bankErrorMessage = firstInvoice >>= (.bankErrorMessage),
             isRetried = Just $ order.isRetried,
             isRetargeted = Just $ order.isRetargeted,
-            retargetLink = order.retargetLink
+            retargetLink = order.retargetLink,
+            refunds = []
           }
     else do
       let serviceName = fromMaybe DP.YATRI_SUBSCRIPTION mbServiceName

--- a/Backend/lib/payment/src/Lib/Payment/Domain/Action.hs
+++ b/Backend/lib/payment/src/Lib/Payment/Domain/Action.hs
@@ -55,7 +55,8 @@ data PaymentStatusResp
         bankErrorCode :: Maybe Text,
         isRetried :: Maybe Bool,
         isRetargeted :: Maybe Bool,
-        retargetLink :: Maybe Text
+        retargetLink :: Maybe Text,
+        refunds :: [Payment.RefundsData]
       }
   | MandatePaymentStatus
       { status :: Payment.TransactionStatus,
@@ -287,7 +288,7 @@ orderStatusService personId orderId orderStatusCall = do
         )
         transactionUUID
       mapM_ updateRefundStatus refunds
-      return $ PaymentStatus {status = transactionStatus, bankErrorCode = orderTxn.bankErrorCode, bankErrorMessage = orderTxn.bankErrorMessage, isRetried = isRetriedOrder, isRetargeted = isRetargetedOrder, retargetLink = retargetPaymentLink}
+      return $ PaymentStatus {status = transactionStatus, bankErrorCode = orderTxn.bankErrorCode, bankErrorMessage = orderTxn.bankErrorMessage, isRetried = isRetriedOrder, isRetargeted = isRetargetedOrder, retargetLink = retargetPaymentLink, refunds = refunds}
     _ -> throwError $ InternalError "Unexpected Order Status Response."
 
 data OrderTxn = OrderTxn


### PR DESCRIPTION
1
added order status api call if any status is in pending refund to update the status
2
Earlier-
there was no check for past ticket booking request so past tickets could also be booked
now -
added the check if current time is greater than start time (visit date and start time of business hour) throw error

 