### PR TITLE
backend/ci: More unique nix eval cache dir

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/nix
-          key: nixcache-${{ matrix.system }}
+          key: nixcache-${{ matrix.host }}-${{ matrix.system }}
 
       - name: Build all flake outputs
         if: steps.check-conditions.outputs.should_build == 'true'


### PR DESCRIPTION
This may deal with failures like this:

https://github.com/nammayatri/nammayatri/actions/runs/12763040102/job/35572514073

<img width="1271" alt="Screenshot 2025-01-14 at 9 25 52 AM" src="https://github.com/user-attachments/assets/18bd571a-eb93-47d2-a269-76219fc18908" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for improved caching and Docker image push conditions
	- Refined build job dependencies and condition checks
	- Centralized logic for determining Docker image push scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->