### PR TITLE
backend/fix: No Estimate wrongly mapped to Feedback

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/State/Utils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/State/Utils.hs
@@ -126,7 +126,7 @@ getTaxiJourneyBookingStatus mbBooking mbRide mbEstimate = do
         Nothing -> do
           case mbEstimate of
             Just estimate -> TaxiEstimate estimate.status
-            Nothing -> Feedback FEEDBACK_PENDING
+            Nothing -> Initial BOOKING_PENDING
 
 getFRFSJourneyBookingStatus :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m) => Maybe DFRFSBooking.FRFSTicketBooking -> m JourneyBookingStatus
 getFRFSJourneyBookingStatus mbBooking = do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Taxi journeys with no ride, booking, or estimate now show “Booking pending” instead of “Feedback pending.”
  * Journey terminal status updates only once all legs are finished; cancellations are detected more consistently across legs.
  * Status indicators and timelines now remain consistent with journey terminal state; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->