### PR TITLE
fix: redirecting homeScreen opening to exit

### DIFF
--- a/Frontend/ui-customer/src/App.purs
+++ b/Frontend/ui-customer/src/App.purs
@@ -239,7 +239,8 @@ data ParcelAction = GO_TO_PARCEL_INSTRUCTIONS HomeScreenState
                     | GO_TO_DELIVERY_DETAILS HomeScreenState
                     | GET_DELIVERY_IMAGE HomeScreenState
 
-data HOME_SCREEN_OUTPUT = LOGOUT
+data HOME_SCREEN_OUTPUT = HybridAppExit
+                        | LOGOUT
                         | RELOAD Boolean
                         | UPDATE_PICKUP_NAME HomeScreenState Number Number
                         | REFRESH_HOME_SCREEN

--- a/Frontend/ui-customer/src/Flow.purs
+++ b/Frontend/ui-customer/src/Flow.purs
@@ -1174,6 +1174,7 @@ homeScreenFlow = do
   flow <- UI.homeScreen
   void $ lift $ lift $ fork $ Remote.pushSDKEvents
   case flow of
+    HybridAppExit -> pure unit
     STAY_IN_HOME_SCREEN -> do
       updateLocalStage HomeScreen
       modifyScreenState $ HomeScreenStateType (\_ -> HomeScreenData.initData)

--- a/Frontend/ui-customer/src/Helpers/Utils.js
+++ b/Frontend/ui-customer/src/Helpers/Utils.js
@@ -615,3 +615,11 @@ export const decodeErrorCode = function (a) {
     return " ";
   }
 };
+
+export const isHybridApp = ()=>{
+  try {
+    return (window.__payload.payload.isHybrid === true);
+  } catch (unhandled){
+    return false;
+  }
+}

--- a/Frontend/ui-customer/src/Helpers/Utils.purs
+++ b/Frontend/ui-customer/src/Helpers/Utils.purs
@@ -1526,3 +1526,5 @@ disableChat fareProductType =
 isDeliveryInitiator :: Maybe (Array String) -> Boolean
 isDeliveryInitiator maybeTags = 
   maybe true (\tags -> elem "Initiator" tags) maybeTags
+
+foreign import isHybridApp :: Effect Boolean


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In Hybrid app flow when opening home page screen, this will redirect to RN app


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
