### PR TITLE
backend/refactor: change gate type for RouteStopMapping

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -35,6 +35,7 @@ imports:
   VehicleCategory: BecknV2.FRFS.Enums
   Provider: Lib.JourneyModule.Types
   Value: Data.Aeson
+  Gate: Domain.Types.Station
 
 module: MultimodalConfirm
 
@@ -201,7 +202,7 @@ types:
     hin: Maybe Text
     sgstdDest: Maybe [SuggestedStations]
     gj: Maybe Value
-    gi: Maybe Value
+    gi: Maybe [Gate]
     ibc: Id IntegratedBPPConfig
 
   TransportRouteStopMapping:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -14,6 +14,7 @@ import qualified Domain.Types.Journey
 import qualified Domain.Types.Location
 import qualified Domain.Types.LocationAddress
 import qualified Domain.Types.MultimodalPreferences
+import qualified Domain.Types.Station
 import qualified Domain.Types.StationType
 import qualified Domain.Types.Trip
 import EulerHS.Prelude hiding (id)
@@ -223,7 +224,7 @@ data TransportRouteStopMapping = TransportRouteStopMapping {ibc :: Kernel.Types.
 data TransportStation = TransportStation
   { ad :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     cd :: Kernel.Prelude.Text,
-    gi :: Kernel.Prelude.Maybe Data.Aeson.Value,
+    gi :: Kernel.Prelude.Maybe [Domain.Types.Station.Gate],
     gj :: Kernel.Prelude.Maybe Data.Aeson.Value,
     hin :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     ibc :: Kernel.Types.Id.Id Domain.Types.IntegratedBPPConfig.IntegratedBPPConfig,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Station.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Station.hs
@@ -14,6 +14,14 @@ import qualified Kernel.Types.Id
 import qualified Kernel.Types.TimeBound
 import qualified Tools.Beam.UtilsTH
 
+data Gate = Gate
+  { gateName :: String,
+    stopCode :: String,
+    lat :: Double,
+    lon :: Double
+  }
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
 data Station = Station
   { address :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     code :: Kernel.Prelude.Text,
@@ -29,7 +37,7 @@ data Station = Station
     regionalName :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     suggestedDestinations :: Kernel.Prelude.Maybe [Domain.Types.StationType.SuggestedStations],
     geoJson :: Maybe Value,
-    gates :: Maybe Value,
+    gates :: Maybe [Gate],
     timeBounds :: Kernel.Types.TimeBound.TimeBound,
     vehicleType :: BecknV2.FRFS.Enums.VehicleCategory,
     createdAt :: Kernel.Prelude.UTCTime,

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Types.hs
@@ -4,6 +4,7 @@ module SharedLogic.External.Nandi.Types where
 
 import qualified BecknV2.FRFS.Enums
 import Data.Aeson
+import Domain.Types.Station
 import qualified Kernel.External.Maps.Types
 import Kernel.Prelude
 import qualified Kernel.Types.Time
@@ -48,7 +49,7 @@ data RouteStopMappingInMemoryServer = RouteStopMappingInMemoryServer
     stopPoint :: Kernel.External.Maps.Types.LatLong,
     vehicleType :: BecknV2.FRFS.Enums.VehicleCategory,
     geoJson :: Maybe Value,
-    gates :: Maybe Value
+    gates :: Maybe [Gate]
   }
   deriving (Generic, FromJSON, ToJSON, ToSchema, Show)
 


### PR DESCRIPTION
* Adds `Gate` type for `TransportStation` and `RouteStopMappingInMemoryServer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a structured representation for station gates, including gate name, stop code, latitude, and longitude.

* **Refactor**
  * Changed station and route gate data fields from generic JSON values to typed lists of gate objects, enhancing data consistency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->