### PR TITLE
Added lock to handle concurrent requests on Multimodal LegSearchId in Add Skip Leg 

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Base.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Base.hs
@@ -110,7 +110,8 @@ getAllLegsInfo ::
   m [JL.LegInfo]
 getAllLegsInfo journeyId = do
   allLegsRawData <- getJourneyLegs journeyId
-  allLegsInfo <-
+  let lockKey = multimodalLegSearchIdAccessLockKey journeyId.getId
+  Redis.withLockRedisAndReturnValue lockKey 5 $ do
     allLegsRawData `forM` \leg -> do
       case leg.legSearchId of
         Just legSearchIdText -> do
@@ -122,7 +123,6 @@ getAllLegsInfo journeyId = do
             DTrip.Subway -> JL.getInfo $ SubwayLegRequestGetInfo $ SubwayLegRequestGetInfoData {searchId = cast legSearchId, fallbackFare = leg.estimatedMinFare, distance = leg.distance, duration = leg.duration}
             DTrip.Bus -> JL.getInfo $ BusLegRequestGetInfo $ BusLegRequestGetInfoData {searchId = cast legSearchId, fallbackFare = leg.estimatedMinFare, distance = leg.distance, duration = leg.duration}
         Nothing -> throwError $ InvalidRequest ("LegId null for Mode: " <> show leg.mode)
-  return $ allLegsInfo
 
 getAllLegsStatus ::
   JL.GetStateFlow m r c =>
@@ -131,10 +131,12 @@ getAllLegsStatus ::
 getAllLegsStatus journey = do
   allLegsRawData <- getJourneyLegs journey.id
   riderLastPoints <- getLastThreePoints journey.id
-  (_, allLegsState) <- foldlM (processLeg riderLastPoints) (True, []) allLegsRawData
-  when ((all (\st -> st.status `elem` [JL.Completed, JL.Skipped, JL.Cancelled]) allLegsState) && journey.status /= DJourney.CANCELLED) $ do
-    updateJourneyStatus journey DJourney.FEEDBACK_PENDING
-  return allLegsState
+  let lockKey = multimodalLegSearchIdAccessLockKey journey.id.getId
+  Redis.withLockRedisAndReturnValue lockKey 5 $ do
+    (_, allLegsState) <- foldlM (processLeg riderLastPoints) (True, []) allLegsRawData
+    when (all (\st -> st.status `elem` [JL.Completed, JL.Skipped, JL.Cancelled]) allLegsState && journey.status /= DJourney.CANCELLED) $ do
+      updateJourneyStatus journey DJourney.FEEDBACK_PENDING
+    return allLegsState
   where
     processLeg ::
       JL.GetStateFlow m r c =>
@@ -463,6 +465,9 @@ cancelRemainingLegs journeyId = do
   unless (null failures) $
     throwError $ InvalidRequest $ "Failed to cancel some legs: " <> show failures
 
+multimodalLegSearchIdAccessLockKey :: Text -> Text
+multimodalLegSearchIdAccessLockKey legSearchId = "Multimodal:Leg:SearchIdAccess:" <> legSearchId
+
 skipLeg ::
   (JL.GetStateFlow m r c, m ~ Kernel.Types.Flow.FlowR AppEnv) =>
   Id DJourney.Journey ->
@@ -519,10 +524,23 @@ addSkippedLeg journeyId legOrder = do
   when (isSkippedOrCancelled /= Just True) $
     throwError $ InvalidRequest $ "isSkipped is not True for legOrder: " <> show legOrder
   when (skippedLeg.mode == DTrip.Walk) $
-    QJourneyLeg.updateIsDeleted Nothing skippedLeg.legSearchId
-  QJourneyLeg.updateLegSearchId Nothing skippedLeg.id
-  QJourneyLeg.updateIsSkipped (Just False) (skippedLeg.legSearchId)
-  addAllLegs journeyId
+    QJourneyLeg.updateIsDeleted (Just False) skippedLeg.legSearchId
+
+  let lockKey = multimodalLegSearchIdAccessLockKey journeyId.getId
+  exep <- try @_ @SomeException $ do
+    Redis.withLockRedis lockKey 5 $ do
+      QJourneyLeg.updateIsSkipped (Just False) skippedLeg.legSearchId
+      QJourneyLeg.updateLegSearchId Nothing skippedLeg.id
+      addAllLegs journeyId
+  case exep of
+    Left _ -> do
+      -- Rollback operations
+      QJourneyLeg.updateLegSearchId skippedLeg.legSearchId skippedLeg.id
+      QJourneyLeg.updateIsSkipped (Just True) skippedLeg.legSearchId
+      when (skippedLeg.mode == DTrip.Walk) $
+        QJourneyLeg.updateIsDeleted (Just True) skippedLeg.legSearchId
+      throwError $ InvalidRequest "Failed to update skipped leg, as Search operation failed"
+    Right _ -> return ()
   where
     checkFRFSBooking legSearchId = do
       frfsBooking <- QTBooking.findBySearchId (Id legSearchId)


### PR DESCRIPTION
… Add Skip Leg

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced journey operations with an advanced concurrency control mechanism to ensure consistent and reliable data updates during simultaneous actions.
  - Improved processing stability during journey updates, providing a more robust experience even under high concurrent activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->