### PR TITLE
Revert "Revert "backend/fix: cache all routes when no remaining via points in multiMo…""

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/API/UI/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/UI/Search.hs
@@ -371,7 +371,7 @@ multiModalSearch searchRequest riderConfig initiateJourney forkInitiateFirstJour
             return (warningType, MInterface.MultiModalResponse {routes = filteredRoutes})
   when (not (null restOfViaPoints) && isJust mbIntegratedBPPConfig) $ do
     fork "Process rest of single mode routes" $ processSingleModeRoutes restOfViaPoints userPreferences mbIntegratedBPPConfig merchantOperatingCityId (getPreliminaryLeg now currentLocation)
-
+  when (null restOfViaPoints) $ cacheAllRoutesLoadedKey searchRequest.id.getId True
   multimodalIntiateHelper singleModeWarningType otpResponse userPreferences merchantOperatingCityId
   where
     processSingleModeRoutes restOfViaPoints userPreferences mbIntegratedBPPConfig merchantOperatingCityId preliminaryLeg = do


### PR DESCRIPTION
Reverts nammayatri/nammayatri#12241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly marks routes as fully loaded when there are no intermediate stops, preventing stuck loading indicators and ensuring results display as expected.
* **Performance**
  * Faster completion of simple route searches due to improved loading state handling.
* **Reliability**
  * More consistent route-loading behavior across different trip scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->