### PR TITLE
backend/enh/driver: makes sms header name based on template and city

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -158,6 +158,7 @@ MerchantMessage:
     templateId: Text
     jsonData: MerchantMessageDefaultDataJSON
     containsUrlButton: Bool
+    senderHeader: Maybe Text
     updatedAt: UTCTime
     createdAt: UTCTime
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/MerchantMessage.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/MerchantMessage.hs
@@ -23,6 +23,7 @@ data MerchantMessageD (s :: UsageSafety) = MerchantMessage
     merchantOperatingCityId :: Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity,
     message :: Kernel.Prelude.Text,
     messageKey :: Domain.Types.MerchantMessage.MessageKey,
+    senderHeader :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     templateId :: Kernel.Prelude.Text,
     updatedAt :: Kernel.Prelude.UTCTime
   }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/MerchantMessage.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/MerchantMessage.hs
@@ -21,6 +21,7 @@ data MerchantMessageT f = MerchantMessageT
     merchantOperatingCityId :: B.C f Kernel.Prelude.Text,
     message :: B.C f Kernel.Prelude.Text,
     messageKey :: B.C f Domain.Types.MerchantMessage.MessageKey,
+    senderHeader :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     templateId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     updatedAt :: B.C f Kernel.Prelude.UTCTime
   }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/MerchantMessage.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/MerchantMessage.hs
@@ -52,6 +52,7 @@ instance FromTType' Beam.MerchantMessage Domain.Types.MerchantMessage.MerchantMe
             merchantOperatingCityId = Kernel.Types.Id.Id merchantOperatingCityId,
             message = message,
             messageKey = messageKey,
+            senderHeader = senderHeader,
             templateId = fromMaybe "" templateId,
             updatedAt = updatedAt
           }
@@ -66,6 +67,7 @@ instance ToTType' Beam.MerchantMessage Domain.Types.MerchantMessage.MerchantMess
         Beam.merchantOperatingCityId = Kernel.Types.Id.getId merchantOperatingCityId,
         Beam.message = message,
         Beam.messageKey = messageKey,
+        Beam.senderHeader = senderHeader,
         Beam.templateId = Just templateId,
         Beam.updatedAt = updatedAt
       }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Driver.hs
@@ -1981,12 +1981,12 @@ sendSmsToDriver merchantShortId opCity driverId volunteerId _req@SendSmsReq {..}
   mobileNumber <- mapM decrypt driver.mobileNumber >>= fromMaybeM (PersonFieldNotPresent "mobileNumber")
   countryCode <- driver.mobileCountryCode & fromMaybeM (PersonFieldNotPresent "mobileCountryCode")
   let phoneNumber = countryCode <> mobileNumber
-      sender = smsCfg.sender
   withLogTag ("personId_" <> personId.getId) $ do
     case channel of
       SMS -> do
         mkey <- fromMaybeM (InvalidRequest "Message Key field is required for channel : SMS") messageKey --whenJust messageKey $ \mkey -> do
-        message <- MessageBuilder.buildGenericMessage merchantOpCityId mkey MessageBuilder.BuildGenericMessageReq {}
+        (mbSender, message) <- MessageBuilder.buildGenericMessage merchantOpCityId mkey MessageBuilder.BuildGenericMessageReq {}
+        let sender = fromMaybe smsCfg.sender mbSender
         Sms.sendSMS driver.merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber sender)
           >>= Sms.checkSmsResult
       WHATSAPP -> do
@@ -2141,14 +2141,14 @@ notifyYatriRentalEventsToDriver vehicleId messageKey personId transporterConfig 
   countryCode <- driver.mobileCountryCode & fromMaybeM (PersonFieldNotPresent "mobileCountryCode")
   nowLocale <- getLocalCurrentTime transporterConfig.timeDiffFromUtc
   let phoneNumber = countryCode <> mobileNumber
