### PR TITLE
Backend/fix: Removed BppOrderId in init for CRIS

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/CallAPI.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/CallAPI.hs
@@ -111,8 +111,7 @@ getBppOrderId integratedBPPConfig booking = do
     CMRL _ -> Just <$> CMRLOrder.getBppOrderId booking
     EBIX _ -> Just <$> EBIXOrder.getBppOrderId booking
     DIRECT _ -> Just <$> DIRECTOrder.getBppOrderId booking
-    CRIS _ -> Just <$> CRISBookJourney.getBppOrderId booking
-    ONDC _ -> return Nothing
+    _ -> return Nothing
 
 getTicketStatus :: (MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r, EncFlow m r) => IntegratedBPPConfig -> FRFSTicketBooking -> m [ProviderTicket]
 getTicketStatus integrationBPPConfig booking = do

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/BookJourney.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/BookJourney.hs
@@ -243,9 +243,7 @@ createOrder config booking = do
       (Just trainTypeCode, Just distance, Just crisRouteId, Just appSession) -> return (trainTypeCode, distance, crisRouteId, appSession)
       _ -> throwError $ InternalError ("Invalid quote data: " <> show quote.fareDetails)
 
-  orderId <- case booking.bppOrderId of
-    Just oid -> return oid
-    Nothing -> getBppOrderId booking
+  frfsTicketBookingPayment <- QFRFSTicketBookingPayment.findNewTBPByBookingId booking.id >>= fromMaybeM (InternalError "FRFS ticket booking payment not found")
   classCode <- getFRFSVehicleServiceTier quote
   startTime <- fromMaybeM (InternalError "Start time not found") booking.startTime
 
@@ -287,7 +285,7 @@ createOrder config booking = do
             tktTypeId = 1,
             agentAccountId = show config.tpAccountId,
             bookAuthCode = bookAuthCode,
-            agentAppTxnId = orderId,
+            agentAppTxnId = show frfsTicketBookingPayment.paymentOrderId,
             bankDeductedAmount = round booking.price.amount.getHighPrecMoney,
             tpBookType = 0
           }
@@ -313,12 +311,6 @@ createOrder config booking = do
               }
           ]
       }
-
-getBppOrderId :: (CacheFlow m r, EsqDBFlow m r) => DFRFSTicketBooking.FRFSTicketBooking -> m Text
-getBppOrderId booking = do
-  frfsTicketBookingPayment <- QFRFSTicketBookingPayment.findNewTBPByBookingId booking.id >>= fromMaybeM (InternalError "FRFS ticket booking payment not found")
-  let orderId = show frfsTicketBookingPayment.paymentOrderId
-  return orderId
 
 -- Helper function to construct JSON string
 constructBookingJson :: CRISBookingRequest -> Text


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Removed adding BPP Order Id in init for CRIS
