### PR TITLE
backend/fleet/query_fix_for_search_driver

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Driver/Registration.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Driver/Registration.hs
@@ -272,7 +272,7 @@ verify authId mbFleet fleetOwnerId req = do
         }
   when mbFleet $ do
     checkAssoc <- runInReplica $ QFDV.findByDriverIdAndFleetOwnerId res.person.id fleetOwnerId
-    whenJust checkAssoc $ \assoc -> when (assoc.isActive) $ throwError (InvalidRequest "Driver already associated with fleet")
+    when (isJust checkAssoc) $ throwError (InvalidRequest "Driver already associated with fleet")
     assoc <- FDV.makeFleetDriverAssociation res.person.id fleetOwnerId (DomainRC.convertTextToUTC (Just "2099-12-12"))
     QFDV.create assoc
   pure Success

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Registration.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Registration.hs
@@ -273,7 +273,7 @@ verifyFleetJoiningOtp merchantShortId _ fleetOwnerId req = do
   otp <- Redis.get key >>= fromMaybeM (InvalidRequest "OTP not found")
   when (otp /= req.otp) $ throwError (InvalidRequest "Invalid OTP")
   checkAssoc <- B.runInReplica $ QFDV.findByDriverIdAndFleetOwnerId person.id fleetOwnerId
-  whenJust checkAssoc $ \assoc -> when (assoc.isActive) $ throwError (InvalidRequest "Driver already associated with fleet")
+  when (isJust checkAssoc) $ throwError (InvalidRequest "Driver already associated with fleet")
   assoc <- FDA.makeFleetDriverAssociation person.id fleetOwnerId (DomainRC.convertTextToUTC (Just "2099-12-12"))
   QFDV.create assoc
   pure Success

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/FleetDriverAssociation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/FleetDriverAssociation.hs
@@ -39,7 +39,8 @@ findByDriverIdAndFleetOwnerId driverId fleetOwnerId =
   findOneWithKV
     [ Se.And
         [ Se.Is BeamFDVA.driverId $ Se.Eq driverId.getId,
-          Se.Is BeamFDVA.fleetOwnerId $ Se.Eq fleetOwnerId
+          Se.Is BeamFDVA.fleetOwnerId $ Se.Eq fleetOwnerId,
+          Se.Is BeamFDVA.isActive $ Se.Eq True
         ]
     ]
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
The issue arose from the query fetching the driver who is currently active in the fleet. Previously, there was no concept of keeping a history of associations, so there was only one entry per fleet owner and driver. However, now we are keeping a history, so when we are doing a "find one," it was giving multiple values, resulting in returning nothing.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
