### PR TITLE
Backend/feat : update journey leg status to Cancelled for re allocation

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnUpdate.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnUpdate.hs
@@ -442,6 +442,7 @@ onUpdate = \case
 
     void $ QEstimate.updateStatus DEstimate.DRIVER_QUOTE_REQUESTED estimate.id
     void $ QRB.updateStatus booking.id DRB.REALLOCATED
+    void $ QEBooking.updateJourneyLegStatus booking.journeyId DRJL.Cancelled
     void $ QRide.updateStatus ride.id DRide.CANCELLED
     void $ QPFS.updateStatus searchReq.riderId DPFS.WAITING_FOR_DRIVER_OFFERS {estimateId = estimate.id, otherSelectedEstimates = Nothing, validTill = searchReq.validTill, providerId = Just estimate.providerId, tripCategory = estimate.tripCategory}
     void $ SPayment.cancelPaymentIntent booking.merchantId booking.merchantOperatingCityId ride.id
@@ -484,6 +485,7 @@ onUpdate = \case
     void $ QRB.createBooking newBooking
     void $ QBPL.createMany newBookingParties
     void $ QRB.updateStatus booking.id DRB.REALLOCATED
+    void $ QEBooking.updateJourneyLegStatus booking.journeyId DRJL.Cancelled
     void $ QRide.updateStatus ride.id DRide.CANCELLED
     void $ QPFS.updateStatus booking.riderId flowStatus
     void $ SPayment.cancelPaymentIntent booking.merchantId booking.merchantOperatingCityId ride.id


### PR DESCRIPTION
updated journeyLEG status for reallocated bookings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking lifecycle handling to ensure journey leg status is correctly set to "Cancelled" during estimate or quote repetition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->