### PR TITLE
backend/fix: resolve race condition with finalBoardedBusNumber update

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/MultiModal.yaml
@@ -199,6 +199,10 @@ JourneyLegMapping:
       where: journeyLegId
 
 JourneyLeg:
+  types:
+    BusNumberUpdateMethod:
+      enum: "GPS, MANUAL"
+      derive: "ToParamSchema"
   fields:
     id: Id JourneyLeg
     groupCode: Maybe Text # <parentSearchRequestId>-<mode>-<fromStopDetails.stopCode>-<toStopDetails.stopCode>
@@ -233,6 +237,7 @@ JourneyLeg:
     isDeleted: Maybe Bool
     sequenceNumber: Int
     multimodalSearchRequestId: Maybe Text
+    busNumberUpdateMethod: Maybe BusNumberUpdateMethod
 
   sqlType:
     serviceTypes: text[]

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/JourneyLeg.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/JourneyLeg.hs
@@ -19,6 +19,7 @@ import qualified Tools.Beam.UtilsTH
 
 data JourneyLeg = JourneyLeg
   { agency :: Kernel.Prelude.Maybe Kernel.External.MultiModal.Interface.Types.MultiModalAgency,
+    busNumberUpdateMethod :: Kernel.Prelude.Maybe Domain.Types.JourneyLeg.BusNumberUpdateMethod,
     changedBusesInSequence :: Kernel.Prelude.Maybe [Kernel.Prelude.Text],
     distance :: Kernel.Prelude.Maybe Kernel.Types.Common.Distance,
     duration :: Kernel.Prelude.Maybe Kernel.Types.Common.Seconds,
@@ -54,3 +55,7 @@ data JourneyLeg = JourneyLeg
     updatedAt :: Kernel.Prelude.UTCTime
   }
   deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
+data BusNumberUpdateMethod = GPS | MANUAL deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema, ToParamSchema)
+
+$(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''BusNumberUpdateMethod)

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/JourneyLeg.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/JourneyLeg.hs
@@ -8,6 +8,7 @@ import qualified Data.Aeson
 import qualified Database.Beam as B
 import Domain.Types.Common ()
 import qualified Domain.Types.Common
+import qualified Domain.Types.JourneyLeg
 import Kernel.External.Encryption
 import Kernel.Prelude
 import qualified Kernel.Prelude
