### PR TITLE
backend/fix: apply redundant brackets hint to separate file/folder

### DIFF
--- a/Backend/nix/scripts.nix
+++ b/Backend/nix/scripts.nix
@@ -79,11 +79,22 @@ _:
           # Automatically applies Redundant bracket hint
           applyHintArg=false
           allArg=false
+          pathArg=""
           for arg in "$@"; do
+            argName=$(echo "$arg" | cut -d "=" -f 1)
+            argValue=$(echo "$arg" | cut -d "=" -f 2)
             if [[ "$arg" == "--apply-hint" ]];
             then applyHintArg=true
             elif [[ "$arg" == "--all" ]];
             then allArg=true
+            elif [[ "$argName" == "--path" ]];
+            then
+              if [[ "$applyHintArg" == false ]]
+              then
+                echo "path arg works only with applyHint arg"
+                exit 1
+              else pathArg=$argValue
+              fi
             fi
           done
 
@@ -114,14 +125,19 @@ _:
 
           if "$applyHintArg"
           then
-            applyHint "''${FLAKE_ROOT}/Backend/app/rider-platform/rider-app/Main/src-read-only" "$allArg"
-            applyHint "''${FLAKE_ROOT}/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only" "$allArg"
-            applyHint "''${FLAKE_ROOT}/Backend/lib/yudhishthira/src-read-only" "$allArg"
-            applyHint "''${FLAKE_ROOT}/Backend/lib/payment/src-read-only" "$allArg"
-            applyHint "''${FLAKE_ROOT}/Backend/app/dashboard/provider-dashboard/src-read-only" "$allArg"
-            applyHint "''${FLAKE_ROOT}/Backend/app/dashboard/rider-dashboard/src-read-only" "$allArg"
-            applyHint "''${FLAKE_ROOT}/Backend/app/dashboard/CommonAPIs/src-read-only" "$allArg"
-            applyHint "''${FLAKE_ROOT}/Backend/app/safety-dashboard/src-read-only" "$allArg"
+            if  [[ "$pathArg" == "" ]]
+            then
+              applyHint "''${FLAKE_ROOT}/Backend/app/rider-platform/rider-app/Main/src-read-only" "$allArg"
+              applyHint "''${FLAKE_ROOT}/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only" "$allArg"
+              applyHint "''${FLAKE_ROOT}/Backend/lib/yudhishthira/src-read-only" "$allArg"
+              applyHint "''${FLAKE_ROOT}/Backend/lib/payment/src-read-only" "$allArg"
+              applyHint "''${FLAKE_ROOT}/Backend/app/dashboard/provider-dashboard/src-read-only" "$allArg"
+              applyHint "''${FLAKE_ROOT}/Backend/app/dashboard/rider-dashboard/src-read-only" "$allArg"
+              applyHint "''${FLAKE_ROOT}/Backend/app/dashboard/CommonAPIs/src-read-only" "$allArg"
+              applyHint "''${FLAKE_ROOT}/Backend/app/safety-dashboard/src-read-only" "$allArg"
+            else
+              applyHint "''${FLAKE_ROOT}/''${pathArg}" true
+            fi
           else
             echo "No hints applied"
           fi


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
Earlier `--aply-hint` flag did not worked for new untracked by git files, and files without uncommitted changes.
Now for this cases we can specify path:
```
, run-generator  -- --apply-hint --path=Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/Booking.hs

, run-generator  -- --apply-hint --path=Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/
```

Can be used in `src` folder also, not only `src-read-only`:

```
, run-generator  -- --apply-hint --path=Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
```



## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
