### PR TITLE
Reintroduce omnix in direnv

### DIFF
--- a/.envrc.backend
+++ b/.envrc.backend
@@ -1,9 +1,9 @@
 source_url https://raw.githubusercontent.com/juspay/omnix/3a82640921c61528b3a4660f2a1611d2a2ca0bed/omnixrc 'sha256-8C2Jb5bHx/0cvm1+9gOlBEdWzbikCWT5UsJWewUAFt4='
 
-nix_direnv_watch_file \
+watch_file \
     $(find Backend -name "*.cabal" | tr '\n' ' ') \
     Backend/cabal.project \
     Backend/*.nix \
     Backend/nix/*.nix
 
-use flake .#backend
+use omnix .#backend

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,9 @@
 {
+  nixConfig = {
+    # Workaround https://github.com/nammayatri/nammayatri/pull/9493#issuecomment-2506672419
+    max-call-depth = "1000000";
+  };
+
   inputs = {
     common.url = "github:nammayatri/common";
     nixpkgs.follows = "common/nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -80,14 +80,5 @@
           };
         };
       };
-
-      flake = {
-        # Configuration for https://github.com/juspay/nix-browser/tree/main/crates/nix_health#nix-health
-        om.health.default = {
-          caches.required = [ "https://nammayatri.cachix.org" ];
-          direnv.required = true;
-          system.min_ram = "24G";
-        };
-      };
     };
 }

--- a/om.yaml
+++ b/om.yaml
@@ -1,0 +1,9 @@
+health:
+  default:
+    caches:
+      required: 
+        - "https://nammayatri.cachix.org"
+    direnv:
+      required: true
+    system:
+      min_ram: "24G"


### PR DESCRIPTION
https://omnix.page/om/develop.html - automated a bunch of things on top of nix devshell (like using cachix cache automatically, and doing health checks)

We had added this before but it was slower. Now, this should now be faster. 

Expect:

![image](https://github.com/user-attachments/assets/6a5acbb2-9298-48a2-938e-25aadb03b2d6)
