### PR TITLE
Backend/fix: remove upcoming vehicles for subway

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/API/UI/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/UI/Search.hs
@@ -381,12 +381,12 @@ multiModalSearch searchRequest riderConfig initiateJourney forkInitiateFirstJour
   where
     processSingleModeRoutes restOfViaPoints userPreferences mbIntegratedBPPConfig preliminaryLeg = do
       (restOfRoutes, _) <- JMU.getSubwayValidRoutes restOfViaPoints preliminaryLeg (fromJust mbIntegratedBPPConfig) searchRequest.merchantId searchRequest.merchantOperatingCityId (fromMaybe BecknV2.OnDemand.Enums.BUS searchRequest.vehicleCategory) (castVehicleCategoryToGeneralVehicleType (fromMaybe BecknV2.OnDemand.Enums.BUS searchRequest.vehicleCategory)) True
+      cacheAllRoutesLoadedKey searchRequest.id.getId True
       when (not (null restOfRoutes)) $
         do
           let multimodalResponse = MInterface.MultiModalResponse {routes = restOfRoutes}
           (indexedRoutesToProcess, showMultimodalWarningForFirstJourney) <- getIndexedRoutesAndWarning userPreferences multimodalResponse
           void $ multimodalIntiateHelper Nothing multimodalResponse userPreferences indexedRoutesToProcess showMultimodalWarningForFirstJourney Nothing False
-      cacheAllRoutesLoadedKey searchRequest.id.getId True
 
     multimodalIntiateHelper singleModeWarningType otpResponse userPreferences indexedRoutesToProcess showMultimodalWarningForFirstJourney mbCrisSdkToken isFirstJourneyReq = do
       mbJourneyWithIndex <- JMU.measureLatency (go indexedRoutesToProcess userPreferences) "Multimodal Init Time" -- process until first journey is found

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
@@ -6,8 +6,6 @@ import qualified BecknV2.FRFS.Enums as Spec
 import BecknV2.FRFS.Utils
 import qualified BecknV2.OnDemand.Enums as Enums
 import Control.Applicative ((<|>))
-import Control.Monad.Extra (concatMapM, mapMaybeM)
-import Data.List (sortOn)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text.Encoding as TE
 import qualified Data.Time as Time
@@ -125,21 +123,13 @@ getState mode searchId riderLastPoints movementDetected routeCodeForDetailedTrac
           finalStateData <- updateFleetNoIfFinalized detailedStateData mbCurrentLegDetails searchId (isJust mbBooking)
           return $ JT.Single finalStateData
         _ -> do