-      sender = smsCfg.sender
       timeStamp = show $ utctDay nowLocale
       merchantOpCityId = transporterConfig.merchantOperatingCityId
       mkey = messageKey
   withLogTag ("personId_" <> personId.getId) $ do
     case channel of
       SMS -> do
-        message <- MessageBuilder.buildGenericMessage merchantOpCityId mkey MessageBuilder.BuildGenericMessageReq {}
+        (mbSender, message) <- MessageBuilder.buildGenericMessage merchantOpCityId mkey MessageBuilder.BuildGenericMessageReq {}
+        let sender = fromMaybe smsCfg.sender mbSender
         Sms.sendSMS driver.merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber sender)
           >>= Sms.checkSmsResult
       WHATSAPP -> do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Registration.hs
@@ -188,14 +188,14 @@ auth isDashboard req' mbBundleVersion mbClientVersion mbClientConfigVersion mbDe
         countryCode <- req.mobileCountryCode & fromMaybeM (InvalidRequest "MobileCountryCode is required for mobileNumber auth")
         mobileNumber <- req.mobileNumber & fromMaybeM (InvalidRequest "MobileCountryCode is required for mobileNumber auth")
         let phoneNumber = countryCode <> mobileNumber
-            sender = smsCfg.sender
         withLogTag ("personId_" <> getId person.id) $ do
-          message <-
+          (mbSender, message) <-
             MessageBuilder.buildSendOTPMessage merchantOpCityId $
               MessageBuilder.BuildSendOTPMessageReq
                 { otp = otpCode,
                   hash = otpHash
                 }
+          let sender = fromMaybe smsCfg.sender mbSender
           Sms.sendSMS person.merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber sender)
             >>= Sms.checkSmsResult
       SP.EMAIL -> do
@@ -467,14 +467,14 @@ resend tokenId = do
   let otpCode = authValueHash
   let otpHash = smsCfg.credConfig.otpHash
       phoneNumber = countryCode <> mobileNumber
-      sender = smsCfg.sender
   withLogTag ("personId_" <> entityId) $ do
-    message <-
+    (mbSender, message) <-
       MessageBuilder.buildSendOTPMessage (Id merchantOperatingCityId) $
         MessageBuilder.BuildSendOTPMessageReq
           { otp = otpCode,
             hash = otpHash
           }
+    let sender = fromMaybe smsCfg.sender mbSender
     Sms.sendSMS person.merchantId (Id merchantOperatingCityId) (Sms.SendSMSReq message phoneNumber sender)
       >>= Sms.checkSmsResult
   _ <- QR.updateAttempts (attempts - 1) id

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/ScheduledRides/ScheduledRideNotificationsToDriver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/ScheduledRides/ScheduledRideNotificationsToDriver.hs
@@ -97,9 +97,9 @@ sendScheduledRideNotificationsToDriver Job {id, jobInfo} = withLogTag ("JobId-" 
         sendOverlay merchantOpCityId driver $ mkOverlayReq overlay
       SMS -> do
         smsCfg <- asks (.smsCfg)
-        let sender = smsCfg.sender
         messageKey <- A.decode (A.encode notificationKey) & fromMaybeM (InvalidRequest "Invalid message key for SMS")
         merchantMessage <- CMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId messageKey >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId notificationKey)
+        let sender = fromMaybe smsCfg.sender merchantMessage.senderHeader
         Sms.sendSMS driver.merchantId merchantOpCityId (Sms.SendSMSReq merchantMessage.message phoneNumber sender) >>= Sms.checkSmsResult
       _ -> pure () -- WHATSAPP or Other Notifications can be implemented here
   return Complete

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/MessageBuilder.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/MessageBuilder.hs
@@ -63,15 +63,17 @@ data BuildSendPaymentLinkReq = BuildSendPaymentLinkReq
   }
   deriving (Generic)
 
