### PR TITLE
Backend/fix: changed m->km for routefare distance

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/RouteFare.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/RouteFare.hs
@@ -193,7 +193,7 @@ getRouteFare config merchantOperatingCityId request = do
                 Just
                   Quote.FRFSFareDetails
                     { providerRouteId = show routeId,
-                      distance = Meters fare.distance,
+                      distance = kilometersToMeters $ Kilometers fare.distance,
                       via = fare.via,
                       ticketTypeCode = fare.ticketTypeCode,
                       trainTypeCode = fare.trainTypeCode,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Changed meters to kilo meters in route fare distance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected distance handling for subway route fares to ensure distances are processed in meters, improving consistency across fare calculations and displays.
  * Aligned route distance units with the rest of the system, reducing discrepancies in fare estimates and trip details.
  * Users may notice more accurate fare estimates and route distance displays, especially on longer trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->