### PR TITLE
backend/enhc/add-strike-off-setting-in-plans

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Plan.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Plan.yaml
@@ -57,6 +57,7 @@ Plan:
     vehicleVariant : Maybe VehicleVariant|NoRelation
     vehicleCategory : VehicleCategory|NoRelation
     listingPriority : Maybe  Int
+    allowStrikeOff: Bool
 
   domainInstance:
     - Custom Kernel.Beam.Lib.UtilsTH.mkBeamInstancesForEnumAndList <PaymentMode>
@@ -141,11 +142,13 @@ Plan:
 
   fromTType:
     vehicleCategory: Storage.Queries.Transformers.Plan.getCategoryFromSubscriptionConfig vehicleCategory merchantOpCityId serviceName|EM
+    allowStrikeOff: Kernel.Prelude.fromMaybe True | I
   toTType:
     vehicleCategory: Kernel.Prelude.Just|I
-
+    allowStrikeOff: Kernel.Prelude.Just|I
   beamType:
     vehicleCategory: Maybe VehicleCategory
+    allowStrikeOff : Maybe Bool
 
   extraOperations:
     - EXTRA_QUERY_FILE

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/Plan.hs
@@ -20,7 +20,8 @@ import qualified Kernel.Utils.TH
 import qualified Tools.Beam.UtilsTH
 
 data Plan = Plan
-  { basedOnEntity :: Domain.Types.Plan.BasedOnEntity,
+  { allowStrikeOff :: Kernel.Prelude.Bool,
+    basedOnEntity :: Domain.Types.Plan.BasedOnEntity,
     cgstPercentage :: Kernel.Types.Common.HighPrecMoney,
     description :: Kernel.Prelude.Text,
     eligibleForCoinDiscount :: Kernel.Prelude.Bool,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Plan.hs
@@ -18,7 +18,8 @@ import qualified Kernel.Types.Common
 import Tools.Beam.UtilsTH
 
 data PlanT f = PlanT
-  { basedOnEntity :: B.C f Domain.Types.Plan.BasedOnEntity,
+  { allowStrikeOff :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Bool),
+    basedOnEntity :: B.C f Domain.Types.Plan.BasedOnEntity,
     cgstPercentage :: B.C f Kernel.Types.Common.HighPrecMoney,
     description :: B.C f Kernel.Prelude.Text,
     eligibleForCoinDiscount :: B.C f Kernel.Prelude.Bool,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/Plan.hs
@@ -20,7 +20,8 @@ instance FromTType' Beam.Plan Domain.Types.Plan.Plan where
     pure $
       Just
         Domain.Types.Plan.Plan
-          { basedOnEntity = basedOnEntity,
+          { allowStrikeOff = Kernel.Prelude.fromMaybe True allowStrikeOff,
+            basedOnEntity = basedOnEntity,
             cgstPercentage = cgstPercentage,
             description = description,
             eligibleForCoinDiscount = eligibleForCoinDiscount,
@@ -50,7 +51,8 @@ instance FromTType' Beam.Plan Domain.Types.Plan.Plan where
 instance ToTType' Beam.Plan Domain.Types.Plan.Plan where
   toTType' (Domain.Types.Plan.Plan {..}) = do
     Beam.PlanT
-      { Beam.basedOnEntity = basedOnEntity,
+      { Beam.allowStrikeOff = Kernel.Prelude.Just allowStrikeOff,
+        Beam.basedOnEntity = basedOnEntity,
         Beam.cgstPercentage = cgstPercentage,
         Beam.description = description,
         Beam.eligibleForCoinDiscount = eligibleForCoinDiscount,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/Plan.hs
@@ -93,7 +93,8 @@ findByPrimaryKey id = do findOneWithKV [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Ty
 updateByPrimaryKey :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.Plan.Plan -> m ())
 updateByPrimaryKey (Domain.Types.Plan.Plan {..}) = do
   updateWithKV
-    [ Se.Set Beam.basedOnEntity basedOnEntity,
+    [ Se.Set Beam.allowStrikeOff (Kernel.Prelude.Just allowStrikeOff),
+      Se.Set Beam.basedOnEntity basedOnEntity,
       Se.Set Beam.cgstPercentage cgstPercentage,
       Se.Set Beam.description description,
       Se.Set Beam.eligibleForCoinDiscount eligibleForCoinDiscount,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Plan.hs
@@ -803,7 +803,9 @@ convertPlanToPlanEntity driverId applicationDate isCurrentPlanEntity plan@Plan {
               then (0.0, baseAmount)
               else do
                 let bestOffer = DL.minimumBy (comparing (.finalOrderAmount)) offers
-                (bestOffer.discountAmount, bestOffer.finalOrderAmount)
+                if plan.allowStrikeOff
+                  then (bestOffer.discountAmount, bestOffer.finalOrderAmount)
+                  else (0.0, baseAmount)
       [ PlanFareBreakup {component = "INITIAL_BASE_FEE", amount = baseAmount, amountWithCurrency = PriceAPIEntity baseAmount currency},
         PlanFareBreakup {component = "REGISTRATION_FEE", amount = plan.registrationAmount, amountWithCurrency = PriceAPIEntity plan.registrationAmount currency},
         PlanFareBreakup {component = "MAX_FEE_LIMIT", amount = plan.maxAmount, amountWithCurrency = PriceAPIEntity plan.maxAmount currency},

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/plan.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/plan.sql
@@ -55,3 +55,8 @@ ALTER TABLE atlas_driver_offer_bpp.plan ADD COLUMN vehicle_category text ;
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.plan ADD COLUMN listing_priority integer ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.plan ADD COLUMN allow_strike_off boolean ;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added `allowStrikeOff` boolean field to Plan configuration.
  - Enhanced plan management with strike-off control option.

- **Database Changes**
  - New column `allow_strike_off` added to the plan table.
  - Supports optional configuration of strike-off permissions.

- **Behavior Update**
  - Discount calculation now respects plan's strike-off settings.
  - Default strike-off setting is `True`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->