-buildSendPaymentLink :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendPaymentLinkReq -> m Text
+buildSendPaymentLink :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendPaymentLinkReq -> m (Maybe Text, Text)
 buildSendPaymentLink merchantOpCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId DMM.SEND_PAYMENT_LINK
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show DMM.SEND_PAYMENT_LINK))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "paymentLink") req.paymentLink
-      & T.replace (templateText "amount") req.amount
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "paymentLink") req.paymentLink
+          & T.replace (templateText "amount") req.amount
+
+  pure (merchantMessage.senderHeader, msg)
 
 data BuildSendOTPMessageReq = BuildSendOTPMessageReq
   { otp :: Text,
@@ -79,39 +81,45 @@ data BuildSendOTPMessageReq = BuildSendOTPMessageReq
   }
   deriving (Generic)
 
-buildSendOTPMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendOTPMessageReq -> m Text
+buildSendOTPMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendOTPMessageReq -> m (Maybe Text, Text)
 buildSendOTPMessage merchantOpCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId DMM.SEND_OTP
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show DMM.SEND_OTP))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "otp") req.otp
-      & T.replace (templateText "hash") req.hash
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "otp") req.otp
+          & T.replace (templateText "hash") req.hash
+
+  pure (merchantMessage.senderHeader, msg)
 
 newtype WelcomeToPlatformMessageReq = WelcomeToPlatformMessageReq
   { orgName :: Text
   }
   deriving (Generic)
 
-buildWelcomeToPlatformMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> WelcomeToPlatformMessageReq -> m Text
+buildWelcomeToPlatformMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> WelcomeToPlatformMessageReq -> m (Maybe Text, Text)
 buildWelcomeToPlatformMessage merchantOpCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId DMM.WELCOME_TO_PLATFORM
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show DMM.WELCOME_TO_PLATFORM))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "orgName") req.orgName
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "orgName") req.orgName
 
-buildSendAlternateNumberOTPMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendOTPMessageReq -> m Text
+  pure (merchantMessage.senderHeader, msg)
+
+buildSendAlternateNumberOTPMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendOTPMessageReq -> m (Maybe Text, Text)
 buildSendAlternateNumberOTPMessage merchantOpCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId DMM.ALTERNATE_NUMBER_OTP
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show DMM.ALTERNATE_NUMBER_OTP))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "otp") req.otp
-      & T.replace (templateText "hash") req.hash
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "otp") req.otp
+          & T.replace (templateText "hash") req.hash
+
+  pure (merchantMessage.senderHeader, msg)
 
 data BuildEndRideMessageReq = BuildEndRideMessageReq
   { rideAmount :: Text,
@@ -119,26 +127,28 @@ data BuildEndRideMessageReq = BuildEndRideMessageReq
   }
   deriving (Generic)
 
-buildEndRideMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildEndRideMessageReq -> m Text
+buildEndRideMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildEndRideMessageReq -> m (Maybe Text, Text)
 buildEndRideMessage merchantOpCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId DMM.END_RIDE_MESSAGE
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show DMM.END_RIDE_MESSAGE))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "rideAmount") req.rideAmount
-      & T.replace (templateText "rideId") req.rideShortId
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "rideAmount") req.rideAmount
+          & T.replace (templateText "rideId") req.rideShortId
+
+  pure (merchantMessage.senderHeader, msg)
 
 data BuildOnboardingMessageReq = BuildOnboardingMessageReq {}
   deriving (Generic)
 
-buildOnboardingMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildOnboardingMessageReq -> m Text
+buildOnboardingMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildOnboardingMessageReq -> m (Maybe Text, Text)
 buildOnboardingMessage merchantOpCityId _ = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId DMM.ONBOARDING_YATRI_MESSAGE
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show DMM.ONBOARDING_YATRI_MESSAGE))
-  return $
-    merchantMessage.message
+
+  pure (merchantMessage.senderHeader, merchantMessage.message)
 
 data BuildBookingMessageReq = BuildBookingMessageReq
   { otp :: Text,
@@ -146,44 +156,50 @@ data BuildBookingMessageReq = BuildBookingMessageReq
   }
   deriving (Generic)
 
-buildBookingMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildBookingMessageReq -> m Text
+buildBookingMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildBookingMessageReq -> m (Maybe Text, Text)
 buildBookingMessage merchantOpCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId DMM.BOOKING_MESSAGE
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show DMM.BOOKING_MESSAGE))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "otp") req.otp
-      & T.replace (templateText "amount") req.amount
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "otp") req.otp
+          & T.replace (templateText "amount") req.amount
+
+  pure (merchantMessage.senderHeader, msg)
 
 newtype BuildCollectCashMessageReq = BuildCollectCashMessageReq
   { amount :: Text
   }
   deriving (Generic)
 
-buildCollectCashMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildCollectCashMessageReq -> m Text
+buildCollectCashMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildCollectCashMessageReq -> m (Maybe Text, Text)
 buildCollectCashMessage merchantOpCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId DMM.CASH_COLLECTED_MESSAGE
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show DMM.CASH_COLLECTED_MESSAGE))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "amount") req.amount
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "amount") req.amount
+
+  pure (merchantMessage.senderHeader, msg)
 
 data BuildGenericMessageReq = BuildGenericMessageReq {}
   deriving (Generic)
 
-buildGenericMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> DMM.MessageKey -> BuildGenericMessageReq -> m Text
+buildGenericMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> DMM.MessageKey -> BuildGenericMessageReq -> m (Maybe Text, Text)
 buildGenericMessage merchantOpCityId messageKey _ = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOpCityId messageKey
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show messageKey))
   let jsonData = merchantMessage.jsonData
-  return $
-    merchantMessage.message
-      & T.replace (templateText "var1") (fromMaybe "" jsonData.var1)
-      & T.replace (templateText "var2") (fromMaybe "" jsonData.var2)
-      & T.replace (templateText "var3") (fromMaybe "" jsonData.var3)
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "var1") (fromMaybe "" jsonData.var1)
+          & T.replace (templateText "var2") (fromMaybe "" jsonData.var2)
+          & T.replace (templateText "var3") (fromMaybe "" jsonData.var3)
+
+  pure (merchantMessage.senderHeader, msg)
 
 addBroadcastMessageToKafka :: Bool -> Message.RawMessage -> Id P.Person -> Flow ()
 addBroadcastMessageToKafka check msg driverId = do
@@ -206,25 +222,29 @@ data BuildFleetJoiningMessageReq = BuildFleetJoiningMessageReq
     otp :: Text
   }
 
-buildFleetJoiningMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildFleetJoiningMessageReq -> m Text
+buildFleetJoiningMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildFleetJoiningMessageReq -> m (Maybe Text, Text)
 buildFleetJoiningMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOperatingCityId DMM.FLEET_JOINING_MESSAGE
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.FLEET_JOINING_MESSAGE))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "fleetOwnerName") req.fleetOwnerName
-      & T.replace (templateText "otp") req.otp
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "fleetOwnerName") req.fleetOwnerName
+          & T.replace (templateText "otp") req.otp
+
+  pure (merchantMessage.senderHeader, msg)
 
 newtype BuildDownloadAppMessageReq = BuildDownloadAppMessageReq
   { fleetOwnerName :: Text
   }
 
-buildFleetJoinAndDownloadAppMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildDownloadAppMessageReq -> m Text
+buildFleetJoinAndDownloadAppMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildDownloadAppMessageReq -> m (Maybe Text, Text)
 buildFleetJoinAndDownloadAppMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOpCityIdAndMessageKey merchantOperatingCityId DMM.FLEET_JOIN_AND_DOWNLOAD_APP_MESSAGE
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.FLEET_JOIN_AND_DOWNLOAD_APP_MESSAGE))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "fleetOwnerName") req.fleetOwnerName
+  let msg =
+        merchantMessage.message
+          & T.replace (templateText "fleetOwnerName") req.fleetOwnerName
+
+  pure (merchantMessage.senderHeader, msg)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs
@@ -221,13 +221,14 @@ sendLinkTroughChannelProvided mbPaymentLink driverId mbAmount mbChannel sendDeep
       when (result._response.status /= "success") $ throwError (InternalError "Unable to send Whatsapp message via dashboard")
     Just MessageKey.SMS -> do
       smsCfg <- asks (.smsCfg)
