### PR TITLE
backend/enh/customer: makes sms header name based on template and city

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
@@ -403,6 +403,7 @@ MerchantMessage:
     templateId: Text
     jsonData: MerchantMessageDefaultDataJSON
     containsUrlButton: Bool
+    senderHeader: Maybe Text
     updatedAt: UTCTime
     createdAt: UTCTime
 

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantMessage.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantMessage.hs
@@ -23,6 +23,7 @@ data MerchantMessageD (s :: UsageSafety) = MerchantMessage
     merchantOperatingCityId :: Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity,
     message :: Kernel.Prelude.Text,
     messageKey :: Domain.Types.MerchantMessage.MessageKey,
+    senderHeader :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     templateId :: Kernel.Prelude.Text,
     updatedAt :: Kernel.Prelude.UTCTime
   }

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantMessage.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantMessage.hs
@@ -21,6 +21,7 @@ data MerchantMessageT f = MerchantMessageT
     merchantOperatingCityId :: B.C f Kernel.Prelude.Text,
     message :: B.C f Kernel.Prelude.Text,
     messageKey :: B.C f Domain.Types.MerchantMessage.MessageKey,
+    senderHeader :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     templateId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     updatedAt :: B.C f Kernel.Prelude.UTCTime
   }

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/MerchantMessage.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/MerchantMessage.hs
@@ -50,6 +50,7 @@ instance FromTType' Beam.MerchantMessage Domain.Types.MerchantMessage.MerchantMe
             merchantOperatingCityId = Kernel.Types.Id.Id merchantOperatingCityId,
             message = message,
             messageKey = messageKey,
+            senderHeader = senderHeader,
             templateId = fromMaybe "" templateId,
             updatedAt = updatedAt
           }
@@ -64,6 +65,7 @@ instance ToTType' Beam.MerchantMessage Domain.Types.MerchantMessage.MerchantMess
         Beam.merchantOperatingCityId = Kernel.Types.Id.getId merchantOperatingCityId,
         Beam.message = message,
         Beam.messageKey = messageKey,
+        Beam.senderHeader = senderHeader,
         Beam.templateId = Just templateId,
         Beam.updatedAt = updatedAt
       }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Profile.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Profile.hs
@@ -390,7 +390,7 @@ sendEmergencyContactAddedMessage personId newPersonDENList oldPersonDENList = do
       newList = DPDEN.makePersonDefaultEmergencyNumberAPIEntity False <$> decNew
   person <- runInReplica $ QPerson.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
   riderConfig <- QRC.findByMerchantOperatingCityId person.merchantOperatingCityId >>= fromMaybeM (RiderConfigDoesNotExist person.merchantOperatingCityId.getId)
-  message <-
+  buildSmsReq <-
     MessageBuilder.buildAddedAsEmergencyContactMessage person.merchantOperatingCityId $
       MessageBuilder.BuildAddedAsEmergencyContactMessageReq
         { userName = SLP.getName person,
@@ -398,7 +398,7 @@ sendEmergencyContactAddedMessage personId newPersonDENList oldPersonDENList = do
         }
   let filterNewContacts personDEN = return $ not $ personDEN.mobileNumber `elem` oldList
   newlyAddedContacts <- filterM filterNewContacts newList
-  SPDEN.notifyEmergencyContacts person (notificationMessage person) "Emergency Contact Added" Notification.EMERGENCY_CONTACT_ADDED (Just message) riderConfig.enableEmergencyContactAddedMessage newlyAddedContacts
+  SPDEN.notifyEmergencyContacts person (notificationMessage person) "Emergency Contact Added" Notification.EMERGENCY_CONTACT_ADDED (Just buildSmsReq) riderConfig.enableEmergencyContactAddedMessage newlyAddedContacts
   where
     notificationMessage person = SLP.getName person <> " has added you as the emergency contact."
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Sos.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Sos.hs
@@ -143,7 +143,7 @@ postSosCreate (mbPersonId, _merchantId) req = do
   riderConfig <- QRC.findByMerchantOperatingCityId person.merchantOperatingCityId >>= fromMaybeM (RiderConfigDoesNotExist person.merchantOperatingCityId.getId)
   let trackLink = riderConfig.trackingShortUrlPattern <> ride.shortId.getShortId
   sosId <- createTicketForNewSos person ride riderConfig trackLink req
