### PR TITLE
Backend/feat: added sorting for suburban routes

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/IntegratedBPPConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/IntegratedBPPConfig.hs
@@ -8,6 +8,9 @@ import Kernel.Prelude
 import Kernel.Types.Base64
 import Kernel.Types.Time
 
+data CRISRouteSortingCriteria = FARE | DISTANCE
+  deriving (Generic, Show, Read, FromJSON, ToJSON, Eq)
+
 data EBIXConfig = EBIXConfig
   { agentId :: Text,
     username :: Text,
@@ -56,7 +59,8 @@ data CRISConfig = CRISConfig
     changeOverIndirectStations :: Maybe [Text],
     changeOverDirectStations :: Maybe [Text],
     agentDataDecryptionKey :: EncryptedField 'AsEncrypted Text,
-    utsDataKey :: EncryptedField 'AsEncrypted Text
+    utsDataKey :: EncryptedField 'AsEncrypted Text,
+    routeSortingCriteria :: Maybe CRISRouteSortingCriteria
   }
   deriving stock (Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/UpdateCrisUtsData.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/UpdateCrisUtsData.hs
@@ -62,7 +62,8 @@ updateCrisUtsDataJob Job {id, jobInfo} = withLogTag ("JobId-" <> id.getId) do
                   consumerKey = consumerKey config,
                   changeOverIndirectStations = changeOverIndirectStations config,
                   changeOverDirectStations = changeOverDirectStations config,
-                  consumerSecret = consumerSecret config
+                  consumerSecret = consumerSecret config,
+                  routeSortingCriteria = routeSortingCriteria config
                 }
       QIntegratedBPPConfig.updateByPrimaryKey integratedBppConfig {providerConfig = updatedProviderConfig}
       let scheduleAfter = secondsToNominalDiffTime (24 * 60 * 60)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Added Sorting for suburban routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable route sorting for CRIS routes, allowing sorting by lowest fare or shortest distance.

* **Improvements**
  * Routes are now ordered based on the selected sorting preference for clearer, more relevant results.
  * Via-point construction now uses detailed fare entries for more accurate multi-stop routing.
  * Incomplete fare entries are skipped, reducing noise and inconsistencies in route options.

* **Chores**
  * Provider configuration updated to persist the chosen route-sorting preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->