### PR TITLE
Backend/fix/time-format-partnerorg

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/GWLink.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/GWLink.hs
@@ -120,3 +120,6 @@ showTimeIst time =
   T.pack $
     formatTime defaultTimeLocale "%d %b %Y, %I:%M %p" $
       addUTCTime (60 * 330) time
+
+utcTimeToText :: UTCTime -> Text
+utcTimeToText = T.pack . formatTime defaultTimeLocale "%FT%TZ"

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
@@ -262,8 +262,8 @@ mkTransitObjects booking pOrgId ticket person serviceAccount = do
   let textModuleValidUntil = TC.TextModule {TC._header = "Valid until", TC.body = istTimeText, TC.id = "myfield2"}
   let textModules = [textModuleTicketNumber, textModuleValidUntil]
   now <- getCurrentTime
-  let nowText = utcTimeToText now
-  let validTillText = utcTimeToText ticket.validTill
+  let nowText = GWSA.utcTimeToText now
+  let validTillText = GWSA.utcTimeToText ticket.validTill
   let timeInterval = TC.TimeInterval {TC.start = TC.DateTime {TC.date = nowText}, TC.end = TC.DateTime {TC.date = validTillText}}
   return
     TC.TransitObject


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a utility function `utcTimeToText` for converting UTC time to ISO 8601 formatted text
- **Refactor**
  - Updated time formatting method in `OnConfirm` module to use the new utility function
  - Improved time representation consistency across modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->