### PR TITLE
backend/feat: handled external ticket booking failures

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
@@ -462,6 +462,10 @@ FRFSTicketBooking:
       kvFunction: updateWithKV
       params: [bppOrderId, status, updatedAt]
       where: id
+    updateBPPOrderIdById:
+      kvFunction: updateWithKV
+      params: [bppOrderId, updatedAt]
+      where: id
     updateFinalPriceById:
       kvFunction: updateWithKV
       params: [finalPrice, updatedAt]

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicketBooking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicketBooking.hs
@@ -57,6 +57,9 @@ updateBPPOrderIdAndStatusById bppOrderId status id = do
   _now <- getCurrentTime
   updateWithKV [Se.Set Beam.bppOrderId bppOrderId, Se.Set Beam.status status, Se.Set Beam.updatedAt _now] [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]
 
+updateBPPOrderIdById :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Types.Id.Id Domain.Types.FRFSTicketBooking.FRFSTicketBooking -> m ())
+updateBPPOrderIdById bppOrderId id = do _now <- getCurrentTime; updateWithKV [Se.Set Beam.bppOrderId bppOrderId, Se.Set Beam.updatedAt _now] [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]
+
 updateBppBankDetailsById ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
   (Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Types.Id.Id Domain.Types.FRFSTicketBooking.FRFSTicketBooking -> m ())

--- a/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/FRFS/OnInit.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Beckn/ACL/FRFS/OnInit.hs
@@ -66,5 +66,6 @@ buildOnInitReq onInitReq = do
         messageId,
         validTill = ttl,
         bankAccNum,
-        bankCode
+        bankCode,
+        bppOrderId = Nothing
       }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnInit.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnInit.hs
@@ -53,7 +53,8 @@ data DOnInit = DOnInit
     transactionId :: Text,
     messageId :: Text,
     bankAccNum :: Text,
-    bankCode :: Text
+    bankCode :: Text,
+    bppOrderId :: Maybe Text
   }
 
 validateRequest :: (EsqDBReplicaFlow m r, BeamFlow m r) => DOnInit -> m (Merchant.Merchant, FTBooking.FRFSTicketBooking)
@@ -80,6 +81,7 @@ onInit onInitReq merchant booking_ = do
   whenJust (onInitReq.validTill) (\validity -> void $ QFRFSTicketBooking.updateValidTillById validity booking_.id)
   void $ QFRFSTicketBooking.updatePriceById onInitReq.totalPrice booking_.id
   void $ QFRFSTicketBooking.updateBppBankDetailsById (Just onInitReq.bankAccNum) (Just onInitReq.bankCode) booking_.id
+  whenJust onInitReq.bppOrderId (\bppOrderId -> void $ QFRFSTicketBooking.updateBPPOrderIdById (Just bppOrderId) booking_.id)
   let booking = booking_ {FTBooking.price = onInitReq.totalPrice, FTBooking.journeyOnInitDone = Just True}
   isMetroTestTransaction <- asks (.isMetroTestTransaction)
   case booking.journeyId of

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/CallAPI.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/CallAPI.hs
@@ -105,6 +105,15 @@ createOrder integrationBPPConfig qrTtl (_mRiderName, mRiderNumber) booking = do
     CRIS config' -> CRISBookJourney.createOrder config' booking
     _ -> throwError $ InternalError "Unimplemented!"
 
+getBppOrderId :: (CacheFlow m r, EsqDBFlow m r, EncFlow m r) => IntegratedBPPConfig -> FRFSTicketBooking -> m (Maybe Text)
+getBppOrderId integratedBPPConfig booking = do
+  case integratedBPPConfig.providerConfig of
+    CMRL _ -> Just <$> CMRLOrder.getBppOrderId booking
+    EBIX _ -> Just <$> EBIXOrder.getBppOrderId booking
+    DIRECT _ -> Just <$> DIRECTOrder.getBppOrderId booking
+    CRIS _ -> Just <$> CRISBookJourney.getBppOrderId booking
+    ONDC _ -> return Nothing
+
 getTicketStatus :: (MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r, EncFlow m r) => IntegratedBPPConfig -> FRFSTicketBooking -> m [ProviderTicket]
 getTicketStatus integrationBPPConfig booking = do
   case integrationBPPConfig.providerConfig of

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Direct/Order.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Direct/Order.hs
@@ -22,12 +22,19 @@ import Tools.Error
 createOrder :: (CoreMetrics m, MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r, EncFlow m r, HasShortDurationRetryCfg r c) => DIRECTConfig -> IntegratedBPPConfig -> Seconds -> FRFSTicketBooking -> m ProviderOrder
 createOrder config integratedBPPConfig qrTtl booking = do
   when (isJust booking.bppOrderId) $ throwError (InternalError $ "Order Already Created for Booking : " <> booking.id.getId)
-  bookingUUID <- UU.fromText booking.id.getId & fromMaybeM (InternalError "Booking Id not being able to parse into UUID")
-  let orderId = show (fromIntegral ((\(a, b, c, d) -> a + b + c + d) (UU.toWords bookingUUID)) :: Integer) -- This should be max 20 characters UUID (Using Transaction UUID)
-      mbRouteStations :: Maybe [FRFSRouteStationsAPI] = decodeFromText =<< booking.routeStationsJson
+  orderId <- case booking.bppOrderId of
+    Just oid -> return oid
+    Nothing -> getBppOrderId booking
+  let mbRouteStations :: Maybe [FRFSRouteStationsAPI] = decodeFromText =<< booking.routeStationsJson
   routeStations <- mbRouteStations & fromMaybeM (InternalError "Route Stations Not Found.")
   tickets <- mapM (getTicketDetail config integratedBPPConfig qrTtl booking) routeStations
   return ProviderOrder {..}
+
+getBppOrderId :: (MonadFlow m) => FRFSTicketBooking -> m Text
+getBppOrderId booking = do
+  bookingUUID <- UU.fromText booking.id.getId & fromMaybeM (InternalError "Booking Id not being able to parse into UUID")
+  let orderId = show (fromIntegral ((\(a, b, c, d) -> a + b + c + d) (UU.toWords bookingUUID)) :: Integer) -- This should be max 20 characters UUID (Using Transaction UUID)
+  return orderId
 
 getTicketDetail :: (MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r, HasShortDurationRetryCfg r c) => DIRECTConfig -> IntegratedBPPConfig -> Seconds -> FRFSTicketBooking -> FRFSRouteStationsAPI -> m ProviderTicket
 getTicketDetail config integratedBPPConfig qrTtl booking routeStation = do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Handed External Ticket booking failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for storing and retrieving an external order ID (bppOrderId) in ticket bookings.
  - Booking details now include the external order ID when available.

- **Bug Fixes**
  - Improved error handling during external order confirmation, ensuring booking status is updated to FAILED if an error occurs.

- **Other Improvements**
  - Enhanced consistency in how external order IDs are generated and accessed across different providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->