### PR TITLE
frontend/fix/added filter in same source lat long fix in one-Click bo…

### DIFF
--- a/Frontend/ui-customer/src/Helpers/SuggestionUtils.purs
+++ b/Frontend/ui-customer/src/Helpers/SuggestionUtils.purs
@@ -392,21 +392,23 @@ correctServiceTierName serviceTierName =
 
 removeDuplicateTrips :: Array Trip -> Int -> Array Trip
 removeDuplicateTrips trips precision = 
-  let 
-    grouped = DA.groupBy 
-      (\trip1 trip2 -> 
-        (getGeoHash trip1.destLat trip1.destLong precision) 
-        == 
-        (getGeoHash trip2.destLat trip2.destLong precision)
-        && trip1.serviceTierNameV2 == trip2.serviceTierNameV2
-      ) 
-      trips
+  let validTrips = filter (\trip -> 
+          (trip.sourceLat /= trip.destLat || trip.sourceLong /= trip.destLong) && (getDistanceBwCordinates trip.sourceLat trip.sourceLong trip.destLat trip.destLong /= 0.0)
+        ) trips
+      grouped = DA.groupBy 
+        (\trip1 trip2 -> 
+          (getGeoHash trip1.destLat trip1.destLong precision) 
+          == 
+          (getGeoHash trip2.destLat trip2.destLong precision)
+          && trip1.serviceTierNameV2 == trip2.serviceTierNameV2
+        ) 
+        validTrips
 
-    maxScoreTrips = map 
-      (maximumBy (comparing (\trip -> trip.locationScore))) 
-      grouped
-  in 
-    catMaybes maxScoreTrips
+      maxScoreTrips = map 
+        (maximumBy (comparing (\trip -> trip.locationScore))) 
+        grouped
+    in 
+      catMaybes maxScoreTrips
 
 isPointWithinXDist :: Trip -> Number -> Number -> Number -> Boolean
 isPointWithinXDist item lat lon thresholdDist =


### PR DESCRIPTION
…oking

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved trip deduplication logic to exclude trips with identical source and destination coordinates.
	- Enhanced trip filtering to ensure only valid trips are considered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->