### PR TITLE
backend/fix: ride status update issue

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
@@ -376,6 +376,7 @@ endRide handle@ServiceHandle {..} rideId req = withLogTag ("rideId-" <> rideId.g
           ride{tripEndTime = Just now,
                chargeableDistance = Just chargeableDistance,
                fare = Just finalFare,
+               status = DRide.COMPLETED,
                tripEndPos = Just tripEndPoint,
                rideEndedBy = Just rideEndedBy',
                fareParametersId = Just newFareParams.id,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -133,10 +133,10 @@ endRideTransaction ::
   m ()
 endRideTransaction driverId booking ride mbFareParams mbRiderDetailsId newFareParams thresholdConfig = do
   updateOnRideStatusWithAdvancedRideCheck ride.driverId (Just ride)
-  QRide.updateStatus ride.id Ride.COMPLETED
   QRB.updateStatus booking.id SRB.COMPLETED
   whenJust mbFareParams QFare.create
   QRide.updateAll ride.id ride
+  QRide.updateStatus ride.id Ride.COMPLETED
   driverInfo <- QDI.findById (cast ride.driverId) >>= fromMaybeM (PersonNotFound ride.driverId.getId)
   QDriverStats.updateIdleTime driverId
   QDriverStats.incrementTotalRidesAndTotalDist (cast ride.driverId) (fromMaybe 0 ride.chargeableDistance)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -136,7 +136,6 @@ endRideTransaction driverId booking ride mbFareParams mbRiderDetailsId newFarePa
   QRB.updateStatus booking.id SRB.COMPLETED
   whenJust mbFareParams QFare.create
   QRide.updateAll ride.id ride
-  QRide.updateStatus ride.id Ride.COMPLETED
   driverInfo <- QDI.findById (cast ride.driverId) >>= fromMaybeM (PersonNotFound ride.driverId.getId)
   QDriverStats.updateIdleTime driverId
   QDriverStats.incrementTotalRidesAndTotalDist (cast ride.driverId) (fromMaybe 0 ride.chargeableDistance)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/RideExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/RideExtra.hs
@@ -325,7 +325,8 @@ updateAll :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id Ride -> Ride -> m
 updateAll rideId ride = do
   now <- getCurrentTime
   updateWithKV
-    [ Se.Set BeamR.chargeableDistance ride.chargeableDistance,
+    [ Se.Set BeamR.status ride.status,
+      Se.Set BeamR.chargeableDistance ride.chargeableDistance,
       Se.Set BeamR.fare $ roundToIntegral <$> ride.fare,
       Se.Set BeamR.fareAmount $ ride.fare,
       Se.Set BeamR.tripEndTime ride.tripEndTime,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
- Moves ride status update after ride object update.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
- Currently, in very rare cases, `endRideTransaction` function execution gets terminated halfway (maybe because of unexpected pod termination), because of which ride status gets set to `COMPLETED` but other ride related fields like `chargeableDistance` and `fare` doesn't get updated. So now when `rideSync` tries to fix it, we get an error that `chargeableDistance` is empty because we expect every `COMPLETED` ride to have those details. 

- So after this fix, even if the execution is halted halfway, `rideSync` should be able to sync it. Although we need to somehow fix this halfway execution, as some other critical calculations also gets affected, for e.g. `driveFeeCalc` is after the ride object update.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing not required.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [x] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
