### PR TITLE
Backend/fix: taxi leg start time error

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Taxi.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Taxi.hs
@@ -67,6 +67,10 @@ instance JT.JourneyLeg TaxiLegRequest m where
 
       mkOneWaySearchReq = do
         (destination, stops') <- lastAndRest stops & fromMaybeM (InvalidRequest "Destination is required!")
+        let startTime =
+              if journeyLegData.sequenceNumber == 0
+                then Nothing
+                else journeyLegData.fromDepartureTime
         return $
           OneWaySearch $
             OneWaySearchReq
@@ -74,7 +78,7 @@ instance JT.JourneyLeg TaxiLegRequest m where
                 isSourceManuallyMoved = Just False,
                 isDestinationManuallyMoved = Just False,
                 isSpecialLocation = Just False, -- Fix it later
-                startTime = journeyLegData.fromDepartureTime,
+                startTime = startTime,
                 isReallocationEnabled = Just True,
                 fareParametersInRateCard = Just True,
                 quotesUnifiedFlow = Just True,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of journey leg start times for taxi bookings, ensuring the start time is omitted for the first leg and correctly set for subsequent legs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->