-          vehiclePositions :: [JT.VehiclePosition] <-
-            concatMapM
-              ( \routeDetails -> do
-                  fromStationCode <- routeDetails.fromStopCode & fromMaybeM (InvalidRequest $ "From station code not found in booking with id: " <> booking.id.getId)
-                  toStationCode <- routeDetails.toStopCode & fromMaybeM (InvalidRequest $ "To station code not found in booking with id: " <> booking.id.getId)
-                  getVehiclePositionsIfAvailable mode fromStationCode toStationCode integratedBppConfig
-              )
-              journeyLeg.routeDetails
           let journeyLegStates =
                 [ JT.JourneyLegStateData
                     { status = JMStateUtils.castTrackingStatusToJourneyLegStatus trackingStatus,
                       bookingStatus,
                       trackingStatus,
                       userPosition,
-                      JT.vehiclePositions = vehiclePositions,
+                      JT.vehiclePositions = [],
                       legOrder = journeyLeg.sequenceNumber,
                       subLegOrder,
                       mode,
@@ -199,15 +189,13 @@ getState mode searchId riderLastPoints movementDetected routeCodeForDetailedTrac
           return $ JT.Single finalStateData
         _ -> do
           -- Other modes (Metro, Subway, etc.)
-          vehiclePositions <- getVehiclePositionsIfAvailable mode searchReq.fromStationCode searchReq.toStationCode integratedBppConfig
-
           let journeyLegStates =
                 [ JT.JourneyLegStateData
                     { status = JMStateUtils.castTrackingStatusToJourneyLegStatus trackingStatus,
                       bookingStatus,
                       trackingStatus,
                       userPosition,
-                      JT.vehiclePositions = vehiclePositions,
+                      JT.vehiclePositions = [],
                       legOrder = journeyLeg.sequenceNumber,
                       subLegOrder = subLegOrder,
                       mode,
@@ -217,51 +205,6 @@ getState mode searchId riderLastPoints movementDetected routeCodeForDetailedTrac
                 ]
           return $ JT.Transit journeyLegStates
   where
-    utcToTimeOfDay :: UTCTime -> TimeOfDay
-    utcToTimeOfDay = Time.timeToTimeOfDay . Time.utctDayTime
-
-    getVehiclePositionsIfAvailable :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, HasShortDurationRetryCfg r c) => DTrip.MultimodalTravelMode -> Text -> Text -> DIBC.IntegratedBPPConfig -> m [JT.VehiclePosition]
-    getVehiclePositionsIfAvailable legMode fromStationCode toStationCode integratedBppConfig = do
-      case legMode of
-        DTrip.Subway -> do
-          routeCodes <- JMU.getRouteCodesFromTo fromStationCode toStationCode integratedBppConfig
-          now <- getCurrentTime
-          let currentTimeOfDay = utcToTimeOfDay now
-          allSchedules <- QRSTT.findByRouteCodeAndStopCode integratedBppConfig integratedBppConfig.merchantId integratedBppConfig.merchantOperatingCityId routeCodes fromStationCode
-          let futureSchedules = take 10 $ filter (\schedule -> schedule.timeOfDeparture > currentTimeOfDay) allSchedules
-          allTripsInfo <- mapMaybeM (\schedule -> OTPRest.getNandiTripInfo integratedBppConfig schedule.tripId.getId) futureSchedules
-          pure $
-            map
-              ( \tripInfo -> do
-                  let stopSchedules = sortOn (.sequenceNum) tripInfo.schedule
-                      stopInfos = sortOn (.sequenceNum) tripInfo.stops
-                      (stopSchedulesToUse, _) =
-                        foldl'
-                          ( \(acc, shouldKeep) (stopSchedule, stopInfo) ->
-                              if shouldKeep
-                                then ((stopSchedule, stopInfo) : acc, stopInfo.stopCode /= toStationCode && shouldKeep)
-                                else (acc, False)
-                          )
-                          ([], True)
-                          (zip stopSchedules stopInfos)
-                  let upcomingStops =
-                        map
-                          ( \(stopSchedule, stopInfo) ->
-                              JT.NextStopDetails
-                                { stopCode = stopInfo.stopCode,
-                                  sequenceNumber = stopInfo.sequenceNum,
-                                  travelTime = Just $ Seconds $ stopSchedule.departureTime - stopSchedule.arrivalTime,
-                                  travelDistance = Nothing,
-                                  stopName = Just stopInfo.stopName
-                                }
-                          )
-                          (reverse stopSchedulesToUse)
-                  JT.VehiclePosition {position = Nothing, vehicleId = tripInfo.tripId, route_state = Nothing, upcomingStops = upcomingStops}
-              )
-              allTripsInfo
-        _ -> do
-          return []
-
     updateFleetNoIfFinalized ::
       (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, HasFlowEnv m r '["ltsCfg" ::: LT.LocationTrackingeServiceConfig], HasField "ltsHedisEnv" r Redis.HedisEnv, HasShortDurationRetryCfg r c, HasKafkaProducer r) =>
       JT.JourneyLegStateData ->


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
removed upcoming vehicles in rider/location for SUBWAY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  * Live vehicle positions are now shown only for bus legs; other transit modes (train, tram, etc.) no longer display vehicle positions.
  * Fleet numbers are hidden for non-bus transit legs; bus legs continue to show live positions as before.
  * Applies to both booked and unbooked journeys: non-bus legs will show no vehicle positions.

* Chores
  * Improved search route caching/timing to reduce redundant work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->