### PR TITLE
backend/fix: onboarding truck range

### DIFF
--- a/Backend/lib/beckn-spec/src/Domain/Types/VehicleVariant.hs
+++ b/Backend/lib/beckn-spec/src/Domain/Types/VehicleVariant.hs
@@ -199,6 +199,7 @@ getTruckVehicleVariant mbGrossVehicleWeight mbUnladdenWeight currentVariant = fl
   \(grossVehicleWeight, unladdenWeight) -> getVariantBasedOnWeight (grossVehicleWeight - unladdenWeight)
   where
     getVariantBasedOnWeight weight
+      | weight > 4000 = DELIVERY_LIGHT_GOODS_VEHICLE
       | weight >= 2500 = DELIVERY_TRUCK_ULTRA_LARGE
       | weight >= 1500 = DELIVERY_TRUCK_LARGE
       | weight >= 1000 = DELIVERY_TRUCK_MEDIUM


### PR DESCRIPTION
add range above 4000 for DELIVERY_LIGHT_GOODS_VEHICLE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced vehicle classification logic: The algorithm determining vehicle variants has been updated. A new condition now automatically categorizes vehicles weighing more than 4000 as delivery light goods. This improvement ensures more accurate classification based on vehicle weight and provides users with more precise results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->