### PR TITLE
backend/fix/ambulance_toggle

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/VehicleServiceTier.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/VehicleServiceTier.hs
@@ -16,6 +16,7 @@ module SharedLogic.VehicleServiceTier where
 
 import qualified Domain.Types.DriverInformation as DI
 import qualified Domain.Types.Vehicle as DV
+import qualified Domain.Types.VehicleCategory as VC
 import qualified Domain.Types.VehicleServiceTier as DVST
 import Kernel.Prelude
 
@@ -28,8 +29,10 @@ selectVehicleTierForDriverWithUsageRestriction onlyAutoSelected driverInfo vehic
       let _seatingCapacityCheck = compareNumber vehicle.capacity vehicleServiceTier.seatingCapacity
           luggageCapacityCheck = compareNumber vehicle.luggageCapacity vehicleServiceTier.luggageCapacity
           airConditionedCheck =
-            (compareNumber vehicleServiceTier.airConditionedThreshold driverInfo.airConditionScore)
-              && (isNothing vehicleServiceTier.airConditionedThreshold || vehicle.airConditioned /= Just False)
+            (vehicleServiceTier.vehicleCategory == Just VC.AMBULANCE)
+              || ( (compareNumber vehicleServiceTier.airConditionedThreshold driverInfo.airConditionScore)
+                     && (isNothing vehicleServiceTier.airConditionedThreshold || vehicle.airConditioned /= Just False)
+                 )
           driverRatingCheck = compareNumber Nothing vehicleServiceTier.driverRating -- driverStats.rating (Fix this later, removed due to perf issues)
           vehicleRatingCheck = compareNumber vehicle.vehicleRating vehicleServiceTier.vehicleRating
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the vehicle tier evaluation process. Vehicles identified as ambulances now follow an optimized selection that bypasses some previous eligibility checks, streamlining the overall matching experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->