### PR TITLE
backend/add: Added routeCode in VehicleInfo of TrackingResp

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/TrackRoute.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/TrackRoute.yaml
@@ -36,6 +36,7 @@ types:
     vehicleInfo: VehicleInfoForRoute
     upcomingStops: [SharedLogic.FRFSUtils.UpcomingStop]
     delay: Maybe Seconds
+    routeCode: Text
 
 apis:
   - GET:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/TrackRoute.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/TrackRoute.hs
@@ -24,7 +24,8 @@ data VehicleInfo = VehicleInfo
     nextStopTravelTime :: Kernel.Prelude.Maybe Kernel.Types.Common.Seconds,
     upcomingStops :: [SharedLogic.FRFSUtils.UpcomingStop],
     vehicleId :: Kernel.Prelude.Text,
-    vehicleInfo :: VehicleInfoForRoute
+    vehicleInfo :: VehicleInfoForRoute,
+    routeCode :: Kernel.Prelude.Text
   }
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TrackRoute.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TrackRoute.hs
@@ -40,6 +40,7 @@ getTrackVehicles (mbPersonId, merchantId) routeCode mbIntegratedBPPConfigId mbPl
           nextStopTravelDistance = nextStopTravelDistance,
           upcomingStops = upcomingStops,
           delay = delay,
-          vehicleInfo = maybe (TrackRoute.VehicleInfoForRoute Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing) mkVehicleInfo vehicleInfo
+          vehicleInfo = maybe (TrackRoute.VehicleInfoForRoute Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing) mkVehicleInfo vehicleInfo,
+          routeCode = routeCode
         }
     mkVehicleInfo VehicleInfo {..} = TrackRoute.VehicleInfoForRoute {..}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Vehicle tracking now includes a route code in vehicle details. The Track Route responses expose a new routeCode field within VehicleInfo, providing the route identifier alongside existing data. This additional information is returned in relevant API responses and reflected in UI surfaces that display vehicle tracking details, enabling clearer identification of the route associated with each vehicle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->