### PR TITLE
backend/feat: added preliminary leg in single mode

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search.hs
@@ -157,6 +157,7 @@ extractSearchDetails now = \case
         destinationStopCode = Nothing,
         originStopCode = Nothing,
         vehicleCategory = Nothing,
+        currentLocation = Nothing,
         ..
       }
   RentalSearch RentalSearchReq {..} ->
@@ -172,6 +173,7 @@ extractSearchDetails now = \case
         originStopCode = Nothing,
         platformType = Nothing,
         vehicleCategory = Nothing,
+        currentLocation = Nothing,
         ..
       }
   InterCitySearch InterCitySearchReq {..} ->
@@ -184,6 +186,7 @@ extractSearchDetails now = \case
         destinationStopCode = Nothing,
         originStopCode = Nothing,
         vehicleCategory = Nothing,
+        currentLocation = Nothing,
         ..
       }
   AmbulanceSearch OneWaySearchReq {..} ->
@@ -200,6 +203,7 @@ extractSearchDetails now = \case
         originStopCode = Nothing,
         platformType = Nothing,
         vehicleCategory = Nothing,
+        currentLocation = Nothing,
         ..
       }
   DeliverySearch OneWaySearchReq {..} ->
@@ -216,6 +220,7 @@ extractSearchDetails now = \case
         originStopCode = Nothing,
         platformType = Nothing,
         vehicleCategory = Nothing,
+        currentLocation = Nothing,
         ..
       }
   PTSearch PublicTransportSearchReq {..} ->

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Search.hs
@@ -122,7 +122,8 @@ data PublicTransportSearchReq = PublicTransportSearchReq
     routeCode :: Maybe Text,
     recentLocationId :: Maybe (Id DTRL.RecentLocation),
     vehicleCategory :: Maybe Enums.VehicleCategory,
-    platformType :: Maybe DIBPC.PlatformType
+    platformType :: Maybe DIBPC.PlatformType,
+    currentLocation :: Maybe LatLong
   }
   deriving (Generic, FromJSON, ToJSON, Show, ToSchema)
 
@@ -191,7 +192,8 @@ data SearchDetails = SearchDetails
     destinationStopCode :: Maybe Text,
     originStopCode :: Maybe Text,
     vehicleCategory :: Maybe Enums.VehicleCategory,
-    platformType :: Maybe DIBPC.PlatformType
+    platformType :: Maybe DIBPC.PlatformType,
+    currentLocation :: Maybe LatLong
   }
   deriving (Generic, Show)
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Added a preliminary leg if current location is far from the JourneyLeg start location


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including a preliminary walking leg in multimodal route searches from the user's current location to the route start when appropriate.
  * Search requests and responses now optionally include the user's current location.

* **Bug Fixes**
  * Enhanced fallback handling when no public transport routes are found by generating suitable auto or walk legs.

* **Refactor**
  * Unified travel leg creation logic to support walking and unspecified modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->