-  message <-
+  buildSmsReq <-
     MessageBuilder.buildSOSAlertMessage person.merchantOperatingCityId $
       MessageBuilder.BuildSOSAlertMessageReq
         { userName = SLP.getName person,
@@ -154,7 +154,7 @@ postSosCreate (mbPersonId, _merchantId) req = do
     when (shouldSendSms person) $ do
       void $ QPDEN.updateShareRideForAll personId True
       enableFollowRideInSos emergencyContacts.defaultEmergencyNumbers
-      SPDEN.notifyEmergencyContacts person (notificationBody person) notificationTitle Notification.SOS_TRIGGERED (Just message) True emergencyContacts.defaultEmergencyNumbers
+      SPDEN.notifyEmergencyContacts person (notificationBody person) notificationTitle Notification.SOS_TRIGGERED (Just buildSmsReq) True emergencyContacts.defaultEmergencyNumbers
   return $
     SosRes
       { sosId = sosId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TicketService.hs
@@ -817,16 +817,14 @@ postTicketServiceCancel (_mbPersonId, merchantId) req = do
 
     _sendSms :: Domain.Types.Person.Person -> Text -> Environment.Flow ()
     _sendSms person categoryName = do
-      smsCfg <- asks (.smsCfg)
       mobileNumber <- mapM decrypt person.mobileNumber
       let countryCode = fromMaybe "+91" person.mobileCountryCode
           merchantOperatingCityId = person.merchantOperatingCityId
-          sender = smsCfg.sender
       case mobileNumber of
         Just mNumber -> do
           let phoneNumber = countryCode <> mNumber
-          message <- MessageBuilder.buildTicketBookingCancelled merchantOperatingCityId $ MessageBuilder.BuildTicketBookingCancelledMessageReq {personName = fromMaybe "" person.firstName, categoryName = categoryName}
-          Sms.sendSMS person.merchantId merchantOperatingCityId (Sms.SendSMSReq message phoneNumber sender)
+          buildSmsReq <- MessageBuilder.buildTicketBookingCancelled merchantOperatingCityId $ MessageBuilder.BuildTicketBookingCancelledMessageReq {personName = fromMaybe "" person.firstName, categoryName = categoryName}
+          Sms.sendSMS person.merchantId merchantOperatingCityId (buildSmsReq phoneNumber)
             >>= Sms.checkSmsResult
         _ -> logDebug $ "Could n't send Ticket Booking Cancellation SMS : " <> person.id.getId
 

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MessageBuilder.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MessageBuilder.hs
@@ -43,15 +43,32 @@ import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.PartnerOrgConfig as DPOC
 import qualified Domain.Types.PartnerOrganization as DPO
 import Kernel.Prelude
+import Kernel.Sms.Config (SmsConfig)
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import qualified Storage.CachedQueries.Merchant.MerchantMessage as QMM
 import qualified Storage.CachedQueries.PartnerOrgConfig as CQPOC
 import Tools.Error
+import qualified Tools.SMS as Sms
 import qualified UrlShortner.Common as UrlShortner
 
 templateText :: Text -> Text
 templateText txt = "{#" <> txt <> "#}"
+
+type BuildMessageFlow m r =
+  ( HasFlowEnv m r '["smsCfg" ::: SmsConfig],
+    EsqDBFlow m r,
+    CacheFlow m r
+  )
+
+type SmsReqBuilder = Text -> Sms.SendSMSReq
+
+buildSendSmsReq :: BuildMessageFlow m r => DMM.MerchantMessage -> [(Text, Text)] -> m SmsReqBuilder
+buildSendSmsReq merchantMessage vars = do
+  smsCfg <- asks (.smsCfg)
+  let smsBody = foldl' (\msg (findKey, replaceVal) -> T.replace (templateText findKey) replaceVal msg) merchantMessage.message vars
+      sender = fromMaybe smsCfg.sender merchantMessage.senderHeader
+  return $ \phoneNumber -> Sms.SendSMSReq {..}
 
 data BuildSendOTPMessageReq = BuildSendOTPMessageReq
   { otp :: Text,
@@ -59,15 +76,12 @@ data BuildSendOTPMessageReq = BuildSendOTPMessageReq
   }
   deriving (Generic)
 
-buildSendOTPMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendOTPMessageReq -> m Text
+buildSendOTPMessage :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> BuildSendOTPMessageReq -> m SmsReqBuilder
 buildSendOTPMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOperatingCityId DMM.SEND_OTP
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.SEND_OTP))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "otp") req.otp
-      & T.replace (templateText "hash") req.hash
+  buildSendSmsReq merchantMessage [("otp", req.otp), ("hash", req.hash)]
 
 data BuildSendBookingOTPMessageReq = BuildSendBookingOTPMessageReq
   { otp :: Text,
@@ -75,44 +89,35 @@ data BuildSendBookingOTPMessageReq = BuildSendBookingOTPMessageReq
   }
   deriving (Generic)
 
-buildSendBookingOTPMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendBookingOTPMessageReq -> m Text
+buildSendBookingOTPMessage :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> BuildSendBookingOTPMessageReq -> m SmsReqBuilder
 buildSendBookingOTPMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOperatingCityId DMM.SEND_BOOKING_OTP
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.SEND_BOOKING_OTP))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "otp") req.otp
-      & T.replace (templateText "amount") req.amount
+  buildSendSmsReq merchantMessage [("otp", req.otp), ("amount", req.amount)]
 
 newtype BuildSendRideEndOTPMessageReq = BuildSendRideEndOTPMessageReq
   { otp :: Text
   }
   deriving (Generic)
 
-buildSendRideEndOTPMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSendRideEndOTPMessageReq -> m Text
+buildSendRideEndOTPMessage :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> BuildSendRideEndOTPMessageReq -> m SmsReqBuilder
 buildSendRideEndOTPMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOperatingCityId DMM.SEND_RIDE_END_OTP
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.SEND_RIDE_END_OTP))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "otp") req.otp
+  buildSendSmsReq merchantMessage [("otp", req.otp)]
 
 data BuildGenericMessageReq = BuildGenericMessageReq {}
   deriving (Generic)
 
-buildGenericMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> DMM.MessageKey -> BuildGenericMessageReq -> m Text
+buildGenericMessage :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> DMM.MessageKey -> BuildGenericMessageReq -> m SmsReqBuilder
 buildGenericMessage merchantOpCityId messageKey _ = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOpCityId messageKey
       >>= fromMaybeM (MerchantMessageNotFound merchantOpCityId.getId (show messageKey))
   let jsonData = merchantMessage.jsonData
-  return $
-    merchantMessage.message
-      & T.replace (templateText "var1") (fromMaybe "" jsonData.var1)
-      & T.replace (templateText "var2") (fromMaybe "" jsonData.var2)
-      & T.replace (templateText "var3") (fromMaybe "" jsonData.var3)
+  buildSendSmsReq merchantMessage [("var1", fromMaybe "" jsonData.var1), ("var2", fromMaybe "" jsonData.var2), ("var3", fromMaybe "" jsonData.var3)]
 
 data BuildSOSAlertMessageReq = BuildSOSAlertMessageReq
   { userName :: Text,
@@ -120,29 +125,24 @@ data BuildSOSAlertMessageReq = BuildSOSAlertMessageReq
   }
   deriving (Generic)
 
-buildSOSAlertMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildSOSAlertMessageReq -> m Text
+buildSOSAlertMessage :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> BuildSOSAlertMessageReq -> m SmsReqBuilder
 buildSOSAlertMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOperatingCityId DMM.SEND_SOS_ALERT
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.SEND_SOS_ALERT))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "userName") req.userName
-      & T.replace (templateText "rideLink") req.rideLink
+  buildSendSmsReq merchantMessage [("userName", req.userName), ("rideLink", req.rideLink)]
 
 newtype BuildMarkRideAsSafeMessageReq = BuildMarkRideAsSafeMessageReq
   { userName :: Text
   }
   deriving (Generic)
 
-buildMarkRideAsSafeMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildMarkRideAsSafeMessageReq -> m Text
+buildMarkRideAsSafeMessage :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> BuildMarkRideAsSafeMessageReq -> m SmsReqBuilder
 buildMarkRideAsSafeMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOperatingCityId DMM.MARK_RIDE_AS_SAFE
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.MARK_RIDE_AS_SAFE))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "userName") req.userName
+  buildSendSmsReq merchantMessage [("userName", req.userName)]
 
 data BuildFollowRideMessageReq = BuildFollowRideMessageReq
   { userName :: Text,
@@ -150,15 +150,12 @@ data BuildFollowRideMessageReq = BuildFollowRideMessageReq
   }
   deriving (Generic)
 
-buildFollowRideStartedMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildFollowRideMessageReq -> m Text
+buildFollowRideStartedMessage :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> BuildFollowRideMessageReq -> m SmsReqBuilder
 buildFollowRideStartedMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOperatingCityId DMM.FOLLOW_RIDE
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.FOLLOW_RIDE))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "userName") req.userName
-      & T.replace (templateText "rideLink") req.rideLink
+  buildSendSmsReq merchantMessage [("userName", req.userName), ("rideLink", req.rideLink)]
 
 data BuildAddedAsEmergencyContactMessageReq = BuildAddedAsEmergencyContactMessageReq
   { userName :: Text,
@@ -166,15 +163,12 @@ data BuildAddedAsEmergencyContactMessageReq = BuildAddedAsEmergencyContactMessag
   }
   deriving (Generic)
 
-buildAddedAsEmergencyContactMessage :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildAddedAsEmergencyContactMessageReq -> m Text
+buildAddedAsEmergencyContactMessage :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> BuildAddedAsEmergencyContactMessageReq -> m SmsReqBuilder
 buildAddedAsEmergencyContactMessage merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOperatingCityId DMM.ADDED_AS_EMERGENCY_CONTACT
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.ADDED_AS_EMERGENCY_CONTACT))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "userName") req.userName
-      & T.replace (templateText "appUrl") req.appUrl
+  buildSendSmsReq merchantMessage [("userName", req.userName), ("appUrl", req.appUrl)]
 
 data BuildTicketBookingCancelledMessageReq = BuildTicketBookingCancelledMessageReq
   { personName :: Text,
@@ -182,15 +176,12 @@ data BuildTicketBookingCancelledMessageReq = BuildTicketBookingCancelledMessageR
   }
   deriving (Generic)
 
-buildTicketBookingCancelled :: (EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> BuildTicketBookingCancelledMessageReq -> m Text
+buildTicketBookingCancelled :: BuildMessageFlow m r => Id DMOC.MerchantOperatingCity -> BuildTicketBookingCancelledMessageReq -> m SmsReqBuilder
 buildTicketBookingCancelled merchantOperatingCityId req = do
   merchantMessage <-
     QMM.findByMerchantOperatingCityIdAndMessageKey merchantOperatingCityId DMM.TICKET_BOOKING_CANCELLED
       >>= fromMaybeM (MerchantMessageNotFound merchantOperatingCityId.getId (show DMM.TICKET_BOOKING_CANCELLED))
-  return $
-    merchantMessage.message
-      & T.replace (templateText "personName") req.personName
-      & T.replace (templateText "categoryName") req.categoryName
+  buildSendSmsReq merchantMessage [("personName", req.personName), ("categoryName", req.categoryName)]
 
 data BuildFRFSTicketBookedMessageReq = BuildFRFSTicketBookedMessageReq
   { countOfTickets :: Int,

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/PersonDefaultEmergencyNumber.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/PersonDefaultEmergencyNumber.hs
@@ -28,8 +28,8 @@ import Tools.Error
 import Tools.Notifications
 import Tools.SMS as Sms
 
-notifyEmergencyContacts :: Person.Person -> Text -> Text -> Notification.Category -> Maybe Text -> Bool -> [DPDEN.PersonDefaultEmergencyNumberAPIEntity] -> Flow ()
-notifyEmergencyContacts person body title notificationType message useSmsAsBackup emergencyContacts = do
+notifyEmergencyContacts :: Person.Person -> Text -> Text -> Notification.Category -> Maybe (Text -> Sms.SendSMSReq) -> Bool -> [DPDEN.PersonDefaultEmergencyNumberAPIEntity] -> Flow ()
+notifyEmergencyContacts person body title notificationType mbBuildSmsReq useSmsAsBackup emergencyContacts = do
   void $
     mapM
       ( \emergencyContact ->
@@ -43,8 +43,8 @@ notifyEmergencyContacts person body title notificationType message useSmsAsBacku
       )
       emergencyContacts
   where
-    sendMessageToContact emergencyContact = when useSmsAsBackup $ case message of
-      Just msg -> sendMessageToEmergencyContact person emergencyContact msg
+    sendMessageToContact emergencyContact = when useSmsAsBackup $ case mbBuildSmsReq of
+      Just buildSmsReq -> sendMessageToEmergencyContact person emergencyContact buildSmsReq
       Nothing -> pure ()
 
 sendNotificationToEmergencyContact :: Person.Person -> Text -> Text -> Notification.Category -> Flow ()
@@ -69,10 +69,8 @@ sendNotificationToEmergencyContact person body title notificationType = do
           sound = notificationSound
         }
 
-sendMessageToEmergencyContact :: Person.Person -> DPDEN.PersonDefaultEmergencyNumberAPIEntity -> Text -> Flow ()
-sendMessageToEmergencyContact person emergencyContact message = do
-  smsCfg <- asks (.smsCfg)
-  let sender = smsCfg.sender
-      contactPhoneNumber = emergencyContact.mobileCountryCode <> emergencyContact.mobileNumber
-  Sms.sendSMS person.merchantId person.merchantOperatingCityId (Sms.SendSMSReq message contactPhoneNumber sender)
+sendMessageToEmergencyContact :: Person.Person -> DPDEN.PersonDefaultEmergencyNumberAPIEntity -> (Text -> Sms.SendSMSReq) -> Flow ()
+sendMessageToEmergencyContact person emergencyContact buildSmsReq = do
+  let contactPhoneNumber = emergencyContact.mobileCountryCode <> emergencyContact.mobileNumber
+  Sms.sendSMS person.merchantId person.merchantOperatingCityId (buildSmsReq contactPhoneNumber)
     >>= Sms.checkSmsResult

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/CheckPNAndSendSMS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/CheckPNAndSendSMS.hs
@@ -58,14 +58,12 @@ sendSMS ::
   Text ->
   m ()
 sendSMS merchantId merchantOpCity phoneNo name trackLink = do
-  smsCfg <- asks (.smsCfg)
-  let sender = smsCfg.sender
-  message <-
+  buildSmsReq <-
     MessageBuilder.buildFollowRideStartedMessage merchantOpCity $
       MessageBuilder.BuildFollowRideMessageReq
         { userName = fromMaybe "" name,
           rideLink = trackLink
         }
   void $
-    Sms.sendSMS merchantId merchantOpCity (Sms.SendSMSReq message phoneNo sender)
+    Sms.sendSMS merchantId merchantOpCity (buildSmsReq phoneNo)
       >>= Sms.checkSmsResult

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
@@ -866,16 +866,14 @@ notifyRideStartToEmergencyContacts booking ride = do
               ]
       notifyPerson booking.merchantId booking.merchantOperatingCityId person.id notificationData
     sendSMS emergencyContact name trackLink = do
