### PR TITLE
frontend/fix/rental-toggle-on-homeScreen

### DIFF
--- a/Frontend/ui-driver/src/Flow.purs
+++ b/Frontend/ui-driver/src/Flow.purs
@@ -1625,7 +1625,7 @@ bookingOptionsFlow :: FlowBT String Unit
 bookingOptionsFlow = do
   (API.DriverVehicleServiceTierResponse resp) <- HelpersAPI.callApiBT $ API.DriverVehicleServiceTierReq
   let ridePreferences' = transfromRidePreferences resp.tiers
-      canSwitchToInterCity' = fromMaybe false resp.canSwitchToInterCity
+      canSwitchToInterCity' = resp.canSwitchToInterCity
       canSwitchToRental' = fromMaybe false resp.canSwitchToRental
       defaultRide = fromMaybe BookingOptionsScreenData.defaultRidePreferenceOption $ find (\item -> item.isDefault) ridePreferences'
 
@@ -1633,10 +1633,14 @@ bookingOptionsFlow = do
    { data { airConditioned = resp.airConditioned
            , vehicleType = show defaultRide.serviceTierType
            , vehicleName = defaultRide.name
-           , canSwitchToInterCity = canSwitchToInterCity'
-           , canSwitchToRental = canSwitchToRental'
            , ridePreferences = ridePreferences'
-           , defaultRidePreference = defaultRide } })
+           , defaultRidePreference = defaultRide 
+          }, 
+     props {
+             canSwitchToRental = canSwitchToRental',
+             canSwitchToIntercity = canSwitchToInterCity'
+           } 
+    })
 
   action <- UI.bookingOptions
   case action of

--- a/Frontend/ui-driver/src/Screens/BookingOptionsScreen/ScreenData.purs
+++ b/Frontend/ui-driver/src/Screens/BookingOptionsScreen/ScreenData.purs
@@ -16,8 +16,6 @@ initData =
       , downgradeOptions: []
       , ridePreferences: []
       , defaultRidePreference: defaultRidePreferenceOption
-      , canSwitchToRental: false
-      , canSwitchToInterCity: false
       , airConditioned: Nothing
       , config: getAppConfig appConfig
       , rateCard : dummyRateCard

--- a/Frontend/ui-driver/src/Screens/Types.purs
+++ b/Frontend/ui-driver/src/Screens/Types.purs
@@ -1886,8 +1886,6 @@ type BookingOptionsScreenData = {
   downgradeOptions :: Array ChooseVehicle.Config,
   ridePreferences :: Array RidePreference,
   defaultRidePreference :: RidePreference,
-  canSwitchToInterCity :: Boolean,
-  canSwitchToRental :: Boolean,
   airConditioned :: Maybe API.AirConditionedTier,
   config :: AppConfig,
   rateCard :: Common.RateCard


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
the rental toggle was not working in the homescreen as the canSwitchToRental field was added to data it should be in props

testing
https://drive.google.com/file/d/1OuPJNh3Q_uOx38e6x7xq9j0OBMKiA97L/view?usp=sharing