### PR TITLE
Revert "backend/feat : split payments between vendors basesd on percentage"

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/VendorDetail.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/VendorDetail.yaml
@@ -9,15 +9,12 @@ VendorSplitDetails:
   types:
     SplitType:
       enum: "FIXED, FLEXIBLE"
-    SplitShare:
-      enum: "Percentage Double, FixedValue Int"
   fields:
     id : Id VendorSplitDetails
     integratedBPPConfigId : Id IntegratedBPPConfig
     vendorId : Text
     splitType : SplitType
     includeInSplit : Maybe Bool
-    splitShare : Maybe SplitShare
 
   constraints:
     id: PrimaryKey

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/VendorSplitDetails.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/VendorSplitDetails.hs
@@ -4,21 +4,17 @@
 module Domain.Types.VendorSplitDetails where
 
 import Data.Aeson
-import qualified Data.List as List
 import qualified Data.Text
-import qualified Data.Text as T
 import qualified Domain.Types.IntegratedBPPConfig
 import qualified Domain.Types.MerchantOperatingCity
 import Kernel.Prelude
 import qualified Kernel.Types.Id
-import qualified Text.Show
 import qualified Tools.Beam.UtilsTH
 
 data VendorSplitDetails = VendorSplitDetails
   { id :: Kernel.Types.Id.Id Domain.Types.VendorSplitDetails.VendorSplitDetails,
     includeInSplit :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
     integratedBPPConfigId :: Kernel.Types.Id.Id Domain.Types.IntegratedBPPConfig.IntegratedBPPConfig,
-    splitShare :: Kernel.Prelude.Maybe Domain.Types.VendorSplitDetails.SplitShare,
     splitType :: Domain.Types.VendorSplitDetails.SplitType,
     vendorId :: Data.Text.Text,
     merchantOperatingCityId :: Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity),
@@ -27,30 +23,6 @@ data VendorSplitDetails = VendorSplitDetails
   }
   deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
 
-instance Show SplitShare where
-  show (Percentage percentage) = "PERCENTAGE_" <> T.unpack (show percentage)
-  show (FixedValue fixedValue) = "FIXEDVALUE_" <> T.unpack (show fixedValue)
-
-data SplitShare = Percentage Kernel.Prelude.Double | FixedValue Kernel.Prelude.Int deriving (Eq, Ord, Generic, ToJSON, FromJSON, ToSchema)
-
-instance Read SplitShare where
-  readsPrec d' =
-    readParen
-      (d' > app_prec)
-      ( \r ->
-          [ (Percentage (read r1 :: Kernel.Prelude.Double), "")
-            | r1 <- stripPrefix "PERCENTAGE_" r
-          ]
-            ++ [ (FixedValue (read r1 :: Kernel.Prelude.Int), "")
-                 | r1 <- stripPrefix "FIXEDVALUE_" r
-               ]
-      )
-    where
-      app_prec = 10
-      stripPrefix pref r = bool [] [List.drop (length pref) r] $ List.isPrefixOf pref r
-
 data SplitType = FIXED | FLEXIBLE deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema)
-
-$(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''SplitShare)
 
 $(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''SplitType)

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/VendorSplitDetails.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/VendorSplitDetails.hs
@@ -16,7 +16,6 @@ data VendorSplitDetailsT f = VendorSplitDetailsT
   { id :: B.C f Data.Text.Text,
     includeInSplit :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Bool),
     integratedBPPConfigId :: B.C f Data.Text.Text,
