### PR TITLE
Backend/feat: remove duplicate fare calls in initiate

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/NearbyBuses.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/NearbyBuses.hs
@@ -238,7 +238,7 @@ getRecentRides person req = do
                 Kernel.Prelude.listToMaybe
                   <$> ( SIBC.fetchFirstIntegratedBPPConfigResult integratedBPPConfigs $ \integratedBPPConfig -> do
                           let fareRouteDetails = fromList [CallAPI.BasicRouteDetail {routeCode, startStopCode = fromStopCode, endStopCode = toStopCode}]
-                          snd <$> Flow.getFares person.id merchant merchantOperatingCity integratedBPPConfig becknConfig fareRouteDetails req.vehicleType Nothing []
+                          snd <$> Flow.getFares person.id merchant merchantOperatingCity integratedBPPConfig becknConfig fareRouteDetails req.vehicleType Nothing Nothing
                       )
               return $
                 mbFare <&> \fare -> do

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/RouteFare.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/RouteFare.hs
@@ -32,6 +32,9 @@ type RouteFareAPI =
     :> ReqBody '[PlainText] Text
     :> Post '[JSON] EncryptedResponse
 
+mkRouteFareKey :: Text -> Text -> Text -> Text
+mkRouteFareKey startStopCode endStopCode searchReqId = "CRIS:" <> searchReqId <> "-" <> startStopCode <> "-" <> endStopCode
+
 -- Main function
 getRouteFare ::
   ( CoreMetrics m,

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Bus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Bus.hs
@@ -36,5 +36,5 @@ instance JT.JourneyLeg BusLegRequest m where
   getInfo (BusLegRequestGetInfo req) = CFRFS.getInfo req.searchId req.journeyLeg
   getInfo _ = throwError (InternalError "Not supported")
 
-  getFare (BusLegRequestGetFare BusLegRequestGetFareData {..}) = CFRFS.getFare riderId merchant merchantOpCity Spec.BUS serviceType routeDetails fromArrivalTime agencyGtfsId []
+  getFare (BusLegRequestGetFare BusLegRequestGetFareData {..}) = CFRFS.getFare riderId merchant merchantOpCity Spec.BUS serviceType routeDetails fromArrivalTime agencyGtfsId Nothing
   getFare _ = throwError (InternalError "Not supported")

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Interface.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Interface.hs
@@ -27,7 +27,6 @@ import Lib.JourneyLeg.Types.Walk
 import Lib.JourneyLeg.Walk ()
 import qualified Lib.JourneyModule.Types as JL
 import qualified Lib.JourneyModule.Utils as JMU
-import qualified SharedLogic.FRFSUtils as FRFSUtils
 import qualified Storage.CachedQueries.Merchant as QMerchant
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 
@@ -40,9 +39,9 @@ getFare ::
   Maybe JMU.VehicleLiveRouteInfo ->
   EMInterface.MultiModalLeg ->
   DTrip.MultimodalTravelMode ->
-  [FRFSUtils.FRFSFare] ->
+  Maybe Text ->
   m (Bool, Maybe JL.GetFareResponse)
-getFare fromArrivalTime riderId merchantId merchantOperatingCityId mbRouteLiveInfo leg mode subwayFares = case mode of
+getFare fromArrivalTime riderId merchantId merchantOperatingCityId mbRouteLiveInfo leg mode searchReqId = case mode of
   DTrip.Taxi -> do
     getFareReq :: TaxiLegRequest <- mkTaxiGetFareReq
     JL.getFare getFareReq
@@ -132,7 +131,7 @@ getFare fromArrivalTime riderId merchantId merchantOperatingCityId mbRouteLiveIn
                   { startLocation = leg.startLocation.latLng,
                     endLocation = leg.endLocation.latLng,
                     agencyGtfsId = leg.agency >>= (.gtfsId),
-                    fares = subwayFares,
+                    searchReqId = searchReqId,
                     ..
                   }
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Metro.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Metro.hs
@@ -30,5 +30,5 @@ instance JT.JourneyLeg MetroLegRequest m where
   getInfo (MetroLegRequestGetInfo req) = CFRFS.getInfo req.searchId req.journeyLeg
   getInfo _ = throwError (InternalError "Not supported")
 
-  getFare (MetroLegRequestGetFare MetroLegRequestGetFareData {..}) = CFRFS.getFare riderId merchant merchantOpCity Spec.METRO Nothing routeDetails fromArrivalTime agencyGtfsId []
+  getFare (MetroLegRequestGetFare MetroLegRequestGetFareData {..}) = CFRFS.getFare riderId merchant merchantOpCity Spec.METRO Nothing routeDetails fromArrivalTime agencyGtfsId Nothing
   getFare _ = throwError (InternalError "Not supported")

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Subway.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Subway.hs
@@ -30,5 +30,5 @@ instance JT.JourneyLeg SubwayLegRequest m where
   getInfo (SubwayLegRequestGetInfo req) = CFRFS.getInfo req.searchId req.journeyLeg
   getInfo _ = throwError (InternalError "Not supported")
 
-  getFare (SubwayLegRequestGetFare SubwayLegRequestGetFareData {..}) = CFRFS.getFare riderId merchant merchantOpCity Spec.SUBWAY Nothing routeDetails fromArrivalTime agencyGtfsId fares
+  getFare (SubwayLegRequestGetFare SubwayLegRequestGetFareData {..}) = CFRFS.getFare riderId merchant merchantOpCity Spec.SUBWAY Nothing routeDetails fromArrivalTime agencyGtfsId searchReqId
   getFare _ = throwError (InternalError "Not supported")

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Types/Subway.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Types/Subway.hs
@@ -15,7 +15,6 @@ import Kernel.Prelude
 import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Types.Id
 import qualified Lib.JourneyModule.Types as JL
-import qualified SharedLogic.FRFSUtils as FRFSUtils
 
 data SubwayLegRequestSearchData = SubwayLegRequestSearchData
   { quantity :: Int,
@@ -77,5 +76,5 @@ data SubwayLegRequestGetFareData = SubwayLegRequestGetFareData
     merchant :: DMerchant.Merchant,
     merchantOpCity :: DMOC.MerchantOperatingCity,
     riderId :: Id DPerson.Person,
-    fares :: [FRFSUtils.FRFSFare]
+    searchReqId :: Maybe Text
   }

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Base.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Base.hs
@@ -142,7 +142,7 @@ init journeyReq userPreferences = do
     mapWithIndex
       ( \idx (mbPrev, leg, mbNext) -> do
           let travelMode = convertMultiModalModeToTripMode leg.mode (straightLineDistance leg) journeyReq.maximumWalkDistance
-          legFare@(_, mbTotalLegFare) <- measureLatency (JLI.getFare leg.fromArrivalTime journeyReq.personId journeyReq.merchantId journeyReq.merchantOperatingCityId journeyReq.routeLiveInfo leg travelMode journeyReq.subwayFares) "multimodal getFare"
+          legFare@(_, mbTotalLegFare) <- measureLatency (JLI.getFare leg.fromArrivalTime journeyReq.personId journeyReq.merchantId journeyReq.merchantOperatingCityId journeyReq.routeLiveInfo leg travelMode (Just journeyReq.parentSearchId.getId)) "multimodal getFare"
           let onboardedSingleModeVehicle =
                 if travelMode `elem` [DTrip.Bus, DTrip.Metro, DTrip.Subway]
                   then
@@ -1103,7 +1103,7 @@ extendLegEstimatedFare journeyId startPoint mbEndLocation _ = do
       let distance = convertMetersToDistance Meter distResp.distance
       now <- getCurrentTime
       let multiModalLeg = mkMultiModalTaxiLeg distance distResp.duration MultiModalTypes.Unspecified startLocation.lat startLocation.lon endLocation.lat endLocation.lon
-      (isFareMandatory, estimatedFare) <- JLI.getFare (Just now) journey.riderId currentLeg.merchantId currentLeg.merchantOperatingCityId Nothing multiModalLeg DTrip.Taxi []
+      (isFareMandatory, estimatedFare) <- JLI.getFare (Just now) journey.riderId currentLeg.merchantId currentLeg.merchantOperatingCityId Nothing multiModalLeg DTrip.Taxi Nothing
       when (isFareMandatory && isNothing estimatedFare) $ throwError (InvalidRequest "Fare is mandatory for this leg, but unavailable")
       return $
         APITypes.ExtendLegGetFareResp

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
@@ -73,9 +73,6 @@ import Lib.SessionizerMetrics.Types.Event
 import qualified Lib.Yudhishthira.Types as YTypes
 import SharedLogic.Booking (getfareBreakups)
 import qualified SharedLogic.External.LocationTrackingService.Types as LT
--- import Tools.Payment (roundToTwoDecimalPlaces)
-
-import qualified SharedLogic.FRFSUtils as FRFSUtils
 import qualified SharedLogic.IntegratedBPPConfig as SIBC
 import qualified SharedLogic.Ride as DARide
 import qualified SharedLogic.Search as SLSearch
@@ -264,8 +261,7 @@ data JourneyInitData = JourneyInitData
     endTime :: Maybe UTCTime,
     maximumWalkDistance :: Meters,
     isSingleMode :: Bool,
-    relevanceScore :: Maybe Double,
-    subwayFares :: [FRFSUtils.FRFSFare]
+    relevanceScore :: Maybe Double
   }
   deriving stock (Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Cache Route Fare api calls to avoid duplicate calls to CRIS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined subway fare handling across search and fare quote flows, reducing payload size and improving response times.
- Chores
  - Added Redis caching for subway (CRIS) route fares keyed by search request, speeding up repeated fare lookups and enhancing consistency during multimodal searches and recent rides.
  - Updated internal integrations to use search request IDs for fare retrieval, improving performance without changing user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->