### PR TITLE
backend/fix/case-when-driver-on-different-stier-ride-after-scheduled-fcm

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator.hs
@@ -160,6 +160,7 @@ type instance JobContent 'UnblockSoftBlockedDriver = UnblockSoftBlockedDriverReq
 
 data SoftBlockNotifyDriverRequestJobData = SoftBlockNotifyDriverRequestJobData
   { driverId :: Id DP.Driver,
+    pendingNotificationRedisKey :: Text,
     entityData :: Notify.IssueBreachEntityData
   }
   deriving (Generic, Show, Eq, FromJSON, ToJSON)


### PR DESCRIPTION

## Type of Change
This is the case when driver is not on ride, so the notification job is scheduled but when the job runs the driver when on different stier ride. So, in this case also we should not send fcm until its cancelled or finished.

This scenario is handled in the pr


- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
