### PR TITLE
frontend/enh: config subscription lottie

### DIFF
--- a/Frontend/ui-common/src/RemoteConfig/Types.purs
+++ b/Frontend/ui-common/src/RemoteConfig/Types.purs
@@ -199,7 +199,25 @@ type SubscriptionConfigVariantLevelEntity = {
    enableSubsV2 :: Maybe Boolean,
    duesConfig :: Maybe RCSubscriptionDues,
    freeTrialPopupDaysList :: Maybe (Array Int),
-   freeTrialPopupOnRidesList :: Maybe (Array Int)
+   freeTrialPopupOnRidesList :: Maybe (Array Int),
+   lottieSubscriptionInfo :: Maybe LottieSubscriptionInfo
+}
+
+type LottieSubscriptionInfo = {
+  freeTrialLottie :: LanguageKeyValue,
+  introductoryLottie :: LanguageKeyValue,
+  subscriptionPlanLottie :: LanguageKeyValue
+}
+
+type LanguageKeyValue = {
+  english :: String,
+  hindi :: String,
+  kannada :: String,
+  tamil :: String,
+  bengali :: String,
+  telugu :: String,
+  malayalam :: String,
+  default :: String
 }
 
 type OfferBanner = {

--- a/Frontend/ui-common/src/RemoteConfig/Utils.purs
+++ b/Frontend/ui-common/src/RemoteConfig/Utils.purs
@@ -14,7 +14,7 @@
 -}
 module Common.RemoteConfig.Utils where
 
-import Common.RemoteConfig.Types (RemoteConfig, RCCarousel(..), ForwardBatchConfigData(..), TipsConfig, defaultForwardBatchConfigData, SubscriptionConfigVariantLevelEntity, SubscriptionConfigVariantLevel, GullakConfig, StuckRideFilterConfig, FeaturesConfigData(..), defaultFeaturesConfigData, AppLanguage, AppConfigRC)
+import Common.RemoteConfig.Types (RemoteConfig, RCCarousel(..), ForwardBatchConfigData(..), TipsConfig, defaultForwardBatchConfigData, SubscriptionConfigVariantLevelEntity, SubscriptionConfigVariantLevel, GullakConfig, StuckRideFilterConfig, FeaturesConfigData(..), LottieSubscriptionInfo(..), LanguageKeyValue(..), defaultFeaturesConfigData, AppLanguage, AppConfigRC)
 import DecodeUtil (decodeForeignObject, parseJSON, setAnyInWindow)
 import Data.String (null, toLower)
 import Data.Maybe (Maybe(..))
@@ -252,6 +252,49 @@ defaultSubscriptionsConfigVariantLevel =
   }
 
 
+defaultLottieSubscriptionInfo :: LottieSubscriptionInfo
+defaultLottieSubscriptionInfo = {
+  freeTrialLottie : defaultFreeTrialLottie,
+  introductoryLottie : defaultIntroductoryLottie,
+  subscriptionPlanLottie: defaultSubscriptionPlanLottie
+}
+
+defaultFreeTrialLottie :: LanguageKeyValue
+defaultFreeTrialLottie = {
+  english: "lottie/ny_ic_subscription_info_01.json",
+  hindi: "lottie/ny_ic_subscription_info_hindi_01.json",
+  kannada: "lottie/ny_ic_subscription_info_kannada_01.json",
+  tamil: "lottie/ny_ic_subscription_info_tamil_01.json",
+  bengali: "lottie/ny_ic_subscription_info_bengali_01.json",
+  telugu: "lottie/ny_ic_subscription_info_01.json",
+  malayalam: "lottie/ny_ic_subscription_info_malayalam_01.json",
+  default: "lottie/ny_ic_subscription_info_01.json"
+}
+
+defaultIntroductoryLottie :: LanguageKeyValue
+defaultIntroductoryLottie = {
+  english: "lottie/ny_sub_intro_english_jan1.json",
+  hindi: "lottie/ny_sub_intro_hindi_jan1.json",
+  kannada: "lottie/ny_sub_intro_kannada_jan1.json",
+  tamil: "lottie/ny_sub_intro_tamil_jan1.json",
+  bengali: "lottie/ny_ic_subscription_info_bengali_03_2.json",
+  telugu: "lottie/ny_sub_intro_telugu_jan1.json",
+  malayalam: "lottie/ny_sub_intro_malayalam_jan1.json",
+  default: "lottie/ny_sub_intro_english_jan1.json"
+}
+
+defaultSubscriptionPlanLottie :: LanguageKeyValue
+defaultSubscriptionPlanLottie = {
+  english: "lottie/ny_ic_subscription_info_02.json",
+  hindi: "lottie/ny_ic_subscription_info_hindi_02.json",
+  kannada: "lottie/ny_ic_subscription_info_kannada_02.json",
+  tamil: "lottie/ny_ic_subscription_info_tamil_02.json",
+  bengali: "lottie/ny_ic_subscription_info_bengali_02.json",
+  telugu: "lottie/ny_ic_subscription_info_02.json",
+  malayalam: "lottie/ny_ic_subscription_info_malayalam_02.json",
+  default: "lottie/ny_ic_subscription_info_02.json"
+}
+
 defaultSubscriptionsConfigVariantLevelEntity :: SubscriptionConfigVariantLevelEntity
 defaultSubscriptionsConfigVariantLevelEntity = 
   { 
@@ -265,7 +308,8 @@ defaultSubscriptionsConfigVariantLevelEntity =
     enableSubsV2 : Just false,
     duesConfig : Just defSubscriptionDues,
     freeTrialPopupDaysList : Just [3,2,1],
-    freeTrialPopupOnRidesList : Just [5,2]
+    freeTrialPopupOnRidesList : Just [5,2],
+    lottieSubscriptionInfo : Just defaultLottieSubscriptionInfo
   }
 
 subscriptionsConfigVariantLevel :: String -> String -> SubscriptionConfigVariantLevelEntity

