### PR TITLE
Backend/fix/Vendor_Fee_Adjustment_On_DriverFee_Splitting

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
@@ -361,7 +361,10 @@ driverFeeSplitter paymentMode plan feeWithoutDiscount totalFee driverFee mandate
   case splittedFees of
     [] -> throwError (InternalError "No driver fee entity with non zero total fee")
     (firstFee : restFees) -> do
-      let adjustment = firstFee.platformFee.fee.getHighPrecMoney / driverFee.platformFee.fee.getHighPrecMoney
+      let adjustment =
+            if driverFee.platformFee.fee.getHighPrecMoney == 0
+              then 1.0
+              else firstFee.platformFee.fee.getHighPrecMoney / driverFee.platformFee.fee.getHighPrecMoney
       mapM_ (\dfee -> processRestFee paymentMode dfee subscriptionConfigs driverFee) restFees
       -- Reset The Original Fee Amount & adjust the vendor fee amount in proportion
       resetFee firstFee.id firstFee.govtCharges firstFee.platformFee (Just feeWithoutDiscount) firstFee.amountPaidByCoin now

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
@@ -72,6 +72,7 @@ import qualified Storage.Queries.DriverStats as QDS
 import qualified Storage.Queries.Invoice as QINV
 import qualified Storage.Queries.Mandate as QMD
 import qualified Storage.Queries.Person as QP
+import Storage.Queries.VendorFeeExtra as QVF
 
 calculateDriverFeeForDrivers ::
   ( CacheFlow m r,
@@ -234,8 +235,9 @@ processRestFee ::
   PaymentMode ->
   DriverFee ->
   SubscriptionConfig ->
+  DriverFee ->
   m ()
-processRestFee paymentMode DriverFee {..} subscriptionConfig = do
+processRestFee paymentMode DriverFee {..} subscriptionConfig parentDriverFee = do
   id_ <- generateGUID
   let driverFee =
         DriverFee
@@ -245,6 +247,7 @@ processRestFee paymentMode DriverFee {..} subscriptionConfig = do
             ..
           }
   QDF.create driverFee
+  QVF.createChildVendorFee parentDriverFee driverFee
   processDriverFee paymentMode driverFee subscriptionConfig
   updateSerialOrderForInvoicesInWindow driverFee.id merchantOperatingCityId startTime endTime driverFee.serviceName
 
@@ -358,8 +361,11 @@ driverFeeSplitter paymentMode plan feeWithoutDiscount totalFee driverFee mandate
   case splittedFees of
     [] -> throwError (InternalError "No driver fee entity with non zero total fee")
     (firstFee : restFees) -> do
+      let adjustment = firstFee.platformFee.fee.getHighPrecMoney / driverFee.platformFee.fee.getHighPrecMoney
+      mapM_ (\dfee -> processRestFee paymentMode dfee subscriptionConfigs driverFee) restFees
+      -- Reset The Original Fee Amount & adjust the vendor fee amount in proportion
       resetFee firstFee.id firstFee.govtCharges firstFee.platformFee (Just feeWithoutDiscount) firstFee.amountPaidByCoin now
-      mapM_ (\dfee -> processRestFee paymentMode dfee subscriptionConfigs) restFees
+      QVF.adjustVendorFee firstFee.id adjustment
 
 getRescheduledTime :: (MonadFlow m) => NominalDiffTime -> m UTCTime
 getRescheduledTime gap = addUTCTime gap <$> getCurrentTime

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/VendorFeeExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/VendorFeeExtra.hs
@@ -37,5 +37,41 @@ updateVendorFee vendorFee = do
         ]
     _ -> pure ()
 
+adjustVendorFee :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => Id DriverFee -> Rational -> m ()
+adjustVendorFee driverFeeId adjustment = do
+  oldVendorFees <- findAllByDriverFeeId driverFeeId
+  for_ oldVendorFees $ \fee -> do
+    now <- getCurrentTime
+    let newAmount = roundToTwoDecimalPlaces $ HighPrecMoney $ ((fee.amount.getHighPrecMoney) * (adjustment))
+    updateWithKV
+      [ Se.Set Beam.amount newAmount,
+        Se.Set Beam.updatedAt now
+      ]
+      [ Se.And
+          [ Se.Is Beam.driverFeeId $ Se.Eq driverFeeId.getId,
+            Se.Is Beam.vendorId $ Se.Eq fee.vendorId
+          ]
+      ]
+
+createChildVendorFee :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => DriverFee -> DriverFee -> m ()
+createChildVendorFee parentFee childFee = do
+  now <- getCurrentTime
+  let adjustment = (getHighPrecMoney childFee.platformFee.fee) / (getHighPrecMoney parentFee.platformFee.fee)
+  vendorFees <- findAllByDriverFeeId parentFee.id
+  let childVendorFees =
+        map
+          ( \vfee ->
+              VendorFee
+                { amount = roundToTwoDecimalPlaces $ HighPrecMoney $ (vfee.amount.getHighPrecMoney * adjustment),
+                  driverFeeId = childFee.id,
+                  vendorId = vfee.vendorId,
+                  createdAt = now,
+                  updatedAt = now
+                }
+          )
+          vendorFees
+  traverse_ createWithKV childVendorFees
+  pure ()
+
 updateManyVendorFee :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => [VendorFee] -> m ()
 updateManyVendorFee = traverse_ updateVendorFee


### PR DESCRIPTION
…o, also create new vendor fees for the splitted (child) driver fees

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
When Driver Fees are split, adjust the existing vendor fees and create new ones for the child driver fees!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vendor fee adjustments are now handled automatically when splitting driver fees, ensuring child fees are properly linked to their parent and vendor fees are proportionally adjusted.

* **Bug Fixes**
  * Vendor fee amounts are now accurately updated during driver fee splitting, maintaining consistency across related transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->