### PR TITLE
ci/nix: Display flake outputs before building

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -20,6 +20,9 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           skipPush: true
 
+      - name: Inspect flake
+        run: om show .
+
       - name: Build all flake outputs
         run: om ci
 


### PR DESCRIPTION
Just a Nix related CI change to show all flake outputs before building using https://github.com/juspay/omnix