### PR TITLE
backend/enh: adds url categories for url-shortner requests

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MessageBuilder.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MessageBuilder.hs
@@ -213,7 +213,8 @@ buildFRFSTicketBookedMessage pOrgId req = do
               { baseUrl,
                 customShortCode = Nothing,
                 shortCodeLength = Nothing,
-                expiryInHours = Nothing
+                expiryInHours = Nothing,
+                urlCategory = UrlShortner.METRO_TICKET_BOOKING
               }
       res <- UrlShortner.generateShortUrl shortUrlReq
       let url = res.shortUrl
@@ -230,7 +231,8 @@ shortenTrackingUrl url = do
           { baseUrl = url,
             customShortCode = Nothing,
             shortCodeLength = Nothing,
-            expiryInHours = Just 24
+            expiryInHours = Just 24,
+            urlCategory = UrlShortner.RIDE_TRACKING
           }
   res <- UrlShortner.generateShortUrl shortUrlReq
   return res.shortUrl

--- a/Backend/lib/shared-services/shared-services.cabal
+++ b/Backend/lib/shared-services/shared-services.cabal
@@ -66,6 +66,7 @@ library
       IssueManagement.Tools.Error
       IssueManagement.Tools.UtilsTH
       UrlShortner.Common
+      UrlShortner.Types
   other-modules:
       Paths_shared_services
   hs-source-dirs:

--- a/Backend/lib/shared-services/src/UrlShortner/Common.hs
+++ b/Backend/lib/shared-services/src/UrlShortner/Common.hs
@@ -9,7 +9,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 
 module UrlShortner.Common
-  ( GenerateShortUrlReq (..),
+  ( UrlCategory (..),
+    GenerateShortUrlReq (..),
     GenerateShortUrlRes (..),
     UrlShortnerConfig (..),
     generateShortUrl,
@@ -22,9 +23,8 @@ import Kernel.Tools.Metrics.CoreMetrics
 import Kernel.Types.Common
 import Kernel.Types.Error
 import Kernel.Utils.Common
-import Kernel.Utils.Dhall (FromDhall)
-import Kernel.Utils.JSON
 import Servant hiding (throwError)
+import UrlShortner.Types
 
 type GenerateShortUrlAPI =
   "internal" :> "generateShortUrl"
@@ -37,38 +37,6 @@ generateShortUrlAPI = Proxy
 
 generateShortUrlClient :: Maybe Text -> GenerateShortUrlReq -> ET.EulerClient GenerateShortUrlRes
 generateShortUrlClient = ET.client generateShortUrlAPI
-
-data GenerateShortUrlReq = GenerateShortUrlReq
-  { baseUrl :: Text,
-    customShortCode :: Maybe Text,
-    shortCodeLength :: Maybe Int,
-    expiryInHours :: Maybe Int
-  }
-  deriving (Generic, Read, Show)
-
-instance FromJSON GenerateShortUrlReq where
-  parseJSON = genericParseJSON removeNullFields
-
-instance ToJSON GenerateShortUrlReq where
-  toJSON = genericToJSON removeNullFields
-
-data GenerateShortUrlRes = GenerateShortUrlRes
-  { shortUrl :: Text,
-    urlExpiry :: UTCTime
-  }
-  deriving (Generic, Read, Show)
-
-instance FromJSON GenerateShortUrlRes where
-  parseJSON = genericParseJSON removeNullFields
-
-instance ToJSON GenerateShortUrlRes where
-  toJSON = genericToJSON removeNullFields
-
-data UrlShortnerConfig = UrlShortnerConfig
-  { url :: BaseUrl,
-    apiKey :: Text
-  }
-  deriving (Generic, Show, FromDhall, FromJSON, ToJSON)
 
 generateShortUrl ::
   ( MonadFlow m,

--- a/Backend/lib/shared-services/src/UrlShortner/Types.hs
+++ b/Backend/lib/shared-services/src/UrlShortner/Types.hs
@@ -1,0 +1,96 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module UrlShortner.Types
+  ( UrlCategory (..),
+    GenerateShortUrlReq (..),
+    GenerateShortUrlRes (..),
+    UrlShortnerConfig (..),
+  )
+where
+
+import qualified Data.Aeson as A
+import Data.Aeson.Types (typeMismatch)
+import qualified Data.Text as T
+import Kernel.Prelude hiding (fromString, toString)
+import Kernel.Utils.Dhall (FromDhall)
+import Kernel.Utils.JSON
+import Prelude (show)
+
+{- Author: Jaypal Mudaliyar
+  Below categories are coupled with the url-shortner service.
+  So whenever adding new category,
+  make sure to add corresponding enum to the url-shortner service as well.
+-}
+metroTicketBooking, mtbEnum, rtkEnum, rideTracking :: String
+metroTicketBooking = "mtb"
+mtbEnum = "METRO_TICKET_BOOKING"
+rideTracking = "rtk"
+rtkEnum = "RIDE_TRACKING"
+
+data UrlCategory = METRO_TICKET_BOOKING | RIDE_TRACKING
+  deriving (Generic)
+
+fromString :: String -> Maybe UrlCategory
+fromString str =
+  if
+      | str == mtbEnum || str == metroTicketBooking -> Just METRO_TICKET_BOOKING
+      | str == rtkEnum || str == rideTracking -> Just RIDE_TRACKING
+      | otherwise -> Nothing
+
+toString :: UrlCategory -> String
+toString METRO_TICKET_BOOKING = metroTicketBooking
+toString RIDE_TRACKING = rideTracking
+
+instance Read UrlCategory where
+  readsPrec _ = maybe [] (\x -> [(x, "")]) . fromString
+
+instance Show UrlCategory where
+  show = toString
+
+instance FromJSON UrlCategory where
+  parseJSON (A.String str) = maybe (fail $ "Invalid UrlCategory:" <> T.unpack str) return (fromString $ T.unpack str)
+  parseJSON e = typeMismatch "String" e
+
+instance ToJSON UrlCategory where
+  toJSON = A.String . T.pack . toString
+
+data GenerateShortUrlReq = GenerateShortUrlReq
+  { baseUrl :: Text,
+    customShortCode :: Maybe Text,
+    shortCodeLength :: Maybe Int,
+    expiryInHours :: Maybe Int,
+    urlCategory :: UrlCategory
+  }
+  deriving (Generic, Read, Show)
+
+instance FromJSON GenerateShortUrlReq where
+  parseJSON = genericParseJSON removeNullFields
+
+instance ToJSON GenerateShortUrlReq where
+  toJSON = genericToJSON removeNullFields
+
+data GenerateShortUrlRes = GenerateShortUrlRes
+  { shortUrl :: Text,
+    urlExpiry :: UTCTime
+  }
+  deriving (Generic, Read, Show)
+
+instance FromJSON GenerateShortUrlRes where
+  parseJSON = genericParseJSON removeNullFields
+
+instance ToJSON GenerateShortUrlRes where
+  toJSON = genericToJSON removeNullFields
+
+data UrlShortnerConfig = UrlShortnerConfig
+  { url :: BaseUrl,
+    apiKey :: Text
+  }
+  deriving (Generic, Show, FromDhall, FromJSON, ToJSON)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
- Adds url categorization for `url-shortner` service

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
- Url categorization was required to have specific `after_expiry_url` for specific categories and also to decide the query param for generated `short_url`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing not required.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
