### PR TITLE
Backend/frfs/change encryption of qr to signing of qr

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/package.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/package.yaml
@@ -207,3 +207,24 @@ executables:
       - rider-app
       - mobility-core
       - beckn-spec
+
+tests:
+  rider-app-test:
+    main: Main.hs
+    source-dirs: test
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+    dependencies:
+      - rider-app
+      - mobility-core
+      - tasty
+      - tasty-hunit
+      - tasty-quickcheck
+      - safe-exceptions
+      - base64-bytestring
+      - cryptonite
+      - time
+      - text
+      - bytestring

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -1340,3 +1340,135 @@ executable rider-app-exe
     ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
+
+test-suite rider-app-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      FRFS.DirectQR
+      Paths_rider_app
+  hs-source-dirs:
+      test
+  default-extensions:
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DerivingStrategies
+      DeriveAnyClass
+      DeriveFunctor
+      DeriveGeneric
+      DerivingStrategies
+      DuplicateRecordFields
+      ExplicitNamespaces
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoImplicitPrelude
+      OverloadedStrings
+      PatternSynonyms
+      PolyKinds
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      ViewPatterns
+      BlockArguments
+      TypeSynonymInstances
+      UndecidableInstances
+      PackageImports
+      TemplateHaskell
+  ghc-options: -fwrite-ide-info -hiedir=.hie -fplugin=RecordDotPreprocessor -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      aeson
+    , amazonka
+    , amazonka-core
+    , amazonka-ses
+    , base >=4.7 && <5
+    , base64-bytestring
+    , beam-core
+    , beam-mysql
+    , beam-postgres
+    , bytestring
+    , casing
+    , cassava
+    , cereal
+    , containers
+    , cryptonite
+    , cryptostore >=0.2.3.0
+    , dashboard-helper-api
+    , data-default-class
+    , directory
+    , euler-hs
+    , extra
+    , filepath
+    , geohash ==1.0.1
+    , hashable
+    , http-api-data
+    , http-client
+    , http-client-tls
+    , http-media
+    , http-types
+    , insert-ordered-containers
+    , json-logic-hs
+    , jwt
+    , lens
+    , lens-aeson
+    , memory
+    , mobility-core
+    , morpheus-graphql-client
+    , mtl
+    , openapi3
+    , passetto-client
+    , persistent
+    , postgresql-simple
+    , prometheus-client
+    , prometheus-metrics-ghc
+    , pureMD5
+    , random
+    , raw-strings-qq
+    , record-dot-preprocessor
+    , record-hasfield
+    , regex-posix
+    , resource-pool
+    , rider-app
+    , safe-exceptions
+    , scheduler
+    , scientific
+    , sequelize
+    , servant
+    , servant-client
+    , servant-client-core
+    , servant-openapi3
+    , servant-server
+    , singletons
+    , singletons-th
+    , split
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell
+    , text
+    , text-conversions
+    , text-format
+    , time
+    , transformers
+    , unliftio-core
+    , unordered-containers
+    , uuid
+    , vector
+    , wai
+    , wai-extra
+    , wai-middleware-prometheus
+    , warp
+    , x509
+    , yudhishthira
+  default-language: Haskell2010

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
@@ -551,6 +551,9 @@ FRFSTicket:
       kvFunction: findOneWithKV
       where:
         and: [frfsTicketBookingId, ticketNumber]
+    findOneByTicketNumber:
+      kvFunction: findOneWithKV
+      where: ticketNumber
     updateStatusByTBookingIdAndTicketNumber:
       kvFunction: updateWithKV
       params: [status, scannedByVehicleNumber, updatedAt]

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicket.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicket.hs
@@ -42,6 +42,9 @@ findByTicketBookingIdTicketNumber frfsTicketBookingId ticketNumber = do
         ]
     ]
 
+findOneByTicketNumber :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Prelude.Text -> m (Maybe Domain.Types.FRFSTicket.FRFSTicket))
+findOneByTicketNumber ticketNumber = do findOneWithKV [Se.Is Beam.ticketNumber $ Se.Eq ticketNumber]
+
 updateAllStatusByBookingId :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.FRFSTicket.FRFSTicketStatus -> Kernel.Types.Id.Id Domain.Types.FRFSTicketBooking.FRFSTicketBooking -> m ())
 updateAllStatusByBookingId status frfsTicketBookingId = do
   _now <- getCurrentTime

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/Common.hs
@@ -53,8 +53,7 @@ data DTicket = DTicket
   }
 
 data DTicketPayload = DTicketPayload
