### PR TITLE
backend/fix/lock-for-ride-cancellation-by-driver

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
@@ -26,7 +26,6 @@ module Domain.Action.Beckn.Cancel
 where
 
 import Data.Maybe (listToMaybe)
-import Domain.Action.UI.Ride.CancelRide (driverDistanceToPickup)
 import qualified Domain.Action.UI.Ride.CancelRide.Internal as CInternal
 import qualified Domain.Types.Booking as SRB
 import qualified Domain.Types.BookingCancellationReason as DBCR
@@ -198,7 +197,7 @@ getDistanceToPickup booking mbRide = do
           Right locations -> return $ listToMaybe locations
       case mbLocation of
         Just location -> do
-          distance <- driverDistanceToPickup booking (getCoordinates location) (getCoordinates booking.fromLocation)
+          distance <- CInternal.driverDistanceToPickup booking (getCoordinates location) (getCoordinates booking.fromLocation)
           return (Just distance, Just location)
         Nothing -> return (Nothing, Nothing)
     _ -> return (Nothing, Nothing)
@@ -238,7 +237,7 @@ customerCancellationChargesCalculation booking mbRide currDistanceToPickup = do
       if ride.isAdvanceBooking
         then do
           forM ride.previousRideTripEndPos $ \location -> do
-            driverDistanceToPickup booking (getCoordinates location) (getCoordinates booking.fromLocation)
+            CInternal.driverDistanceToPickup booking (getCoordinates location) (getCoordinates booking.fromLocation)
         else return booking.distanceToPickup
     getTimeSpentByDriver ride = do
       now <- getCurrentTime

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -15,6 +15,7 @@
 module Domain.Action.UI.Ride.CancelRide.Internal
   ( cancelRideImpl,
     updateNammaTagsForCancelledRide,
+    driverDistanceToPickup,
   )
 where
 
@@ -26,18 +27,22 @@ import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import qualified Domain.Types.Booking as SRB
 import qualified Domain.Types.BookingCancellationReason as SBCR
 import qualified Domain.Types.CancellationFarePolicy as DTC
+import qualified Domain.Types.CancellationReason as DTCR
 import qualified Domain.Types.Merchant as DMerc
 import qualified Domain.Types.Ride as DRide
 import qualified Domain.Types.Yudhishthira as TY
 import EulerHS.Prelude
-import Kernel.External.Maps.Types
+import Kernel.External.Maps
+-- import Kernel.External.Maps.Types
 import Kernel.Prelude hiding (any, elem, map)
 import qualified Kernel.Storage.Esqueleto as Esq hiding (whenJust_)
 import Kernel.Storage.Esqueleto.Config (EsqDBReplicaFlow)
 import qualified Kernel.Storage.Hedis as Redis
-import Kernel.Streaming.Kafka.Producer.Types (KafkaProducerTools)
+import Kernel.Streaming.Kafka.Producer.Types (HasKafkaProducer, KafkaProducerTools)
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import qualified Lib.DriverCoins.Coins as DC
+import qualified Lib.DriverCoins.Types as DCT
 import qualified Lib.DriverScore as DS
 import qualified Lib.DriverScore.Types as DST
 import Lib.Scheduler (SchedulerType)
@@ -71,6 +76,7 @@ import qualified Storage.Queries.Vehicle as QVeh
 import Tools.Constants
 import Tools.Error
 import Tools.Event
+import qualified Tools.Maps as Maps
 import qualified Tools.Metrics as Metrics
 import qualified Tools.Notifications as Notify
 import TransactionLogs.Types
@@ -114,29 +120,54 @@ cancelRideImpl ::
   Maybe Bool ->
   m ()
 cancelRideImpl rideId rideEndedBy bookingCReason isForceReallocation doCancellationRateBasedBlocking = do
