### PR TITLE
backend/fix: made bearing type as nullable in nearByDriver api

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/Nearby.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/Nearby.yaml
@@ -28,7 +28,7 @@ types:
     applicableServiceTierTypes: "[ServiceTierType]"
     distance: Meters
     driverId: Text
-    bearing: Int
+    bearing: Maybe Int
 
 apis:
   - POST:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/NearbyDrivers.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/NearbyDrivers.hs
@@ -16,7 +16,7 @@ import Tools.Auth
 
 data DriverInfo = DriverInfo
   { applicableServiceTierTypes :: [Domain.Types.ServiceTierType.ServiceTierType],
-    bearing :: Kernel.Prelude.Int,
+    bearing :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
     distance :: Kernel.Types.Distance.Meters,
     driverId :: Data.Text.Text,
     lat :: Kernel.Prelude.Double,

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/LocationTrackingService/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/LocationTrackingService/Types.hs
@@ -86,7 +86,7 @@ data NearByDriverRes = NearByDriverRes
     coordinatesCalculatedAt :: UTCTime,
     createdAt :: UTCTime,
     updatedAt :: UTCTime,
-    bear :: Int,
+    bear :: Maybe Int,
     vehicleType :: VV.VehicleVariant
   }
   deriving (Generic, Show, HasCoordinates, FromJSON, ToJSON)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced driver data handling by allowing the directional (“bearing”) information to be optional. This improvement better accommodates scenarios where such details may be missing, ensuring a more robust and flexible presentation of driver information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->