### PR TITLE
backend/fix/sending-timestamp-and-speed-to-frontend

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
@@ -21,6 +21,7 @@ import Data.Aeson as A
 import Data.List (groupBy, nub, sortBy)
 import qualified Data.Text as T
 import qualified Data.Time as Time
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Domain.Types.AadhaarVerification as DAadhaarVerification
 import qualified Domain.Types.FRFSConfig as Config
 import qualified Domain.Types.FRFSFarePolicy as DFRFSFarePolicy
@@ -510,10 +511,10 @@ trackVehicles _personId _merchantId merchantOpCityId vehicleType routeCode platf
                         { latitude = Just busData.latitude,
                           longitude = Just busData.longitude,
                           scheduleRelationship = Nothing,
-                          speed = Nothing,
+                          speed = Just busData.speed,
                           startDate = Nothing,
                           startTime = Nothing,
-                          timestamp = Nothing,
+                          timestamp = Just . show $ epochToUTCTime busData.timestamp,
                           tripId = Nothing,
                           upcomingStops = Nothing
                         },
@@ -573,6 +574,8 @@ trackVehicles _personId _merchantId merchantOpCityId vehicleType routeCode platf
       forM stopPairs $ \(currStop, nextStop) -> do
         let waypointsBetweenStops = fromMaybe [] (getWaypointsBetweenStops currStop.stopPoint nextStop.stopPoint waypoints)
         pure ((currStop, nextStop), (waypointsBetweenStops, Nothing :: Maybe Seconds))
+
+    epochToUTCTime epoch = posixSecondsToUTCTime (fromIntegral epoch)
 
     getWaypointsBetweenStops curStopPoint nextStopPoint waypoints = do
       let nearestToCurStop = findNearestWaypoint curStopPoint waypoints


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vehicle tracking information for buses now includes actual speed and a human-readable timestamp.

* **Bug Fixes**
  * Timestamp and speed fields in tracked vehicle data are now correctly populated instead of being left empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->