### PR TITLE
ci: Add github workflow to build Nix outputs

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,21 @@
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: x86_64-linux
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: om ci

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: cachix/cachix-action@v15
         with:
           name: nammayatri
-          # authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           skipPush: true
 
       - name: Build all flake outputs

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,6 +1,5 @@
 name: CI
 
-# Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
@@ -18,4 +17,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: om ci
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: nammayatri
+          # authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          skipPush: true
+
+      - name: Build all flake outputs
+        run: om ci


### PR DESCRIPTION
Add a GitHub workflow that will build all flake outputs. The i9 self-hosted runner is defined in https://github.com/nammayatri/ci

This is the first step towards moving away from Jenkins entirely. In later PRs we will incrementally migrate away from `Jenkinsfile`.