### PR TITLE
backend/fix/allow-coins-without-expirationDate-to-be-deducted

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Coins/CoinHistory.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Coins/CoinHistory.hs
@@ -105,7 +105,10 @@ getDriverCoinInfo (Id driverId) timeDiffFromUtc = do
     [ Se.And
         [ Se.Is BeamDC.driverId $ Se.Eq driverId,
           Se.Is BeamDC.status $ Se.Eq Remaining,
-          Se.Is BeamDC.expirationAt $ Se.GreaterThanOrEq (Just istTime)
+          Se.Or
+            [ Se.Is BeamDC.expirationAt $ Se.GreaterThanOrEq (Just istTime),
+              Se.Is BeamDC.expirationAt $ Se.Eq Nothing
+            ]
         ]
     ]
     (Se.Asc BeamDC.createdAt)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Allow Coin history with null expiration_date to be deducted during coin conversion.