-  ride <- QRide.findById rideId >>= fromMaybeM (RideDoesNotExist rideId.getId)
-  booking <- QRB.findById ride.bookingId >>= fromMaybeM (BookingNotFound ride.bookingId.getId)
-  isValueAddNP <- CQVAN.isValueAddNP booking.bapId
-  let merchantId = booking.providerId
-  merchant <-
-    CQM.findById merchantId
-      >>= fromMaybeM (MerchantNotFound merchantId.getId)
-  transporterConfig <- CTC.findByMerchantOpCityId booking.merchantOperatingCityId Nothing >>= fromMaybeM (TransporterConfigNotFound booking.merchantOperatingCityId.getId)
-  noShowCharges <- if transporterConfig.canAddCancellationFee then calculateNoShowCharges booking ride else return Nothing
-  cancelRideTransaction booking ride bookingCReason merchantId rideEndedBy noShowCharges
-  logTagInfo ("rideId-" <> getId rideId) ("Cancellation reason " <> show bookingCReason.source)
-  driver <- QPerson.findById ride.driverId >>= fromMaybeM (PersonNotFound ride.driverId.getId)
-  vehicle <- QVeh.findById ride.driverId >>= fromMaybeM (DriverWithoutVehicle ride.driverId.getId)
-  fork "cancelRide - Notify driver" $ do
-    rideTags <- updateNammaTagsForCancelledRide booking ride bookingCReason
-    triggerRideCancelledEvent RideEventData {ride = ride{status = DRide.CANCELLED}, personId = driver.id, merchantId = merchantId}
-    triggerBookingCancelledEvent BookingEventData {booking = booking{status = SRB.CANCELLED}, personId = driver.id, merchantId = merchantId}
-    when (bookingCReason.source == SBCR.ByDriver) $
-      DS.driverScoreEventHandler ride.merchantOperatingCityId DST.OnDriverCancellation {rideTags, merchantId = merchantId, driver = driver, rideFare = Just booking.estimatedFare, currency = booking.currency, distanceUnit = booking.distanceUnit, doCancellationRateBasedBlocking}
-    Notify.notifyOnCancel ride.merchantOperatingCityId booking driver bookingCReason.source
-  fork "cancelRide/ReAllocate - Notify BAP" $ do
-    isReallocated <- reAllocateBookingIfPossible isValueAddNP False merchant booking ride driver vehicle bookingCReason isForceReallocation
-    unless isReallocated $ BP.sendBookingCancelledUpdateToBAP booking merchant bookingCReason.source noShowCharges
+  isLocked <- Redis.tryLockRedis (buildCancelRideTransactionKey rideId) 15
+  if isLocked
+    then do
+      finally
+        ( do
+            ride <- QRide.findById rideId >>= fromMaybeM (RideDoesNotExist rideId.getId)
+            booking <- QRB.findById ride.bookingId >>= fromMaybeM (BookingNotFound ride.bookingId.getId)
+            isValueAddNP <- CQVAN.isValueAddNP booking.bapId
+            let merchantId = booking.providerId
+            merchant <-
+              CQM.findById merchantId
+                >>= fromMaybeM (MerchantNotFound merchantId.getId)
+            transporterConfig <- CTC.findByMerchantOpCityId booking.merchantOperatingCityId Nothing >>= fromMaybeM (TransporterConfigNotFound booking.merchantOperatingCityId.getId)
+            noShowCharges <- if transporterConfig.canAddCancellationFee then calculateNoShowCharges booking ride else return Nothing
+            driver <- QPerson.findById ride.driverId >>= fromMaybeM (PersonNotFound ride.driverId.getId)
+            vehicle <- QVeh.findById ride.driverId >>= fromMaybeM (DriverWithoutVehicle ride.driverId.getId)
+            unless (isValidRide ride) $ throwError (InternalError "Ride is not valid for cancellation")
+            cancelRideTransaction booking ride bookingCReason merchantId rideEndedBy noShowCharges
+            logTagInfo ("rideId-" <> getId rideId) ("Cancellation reason " <> show bookingCReason.source)
+
+            fork "DriverRideCancelledCoin Event : " $ do
+              mbLocation <- do
+                driverLocations <- LF.driversLocation [ride.driverId]
+                return $ listToMaybe driverLocations
+              disToPickup <- forM mbLocation $ \location -> do
+                driverDistanceToPickup booking (getCoordinates location) (getCoordinates booking.fromLocation)
+              when (bookingCReason.source == SBCR.ByDriver) $
+                DC.driverCoinsEvent ride.driverId driver.merchantId booking.merchantOperatingCityId (DCT.Cancellation ride.createdAt booking.distanceToPickup disToPickup DCT.CancellationByDriver (fromMaybe (DTCR.CancellationReasonCode "OTHER") bookingCReason.reasonCode)) (Just ride.id.getId) ride.vehicleVariant (Just booking.configInExperimentVersions)
+
+            fork "cancelRide - Notify driver" $ do
+              rideTags <- updateNammaTagsForCancelledRide booking ride bookingCReason
+              triggerRideCancelledEvent RideEventData {ride = ride{status = DRide.CANCELLED}, personId = driver.id, merchantId = merchantId}
+              triggerBookingCancelledEvent BookingEventData {booking = booking{status = SRB.CANCELLED}, personId = driver.id, merchantId = merchantId}
+              when (bookingCReason.source == SBCR.ByDriver) $
+                DS.driverScoreEventHandler ride.merchantOperatingCityId DST.OnDriverCancellation {rideTags, merchantId = merchantId, driver = driver, rideFare = Just booking.estimatedFare, currency = booking.currency, distanceUnit = booking.distanceUnit, doCancellationRateBasedBlocking}
+              Notify.notifyOnCancel ride.merchantOperatingCityId booking driver bookingCReason.source
+            fork "cancelRide/ReAllocate - Notify BAP" $ do
+              isReallocated <- reAllocateBookingIfPossible isValueAddNP False merchant booking ride driver vehicle bookingCReason isForceReallocation
+              unless isReallocated $ BP.sendBookingCancelledUpdateToBAP booking merchant bookingCReason.source noShowCharges
+        )
+        ( do
+            logDebug $ "CancelRideTransaction:RID:-" <> rideId.getId <> " Unlocked"
+            Redis.unlockRedis (buildCancelRideTransactionKey rideId)
+        )
+    else throwError (InternalError "Ride is already cancelled")
+  where
+    buildCancelRideTransactionKey rideId' = "CancelRideTransaction:RID:-" <> rideId'.getId
+    isValidRide ride = ride.status `elem` [DRide.NEW, DRide.UPCOMING]
 
 calculateNoShowCharges :: (MonadFlow m, CacheFlow m r) => SRB.Booking -> DRide.Ride -> m (Maybe PriceAPIEntity)
 calculateNoShowCharges booking ride = do
