### PR TITLE
Fix: Allow setting journey sub-leg status to Completed or Cancelled

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -833,11 +833,12 @@ postMultimodalOrderSublegSetStatus ::
 postMultimodalOrderSublegSetStatus (mbPersonId, merchantId) journeyId legOrder subLegOrder newStatus = do
   personId <- fromMaybeM (InvalidRequest "Invalid person id") mbPersonId
   journey <- JM.getJourney journeyId
-  unless (newStatus `elem` [JL.Completed, JL.Cancelled]) $ do
-    legs <- JM.getAllLegsInfo journeyId False
-    journeyLegInfo <- find (\leg -> leg.order == legOrder) legs & fromMaybeM (InvalidRequest $ "No matching journey leg found for the given legOrder")
 
-    markLegStatus newStatus journeyLegInfo.legExtraInfo (Just subLegOrder)
+  -- Removed the 'unless' condition to allow updates for JL.Completed and JL.Cancelled statuses
+  legs <- JM.getAllLegsInfo journeyId False
+  journeyLegInfo <- find (\leg -> leg.order == legOrder) legs & fromMaybeM (InvalidRequest $ "No matching journey leg found for the given legOrder")
+
+  markLegStatus newStatus journeyLegInfo.legExtraInfo (Just subLegOrder)
 
   -- refetch updated legs and journey
   updatedLegStatus <- JM.getAllLegsStatus journey


### PR DESCRIPTION
The `postMultimodalOrderSublegSetStatus` function previously had a condition that prevented the `markLegStatus` function from being called if the new status was JL.Completed or JL.Cancelled.

This commit removes that `unless` condition, allowing these statuses to be set for a journey sub-leg via the API endpoint: POST /multimodal/{journeyId}/order/{legOrder}/subleg/{subLegOrder}/setStatus/{status}

The underlying `markLegStatus` function in JourneyModule.Base does not have such restrictions and will update the status as requested.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leg status updates to ensure all journey legs are updated correctly, including when the status is set to Completed or Cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->