### PR TITLE
backend/fix/adhere-to-blocked-till-for-overcharging-blocking

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -960,6 +960,7 @@ buildDriverEntityRes (person, driverInfo, driverStats, merchantOpCityId) service
       mbTotalRidesConsideredForFareIssues = Yudhishthira.accessTagKey (LYT.TagName "TotalRidesConsideredForFareIssues") driverTags
       mbRidesWithFareIssues = Yudhishthira.accessTagKey (LYT.TagName "RidesWithFareIssue") driverTags
       mbOverchargingBlockedTill = Yudhishthira.accessTagKey (LYT.TagName "OverchargingBlockedTill") driverTags
+  currentLocalTime <- getLocalCurrentTime transporterConfig.timeDiffFromUtc
   let (overchargingBlocked, blockedTill, driverOverchargingTag) =
         case (mbDriverOverchargingTag, mbOverchargingBlockedTill) of
           (Just driverOverchargingTag', Just overchargingBlockedTillV) | transporterConfig.enableOverchargingBlocker -> do
@@ -967,8 +968,11 @@ buildDriverEntityRes (person, driverInfo, driverStats, merchantOpCityId) service
             case bt of
               DA.Success bt' -> do
                 let bt'' = epochToUTCTime (bt' - fromIntegral transporterConfig.timeDiffFromUtc)
-                let highOC = highOverchargingTag driverOverchargingTag'
-                (highOC, bool Nothing (Just bt'') highOC, Just driverOverchargingTag')
+                let isInBlockedTimeRange = currentLocalTime < bt''
+                let highOC = highOverchargingTag driverOverchargingTag' && isInBlockedTimeRange
+                if highOC
+                  then (highOC, Just bt'', Just driverOverchargingTag')
+                  else (False, Nothing, Nothing)
               _ -> (False, Nothing, Nothing)
           _ -> (False, Nothing, Nothing)
   return $


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in determining when a driver is blocked due to overcharging by considering the current local time and block expiry time. This ensures drivers are only blocked when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->