### PR TITLE
fix: ensure database entry creation on Kafka failure

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Create.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Create.hs
@@ -41,6 +41,7 @@ runCreate createDataEntry streamName = do
             Left err -> do
               EL.logError ("KAFKA CREATE FAILED" :: Text) ("Kafka create failed for drainer : " <> err <> " for table :: " <> show tableName)
               void $ publishDBSyncMetric $ Event.KafkaPushFailure "Create" tableName.getDBModel
+              _ <- runCreateQuery createDataEntry createDBModel --- it should push that entry to db what if isForcePushEnabled is true then it will get missed
               return $ Left entryId
             Right _ -> do
               EL.logInfo ("KAFKA CREATE SUCCESSFUL" :: Text) (" Create successful for object :: " <> show createDBModel.contents)
@@ -71,7 +72,6 @@ runCreateQuery createDataEntry dbCreateObject = do
               return $ Left entryId
             Right _ -> do
               EL.logDebug ("QUERY INSERT SUCCESSFUL" :: Text) (" Insert successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
-              _ <- runCreateQuery createDataEntry dbCreateObject --- it should push that entry to db what if isForcePushEnabled is true then it will get missed
               return $ Right entryId
         Nothing -> do
           EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate database entries by ensuring each item is written only once.
* **Reliability**
  * Improved data resilience: items are now saved to the database even if event dispatch fails.
  * Ensures consistent processing by handling database writes at a single, top-level step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->