### PR TITLE
ci/nix: Skip macOS builds unless main branch

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Nix CI
 on:
   push:
     branches: ["main", "prodHotPush-Common"]
@@ -47,6 +47,11 @@ jobs:
     strategy:
       matrix:
         system: [x86_64-linux, aarch64-darwin]
+        isMain:
+          - ${{ contains(github.ref, 'main') }}
+        exclude:
+          - system: aarch64-darwin
+            isMain: false
     needs: [process-labels]
     runs-on: ny-ci-nixos
     if: |


### PR DESCRIPTION
Doing this until investigating the slow builds on macOS (which then block other builds)