### PR TITLE
backend : add stop charges fix

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Common.hs
@@ -116,7 +116,8 @@ filterRequiredBreakups fParamsType breakup = do
                  "CANCELLATION_CHARGES",
                  "PARKING_CHARGE",
                  "NIGHT_SHIFT_CHARGE",
-                 "RIDE_STOP_CHARGES"
+                 "RIDE_STOP_CHARGES",
+                 "PER_STOP_CHARGES"
                ]
     DFParams.Slab ->
       title

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnSelect.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnSelect.hs
@@ -249,6 +249,7 @@ mkQuoteBreakupInner quote = do
         || breakup.quotationBreakupInnerTitle == Just (show Enums.NIGHT_SHIFT_CHARGE)
         || breakup.quotationBreakupInnerTitle == Just (show Enums.SAFETY_PLUS_CHARGES)
         || breakup.quotationBreakupInnerTitle == Just (show Enums.RIDE_STOP_CHARGES)
+        || breakup.quotationBreakupInnerTitle == Just (show Enums.PER_STOP_CHARGES)
 
 mkQuotationPrice :: DQuote.DriverQuote -> Maybe Spec.Price
 mkQuotationPrice quote =

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/Common.hs
@@ -1248,6 +1248,7 @@ mkQuotationBreakup fareParams =
             || breakup.quotationBreakupInnerTitle == Just (show Enums.TOLL_CHARGES)
             || breakup.quotationBreakupInnerTitle == Just (show Enums.NIGHT_SHIFT_CHARGE)
             || breakup.quotationBreakupInnerTitle == Just (show Enums.RIDE_STOP_CHARGES)
+            || breakup.quotationBreakupInnerTitle == Just (show Enums.PER_STOP_CHARGES)
         DFParams.Slab ->
           breakup.quotationBreakupInnerTitle == Just (show Enums.BASE_FARE)
             || breakup.quotationBreakupInnerTitle == Just (show Enums.SERVICE_CHARGE)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/OnUpdate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/OnUpdate.hs
@@ -110,6 +110,7 @@ mkRideCompletedQuote ride fareParams = do
                      Just (show Enums.TOLL_CHARGES),
                      Just (show Enums.PARKING_CHARGE),
                      Just (show Enums.RIDE_STOP_CHARGES),
+                     Just (show Enums.PER_STOP_CHARGES),
                      Just (show Enums.NIGHT_SHIFT_CHARGE)
                    ]
         DFParams.Slab ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Invoice.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Invoice.hs
@@ -49,7 +49,8 @@ getInvoiceInvoice merchantShortId _ from phoneNumber to = do
                   ("EXTRA_DISTANCE_FARE", "Extra Distance Fare"),
                   ("WAITING_OR_PICKUP_CHARGES", "Wating Charge"),
                   ("PARKING_CHARGE", "Parking Charge"),
-                  ("RIDE_STOP_CHARGES", "Ride Stop Charges")
+                  ("RIDE_STOP_CHARGES", "Ride Stop Charges"),
+                  ("PER_STOP_CHARGES", "Per Stop Charges")
                 ]
           fareBreakups <- mapM (getFareBreakup booking) breakupItems
           mbSource <- case booking.fromLocationId of

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Invoice.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Invoice.hs
@@ -43,7 +43,8 @@ getInvoice (mbPersonId, merchantId) from to = do
                   ("EXTRA_DISTANCE_FARE", "Extra Distance Fare"),
                   ("WAITING_OR_PICKUP_CHARGES", "Wating Charge"),
                   ("PARKING_CHARGE", "Parking Charge"),
-                  ("RIDE_STOP_CHARGES", "Ride Stop Charges")
+                  ("RIDE_STOP_CHARGES", "Ride Stop Charges"),
+                  ("PER_STOP_CHARGES", "Per Stop Charges")
                 ]
           fareBreakups <- mapM (getFareBreakup booking) breakupItems
           mbSource <- case booking.fromLocationId of

--- a/Backend/lib/beckn-spec/src/BecknV2/OnDemand/Enums.hs
+++ b/Backend/lib/beckn-spec/src/BecknV2/OnDemand/Enums.hs
@@ -181,6 +181,7 @@ data QuoteBreakupTitle
   | SAFETY_PLUS_CHARGES
   | NO_CHARGES
   | RIDE_STOP_CHARGES
+  | PER_STOP_CHARGES
   | NYREGULAR_SUBSCRIPTION_CHARGE
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 


### PR DESCRIPTION
- fixed PER_STOP_CHARGES not coming in estimate fare params
- fixed RIDE_STOP_CHARGES not coming in booking fare params

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new fare breakup component: "Per Stop Charges" across driver and rider invoices.
  * "Per Stop Charges" now appears as a distinct item in fare breakdowns for relevant bookings.

* **Bug Fixes**
  * Ensured that "Per Stop Charges" are correctly included in fare calculations and displayed in invoices where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->