### PR TITLE
fix: use otp gates as fallback

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
@@ -1223,10 +1223,10 @@ mkJourneyLeg idx (mbPrev, leg, mbNext) journeyStartLocation journeyEndLocation m
         legPricingId = Nothing,
         changedBusesInSequence = Nothing,
         finalBoardedBusNumber = Nothing,
-        osmEntrance = gates >>= (.osmEntrance),
-        osmExit = gates >>= (.osmExit),
-        straightLineEntrance = gates >>= (.straightLineEntrance),
-        straightLineExit = gates >>= (.straightLineExit),
+        osmEntrance = chooseGate (gates >>= (.osmEntrance)) (leg.entrance),
+        osmExit = chooseGate (gates >>= (.osmExit)) (leg.exit),
+        straightLineEntrance = chooseGate (gates >>= (.straightLineEntrance)) (leg.entrance),
+        straightLineExit = chooseGate (gates >>= (.straightLineExit)) (leg.exit),
         journeyId = journeyId,
         isDeleted = Just False,
         sequenceNumber = idx
@@ -1315,6 +1315,9 @@ mkJourneyLeg idx (mbPrev, leg, mbNext) journeyStartLocation journeyEndLocation m
             createdAt = now,
             updatedAt = now
           }
+
+    chooseGate :: Maybe KEMIT.MultiModalLegGate -> Maybe KEMIT.MultiModalLegGate -> Maybe KEMIT.MultiModalLegGate
+    chooseGate fromGates fromLeg = fromGates <|> fromLeg
 
 getServiceTypeFromProviderCode :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> Text -> m Spec.ServiceTierType
 getServiceTypeFromProviderCode merchantOperatingCityId providerCode = do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection of station entrances/exits in journey legs with a smarter fallback when gate data is missing.
  * Reduces cases of blank or incorrect gate information, providing more consistent navigation cues and map annotations.
  * Enhances overall reliability of journey details without changing any visible settings or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->