### PR TITLE
Backend/fix: updated agentAppTxnId for cris

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/CallAPI.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/CallAPI.hs
@@ -123,6 +123,7 @@ getBppOrderId integratedBPPConfig booking = do
     CMRL _ -> Just <$> CMRLOrder.getBppOrderId booking
     EBIX _ -> Just <$> EBIXOrder.getBppOrderId booking
     DIRECT _ -> Just <$> DIRECTOrder.getBppOrderId booking
+    CRIS _ -> Just <$> CRISBookJourney.getBppOrderId booking
     _ -> return Nothing
 
 getTicketStatus :: (MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r, EncFlow m r) => IntegratedBPPConfig -> FRFSTicketBooking -> m [ProviderTicket]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Updated agentAppTxnId to alphaNumeric 21 length UUID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the CRIS provider when retrieving order IDs, enhancing compatibility with additional providers.

* **Bug Fixes**
  * Improved logic for generating order IDs by using existing IDs when available or generating new ones as needed.

* **Chores**
  * Updated imports by removing unused dependencies and adding necessary ones for UUID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->