### PR TITLE
backend/feat(walk-leg): enhance status detection using station gate proximity

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
@@ -394,7 +394,7 @@ getState mode searchId riderLastPoints isLastCompleted movementDetected routeCod
       mbToStation <- OTPRest.getStationByGtfsIdAndStopCode toStationCode integratedBppConfig
       let mbToLatLong = LatLong <$> (mbToStation >>= (.lat)) <*> (mbToStation >>= (.lon))
       let oldStatus = fromMaybe (if isLastCompleted' then JPT.OnTheWay else JPT.InPlan) mbOldStatus
-      return $ maybe (False, oldStatus) (\latLong -> updateJourneyLegStatus mode riderLastPoints latLong oldStatus isLastCompleted') mbToLatLong
+      return $ maybe (False, oldStatus) (\latLong -> updateJourneyLegStatus mode riderLastPoints latLong oldStatus isLastCompleted' mbToStation) mbToLatLong
 
     getStatusForMetroAndSubway :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, HasShortDurationRetryCfg r c) => [JPT.MultiModalJourneyRouteDetails] -> Id Domain.Types.FRFSSearch.FRFSSearch -> DIBC.IntegratedBPPConfig -> Bool -> m [(JPT.MultiModalJourneyRouteDetails, Bool, JPT.JourneyLegStatus)]
     getStatusForMetroAndSubway journeyRouteDetails searchId' integratedBppConfig isLastCompleted' = do

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Types/Walk.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Types/Walk.hs
@@ -3,6 +3,7 @@ module Lib.JourneyLeg.Types.Walk where
 import qualified API.Types.UI.MultimodalConfirm as ApiTypes
 import qualified Domain.Types.JourneyLeg as DJourneyLeg
 import qualified Domain.Types.SearchRequest as DSR
+import qualified Domain.Types.Station as Station
 import qualified Domain.Types.WalkLegMultimodal as DWalkLeg
 import Kernel.Prelude
 import Kernel.Types.Id
@@ -18,7 +19,8 @@ data WalkLegRequestSearchData = WalkLegRequestSearchData
 data WalkLegRequestGetStateData = WalkLegRequestGetStateData
   { walkLegId :: Id DWalkLeg.WalkLegMultimodal,
     riderLastPoints :: [ApiTypes.RiderLocationReq],
-    isLastCompleted :: Bool
+    isLastCompleted :: Bool,
+    mbToStation :: Maybe Station.Station
   }
 
 data WalkLegRequestGetInfoData = WalkLegRequestGetInfoData

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Walk.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Walk.hs
@@ -76,7 +76,7 @@ instance JT.JourneyLeg WalkLegRequest m where
     journeyLegInfo <- legData.journeyLegInfo & fromMaybeM (InvalidRequest "WalkLeg journey legInfo data missing")
     toLocation <- legData.toLocation & fromMaybeM (InvalidRequest "ToLocation of walkleg journey data is missing")
     let status = JT.getWalkLegStatusFromWalkLeg legData journeyLegInfo
-    let (statusChanged, newStatus) = updateJourneyLegStatus DTrip.Walk req.riderLastPoints (locationToLatLng toLocation) status req.isLastCompleted
+    let (statusChanged, newStatus) = updateJourneyLegStatus DTrip.Walk req.riderLastPoints (locationToLatLng toLocation) status req.isLastCompleted req.mbToStation
     when statusChanged $ do
       let walkLegStatus = JT.castWalkLegStatusFromLegStatus newStatus
       QWalkLeg.updateStatus walkLegStatus req.walkLegId


### PR DESCRIPTION
- Include optional toStation in walk leg state request
- Use gate proximity in status updates for better accuracy
- Update getAllLegsStatus to fetch toStation from stopCode
- Since `WALK` leg won't have a `integratedBPPConfigId` we will instead use the `integratedBppConfigId` of the next leg 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Walk journey segments can now include optional destination station details, allowing for more precise tracking.
  * Arrival detection for journey legs now considers proximity to station gates, improving accuracy for journeys ending at stations.

* **Bug Fixes**
  * Enhanced logic for determining arrival and completion status, reducing false positives or negatives when approaching station destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->