### PR TITLE
backend/fix: remove redundant user action type from access matrix

### DIFF
--- a/Backend/dev/migrations-read-only/rider-dashboard/Local_API_AppManagement_Tickets.sql
+++ b/Backend/dev/migrations-read-only/rider-dashboard/Local_API_AppManagement_Tickets.sql
@@ -103,9 +103,6 @@ INSERT INTO atlas_bap_dashboard.access_matrix (id, role_id, api_entity, user_acc
 -- {"api":"GetTicketBookingDetails","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bap_dashboard"}
 INSERT INTO atlas_bap_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bap_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'RIDER_APP_MANAGEMENT/TICKETS/GET_TICKET_BOOKING_DETAILS' ) ON CONFLICT DO NOTHING;
 
--- {"api":"GetTicketBookingStatus","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bap_dashboard"}
-INSERT INTO atlas_bap_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bap_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'RIDER_APP_MANAGEMENT/TICKETS/GET_TICKET_BOOKING_STATUS' ) ON CONFLICT DO NOTHING;
-
 -- {"api":"GetAllTicketBookings","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bap_dashboard"}
 INSERT INTO atlas_bap_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bap_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'RIDER_APP_MANAGEMENT/TICKETS/GET_ALL_TICKET_BOOKINGS' ) ON CONFLICT DO NOTHING;
 
@@ -120,18 +117,6 @@ INSERT INTO atlas_bap_dashboard.access_matrix (id, role_id, api_entity, user_acc
 
 -- {"api":"PostTicketPlacesDirectBook","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bap_dashboard"}
 INSERT INTO atlas_bap_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bap_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'RIDER_APP_MANAGEMENT/TICKETS/POST_TICKET_PLACES_DIRECT_BOOK' ) ON CONFLICT DO NOTHING;
-
-
-------- SQL updates -------
-
--- {"api":"GetTicketDashboardBookingStatus","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bap_dashboard"}
-INSERT INTO atlas_bap_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bap_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'RIDER_APP_MANAGEMENT/TICKETS/GET_TICKET_DASHBOARD_BOOKING_STATUS' ) ON CONFLICT DO NOTHING;
-
-
-------- SQL updates -------
-
--- {"api":"GetTicketsDashboardTicketBookingStatus","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bap_dashboard"}
-INSERT INTO atlas_bap_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bap_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'RIDER_APP_MANAGEMENT/TICKETS/GET_TICKETS_DASHBOARD_TICKET_BOOKING_STATUS' ) ON CONFLICT DO NOTHING;
 
 
 ------- SQL updates -------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access permissions for rider dashboard ticket-related APIs, removing broad default access for several endpoints.
  * Tightened role-based access; endpoints previously available to public/default roles may now require explicit authorization.
  * No functional impact for users with proper permissions; improves consistency with current access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->