### PR TITLE
frontend/feat: Rental and Intercity otp flow in spl zone

### DIFF
--- a/Frontend/ui-customer/src/Components/DriverInfoCard/Common/Types.purs
+++ b/Frontend/ui-customer/src/Components/DriverInfoCard/Common/Types.purs
@@ -9,21 +9,21 @@ import Screens.Types (City, SearchResultType, FareProductType)
 
 type DriverDetailsType
   = { fareProductType :: FareProductType
-    , rating :: Number
-    , driverName :: String
-    , vehicleDetails :: String
-    , vehicleVariant :: String
-    , merchantCity :: City
-    , registrationNumber :: String
-    , config :: AppConfig
-    , rideStarted :: Boolean
-    , enablePaddingBottom :: Boolean
-    , vehicleModel :: String
-    , vehicleColor :: String
-    , serviceTierName :: Maybe String
-    , providerType :: CTP.ProviderType
-    , showAcView :: Boolean
-    , isSpecialZone :: Boolean
+      , rating :: Number
+      , driverName :: String
+      , vehicleDetails :: String
+      , vehicleVariant :: String
+      , merchantCity :: City
+      , registrationNumber :: String
+      , config :: AppConfig
+      , rideStarted :: Boolean
+      , enablePaddingBottom :: Boolean
+      , vehicleModel :: String
+      , vehicleColor :: String
+      , serviceTierName :: Maybe String
+      , providerType :: CTP.ProviderType
+      , showAcView :: Boolean
+      , isOtpRideFlow :: Boolean
     }
 
 type TripDetails a
@@ -35,6 +35,6 @@ type TripDetails a
   , enablePaddingBottom :: Boolean
   , fareProductType :: FareProductType
   , enableEditDestination :: Boolean
-  , isSpecialZone :: Boolean
+  , isOtpRideFlow :: Boolean
   , editingDestinationLoc :: a
     }

--- a/Frontend/ui-customer/src/Components/DriverInfoCard/Common/View.purs
+++ b/Frontend/ui-customer/src/Components/DriverInfoCard/Common/View.purs
@@ -60,10 +60,10 @@ driverDetailsView config uid nid =
   , padding $ Padding 16 16 16 8
   , width MATCH_PARENT
   , id $ getNewIDWithTag uid
-  , margin $ Margin 16 (if config.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || config.isSpecialZone then 12 else 0) 16 (if config.enablePaddingBottom then safeMarginBottom else 0)
+  , margin $ Margin 16 (if config.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || config.isOtpRideFlow then 12 else 0) 16 (if config.enablePaddingBottom then safeMarginBottom else 0)
   , background Color.white900
   , cornerRadius 8.0
-  , visibility $  boolToVisibility $ if config.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || config.isSpecialZone then config.rideStarted else true
+  , visibility $  boolToVisibility $ if config.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || config.isOtpRideFlow then config.rideStarted else true
   ][  linearLayout
       [ orientation VERTICAL
       , height WRAP_CONTENT
@@ -381,7 +381,7 @@ sourceDestinationView push config =
                 , cornerRadius if os == "IOS" then 16.0 else 32.0
                 , stroke $ "1," <> Color.grey900
                 , padding $ Padding 12 8 12 8
-                , visibility $ boolToVisibility $ config.enableEditDestination && isNotRentalRide && (config.fareProductType /= FPT.ONE_WAY_SPECIAL_ZONE) && not config.isSpecialZone
+                , visibility $ boolToVisibility $ config.enableEditDestination && isNotRentalRide && (config.fareProductType /= FPT.ONE_WAY_SPECIAL_ZONE) && not config.isOtpRideFlow
                 , onClick push $ const config.editingDestinationLoc
                 , rippleColor Color.rippleShade
               ] <> FontStyle.body1 TypoGraphy

--- a/Frontend/ui-customer/src/Components/DriverInfoCard/Controller.purs
+++ b/Frontend/ui-customer/src/Components/DriverInfoCard/Controller.purs
@@ -79,7 +79,8 @@ type DriverInfoCardProps =
     rideDurationTimerId :: String,
     endOTPShown :: Boolean,
     showEndOTP :: Boolean,
-    stageBeforeChatScreen :: Stage
+    stageBeforeChatScreen :: Stage,
+    isOtpRideFlow :: Boolean
   }
 
 type DriverInfoCardData =

