### PR TITLE
backend/fix: Skip aarch Intel build

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -2,12 +2,12 @@ name: Nix CI
 
 on:
   push:
-    branches: 
+    branches:
       - "main"
       - "prodHotPush-Common"
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    branches: 
+    branches:
       - "main"
       - "prodHotPush-Common"
   workflow_dispatch:
@@ -31,7 +31,7 @@ jobs:
         uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-      
+
       - name: Check global conditions
         id: evaluate
         run: |
@@ -43,7 +43,7 @@ jobs:
           else
             echo "should_proceed=false" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: Check for backend label
         id: check-labels
         run: |
@@ -81,8 +81,8 @@ jobs:
             host: x86_64-linux
           - system: aarch64-darwin
             host: aarch64-darwin
-          - system: aarch64-linux
-            host: aarch64-darwin
+          # - system: aarch64-linux
+          #   host: aarch64-darwin
     runs-on: ${{ matrix.host }}
     outputs:
       docker-image-name: ${{ steps.docker.outputs.image_name }}
@@ -112,7 +112,7 @@ jobs:
         run: |
           nix build .#dockerImage -o docker-image.tgz
           echo "image_name=$(nix eval --raw .#dockerImage.imageName):$(nix eval --raw .#dockerImage.imageTag)" >> $GITHUB_OUTPUT
-      
+
       - name: Upload Docker image
         if: steps.check-conditions.outputs.should_build == 'true' && matrix.system == 'x86_64-linux' && needs.check-conditions.outputs.should-push-docker == 'true'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD Workflow Updates**
	- Enhanced GitHub Actions workflow configuration
	- Improved condition checking for pull request processing
	- Added Docker image upload and artifact management steps
	- Refined build matrix configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->