### PR TITLE
[WIP] backend/fix: cancel driver side ride on journey completion

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -40,6 +40,7 @@ import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as T
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import qualified Domain.Action.UI.FRFSTicketService as FRFSTicketService
+import qualified Domain.Types.CancellationReason as SCR
 import qualified Domain.Types.Common as DTrip
 import qualified Domain.Types.Estimate as DEst
 import qualified Domain.Types.FRFSTicketBooking as DFRFSB
@@ -900,6 +901,7 @@ postMultimodalComplete (mbPersonId, merchantId) journeyId = do
   personId <- fromMaybeM (InvalidRequest "Invalid person id") mbPersonId
   journey <- JM.getJourney journeyId
   legs <- JM.getAllLegsInfo journeyId False
+  mapM_ (\leg -> when (leg.travelMode == DTrip.Taxi) $ JM.cancelLeg leg (SCR.CancellationReasonCode "") False False) legs
   mapM_ (markAllSubLegsCompleted . (.legExtraInfo)) legs
 
   updatedLegStatus <- JM.getAllLegsStatus journey


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Cancel ride on driver side when the journey is completed in the user side


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Taxi legs are now automatically cancelled when a multimodal journey is completed.

* **Bug Fixes**
  * Ensured that all taxi bookings associated with completed journeys are properly handled and updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->