@@ -216,3 +247,29 @@ updateNammaTagsForCancelledRide booking ride bookingCReason = do
   when (validCustomerCancellation `elem` tags) $ do
     QDriverStats.updateValidCustomerCancellationTagCount (driverStats.validCustomerCancellationTagCount + 1) ride.driverId
   return $ fromMaybe [] allTags
+
+driverDistanceToPickup ::
+  ( EncFlow m r,
+    CacheFlow m r,
+    EsqDBFlow m r,
+    Maps.HasCoordinates tripStartPos,
+    Maps.HasCoordinates tripEndPos,
+    ToJSON tripStartPos,
+    ToJSON tripEndPos,
+    HasKafkaProducer r
+  ) =>
+  SRB.Booking ->
+  tripStartPos ->
+  tripEndPos ->
+  m Meters
+driverDistanceToPickup booking tripStartPos tripEndPos = do
+  distRes <-
+    Maps.getDistanceForCancelRide booking.providerId booking.merchantOperatingCityId (Just booking.id.getId) $
+      Maps.GetDistanceReq
+        { origin = tripStartPos,
+          destination = tripEndPos,
+          travelMode = Just Maps.CAR,
+          distanceUnit = booking.distanceUnit,
+          sourceDestinationMapping = Nothing
+        }
+  return $ distRes.distance


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents duplicate/parallel ride cancellations with a short-lived lock, ensuring a single, consistent outcome.
  - Provides clearer feedback when a ride has already been canceled.
  - Improves reliability of distance-to-pickup calculations used during cancellation.

- Refactor
  - Streamlines the cancellation flow and centralizes distance computation to improve reliability and maintainability; no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->