-  { transactionId :: Text,
-    fromRouteProviderCode :: Text,
+  { fromRouteProviderCode :: Text,
     toRouteProviderCode :: Text,
     adultQuantity :: Int,
     childQuantity :: Int,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnStatus.hs
@@ -50,8 +50,8 @@ validateRequest (Booking DOrder {..}) = do
   merchant <- QMerch.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
   return (merchant, booking)
 validateRequest (TicketVerification DTicketPayload {..}) = do
-  _ <- runInReplica $ QSearch.findById (Id transactionId) >>= fromMaybeM (SearchRequestDoesNotExist transactionId)
-  booking <- runInReplica $ QTBooking.findBySearchId (Id transactionId) >>= fromMaybeM (BookingDoesNotExist transactionId)
+  ticket <- runInReplica $ QTicket.findOneByTicketNumber ticketNumber >>= fromMaybeM (TicketDoesNotExist ticketNumber)
+  booking <- runInReplica $ QTBooking.findById ticket.frfsTicketBookingId >>= fromMaybeM (BookingDoesNotExist ticket.frfsTicketBookingId.getId)
   let merchantId = booking.merchantId
   merchant <- QMerch.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
   return (merchant, booking)

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Direct/Order.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Direct/Order.hs
@@ -58,8 +58,7 @@ getTicketDetail config integratedBPPConfigId qrTtl booking routeStation = do
   qrData <-
     generateQR config $
       TicketPayload
-        { transactionId = booking.searchId.getId,
-          fromRouteProviderCode = fromRoute.providerCode,
+        { fromRouteProviderCode = fromRoute.providerCode,
           toRouteProviderCode = toRoute.providerCode,
           adultQuantity = adultQuantity,
           childQuantity = 0,

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Direct/Utils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Direct/Utils.hs
@@ -1,10 +1,11 @@
 module ExternalBPP.ExternalAPI.Direct.Utils where
 
-import Crypto.Cipher.TripleDES
-import Crypto.Cipher.Types
-import Crypto.Data.Padding
-import Crypto.Error (CryptoFailable (..))
+import Crypto.Error as Crypto
+import qualified Crypto.PubKey.Ed25519 as Ed25519
+import qualified Data.ByteArray as BA
+import Data.ByteString
 import qualified Data.ByteString.Base64 as Base64
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Domain.Types.IntegratedBPPConfig
 import ExternalBPP.ExternalAPI.Types
@@ -14,45 +15,51 @@ import Kernel.Types.Base64
 import Kernel.Utils.Common
 import Tools.Error
 
+-- | Sign a request given the key
+sign :: Base64 -> Text -> Either Crypto.CryptoError ByteString
+sign (Base64 privateKey) msg =
+  let sk = Ed25519.secretKey privateKey
+      pk = Ed25519.toPublic <$> sk
+      signature = Ed25519.sign <$> sk <*> pk <*> pure (TE.encodeUtf8 msg)
+   in Crypto.eitherCryptoError $ BA.convert <$> signature
+
+verify :: Base64 -> Text -> ByteString -> Either Crypto.CryptoError Bool
+verify (Base64 privateKey) msg signatureBs =
+  let sk = Ed25519.secretKey privateKey
+      pk = Ed25519.toPublic <$> sk
+      signature = Ed25519.signature signatureBs
+   in Crypto.eitherCryptoError $ Ed25519.verify <$> pk <*> pure (TE.encodeUtf8 msg) <*> signature
+
 generateQR :: (MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r) => DIRECTConfig -> TicketPayload -> m Text
 generateQR config ticket = do
-  let cipherKey = config.cipherKey
-      qrData = encodeToText ticket
-  encryptedQR <- encryptDES cipherKey qrData & fromEitherM (\err -> InternalError $ "Failed to encrypt: " <> show err)
-  return encryptedQR
-  where
-    encryptDES :: Base64 -> Text -> Either String Text
-    encryptDES (Base64 cipherKey) plainText = do
-      let cipherEither = cipherInit cipherKey :: CryptoFailable DES_EDE3
-      case cipherEither of
-        CryptoPassed cipher ->
-          let paddedPlainText = pad (PKCS7 (blockSize cipher)) (TE.encodeUtf8 plainText)
-           in Right $ TE.decodeUtf8 $ Base64.encode $ ecbEncrypt cipher paddedPlainText
-        CryptoFailed err -> Left $ show err
+  let secretKey = config.cipherKey
+      qrData = ticket.ticketNumber <> "," <> ticket.fromRouteProviderCode <> "," <> ticket.toRouteProviderCode <> "," <> show ticket.adultQuantity <> "," <> show ticket.childQuantity <> "," <> ticket.vehicleTypeProviderCode <> "," <> show ticket.ticketAmount.getMoney <> "," <> ticket.expiry <> "," <> maybe "" show ticket.refreshAt
+  signature <- sign secretKey qrData & fromEitherM (\err -> InternalError $ "Failed to encrypt: " <> show err)
+  return $ (TE.decodeUtf8 $ Base64.encode signature) <> "," <> qrData
 
 decodeQR :: (MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r) => DIRECTConfig -> Text -> m TicketPayload
-decodeQR config encryptedQrData = do
-  let cipherKey = config.cipherKey
-  decryptedQR <- decryptDES cipherKey encryptedQrData & fromEitherM (\err -> InternalError $ "Failed to decrypt: " <> show err)
-  ticket :: TicketPayload <- decodeFromText decryptedQR & fromMaybeM (InternalError "Could not decode the QR!")
-  return ticket
-  where
-    decryptDES :: Base64 -> Text -> Either String Text
-    decryptDES (Base64 cipherKey) encryptedText = do
-      let cipherEither = cipherInit cipherKey :: CryptoFailable DES_EDE3
-      case cipherEither of
-        CryptoPassed cipher -> do
-          let decodedCipherText = Base64.decodeLenient (TE.encodeUtf8 encryptedText)
-              decryptedPaddedText = ecbDecrypt cipher decodedCipherText
-              decryptedText = unpad (PKCS7 (blockSize cipher)) decryptedPaddedText
-          case decryptedText of
-            Just decryptText -> Right $ TE.decodeUtf8 decryptText
-            Nothing -> Left "Could not decrypt!"
-        CryptoFailed err -> Left $ show err
+decodeQR config signatureAndQrData = do
+  let secretKey = config.cipherKey
+  signature <- Base64.decode (TE.encodeUtf8 $ T.takeWhile (/= ',') signatureAndQrData) & fromEitherM (\err -> InternalError $ "Failed to decode signature to base64: " <> show err)
+  let qrData = T.drop 1 $ T.dropWhile (/= ',') signatureAndQrData
+  isVerified <- verify secretKey qrData signature & fromEitherM (\err -> InternalError $ "Failed to decrypt: " <> show err)
+  unless isVerified $ throwError (InvalidRequest "Invalid QR data")
+  (ticketNumber, fromRouteProviderCode, toRouteProviderCode, adultQuantity', childQuantity', vehicleTypeProviderCode, ticketAmount', expiry, refreshAt') <-
+    case T.strip <$> T.splitOn "," qrData of
+      [ticketNumber, fromRouteProviderCode, toRouteProviderCode, adultQuantity', childQuantity', vehicleTypeProviderCode, ticketAmount', expiry, refreshAt'] -> pure (ticketNumber, fromRouteProviderCode, toRouteProviderCode, adultQuantity', childQuantity', vehicleTypeProviderCode, ticketAmount', expiry, refreshAt')
+      _ -> throwError (InvalidRequest "Unable to decode QR data")
+  adultQuantity :: Int <- (readMaybe . T.unpack $ adultQuantity') & fromMaybeM (InvalidRequest "Unable to decode adult quantity")
+  childQuantity :: Int <- (readMaybe . T.unpack $ childQuantity') & fromMaybeM (InvalidRequest "Unable to decode child quantity")
+  ticketAmount :: Money <- (readMaybe . T.unpack $ ticketAmount') & fromMaybeM (InvalidRequest "Unable to decode ticket amount")
+  let refreshAt :: Maybe UTCTime = readMaybe . T.unpack $ refreshAt'
+  return $
+    TicketPayload
+      { ..
+      }
 
 refreshQR :: (MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r) => DIRECTConfig -> Text -> m (Maybe (Text, UTCTime))
-refreshQR config encryptedQrData = do
-  ticket :: TicketPayload <- decodeQR config encryptedQrData
+refreshQR config signatureAndQrData = do
+  ticket :: TicketPayload <- decodeQR config signatureAndQrData
   now <- getCurrentTime
   let mbRefreshAt = config.qrRefreshTtl <&> (\ttl -> addUTCTime (secondsToNominalDiffTime ttl) now)
   case (ticket.refreshAt, mbRefreshAt) of

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Types.hs
@@ -5,8 +5,7 @@ import Kernel.Types.Price
 
 -- Encrypted QR code generation
 data TicketPayload = TicketPayload
-  { transactionId :: Text,
-    fromRouteProviderCode :: Text,
+  { fromRouteProviderCode :: Text,
     toRouteProviderCode :: Text,
     adultQuantity :: Int,
     childQuantity :: Int,
@@ -16,7 +15,7 @@ data TicketPayload = TicketPayload
     ticketAmount :: Money,
     refreshAt :: Maybe UTCTime
   }
-  deriving (Generic, FromJSON, ToJSON, Show, Read)
+  deriving (Generic, FromJSON, ToJSON, Show, Read, Eq)
 
 data ProviderTicket = ProviderTicket
   { ticketNumber :: Text,

--- a/Backend/app/rider-platform/rider-app/Main/test/FRFS/DirectQR.hs
+++ b/Backend/app/rider-platform/rider-app/Main/test/FRFS/DirectQR.hs
@@ -1,0 +1,88 @@
+module FRFS.DirectQR where
+
+import App.Server
+import Control.Exception.Safe (SomeException)
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Time (Day (..), UTCTime (..), secondsToDiffTime)
+import Data.Time.Clock (NominalDiffTime)
+import Domain.Types.IntegratedBPPConfig
+import Environment
+import qualified EulerHS.Interpreters as R
+import EulerHS.Prelude
+import qualified EulerHS.Runtime as ER
+import ExternalBPP.ExternalAPI.Direct.Utils
+import ExternalBPP.ExternalAPI.Types
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics.Types
+import Kernel.Types.Base64
+import Kernel.Types.Flow
+import Kernel.Utils.Common
+import Kernel.Utils.FlowLogging
+import qualified Kernel.Utils.SignatureAuth as HttpSig
+import Test.Tasty
+import Test.Tasty.HUnit
+import Tools.Error
+
+-- Test configuration as JSON string
+testConfigJson :: Text
+testConfigJson = T.pack "{\"cipherKey\":\"4nLE9cN2golcxW16Df5aOcajSJqDAupo2B4rLcczKEI=\",\"qrRefreshTtl\":3600}"
+
+-- Test ticket payload as JSON string
+testTicketJson :: Text
+testTicketJson = T.pack "{\"ticketNumber\":\"313356\",\"fromRouteProviderCode\":\"SCM\",\"toRouteProviderCode\":\"SKO\",\"adultQuantity\":2,\"childQuantity\":0,\"vehicleTypeProviderCode\":\"1\",\"ticketAmount\":5,\"expiry\":\"2025-10-01T00:00:00Z\",\"refreshAt\":\"2025-09-01T00:00:00Z\"}"
+
+decodeFromTextEither :: (FromJSON a) => Text -> Either String a
+decodeFromTextEither = A.eitherDecode . BSL.fromStrict . TE.encodeUtf8
+
+tests :: ER.FlowRuntime -> AppEnv -> Flow ()
+tests flowRt' appEnv = do
+  logInfo "Running QR code generation and decoding functions..."
+
+  -- Generate key pair
+  logInfo "Generating key pair..."
+  (privateKey, publicKey) <- liftIO $ HttpSig.generateKeyPair
+  logInfo $ "Private key: " <> (TE.decodeUtf8 $ BSL.toStrict $ A.encode privateKey)
+  logInfo $ "Public key: " <> (TE.decodeUtf8 $ BSL.toStrict $ A.encode publicKey)
+
+  -- Decode test configuration
+  logInfo "Decoding test configuration..."
+  testConfig <-
+    decodeFromTextEither @DIRECTConfig testConfigJson & \case
+      Right config -> pure config
+      Left err -> throwError $ InvalidRequest $ "Failed to decode test config: " <> show err
+
+  -- Decode test ticket
+  logInfo "Decoding test ticket..."
+  testTicket <-
+    decodeFromTextEither @TicketPayload testTicketJson & \case
+      Right ticket -> pure ticket
+      Left err -> throwError $ InvalidRequest $ "Failed to decode test ticket: " <> show err
+
+  -- Generate QR code
+  logInfo "Generating QR code..."
+  qrData <- generateQR testConfig testTicket
+  logInfo $ "Generated QR data: " <> qrData
+
+  -- Decode QR code
+  logInfo "Decoding QR code..."
+  decodedTicket <- decodeQR testConfig qrData
+  logInfo $ "Decoded ticket: " <> show decodedTicket
+
+  -- Try QR code refresh
+  logInfo "Attempting QR code refresh..."
+  mbRefreshed <- refreshQR testConfig qrData
+  case mbRefreshed of
+    Just (newQrData, newRefreshAt) -> do
+      logInfo $ "New QR data: " <> newQrData
+      logInfo $ "New refresh time: " <> show newRefreshAt
+    Nothing -> logInfo "QR code refresh failed"
+
+  -- Try invalid QR code
+  logInfo "Testing invalid QR code..."
+  result <- try @_ @SomeException $ decodeQR testConfig "invalid_qr_data"
+  case result of
+    Left err -> logInfo $ "Expected error for invalid QR: " <> show err
+    Right _ -> logInfo "Unexpected success for invalid QR"

--- a/Backend/app/rider-platform/rider-app/Main/test/Main.hs
+++ b/Backend/app/rider-platform/rider-app/Main/test/Main.hs
@@ -1,0 +1,35 @@
+import App
+import qualified Data.Text as T
+import Environment
+import qualified EulerHS.Language as L
+import EulerHS.Prelude
+import EulerHS.Runtime (withFlowRuntime)
+import qualified FRFS.DirectQR as DirectQR
+import Kernel.Beam.Types (KafkaConn (..))
+import Kernel.Exit
+import Kernel.Tools.Metrics.CoreMetrics.Types
+import Kernel.Types.Flow
+import Kernel.Utils.App
+import Kernel.Utils.Common
+import Kernel.Utils.Dhall
+import Kernel.Utils.FlowLogging
+import System.Environment (lookupEnv)
+import System.Environment as Env (setEnv)
+
+main :: IO ()
+main = do
+  -- setEnv "RIDER_APP_CONFIG_PATH" "../../../../dhall-configs/dev/rider-app.dhall"
+  -- appCfg <- readDhallConfigDefault "rider-app"
+  -- hostname <- (T.pack <$>) <$> lookupEnv "POD_NAME"
+  -- let loggerRt = getEulerLoggerRuntime hostname $ appCfg.loggerConfig
+  -- appEnv <- try (buildAppEnv appCfg) >>= handleLeftIO @SomeException exitBuildingAppEnvFailure "Couldn't build AppEnv: "
+
+  -- withFlowRuntime (Just loggerRt) $ \flowRt -> do
+  --   runFlowR flowRt appEnv $ do
+  --     logInfo "Starting Direct QR tests..."
+  --     DirectQR.tests flowRt appEnv
+  --     logInfo "Finished Direct QR tests"
+
+  -- -- Let the Logs be flushed
+  -- threadDelaySec (Seconds 10)
+  pure ()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
## Reduce Size of QR Data By Changing Encryption to Signing

**Earlier QR Data Size (Approx 460 Bytes)**
```
mIJy4Q1kldiSM7oRa2gXhdLbFcuYL8yZjbrHpt+NYlo9uE7CSQhI1L1ldHcg8c08jWY6Gjw40Ts+dubjN4MTENKgJb7YE05G5b7/HclbUUaQb1I+7vwvabjQ4Nt4r4PW+piMuVJ/wTIpSByBg422owNpVaooUT8Ni04qCfcGf42uakwKWk7xhE/Oq4ppbY3+85Z5ARo4PiHEpNZoFma8cSigklyOAVlLiNLv0mjKRa5HREk69lned6dJ5dH2jL0hNtLx7LaXnm0wDqyYt/5B2zaoWzIThZuBxabpF709wDF4PSv311iCMrqJ2hqRN1KOq5j2rKV0DciLJb24EP3bW7FsBa/7KO6GWLY93tloU3XVTRFhPw81zY+Ba0ewLaFM0bB5wxE3sD1k3hfuAujqsJdcnD9PL4CP/aeOvzoa5+wwDqyYt/5B2zaoWzIThZuB681ay8Wv32U=
```

**New QR Data Size (Approx 156 Bytes)**
```
r9gVjZEwK0gP8sSt3euL3N3MBzymJPbPZmtm3Fch068yTV/kxKSkkwHzLcNW3ECtKczqvfKgC2VPI12AWM2FDw==,313356,SCM,SKO,2,0,1,5,2025-10-01T00:00:00Z,2025-09-01 00:00:00 UTC
```

**Test Case**
```
Test suite rider-app-test: RUNNING...
{"log":"2025-05-12 21:53:16.873239 UTC INFO>   |> Starting Direct QR tests..."}
{"log":"2025-05-12 21:53:16.873337 UTC INFO>   |> Running QR code generation and decoding functions..."}
{"log":"2025-05-12 21:53:16.873349 UTC INFO>   |> Generating key pair..."}
{"log":"2025-05-12 21:53:16.873452 UTC INFO>   |> Private key: \"aEh3FumY79ZxoUkydsDnyN+mSeBRmt7WuqgwuTbwoJg=\""}
{"log":"2025-05-12 21:53:16.873556 UTC INFO>   |> Public key: \"DBI8XhWgYAnDI7QhTbJyM7tUMcsgRxivRSRsLvLEb+s=\""}
{"log":"2025-05-12 21:53:16.873633 UTC INFO>   |> Decoding test configuration..."}
{"log":"2025-05-12 21:53:16.873713 UTC INFO>   |> Decoding test ticket..."}
{"log":"2025-05-12 21:53:16.873747 UTC INFO>   |> Generating QR code..."}
{"log":"2025-05-12 21:53:16.873766 UTC INFO>   |> Generated QR data: r9gVjZEwK0gP8sSt3euL3N3MBzymJPbPZmtm3Fch068yTV/kxKSkkwHzLcNW3ECtKczqvfKgC2VPI12AWM2FDw==,313356,SCM,SKO,2,0,1,5,2025-10-01T00:00:00Z,2025-09-01 00:00:00 UTC"}
{"log":"2025-05-12 21:53:16.873821 UTC INFO>   |> Decoding QR code..."}
{"log":"2025-05-12 21:53:16.873902 UTC INFO>   |> Decoded ticket: TicketPayload {fromRouteProviderCode = \"SCM\", toRouteProviderCode = \"SKO\", adultQuantity = 2, childQuantity = 0, vehicleTypeProviderCode = \"1\", expiry = \"2025-10-01T00:00:00Z\", ticketNumber = \"313356\", ticketAmount = 5, refreshAt = Just 2025-09-01 00:00:00 UTC}"}
{"log":"2025-05-12 21:53:16.873985 UTC INFO>   |> Attempting QR code refresh..."}
{"log":"2025-05-12 21:53:16.874093 UTC INFO>   |> QR code refresh failed"}
{"log":"2025-05-12 21:53:16.8741 UTC INFO>   |> Testing invalid QR code..."}
{"log":"2025-05-12 21:53:16.874119 UTC WARNING>   |> E500 INTERNAL_ERROR: Failed to decode signature to base64: \"Base64-encoded bytestring is unpadded or has invalid padding\""}
{"log":"2025-05-12 21:53:16.874177 UTC DEBUG>  [CallStack] |> CallStack (from HasCallStack):\n  throwError, called at src/Kernel/Utils/Error/Throwing.hs:44:35 in mobility-core-0.1.0.0-KqRSVtj8Eq1E1mY6uJkiTJ:Kernel.Utils.Error.Throwing\n  fromEitherM, called at src/ExternalBPP/ExternalAPI/Direct/Utils.hs:43:90 in rider-app-0.1.0.0-inplace:ExternalBPP.ExternalAPI.Direct.Utils"}
{"log":"2025-05-12 21:53:16.874202 UTC INFO>   |> Expected error for invalid QR: InternalError \"Failed to decode signature to base64: \\\"Base64-encoded bytestring is unpadded or has invalid padding\\\"\""}
{"log":"2025-05-12 21:53:16.874216 UTC INFO>   |> Finished Direct QR tests"}
Creating async loggers...
Creating file logger (/tmp/rider-app-eul.log)...
Creating console logger...
Disposing async logger...
Test suite rider-app-test: PASS
Test suite logged to: /Users/khuzema.khomosi/Documents/nammayatri/Backend/dist-newstyle/build/aarch64-osx/ghc-9.2.7/rider-app-0.1.0.0/t/rider-app-test/test/rider-app-0.1.0.0-rider-app-test.log
```


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated test suite for QR code generation, decoding, and refreshing, including new test modules and configuration.
  - Added a new query to find tickets by ticket number.

- **Bug Fixes**
  - Improved error handling and validation in QR code decoding and ticket retrieval processes.

- **Refactor**
  - Switched QR code security from TripleDES encryption to Ed25519 digital signatures for enhanced cryptographic integrity.
  - Updated ticket payload structure by removing the transaction ID field and reordering fields.
  - Simplified ticket verification logic to use direct ticket lookup by ticket number.

- **Tests**
  - Added comprehensive tests for QR code logic and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->