-      smsCfg <- asks (.smsCfg)
-      let sender = smsCfg.sender
-      message <-
+      buildSmsReq <-
         MessageBuilder.buildFollowRideStartedMessage booking.merchantOperatingCityId $
           MessageBuilder.BuildFollowRideMessageReq
             { userName = fromMaybe "" name,
               rideLink = trackLink
             }
       void $
-        Sms.sendSMS booking.merchantId booking.merchantOperatingCityId (Sms.SendSMSReq message emergencyContact.mobileNumber sender)
+        Sms.sendSMS booking.merchantId booking.merchantOperatingCityId (buildSmsReq emergencyContact.mobileNumber)
           >>= Sms.checkSmsResult
 
 checkTimeConstraintForFollowRide :: DRC.RiderConfig -> UTCTime -> Bool

--- a/Backend/dev/migrations-read-only/rider-app/merchant_message.sql
+++ b/Backend/dev/migrations-read-only/rider-app/merchant_message.sql
@@ -10,3 +10,8 @@ ALTER TABLE atlas_app.merchant_message ADD COLUMN message_key character varying(
 ALTER TABLE atlas_app.merchant_message ADD COLUMN template_id character varying(255) ;
 ALTER TABLE atlas_app.merchant_message ADD COLUMN updated_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
 ALTER TABLE atlas_app.merchant_message ADD PRIMARY KEY ( merchant_operating_city_id, message_key);
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.merchant_message ADD COLUMN sender_header text ;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
- Adds `sender_header` column to `merchant_message` table on rider side, for template wise control over header name to be passed in SMS.

### Additional Changes
- [x] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
- As we have migrated some of the templates to new headers, we needed template wise control over header names, so this change is incorporating that.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Can't test sms flow locally.
But did sanity flow for ride test, got some `GOOGLE_MAPS_ERROR` which shouldn't be related to this change.
![image](https://github.com/user-attachments/assets/517c1fd9-3982-4662-9d8e-aec49be1bfa8)

## Screenshot of test results
<!-- Provide screenshot of the test results -->
![image](https://github.com/user-attachments/assets/26744716-2d58-409b-8dd5-5515fa7229cf)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [x] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
