### PR TITLE
Backend/feat : update FlowStatus to ACTIVE_BOOKINGS for normal ride j…

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Booking/API.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Booking/API.hs
@@ -28,6 +28,7 @@ import Domain.Types.CancellationReason
 import qualified Domain.Types.Exophone as DExophone
 import Domain.Types.Extra.Ride (RideAPIEntity (..))
 import Domain.Types.FareBreakup as DFareBreakup
+import qualified Domain.Types.Journey as DJourney
 import Domain.Types.Location (Location, LocationAPIEntity)
 import Domain.Types.ParcelDetails as DParcel
 import qualified Domain.Types.Person as Person
@@ -120,7 +121,8 @@ data BookingAPIEntity = BookingAPIEntity
     estimatedEndTimeRange :: Maybe DRide.EstimatedEndTimeRange,
     isSafetyPlus :: Bool,
     isInsured :: Maybe Bool,
-    insuredAmount :: Maybe Text
+    insuredAmount :: Maybe Text,
+    mbJourneyId :: Maybe (Id DJourney.Journey)
   }
   deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
 
@@ -324,7 +326,8 @@ makeBookingAPIEntity requesterId booking activeRide allRides estimatedFareBreaku
         vehicleIconUrl = fmap showBaseUrl booking.vehicleIconUrl,
         isSafetyPlus = fromMaybe False $ activeRide <&> (.isSafetyPlus),
         isInsured = Just booking.isInsured,
-        insuredAmount = booking.insuredAmount
+        insuredAmount = booking.insuredAmount,
+        mbJourneyId = booking.journeyId
       }
   where
     getRideDuration :: Maybe DRide.Ride -> Maybe Seconds

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/RideExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/RideExtra.hs
@@ -396,7 +396,6 @@ findAllByRiderIdAndRide (Id personId) mbLimit mbOffset mbOnlyActive mbBookingSta
               <> ([Se.Is BeamB.createdAt $ Se.GreaterThanOrEq (fromJust mbFromDate) | isJust mbFromDate])
               <> ([Se.Is BeamB.createdAt $ Se.LessThanOrEq (fromJust mbToDate) | isJust mbToDate])
               <> ([Se.Is BeamB.status $ Se.In mbBookingStatusList | not (null mbBookingStatusList)])
-              <> ([Se.Is BeamB.journeyId $ Se.Eq Nothing])
           )
       ]
       (if isOnlyActive then Se.Asc BeamB.startTime else Se.Desc BeamB.startTime)


### PR DESCRIPTION
ACTIVE_BOOKINGS  flow status for 
- normal ride with single TAXI mode journey

rest would be same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new field to booking details, allowing users to view associated journey information when available.

* **Bug Fixes**
  * Improved the display logic for active journeys, ensuring more accurate status updates for rides.

* **Improvements**
  * Broadened the set of bookings shown to users by including those linked to journeys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="662" height="606" alt="Screenshot 2025-07-16 at 3 29 12 PM" src="https://github.com/user-attachments/assets/45015329-d6b8-4a21-828c-4751962ec0bb" />
<img width="1189" height="476" alt="Screenshot 2025-07-16 at 3 28 53 PM" src="https://github.com/user-attachments/assets/180c0a8b-5396-4101-9df5-67f6fba0e917" />