@@ -17,6 +18,7 @@ import Tools.Beam.UtilsTH
 data JourneyLegT f = JourneyLegT
   { agencyGtfsId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     agencyName :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    busNumberUpdateMethod :: B.C f (Kernel.Prelude.Maybe Domain.Types.JourneyLeg.BusNumberUpdateMethod),
     changedBusesInSequence :: B.C f (Kernel.Prelude.Maybe [Kernel.Prelude.Text]),
     distance :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecDistance),
     distanceUnit :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit),

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/JourneyLeg.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/JourneyLeg.hs
@@ -86,6 +86,7 @@ updateByPrimaryKey (Domain.Types.JourneyLeg.JourneyLeg {..}) = do
   updateWithKV
     [ Se.Set Beam.agencyGtfsId (agency >>= (.gtfsId)),
       Se.Set Beam.agencyName (agency <&> (.name)),
+      Se.Set Beam.busNumberUpdateMethod busNumberUpdateMethod,
       Se.Set Beam.changedBusesInSequence changedBusesInSequence,
       Se.Set Beam.distance ((.value) <$> distance),
       Se.Set Beam.distanceUnit ((.unit) <$> distance),

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/JourneyLeg.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/JourneyLeg.hs
@@ -32,6 +32,7 @@ instance FromTType' Beam.JourneyLeg Domain.Types.JourneyLeg.JourneyLeg where
       Just
         Domain.Types.JourneyLeg.JourneyLeg
           { agency = Kernel.External.MultiModal.Interface.Types.MultiModalAgency agencyGtfsId <$> agencyName,
+            busNumberUpdateMethod = busNumberUpdateMethod,
             changedBusesInSequence = changedBusesInSequence,
             distance = Kernel.Types.Common.Distance <$> distance <*> distanceUnit,
             duration = duration,
@@ -72,6 +73,7 @@ instance ToTType' Beam.JourneyLeg Domain.Types.JourneyLeg.JourneyLeg where
     Beam.JourneyLegT
       { Beam.agencyGtfsId = agency >>= (.gtfsId),
         Beam.agencyName = agency <&> (.name),
+        Beam.busNumberUpdateMethod = busNumberUpdateMethod,
         Beam.changedBusesInSequence = changedBusesInSequence,
         Beam.distance = (.value) <$> distance,
         Beam.distanceUnit = (.unit) <$> distance,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -1487,6 +1487,6 @@ postMultimodalOrderSublegSetOnboardedVehicleDetails (_mbPersonId, _merchantId) j
   unless (maybe False (\legServiceTypes -> vehicleLiveRouteInfo.serviceType `elem` legServiceTypes) journeyLeg.serviceTypes) $
     throwError $ VehicleServiceTierUnserviceable ("Vehicle " <> vehicleNumber <> ", the service tier" <> show vehicleLiveRouteInfo.serviceType <> ", not found on any route: " <> show journeyLeg.serviceTypes)
 
-  QJourneyLeg.updateByPrimaryKey $ journeyLeg {DJourneyLeg.finalBoardedBusNumber = Just vehicleNumber}
+  QJourneyLeg.updateByPrimaryKey $ journeyLeg {DJourneyLeg.finalBoardedBusNumber = Just vehicleNumber, DJourneyLeg.busNumberUpdateMethod = Just DJourneyLeg.MANUAL}
   updatedLegs <- JM.getAllLegsInfo journey.riderId journeyId
   generateJourneyInfoResponse journey updatedLegs

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Select.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Select.hs
@@ -494,7 +494,8 @@ mkJourneyForSearch searchRequest estimate personId = do
             journeyId = journeyGuid,
             isDeleted = Just False,
             sequenceNumber = 0,
-            multimodalSearchRequestId = Nothing
+            multimodalSearchRequestId = Nothing,
+            busNumberUpdateMethod = Nothing
           }
   pure (journey, journeyLeg)
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
@@ -242,7 +242,7 @@ getState mode searchId riderLastPoints movementDetected routeCodeForDetailedTrac
                   case bestCandidateResult of
                     [] -> pure detailedStateData
                     ((bestVehicleNumber, _) : _) -> do
-                      QJourneyLeg.updateByPrimaryKey legToUpdate {DJourneyLeg.finalBoardedBusNumber = Just bestVehicleNumber}
+                      QJourneyLeg.updateByPrimaryKeyIfUnsetFinalBoardedBus legToUpdate {DJourneyLeg.finalBoardedBusNumber = Just bestVehicleNumber, DJourneyLeg.busNumberUpdateMethod = Just DJourneyLeg.GPS}
                       -- Update in-memory detailedStateData as well
                       pure (detailedStateData :: JT.JourneyLegStateData) {JT.fleetNo = Just bestVehicleNumber}
                 Just _ -> pure detailedStateData

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/JourneyLegExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/JourneyLegExtra.hs
@@ -106,3 +106,20 @@ findByJourneyIdAndSequenceNumber journeyId sequenceNumber = do
                 [Se.Is Beam.isDeleted $ Se.Eq (Just False), Se.Is Beam.isDeleted $ Se.Eq Nothing]
             ]
         ]
+
+updateByPrimaryKeyIfUnsetFinalBoardedBus ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  JL.JourneyLeg ->
+  m ()
+updateByPrimaryKeyIfUnsetFinalBoardedBus (JL.JourneyLeg {..}) = do
+  _now <- getCurrentTime
+  updateWithKV
+    [ Se.Set Beam.finalBoardedBusNumber finalBoardedBusNumber,
+      Se.Set Beam.busNumberUpdateMethod busNumberUpdateMethod,
+      Se.Set Beam.updatedAt _now
+    ]
+    [ Se.And
+        [ Se.Is Beam.id (Se.Eq (Kernel.Types.Id.getId id)),
+          Se.Is Beam.finalBoardedBusNumber Se.Null
+        ]
+    ]

--- a/Backend/dev/migrations-read-only/rider-app/journey.sql
+++ b/Backend/dev/migrations-read-only/rider-app/journey.sql
@@ -510,3 +510,13 @@ ALTER TABLE atlas_app.journey ADD COLUMN has_started_tracking_without_booking bo
 
 
 ------- SQL updates -------
+
+
+
+------- SQL updates -------
+
+
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/rider-app/journey_leg.sql
+++ b/Backend/dev/migrations-read-only/rider-app/journey_leg.sql
@@ -319,3 +319,13 @@ ALTER TABLE atlas_app.journey_leg ADD COLUMN multimodal_search_request_id text ;
 
 
 ------- SQL updates -------
+
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.journey_leg ADD COLUMN bus_number_update_method text ;
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/rider-app/route_details.sql
+++ b/Backend/dev/migrations-read-only/rider-app/route_details.sql
@@ -256,3 +256,12 @@ ALTER TABLE atlas_app.route_details ADD COLUMN leg_end_time timestamp with time 
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.route_details ADD COLUMN tracking_status_last_updated_at timestamp with time zone ;
+
+
+------- SQL updates -------
+
+
+
+
+------- SQL updates -------
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents accidental overwriting of the final boarded bus number once set, keeping trip details stable.
  - Only records the final bus number when it was previously unset, improving data consistency.
  - Ensures timestamps reflect when the final bus number is first recorded.

- New Features
  - Records how a bus number was set (GPS or Manual) for journey legs.
  - Adds a timestamp field for route tracking-status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->