### PR TITLE
frontend/fix: Discarding empty string case in auth call, and proper type matching while storing DRIVER_LOCATION

### DIFF
--- a/Frontend/ui-common/src/Engineering/Helpers/Utils.purs
+++ b/Frontend/ui-common/src/Engineering/Helpers/Utils.purs
@@ -324,11 +324,11 @@ cityCodeMap =
   , Tuple "std:0124" "gurugram"
   ]
 
-getCityFromCode :: String -> String
+getCityFromCode :: String -> Maybe String
 getCityFromCode code = 
   let 
     cityCodeTuple = DA.find (\ tuple -> (fst tuple) == code) cityCodeMap
-  in maybe "" (\tuple -> snd tuple) cityCodeTuple
+  in snd <$> cityCodeTuple
 
 getCodeFromCity :: String -> String
 getCodeFromCity city = 

--- a/Frontend/ui-driver/src/Flow.purs
+++ b/Frontend/ui-driver/src/Flow.purs
@@ -418,7 +418,7 @@ getDriverInfoFlow event activeRideResp driverInfoResp updateShowSubscription isA
       config <- getAppConfigFlowBT Constants.appConfig
       case driverInfoRes of
         Right (GetDriverInfoResp getDriverInfoResp) -> do
-          void $ pure $ setValueToLocalStore DRIVER_LOCATION <$> (capitalize <$> getCityFromCode <$> getDriverInfoResp.operatingCity)
+          maybe (pure unit) (void <<< pure <<< setValueToLocalStore DRIVER_LOCATION <<< capitalize <<< fromMaybe "") $ getCityFromCode <$> getDriverInfoResp.operatingCity
           updateFirebaseToken getDriverInfoResp.maskedDeviceToken getUpdateToken
           liftFlowBT $ updateCleverTapUserProps (GetDriverInfoResp getDriverInfoResp)
           maybe (pure unit) (setValueToLocalStore MOBILE_NUMBER_KEY) getDriverInfoResp.mobileNumber

--- a/Frontend/ui-driver/src/Services/Backend.purs
+++ b/Frontend/ui-driver/src/Services/Backend.purs
@@ -207,7 +207,7 @@ makeTriggerOTPReq mobileNumber (LatLon lat lng _) = TriggerOTPReq
     where 
         mkOperatingCity :: String -> Maybe String
         mkOperatingCity operatingCity
-            | operatingCity `DA.elem` ["__failed", "--"] = Nothing
+            | operatingCity `DA.elem` ["__failed", "--", ""] = Nothing
             | operatingCity == "Puducherry"          = Just "Pondicherry"
             | operatingCity == "Tamil Nadu"          = Just "TamilNaduCities"
             | otherwise                              = Just operatingCity


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
If a `cityCodeMapping` is not done for new city (or older bundle for driver) then `""` string case matching was done as per `getCityCodeMap` maybe case which was getting stored in `DRIVER_LOCATION`. Now after logout, chooseCityFlow was not getting called because `getValueToLocalStore DRIVER_LOCATION` is not equals to `__failed` thus sending an empty string in merchantOperatingCity of auth request, resulting in `MERCHANT_OPERATING_CITY_NOT_FOUND` error.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
