### PR TITLE
Backend/fix: updated switch tier resp

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -47,10 +47,6 @@ types:
     crisSdkToken : Maybe Text
     derive: "Show"
 
-  JourneyInfoRespWithFare:
-    journeyInfoResponse: JourneyInfoResp
-    totalFare: Maybe HighPrecMoney
-
   LegStatus:
     legOrder: Int
     subLegOrder: Int
@@ -319,7 +315,7 @@ apis:
       request:
         type: SwitchFRFSTierReq
       response:
-        type: JourneyInfoRespWithFare
+        type: JourneyInfoResp
 
   - POST:
       endpoint: multimodal/{journeyId}/journeyFeedback

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/MultimodalConfirm.hs
@@ -208,7 +208,7 @@ type API =
            API.Types.UI.MultimodalConfirm.SwitchFRFSTierReq
       :> Post
            '[JSON]
-           API.Types.UI.MultimodalConfirm.JourneyInfoRespWithFare
+           API.Types.UI.MultimodalConfirm.JourneyInfoResp
       :<|> TokenAuth
       :> "multimodal"
       :> Capture
@@ -431,7 +431,7 @@ postMultimodalOrderSwitchFRFSTier ::
     Kernel.Types.Id.Id Domain.Types.Journey.Journey ->
     Kernel.Prelude.Int ->
     API.Types.UI.MultimodalConfirm.SwitchFRFSTierReq ->
-    Environment.FlowHandler API.Types.UI.MultimodalConfirm.JourneyInfoRespWithFare
+    Environment.FlowHandler API.Types.UI.MultimodalConfirm.JourneyInfoResp
   )
 postMultimodalOrderSwitchFRFSTier a4 a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.MultimodalConfirm.postMultimodalOrderSwitchFRFSTier (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a4) a3 a2 a1
 

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -98,10 +98,6 @@ data JourneyInfoResp = JourneyInfoResp
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data JourneyInfoRespWithFare = JourneyInfoRespWithFare {journeyInfoResponse :: JourneyInfoResp, totalFare :: Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecMoney}
-  deriving stock (Generic)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
-
 data JourneyStatusResp = JourneyStatusResp
   { journeyChangeLogCounter :: Kernel.Prelude.Int,
     journeyPaymentStatus :: Kernel.Prelude.Maybe API.Types.UI.FRFSTicketService.FRFSBookingPaymentStatusAPI,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Removed updated fare from the switch tier API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- The response for switching FRFS tier in multimodal journeys no longer includes the total fare; only journey information is returned. This may affect users expecting fare details in the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->