-    splitShare :: B.C f (Kernel.Prelude.Maybe Domain.Types.VendorSplitDetails.SplitShare),
     splitType :: B.C f Domain.Types.VendorSplitDetails.SplitType,
     vendorId :: B.C f Data.Text.Text,
     merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Data.Text.Text),

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/VendorSplitDetails.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/VendorSplitDetails.hs
@@ -50,7 +50,6 @@ updateByPrimaryKey (Domain.Types.VendorSplitDetails.VendorSplitDetails {..}) = d
   updateWithKV
     [ Se.Set Beam.includeInSplit includeInSplit,
       Se.Set Beam.integratedBPPConfigId (Kernel.Types.Id.getId integratedBPPConfigId),
-      Se.Set Beam.splitShare splitShare,
       Se.Set Beam.splitType splitType,
       Se.Set Beam.vendorId vendorId,
       Se.Set Beam.merchantOperatingCityId (Kernel.Types.Id.getId <$> merchantOperatingCityId),
@@ -67,7 +66,6 @@ instance FromTType' Beam.VendorSplitDetails Domain.Types.VendorSplitDetails.Vend
           { id = Kernel.Types.Id.Id id,
             includeInSplit = includeInSplit,
             integratedBPPConfigId = Kernel.Types.Id.Id integratedBPPConfigId,
-            splitShare = splitShare,
             splitType = splitType,
             vendorId = vendorId,
             merchantOperatingCityId = Kernel.Types.Id.Id <$> merchantOperatingCityId,
@@ -81,7 +79,6 @@ instance ToTType' Beam.VendorSplitDetails Domain.Types.VendorSplitDetails.Vendor
       { Beam.id = Kernel.Types.Id.getId id,
         Beam.includeInSplit = includeInSplit,
         Beam.integratedBPPConfigId = Kernel.Types.Id.getId integratedBPPConfigId,
-        Beam.splitShare = splitShare,
         Beam.splitType = splitType,
         Beam.vendorId = vendorId,
         Beam.merchantOperatingCityId = Kernel.Types.Id.getId <$> merchantOperatingCityId,

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CreateFareForMultiModal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CreateFareForMultiModal.hs
@@ -107,47 +107,26 @@ convertVendorDetails ::
   Bool ->
   m [Payment.VendorSplitDetails]
 convertVendorDetails vendorDetails bookings isFRFSTestingEnabled = do
-  let vendorDetailsMap =
-        Map.fromListWith
-          (++)
-          [(vd.integratedBPPConfigId, [vd]) | vd <- vendorDetails]
+  let vendorDetailsMap = Map.fromList [(vd.integratedBPPConfigId, vd) | vd <- vendorDetails]
       requiredVendors = filter (\vd -> fromMaybe False vd.includeInSplit) vendorDetails
-      validVendorSplitDetails = concatMap (createVendorSplitsForBooking vendorDetailsMap) bookings
+      validVendorSplitDetails = mapMaybe (createVendorSplitForBooking vendorDetailsMap) bookings
       finalSplits =
         ensureAllRequiredVendorsExist requiredVendors validVendorSplitDetails
   logInfo $ "finalSplits" <> show finalSplits
   return finalSplits
   where
-    -- Updated this to handle multiple vendor splits per booking
-    createVendorSplitsForBooking vendorDetailsMap booking =
+    createVendorSplitForBooking vendorDetailsMap booking =
       case Map.lookup booking.integratedBppConfigId vendorDetailsMap of
-        Just vendorSplitList ->
-          -- Processed All vendor splits per booking
-          map (toPaymentVendorDetails booking) vendorSplitList
-        Nothing -> []
+        Just vd -> Just $ toPaymentVendorDetails vd booking
+        Nothing -> Nothing
 
-    toPaymentVendorDetails booking vd =
-      let totalAmount = if isFRFSTestingEnabled then (1 :: HighPrecMoney) else booking.price.amount
-          splitAmount =
-            if vd.splitType == VendorSplitDetails.FLEXIBLE
-              then calculateSplitAmount vd.splitShare totalAmount
-              else totalAmount
-       in Payment.VendorSplitDetails
-            { splitAmount = splitAmount,
-              splitType = vendorSplitDetailSplitTypeToPaymentSplitType vd.splitType,
-              vendorId = vd.vendorId,
-              ticketId = Just $ booking.id.getId
-            }
-
-    calculateSplitAmount :: Maybe VendorSplitDetails.SplitShare -> HighPrecMoney -> HighPrecMoney
-    calculateSplitAmount mbSplitPercentage totalAmount =
-      case mbSplitPercentage of
-        Just (VendorSplitDetails.Percentage percentage) ->
-          totalAmount * (fromRational (toRational percentage) / 100.0)
-        Just (VendorSplitDetails.FixedValue fixedValue) ->
-          fromIntegral fixedValue
-        Nothing ->
-          totalAmount
+    toPaymentVendorDetails vd booking =
+      Payment.VendorSplitDetails
+        { splitAmount = if isFRFSTestingEnabled then (1 :: HighPrecMoney) else booking.price.amount,
+          splitType = vendorSplitDetailSplitTypeToPaymentSplitType vd.splitType,
+          vendorId = vd.vendorId,
+          ticketId = Just $ booking.id.getId
+        }
 
     ensureAllRequiredVendorsExist :: [VendorSplitDetails.VendorSplitDetails] -> [Payment.VendorSplitDetails] -> [Payment.VendorSplitDetails]
     ensureAllRequiredVendorsExist requiredVendors existingVendorSplits =

--- a/Backend/dev/migrations-read-only/rider-app/vendor_split_details.sql
+++ b/Backend/dev/migrations-read-only/rider-app/vendor_split_details.sql
@@ -14,7 +14,3 @@ ALTER TABLE atlas_app.vendor_split_details ADD PRIMARY KEY ( id);
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.vendor_split_details ADD COLUMN include_in_split boolean ;
-
-------- SQL updates -------
-
-ALTER TABLE atlas_app.vendor_split_details ADD COLUMN split_share text ;


### PR DESCRIPTION
Reverts nammayatri/nammayatri#11831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified vendor split processing by removing support for multiple splits per booking and eliminating split share calculations.
  * The split amount for vendors is now set directly to the booking price or a default value for testing.
* **Chores**
  * Removed the split share field and related logic from vendor split details across the platform.
  * Updated database migration scripts to exclude the split share column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->