--- a/Frontend/ui-driver/src/Screens/SubscriptionScreen/View.purs
+++ b/Frontend/ui-driver/src/Screens/SubscriptionScreen/View.purs
@@ -1872,28 +1872,27 @@ offerCardBannerView push useMargin visibility' isPlanCard offerBannerProps isFre
 
 lottieJsonAccordingToLang :: Boolean -> Boolean -> String
 lottieJsonAccordingToLang isOnFreeTrial isIntroductory = 
-  (HU.getAssetsBaseUrl FunctionCall) <> case getLanguageLocale languageKey of 
-    "HI_IN" -> if isIntroductory then "lottie/ny_sub_intro_hindi_jan1.json"
-               else if isOnFreeTrial then "lottie/ny_ic_subscription_info_hindi_01.json" 
-               else "lottie/ny_ic_subscription_info_hindi_02.json"
-    "KN_IN" -> if isIntroductory then "lottie/ny_sub_intro_kannada_jan1.json"
-               else if isOnFreeTrial then "lottie/ny_ic_subscription_info_kannada_01.json" 
-               else "lottie/ny_ic_subscription_info_kannada_02.json"
-    "TA_IN" -> if isIntroductory then "lottie/ny_sub_intro_tamil_jan1.json"
-               else if isOnFreeTrial then "lottie/ny_ic_subscription_info_tamil_01.json" 
-               else "lottie/ny_ic_subscription_info_tamil_02.json"
-    "BN_IN" -> if isIntroductory then "lottie/ny_ic_subscription_info_bengali_03_2.json"
-               else if isOnFreeTrial then "lottie/ny_ic_subscription_info_bengali_01.json" 
-               else "lottie/ny_ic_subscription_info_bengali_02.json"
-    "TE_IN" -> if isIntroductory then "lottie/ny_sub_intro_telugu_jan1.json"
-               else if isOnFreeTrial then "lottie/ny_ic_subscription_info_01.json" 
-               else "lottie/ny_ic_subscription_info_02.json"
-    "ML_IN" -> if isIntroductory then "lottie/ny_sub_intro_malayalam_jan1.json"
-               else if isOnFreeTrial then "lottie/ny_ic_subscription_info_malayalam_01.json" 
-               else "lottie/ny_ic_subscription_info_malayalam_02.json"
-    _       -> if isIntroductory then "lottie/ny_sub_intro_english_jan1.json"
-               else if isOnFreeTrial then "lottie/ny_ic_subscription_info_01.json" 
-               else "lottie/ny_ic_subscription_info_02.json"
+  let lang = getLanguageLocale languageKey
+      driverCity = getValueToLocalStore DRIVER_LOCATION
+      driverVehicle = getValueToLocalStore VEHICLE_VARIANT
+      vehicleAndCityConfig = RemoteConfig.subscriptionsConfigVariantLevel driverCity "default"
+      lottieSubscriptionInfo = fromMaybe RemoteConfig.defaultLottieSubscriptionInfo vehicleAndCityConfig.lottieSubscriptionInfo
+      getLottieByLang lottieConfig = case lang of
+        "HI_IN" -> lottieConfig.hindi
+        "KN_IN" -> lottieConfig.kannada
+        "TA_IN" -> lottieConfig.tamil
+        "BN_IN" -> lottieConfig.bengali
+        "TE_IN" -> lottieConfig.telugu
+        "ML_IN" -> lottieConfig.malayalam
+        _       -> lottieConfig.english
+      lottieUrl = if isOnFreeTrial then
+            getLottieByLang lottieSubscriptionInfo.freeTrialLottie
+          else if isIntroductory then
+            getLottieByLang lottieSubscriptionInfo.introductoryLottie
+          else
+            getLottieByLang lottieSubscriptionInfo.subscriptionPlanLottie
+  in (HU.getAssetsBaseUrl FunctionCall) <> lottieUrl
+
 
 isPaymentPending :: SubscriptionScreenState -> Boolean
 isPaymentPending state = ((state.data.config.subscriptionConfig.enableSubscriptionPopups && state.data.orderId /= Nothing) || state.props.lastPaymentType == Just AUTOPAY_REGISTRATION_TYPE)


### PR DESCRIPTION
## Type of Change
- [x] Enhancement

## Description
Move the Subscription page Lottie banner to remote config so that it can be used on based on cities