### PR TITLE
feat: added route_state to vehicle tracking info api

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/TrackRoute.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/TrackRoute.yaml
@@ -7,6 +7,7 @@ imports:
   VehicleCategory: BecknV2.FRFS.Enums
   PlatformType: Domain.Types.IntegratedBPPConfig
   IntegratedBPPConfig: Domain.Types.IntegratedBPPConfig
+  RouteState: Storage.CachedQueries.Merchant.MultiModalBus
 
 module: TrackRoute
 
@@ -34,6 +35,7 @@ types:
     vehicleInfo: VehicleInfoForRoute
     upcomingStops: [SharedLogic.FRFSUtils.UpcomingStop]
     delay: Maybe Seconds
+    routeState: Maybe RouteState
 
 apis:
   - GET:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/TrackRoute.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/TrackRoute.hs
@@ -10,6 +10,7 @@ import qualified Kernel.Types.Common
 import Servant
 import qualified SharedLogic.External.LocationTrackingService.Types
 import qualified SharedLogic.FRFSUtils
+import qualified Storage.CachedQueries.Merchant.MultiModalBus
 import Tools.Auth
 
 data TrackingResp = TrackingResp {vehicleTrackingInfo :: [VehicleInfo]}
@@ -21,6 +22,7 @@ data VehicleInfo = VehicleInfo
     nextStop :: Kernel.Prelude.Maybe Domain.Types.RouteStopMapping.RouteStopMapping,
     nextStopTravelDistance :: Kernel.Prelude.Maybe Kernel.Types.Common.Meters,
     nextStopTravelTime :: Kernel.Prelude.Maybe Kernel.Types.Common.Seconds,
+    routeState :: Kernel.Prelude.Maybe Storage.CachedQueries.Merchant.MultiModalBus.RouteState,
     upcomingStops :: [SharedLogic.FRFSUtils.UpcomingStop],
     vehicleId :: Kernel.Prelude.Text,
     vehicleInfo :: VehicleInfoForRoute

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TrackRoute.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TrackRoute.hs
@@ -40,6 +40,7 @@ getTrackVehicles (mbPersonId, merchantId) routeCode mbIntegratedBPPConfigId mbPl
           nextStopTravelDistance = nextStopTravelDistance,
           upcomingStops = upcomingStops,
           delay = delay,
+          routeState = routeState,
           vehicleInfo = maybe (TrackRoute.VehicleInfoForRoute Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing) mkVehicleInfo vehicleInfo
         }
     mkVehicleInfo VehicleInfo {..} = TrackRoute.VehicleInfoForRoute {..}

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
@@ -450,7 +450,8 @@ data VehicleTracking = VehicleTracking
     upcomingStops :: [UpcomingStop],
     vehicleId :: Text,
     vehicleInfo :: Maybe VehicleInfo,
-    delay :: Maybe Seconds
+    delay :: Maybe Seconds,
+    routeState :: Maybe CQMMB.RouteState
   }
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -509,7 +510,8 @@ trackVehicles _personId _merchantId merchantOpCityId vehicleType routeCode platf
                       upcomingStops = [],
                       vehicleId = vehicleId,
                       vehicleInfo = Just vehicleInfo,
-                      delay = Nothing
+                      delay = Nothing,
+                      routeState = Nothing
                     }
             )
             vehicleTrackingInfo
@@ -564,7 +566,8 @@ trackVehicles _personId _merchantId merchantOpCityId vehicleType routeCode platf
                           tripId = Nothing,
                           upcomingStops = Nothing
                         },
-                  delay = Nothing
+                  delay = Nothing,
+                  routeState = busData.route_state
                 }
     _ -> do
       route <- OTPRest.getRouteByRouteId integratedBPPConfig routeCode >>= fromMaybeM (RouteNotFound routeCode)
@@ -605,7 +608,8 @@ trackVehicles _personId _merchantId merchantOpCityId vehicleType routeCode platf
                       upcomingStops = [],
                       vehicleId = show vehicleType,
                       vehicleInfo = Nothing,
-                      delay = Nothing
+                      delay = Nothing,
+                      routeState = Nothing
                     }
             pure vehicleTracking
         Nothing -> do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track Route now includes an optional “route state” for vehicles, giving extra context about a vehicle’s current routing status when available (primarily for buses).
  * The Track Route API responses include this new route state field so clients can surface richer status information.
  * Vehicle detail views and timings are unchanged; route state is shown only when provided.
  * Internal tracking payloads now carry the optional route state through the flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->