### PR TITLE
backend/feat/fcm_for_first_ride_event

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Call.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Call.hs
@@ -119,7 +119,7 @@ initiateCallToCustomer rideId merchantOpCityId = do
   let callReq =
         InitiateCallReq
           { fromPhoneNum = providerPhone,
-            toPhoneNum = customerPhone,
+            toPhoneNum = Just customerPhone,
             attachments = Attachments $ CallAttachments {callStatusId = callStatusId, entityId = rideId.getId}
           }
   exotelResponse <- initiateCall booking.providerId merchantOpCityId callReq
@@ -155,7 +155,7 @@ getDriverMobileNumber (driverId, merchantId, merchantOpCityId) rcNo = do
   let callReq =
         InitiateCallReq
           { fromPhoneNum = linkedDriverNumber,
-            toPhoneNum = driverRequestedNumber,
+            toPhoneNum = Just driverRequestedNumber,
             attachments = Attachments $ CallAttachments {callStatusId = callStatusId, entityId = vehicleRC.id.getId}
           }
   exotelResponse <- initiateCall merchantId merchantOpCityId callReq

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
@@ -384,6 +384,8 @@ rideCompletedReqHandler ValidatedRideCompletedReq {..} = do
         totalCount <- B.runInReplica $ QRB.findCountByRideIdStatusAndVehicleServiceTierType booking.riderId BT.COMPLETED (getListOfServiceTireTypes $ DVST.castServiceTierToCategory booking.vehicleServiceTierType)
         personClientInfo <- buildPersonClientInfo booking.riderId booking.clientId booking.merchantOperatingCityId booking.merchantId (DVST.castServiceTierToCategory booking.vehicleServiceTierType) (totalCount + 1)
         QCP.create personClientInfo
+        when (totalCount + 1 == 1) $ do
+          Notify.notifyFirstRideEvent booking.riderId (DVST.castServiceTierToCategory booking.vehicleServiceTierType)
   triggerRideEndEvent RideEventData {ride = updRide, personId = booking.riderId, merchantId = booking.merchantId}
   triggerBookingCompletedEvent BookingEventData {booking = booking{status = DRB.COMPLETED}}
   when shouldUpdateRideComplete $ void $ QP.updateHasTakenValidRide booking.riderId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Call.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Call.hs
@@ -110,7 +110,7 @@ initiateCallToDriver rideId = do
   let callReq =
         Call.InitiateCallReq
           { fromPhoneNum = customerPhone,
-            toPhoneNum = providerPhone,
+            toPhoneNum = Just providerPhone,
             attachments = Call.Attachments $ CallAttachments {callStatusId = callStatusId, rideId = rideId}
           }
   let merchantOperatingCityId = booking.merchantOperatingCityId

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
@@ -19,6 +19,7 @@ import qualified Data.List as L
 import qualified Data.Text as T
 import Data.Time hiding (secondsToNominalDiffTime)
 import Domain.Action.UI.Quote as UQuote
+import qualified Domain.Types.BecknConfig as BecknConfig
 import qualified Domain.Types.Booking as SRB
 import qualified Domain.Types.BookingCancellationReason as SBCR
 import qualified Domain.Types.BppDetails as DBppDetails
@@ -236,6 +237,12 @@ notifyOnRideStarted booking ride = do
             "has started. Enjoy the ride!"
           ]
   notifyPerson person.merchantId merchantOperatingCityId person.id notificationData
+
+data FirstRideEventParam = FirstRideEventParam
+  { vehicleCategory :: BecknConfig.VehicleCategory,
+    hasTakenFirstValidRide :: Bool
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data RideCompleteParam = RideCompleteParam
   { driverName :: Text,
@@ -929,3 +936,28 @@ notifyTicketCancelled ticketBookingId ticketBookingCategoryName person = do
             "Check the app for details"
           ]
   notifyPerson person.merchantId person.merchantOperatingCityId person.id notificationData
+
+notifyFirstRideEvent :: (ServiceFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r) => Id Person -> BecknConfig.VehicleCategory -> m ()
+notifyFirstRideEvent personId vehicleCategory = do
+  person <- runInReplica $ Person.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
+  let merchantOperatingCityId = person.merchantOperatingCityId
+  let notificationData =
+        Notification.NotificationReq
+          { category = Notification.FIRST_RIDE_EVENT,
+            subCategory = Nothing,
+            showNotification = Notification.DO_NOT_SHOW,
+            messagePriority = Nothing,
+            entity = Notification.Entity Notification.Product person.id.getId (),
+            body = body,
+            title = title,
+            dynamicParams = FirstRideEventParam vehicleCategory True,
+            auth = Notification.Auth person.id.getId person.deviceToken person.notificationToken,
+            ttl = Nothing,
+            sound = Nothing
+          }
+      title = T.pack "First Ride Event"
+      body =
+        unwords
+          [ "Congratulations! You have taken your first ride with us."
+          ]
+  notifyPerson person.merchantId merchantOperatingCityId person.id notificationData

--- a/flake.lock
+++ b/flake.lock
@@ -4139,11 +4139,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1717514096,
-        "narHash": "sha256-XS82eMt0X1jKpObNf5YVSagAPQvLU+kG9ohDiUus6lQ=",
+        "lastModified": 1717595400,
+        "narHash": "sha256-vVz1Fi52IIrHVfbYSpL//KCP/W6JdfHFewK4u1Uk5QA=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "cf1a877737141ebc103899a8595ffa68d80b790b",
+        "rev": "8b9c5e85df85efffeffee100d9f06988ebd02b0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
So currently, we were sending the first ride event in the customer profile API. However, generally, when a ride ends, the customer doesn't open the app immediately; they might open it the next day or after some time. This was not providing accurate information about the first ride event. The requirement is that if the first ride happens, that event should be triggered at the same time. Therefore, we created a new notification for the first ride info, which will be sent only when the first ride happens for that vehicle variant. 

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
![image](https://github.com/nammayatri/nammayatri/assets/67087070/146f11e2-a681-4443-8391-6cf8b3230d79)


## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
