### PR TITLE
backend/fix: makes card charge multiplier result always positive

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareCalculator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareCalculator.hs
@@ -545,7 +545,7 @@ calculateFareParameters params = do
            in HighPrecMoney $ distance.value.getHighPrecDistance * chargePerUnit.getHighPrecMoney
     countCardChargeOnFare :: HighPrecMoney -> Double -> HighPrecMoney
     countCardChargeOnFare fullCompleteRideCost cardCharge =
-      HighPrecMoney (fullCompleteRideCost.getHighPrecMoney * toRational cardCharge) - fullCompleteRideCost
+      HighPrecMoney ((max 1 fullCompleteRideCost.getHighPrecMoney) * toRational cardCharge) - fullCompleteRideCost
 
 countFullFareOfParamsDetails :: DFParams.FareParametersDetails -> (HighPrecMoney, HighPrecMoney, HighPrecMoney)
 countFullFareOfParamsDetails = \case

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0461-time-based-farepolicy.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0461-time-based-farepolicy.sql
@@ -1,9 +1,19 @@
 -- ADD COLUMN: fare_policy table
 ALTER TABLE
     atlas_driver_offer_bpp.fare_policy
-ADD COLUMN per_distance_unit_insurance_charge double precision NOT NULL DEFAULT 0.0,
-ADD COLUMN card_charge_per_distance_unit_multiplier double precision NOT NULL DEFAULT 0,
-ADD COLUMN fixed_card_charge double precision NOT NULL DEFAULT 0.0;
+ADD COLUMN per_distance_unit_insurance_charge double precision,
+ADD COLUMN card_charge_per_distance_unit_multiplier double precision,
+ADD COLUMN fixed_card_charge double precision;
+
+-- NOTE: Queries for MASTER
+-- ALTER TABLE atlas_driver_offer_bpp.fare_policy ALTER COLUMN per_distance_unit_insurance_charge DROP NOT NULL;
+-- UPDATE atlas_driver_offer_bpp.fare_policy SET per_distance_unit_insurance_charge = NULL;
+--
+-- ALTER TABLE atlas_driver_offer_bpp.fare_policy ALTER COLUMN card_charge_per_distance_unit_multiplier DROP NOT NULL;
+-- UPDATE atlas_driver_offer_bpp.fare_policy SET card_charge_per_distance_unit_multiplier = NULL;
+--
+-- ALTER TABLE atlas_driver_offer_bpp.fare_policy ALTER COLUMN fixed_card_charge DROP NOT NULL;
+-- UPDATE atlas_driver_offer_bpp.fare_policy SET fixed_card_charge = NULL;
 
 -- ADD COLUMN: fare_parameters table
 ALTER TABLE


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Fixes queries and handles card charge multiplier result negative values.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [x] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