--- a/Frontend/ui-customer/src/Components/DriverInfoCard/View.purs
+++ b/Frontend/ui-customer/src/Components/DriverInfoCard/View.purs
@@ -194,7 +194,7 @@ driverInfoViewSpecialZone push state =
   linearLayout
   [ width  MATCH_PARENT
   , height WRAP_CONTENT
-  , visibility $ boolToVisibility $ isSpecialZone state
+  , visibility $ boolToVisibility $ isOtpRideFlow state
   ][ (if os == "IOS" then linearLayout else scrollView)
       [ height MATCH_PARENT
       , width MATCH_PARENT
@@ -366,9 +366,9 @@ otpAndWaitView push state =
         , otpView push state
         ]
       -- , trackRideView push state -- TODO :: may use in future
-     ] <> if (isSpecialZone state|| state.data.driverArrived) then 
+     ] <> if (isOtpRideFlow state|| state.data.driverArrived) then 
            [(PrestoAnim.animationSet [ fadeIn true ] $ 
-           let isQuotes = isSpecialZone state
+           let isQuotes = isOtpRideFlow state
            in
            linearLayout
            [ width WRAP_CONTENT
@@ -464,7 +464,7 @@ waitTimeView push state =
   ]
 
 waitTimeHint :: DriverInfoCardState -> String
-waitTimeHint state = (if isSpecialZone state then "O T P Expires in : " else "Wait Time : ") <> case STR.split (STR.Pattern ":") state.data.waitingTime of
+waitTimeHint state = (if isOtpRideFlow state then "O T P Expires in : " else "Wait Time : ") <> case STR.split (STR.Pattern ":") state.data.waitingTime of
                         [minutes, seconds] -> do 
                           let min = STR.trim $ minutes
                           let sec = STR.trim $ seconds
@@ -478,7 +478,7 @@ colorForWaitTime state =
   case waitTime of
     [minutes, _] -> 
       let mins = fromMaybe 0 (fromString (STR.trim minutes))
-          threshold = if isSpecialZone state then mins < 5 else mins > 2
+          threshold = if isOtpRideFlow state then mins < 5 else mins > 2
       in
       if threshold then Color.carnation100 else Color.grey700 
     _ -> Color.grey700
@@ -629,7 +629,7 @@ navigateView push state =
   , accessibility ENABLE
   , accessibilityHint $ (getEN $ GO_TO_ZONE "GO_TO_ZONE") <> " : Button"
   , accessibility DISABLE_DESCENDANT
-  , visibility $ boolToVisibility $ isSpecialZone state && rideNotStarted state
+  , visibility $ boolToVisibility $ isOtpRideFlow state && rideNotStarted state
   , onClick push $ const $ ShowDirections state.data.sourceLat state.data.sourceLng
   ][ imageView
      [ width $ V 20
@@ -657,7 +657,7 @@ driverInfoView push state =
   linearLayout
   [ width MATCH_PARENT
   , height WRAP_CONTENT
-  , visibility $ boolToVisibility $ not $  isSpecialZone state 
+  , visibility $ boolToVisibility $ not $ isOtpRideFlow state 
   ][ (if os == "IOS" then linearLayout else scrollView)
       [ height MATCH_PARENT
       , width MATCH_PARENT
@@ -1507,7 +1507,7 @@ getDriverDetails state = {
   , providerType : state.data.providerType
   , showAcView : state.data.cityConfig.enableAcViews
   , fareProductType : state.data.fareProductType
-  , isSpecialZone : state.data.isSpecialZone
+  , isOtpRideFlow : state.props.isOtpRideFlow
 }
 
 endOTPAnimConfig :: DriverInfoCardState -> AnimConfig.AnimConfig
@@ -1539,7 +1539,7 @@ getTripDetails state = {
   , fareProductType : state.data.fareProductType
   , enableEditDestination : state.data.config.feature.enableEditDestination
   , editingDestinationLoc : EditingDestination
-  , isSpecialZone : state.data.isSpecialZone
+  , isOtpRideFlow : state.props.isOtpRideFlow
 }
 
 driverPickUpStatusText :: DriverInfoCardState -> String -> String
@@ -1731,5 +1731,5 @@ rideInfoPill state rideData =
       
     ]
 
-isSpecialZone :: DriverInfoCardState -> Boolean
-isSpecialZone state = state.data.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || (state.props.isSpecialZone && state.props.currentStage == RideAccepted)
+isOtpRideFlow :: DriverInfoCardState -> Boolean
+isOtpRideFlow state = state.data.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || (state.props.isOtpRideFlow && state.props.currentStage == RideAccepted)

--- a/Frontend/ui-customer/src/Components/MessagingView/Common/Types.purs
+++ b/Frontend/ui-customer/src/Components/MessagingView/Common/Types.purs
@@ -14,7 +14,7 @@ type MessageNotificationView a = {
 , enableChatWidget :: Boolean
 , isNotificationExpanded :: Boolean
 , fareProductType :: FareProductType
-, isSpecialZone :: Boolean
+, isOtpRideFlow :: Boolean
 , config :: AppConfig
 , rideStarted ::Boolean
 , lastMessage :: ChatComponent

--- a/Frontend/ui-customer/src/Components/MessagingView/Common/View.purs
+++ b/Frontend/ui-customer/src/Components/MessagingView/Common/View.purs
@@ -114,7 +114,7 @@ messageNotificationView push state =
   , accessibility $ if state.isNotificationExpanded && os /= "IOS" then ENABLE else if not state.isNotificationExpanded then DISABLE_DESCENDANT else DISABLE
   , accessibilityHint $ "Quick Chat : Widget"
   , onAnimationEnd push $ const state.messageViewAnimationEnd
-  , visibility $ boolToVisibility $ (((any (_ == state.currentStage)) [ RideAccepted, ChatWithDriver, RideStarted]) && (state.fareProductType /= FPT.ONE_WAY_SPECIAL_ZONE && not (state.currentStage == RideAccepted && state.isSpecialZone) ) && state.config.feature.enableChat) && state.config.feature.enableSuggestions && not state.removeNotification
+  , visibility $ boolToVisibility $ (((any (_ == state.currentStage)) [ RideAccepted, ChatWithDriver, RideStarted]) && (state.fareProductType /= FPT.ONE_WAY_SPECIAL_ZONE && not (state.currentStage == RideAccepted && state.isOtpRideFlow) ) && state.config.feature.enableChat) && state.config.feature.enableSuggestions && not state.removeNotification
   , cornerRadius 20.0
   ][linearLayout 
     [ height $ WRAP_CONTENT

--- a/Frontend/ui-customer/src/Helpers/Ride.purs
+++ b/Frontend/ui-customer/src/Helpers/Ride.purs
@@ -138,6 +138,7 @@ checkRideStatus rideAssigned = do
                     homeScreen
                     { props
                       { isSpecialZone = true
+                      , isOtpRideFlow = true
                       , isInApp = true
                       }
                     , data
@@ -149,7 +150,7 @@ checkRideStatus rideAssigned = do
             Just (RideAPIEntity _) ->
               if isJust otpCode then do
                 setValueToLocalStore TRACKING_ENABLED "True"
-                modifyScreenState $ HomeScreenStateType (\homeScreen → homeScreen{props{isSpecialZone = true,isInApp = true }}) else
+                modifyScreenState $ HomeScreenStateType (\homeScreen → homeScreen{props{isSpecialZone = true,isInApp = true, isOtpRideFlow = true }}) else
                 pure unit
       else if ((getValueToLocalStore RATING_SKIPPED) == "false") then do
         updateLocalStage HomeScreen

--- a/Frontend/ui-customer/src/Screens/RentalBookingFlow/RentalScreen/ScreenData.purs
+++ b/Frontend/ui-customer/src/Screens/RentalBookingFlow/RentalScreen/ScreenData.purs
@@ -71,6 +71,6 @@ initData =
     , showPrimaryButton : true
     , showPopUpModal : false
     , showRentalPolicy : false
-    , isSpecialZone : false
+    , isOtpRideFlow : false
     }
   }

--- a/Frontend/ui-customer/src/Screens/RentalBookingFlow/RentalScreen/View.purs
+++ b/Frontend/ui-customer/src/Screens/RentalBookingFlow/RentalScreen/View.purs
@@ -123,7 +123,7 @@ rentalPackageSelectionView push state =
       , width MATCH_PARENT 
       , background Color.black900 
       , padding $ PaddingTop EHC.safeMarginTop
-      , visibility $ boolToVisibility $ not $ state.props.isSpecialZone
+      , visibility $ boolToVisibility $ not $ state.props.isOtpRideFlow
       ][InputView.view (push <<< InputViewAC) $ mapInputViewConfig state]
     , linearLayout
       [ height WRAP_CONTENT

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ComponentConfig.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ComponentConfig.purs
@@ -881,7 +881,7 @@ isMockLocationConfig state =
 
 waitTimeInfoCardConfig :: ST.HomeScreenState -> RequestInfoCard.Config
 waitTimeInfoCardConfig state = let
-  isQuotes = state.data.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || state.props.isSpecialZone
+  isQuotes = state.data.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || state.props.isOtpRideFlow
   waitTimeConfig = textConfig isQuotes  
   config = RequestInfoCard.config
   requestInfoCardConfig' = config{
@@ -1034,6 +1034,7 @@ driverInfoCardViewState state = { props:
                                   , unReadMessages : state.props.unReadMessages
                                   , showCallPopUp: state.props.showCallPopUp
                                   , isSpecialZone: state.props.isSpecialZone
+                                  , isOtpRideFlow: state.props.isOtpRideFlow
                                   , estimatedTime : state.data.rideDuration
                                   , zoneType : state.props.zoneType
                                   , merchantCity : state.props.city
@@ -1100,7 +1101,7 @@ messagingViewConfig state =
 
 getDefaultPeekHeight :: ST.HomeScreenState -> Int
 getDefaultPeekHeight state =
-  let isQuotes = state.data.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || state.props.isSpecialZone
+  let isQuotes = state.data.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE || state.props.isOtpRideFlow
       height = case state.props.currentStage == ST.RideAccepted of
         true -> if isQuotes then 285 else 381
         false -> if isQuotes then 377 else 368

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/Controller.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/Controller.purs
@@ -99,6 +99,7 @@ import Screens.RideBookingFlow.HomeScreen.Config
 import Screens.SuccessScreen.Handler as UI
 import Screens.Types (CallType(..), CardType(..), CurrentLocationDetails, CurrentLocationDetailsWithDistance(..), HomeScreenState, LocationItemType(..), LocationListItemState, PopupType(..), RatingCard, SearchLocationModelType(..), SearchResultType(..), SheetState(..), SpecialTags, Stage(..), TipViewStage(..), ZoneType(..), Trip, BottomNavBarIcon(..), City(..), ReferralStatus(..), NewContacts(..), City(..), CancelSearchType(..))
 import Services.API (BookingLocationAPIEntity(..), EstimateAPIEntity(..), FareRange, GetDriverLocationResp, GetQuotesRes(..), GetRouteResp, LatLong(..), OfferRes, PlaceName(..), QuoteAPIEntity(..), RideBookingRes(..), SelectListRes(..), GetEditLocResultResp(..), BookingUpdateRequestDetails(..),  SelectedQuotes(..), RideBookingAPIDetails(..), GetPlaceNameResp(..), RideBookingListRes(..), FollowRideRes(..), Followers(..), Route(..), RideAPIEntity(..), RideBookingDetails(..))
+import Services.API (BookingLocationAPIEntity(..), EstimateAPIEntity(..), FareRange, GetDriverLocationResp, GetQuotesRes(..), GetRouteResp, LatLong(..), OfferRes, PlaceName(..), QuoteAPIEntity(..), RideBookingRes(..), SelectListRes(..), GetEditLocResultResp(..), BookingUpdateRequestDetails(..),  SelectedQuotes(..), RideBookingAPIDetails(..), GetPlaceNameResp(..), RideBookingListRes(..), FollowRideRes(..), Followers(..), Route(..), RideAPIEntity(..), RideBookingDetails(..))
 import Services.Backend as Remote
 import Services.Config (getDriverNumber, getSupportNumber)
 import Storage (KeyStore(..), isLocalStageOn, updateLocalStage, getValueToLocalStore, setValueToLocalStore, getValueToLocalNativeStore, setValueToLocalNativeStore, deleteValueFromLocalStore)
@@ -2075,12 +2076,13 @@ eval (GetRideConfirmation (RideBookingRes response)) state = do
               _ -> RideAccepted
           Nothing -> RideAccepted
       (RideBookingAPIDetails bookingDetails) = response.bookingDetails
-      isSpecialZoneOtpRide = bookingDetails.fareProductType == "OneWaySpecialZoneAPIDetails" || isJust otpCode
+      isSpecialZoneOtpRide = bookingDetails.fareProductType == "OneWaySpecialZoneAPIDetails"
       newState = state {  props { currentStage = currentStage
                                 , isSearchLocation = NoView
                                 , bookingId = response.id
                                 , isInApp = true
                                 , isSpecialZone = isSpecialZoneOtpRide
+                                , isOtpRideFlow = isJust otpCode
                                 }
                         , data { driverInfoCardState = getDriverInfo state.data.specialZoneSelectedVariant (RideBookingRes response) (state.data.fareProductType == ST.ONE_WAY_SPECIAL_ZONE || isJust otpCode) state.data.driverInfoCardState }
                         }
@@ -3140,12 +3142,16 @@ normalRideFlow  (RideBookingRes response) state = do
 specialZoneRideFlow :: RideBookingRes -> HomeScreenState -> Eval Action ScreenOutput HomeScreenState
 specialZoneRideFlow  (RideBookingRes response) state = do
   let
+    (RideBookingAPIDetails bookingDetails) = response.bookingDetails
+    (RideBookingDetails contents) = bookingDetails.contents
+    isOtpRideFlow = isJust contents.otpCode
     newState =
       state
         { props
           { currentStage = RideAccepted
           , isSearchLocation = NoView
           , bookingId = response.id
+          , isOtpRideFlow = isOtpRideFlow
           }
         , data
           { driverInfoCardState = getDriverInfo state.data.specialZoneSelectedVariant (RideBookingRes response) (state.data.fareProductType == FPT.ONE_WAY_SPECIAL_ZONE) state.data.driverInfoCardState

--- a/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ScreenData.purs
+++ b/Frontend/ui-customer/src/Screens/RideBookingFlow/HomeScreen/ScreenData.purs
@@ -376,6 +376,7 @@ initData = let
     , isKeyBoardOpen : false
     , isContactSupportPopUp : false
     , isSharedLocationFlow : false
+    , isOtpRideFlow : false
   }
 }
 

--- a/Frontend/ui-customer/src/Screens/TrackRide/FollowRideScreen/ComponentConfig.purs
+++ b/Frontend/ui-customer/src/Screens/TrackRide/FollowRideScreen/ComponentConfig.purs
@@ -110,7 +110,7 @@ getDriverDetails state =
     , serviceTierName : ride.serviceTierName
     , providerType : Common.ONUS
     , showAcView : false
-    , isSpecialZone : false
+    , isOtpRideFlow : false
     }
 
 
@@ -128,7 +128,7 @@ getTripDetails state color =
     , fareProductType : ride.fareProductType
     , enableEditDestination : false
     , editingDestinationLoc : NoAction
-    , isSpecialZone : false
+    , isOtpRideFlow : false
     }
 
 getCurrentFollower :: Maybe Followers -> Followers

--- a/Frontend/ui-customer/src/Screens/TrackRide/FollowRideScreen/View.purs
+++ b/Frontend/ui-customer/src/Screens/TrackRide/FollowRideScreen/View.purs
@@ -412,7 +412,7 @@ getMessageNotificationViewConfig state =
   , user :{ userName : name
     , receiver : name
     }
-  , isSpecialZone : false
+  , isOtpRideFlow : false
   }
 
 bottomSheetView ::

--- a/Frontend/ui-customer/src/Screens/Types.purs
+++ b/Frontend/ui-customer/src/Screens/Types.purs
@@ -944,6 +944,7 @@ type HomeScreenStateProps =
   , isKeyBoardOpen :: Boolean
   , isContactSupportPopUp :: Boolean
   , isSharedLocationFlow :: Boolean
+  , isOtpRideFlow :: Boolean
   }
 
 data BottomNavBarIcon = TICKETING | MOBILITY
@@ -2596,7 +2597,7 @@ type RentalScreenProps = {
   , showPrimaryButton :: Boolean
   , showPopUpModal :: Boolean
   , showRentalPolicy :: Boolean
-  , isSpecialZone :: Boolean
+  , isOtpRideFlow :: Boolean
 }
 
 type DateTimeConfig = {

--- a/Frontend/ui-customer/src/Services/Backend.purs
+++ b/Frontend/ui-customer/src/Services/Backend.purs
@@ -386,7 +386,7 @@ makeRideSearchReq slat slong dlat dlong srcAdd desAdd startTime sourceManuallyMo
                 , "isDestinationManuallyMoved" : Just destManuallyMoved
                 , "sessionToken" : Just sessionToken
                 , "isSpecialLocation" : Just isSpecialLocation
-                , "quotesUnifiedFlow" : Just true -- Hybrid Flow backward compatibility check for Backend
+                , "quotesUnifiedFlow" : Just true
                 , "rideRequestAndRideOtpUnifiedFlow" : Just true 
                 }
             )
@@ -1424,7 +1424,7 @@ mkRentalSearchReq slat slong dlat dlong srcAdd desAdd startTime estimatedRentalD
                                                   "startTime" : startTime,
                                                   "estimatedRentalDistance" : estimatedRentalDistance,
                                                   "estimatedRentalDuration" : estimatedRentalDuration,
-                                                  "quotesUnifiedFlow" : Just true, -- Hybrid Flow backward compatibility check for Backend
+                                                  "quotesUnifiedFlow" : Just true,
                                                   "rideRequestAndRideOtpUnifiedFlow": Just true
                                                  }),
                     "fareProductType" : "RENTAL"


### PR DESCRIPTION
## Type of Change
Add otp ride flow for rental and intercity when backend is sending otpCode in booking Details
mainly for siliguri special zone

- [x] Enhancement

<img width="419" alt="Screenshot 2024-08-14 at 6 27 33 PM" src="https://github.com/user-attachments/assets/ef1780ab-ec25-438e-af36-6f6b99a72d5b">

## Description
utilizing the field isOtpCode to determine the otp ride flow

