### PR TITLE
Backend/fix:specic-pattern-api-introduction

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/API/Nandi.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/API/Nandi.hs
@@ -7,7 +7,7 @@ import SharedLogic.External.Nandi.Types
 
 type NandiPatternsAPI = "patterns" :> Capture "gtfs_id" Text :> Get '[JSON] [NandiPattern]
 
-type NandiGetSpecificPatternAPI = "patterns" :> Capture "patternId" Text :> Get '[JSON] NandiPatternDetails
+type NandiGetSpecificPatternAPI = "pattern" :> Capture "patternId" Text :> Get '[JSON] NandiPatternDetails
 
 type RoutesAPI = "routes" :> Capture "gtfs_id" Text :> Get '[JSON] [NandiRoutesRes]
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the API endpoint path for fetching a specific pattern to use a singular form ("pattern" instead of "patterns"). This change affects how the endpoint is accessed but does not alter any other functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->