-      message <-
+      (mbSender, message) <-
         MessageBuilder.buildSendPaymentLink merchantOpCityId $
           MessageBuilder.BuildSendPaymentLinkReq
             { paymentLink = webPaymentLink,
               amount = show (fromMaybe 0 mbAmount)
             }
-      Sms.sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber smsCfg.sender)
+      let sender = fromMaybe smsCfg.sender mbSender
+      Sms.sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber sender)
         >>= Sms.checkSmsResult
     _ -> pure ()
   return ()

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/SMS.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/SMS.hs
@@ -95,34 +95,34 @@ sendDashboardSms merchantId merchantOpCityId messageType mbRide driverId mbBooki
       case messageType of
         BOOKING -> whenJust mbRide \ride ->
           whenJust mbBooking \booking -> do
-            message <-
+            (mbSender, message) <-
               MessageBuilder.buildBookingMessage merchantOpCityId $
                 MessageBuilder.BuildBookingMessageReq
                   { otp = ride.otp,
                     amount = show booking.estimatedFare
                   }
-            sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber sender) >>= Sms.checkSmsResult
+            sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber $ fromMaybe sender mbSender) >>= Sms.checkSmsResult
         ENDRIDE -> whenJust mbRide \ride -> do
-          message <-
+          (mbSender, message) <-
             MessageBuilder.buildEndRideMessage merchantOpCityId $
               MessageBuilder.BuildEndRideMessageReq
                 { rideAmount = show amount,
                   rideShortId = ride.shortId.getShortId
                 }
-          sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber sender) >>= Sms.checkSmsResult
+          sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber $ fromMaybe sender mbSender) >>= Sms.checkSmsResult
         ONBOARDING -> do
-          message <-
+          (mbSender, message) <-
             MessageBuilder.buildOnboardingMessage merchantOpCityId $
               MessageBuilder.BuildOnboardingMessageReq
                 {
                 }
-          sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber sender) >>= Sms.checkSmsResult
+          sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber $ fromMaybe sender mbSender) >>= Sms.checkSmsResult
         CASH_COLLECTED -> do
-          message <-
+          (mbSender, message) <-
             MessageBuilder.buildCollectCashMessage merchantOpCityId $
               MessageBuilder.BuildCollectCashMessageReq
                 { amount = show amount
                 }
-          sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber sender) >>= Sms.checkSmsResult
+          sendSMS merchantId merchantOpCityId (Sms.SendSMSReq message phoneNumber $ fromMaybe sender mbSender) >>= Sms.checkSmsResult
     else do
       logInfo "Merchant not configured to send dashboard sms"

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/merchant_message.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/merchant_message.sql
@@ -10,3 +10,8 @@ ALTER TABLE atlas_driver_offer_bpp.merchant_message ADD COLUMN message_key chara
 ALTER TABLE atlas_driver_offer_bpp.merchant_message ADD COLUMN template_id character varying(255) ;
 ALTER TABLE atlas_driver_offer_bpp.merchant_message ADD COLUMN updated_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
 ALTER TABLE atlas_driver_offer_bpp.merchant_message ADD PRIMARY KEY ( merchant_operating_city_id, message_key);
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.merchant_message ADD COLUMN sender_header text ;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
- Makes sms sender header configurable based on template and city.

### Additional Changes

- [x] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->
- Adds `sender_header` column to `merchant_message` table.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
- To remove dhall config based sms header
- Smooth migration from old header to newer ones.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- wasn't able to test, as nix had some issue.

## Screenshot of test results
<!-- Provide screenshot of the test results -->
NA

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
