### PR TITLE
frontend/fix: Show RR in Silent while driver is Collecting money

### DIFF
--- a/Frontend/android-native/mobility-app/src/main/java/in/juspay/mobility/app/NotificationUtils.java
+++ b/Frontend/android-native/mobility-app/src/main/java/in/juspay/mobility/app/NotificationUtils.java
@@ -815,7 +815,8 @@ public class NotificationUtils {
         sharedPref.edit().putString(context.getString(R.string.RIDE_STATUS), context.getString(R.string.NEW_RIDE_AVAILABLE)).apply();
         boolean isAppOnAnotherActivity = sharedPref.getString("ANOTHER_ACTIVITY_LAUNCHED", "false").equals("true");
         boolean activityBasedChecks = Arrays.asList("onPause", "onDestroy").contains(sharedPref.getString("ACTIVITY_STATUS", "null"));
-        boolean useWidgetService = !isAppOnAnotherActivity && ((sharedPref.getString("DRIVER_STATUS_N", "null").equals("Silent") && activityBasedChecks) || useSilentFCMForForwardBatch);
+        boolean checkExplicitCondition = sharedPref.getString("SHOW_RR_IN_SILENT", "null").equals("true");
+        boolean useWidgetService = !isAppOnAnotherActivity && ((sharedPref.getString("DRIVER_STATUS_N", "null").equals("Silent") && activityBasedChecks) || useSilentFCMForForwardBatch || checkExplicitCondition);
         boolean widgetCheckForNonOverlay = useWidgetService && !NotificationUtils.overlayFeatureNotAvailable(context);
          boolean reqPresentCheckForWidget = binder == null && widgetCheckForNonOverlay;
          if (reqPresentCheckForWidget) {
@@ -830,9 +831,10 @@ public class NotificationUtils {
         Intent widgetService = new Intent(context, WidgetService.class);
         String key = context.getString(R.string.service);
         boolean useSilentFCMForForwardBatch = fetchUseSilentFCMForForwardBatch(payload);
+        boolean checkExplicitCondition = sharedPref.getString("SHOW_RR_IN_SILENT", "null").equals("true");
         boolean activityStatusCheck = (sharedPref.getString(context.getResources().getString(R.string.ACTIVITY_STATUS), "null").equals("onPause") || sharedPref.getString(context.getResources().getString(R.string.ACTIVITY_STATUS), "null").equals("onDestroy"));
         String merchantType = key.contains("partner") || key.contains("driver") || key.contains("provider")? "DRIVER" : "USER";
-        if (merchantType.equals("DRIVER") && Settings.canDrawOverlays(context) && !sharedPref.getString(context.getResources().getString(R.string.REGISTERATION_TOKEN), "null").equals("null") && !sharedPref.getString("ANOTHER_ACTIVITY_LAUNCHED", "false").equals("true") && (activityStatusCheck || useSilentFCMForForwardBatch)) {
+        if (merchantType.equals("DRIVER") && Settings.canDrawOverlays(context) && !sharedPref.getString(context.getResources().getString(R.string.REGISTERATION_TOKEN), "null").equals("null") && !sharedPref.getString("ANOTHER_ACTIVITY_LAUNCHED", "false").equals("true") && (activityStatusCheck || useSilentFCMForForwardBatch || checkExplicitCondition)) {
             widgetService.putExtra(context.getResources().getString(R.string.WIDGET_MESSAGE), widgetMessage);
             widgetService.putExtra("payload", payload != null ? payload.toString() : null);
             widgetService.putExtra("data", data != null ? data.toString() : null);

--- a/Frontend/ui-driver/src/Helpers/Storage.purs
+++ b/Frontend/ui-driver/src/Helpers/Storage.purs
@@ -180,7 +180,7 @@ data KeyStore = USER_NAME
                 | LOCATION_PRIORITY
                 | METER_RIDE_ACTIVE
                 | PET_RIDES_POPUP_SHOWN
-
+                | SHOW_RR_IN_SILENT
 
 derive instance genericKeyStore :: Generic KeyStore _
 instance showKeyStore :: Show KeyStore where

--- a/Frontend/ui-driver/src/Screens/HomeScreen/View.purs
+++ b/Frontend/ui-driver/src/Screens/HomeScreen/View.purs
@@ -204,6 +204,8 @@ screen initialState (GlobalState globalState) =
           when (isNothing initialState.data.bannerData.bannerItem) $ void $ launchAff $ EHC.flowRunner defaultGlobalState $ computeListItem push
           void $ launchAff $ flowRunner defaultGlobalState $ checkBgLocation push BgLocationAC initialState globalState.globalProps.bgLocPopupShown
           void $ triggerOnRideBannerTimer push initialState
+          let showRrInSilent = initialState.props.currentStage == RideCompleted
+          void $ pure $ setValueToLocalStore SHOW_RR_IN_SILENT (show showRrInSilent)
           -- void $ launchAff $ EHC.flowRunner defaultGlobalState $ getScheduledRidecount push GetRideCount initialState -- needs to be check later
           case localStage of
             "RideRequested"  -> do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control the display of ride requests in silent mode, based on user activity and ride stage.
  * The app now stores and checks a new preference to determine if ride requests should be shown when notifications are silent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->