### PR TITLE
Backend/enhc: increase cris booking timeout to 60s

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/App.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/App.hs
@@ -137,7 +137,7 @@ runRiderApp' appCfg = do
                 Just (Nothing, prepareAuthManagers flowRt appEnv allFRFSSubIds),
                 Just (Just 150000, prepareGridlineHttpManager 150000),
                 Just (Just 10000, prepareJourneyMonitoringHttpManager 10000),
-                Just (Just 30000, prepareCRISHttpManager 30000)
+                Just (Just 60000, prepareCRISHttpManager 60000)
               ]
         logInfo ("Runtime created. Starting server at port " <> show (appCfg.port))
         pure flowRt'

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Metrics.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Metrics.hs
@@ -35,7 +35,7 @@ processMetrics mbPersonId metricName message = do
         Nothing -> pure []
     Nothing -> pure []
 
-  let isBlacklisted = Kernel.Prelude.any (\blacklistPattern -> T.unpack message =~ T.unpack blacklistPattern) blacklistPatterns
+  let isBlacklisted = Kernel.Prelude.any (\blacklistPattern -> (T.unpack message =~ T.unpack blacklistPattern :: Bool)) blacklistPatterns
 
   unless isBlacklisted $ do
     logError $ "FRONTEND_METRIC | metric: " <> metricName <> " | message: " <> message


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Updated CRIS Booking timeout to 60s
Added bool type cast to pattern matching check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a type issue in metrics blacklist evaluation to consistently treat regex matches as boolean, improving reliability and preventing potential runtime errors.

* **Chores**
  * Increased the HTTP manager initialization timeout from 30s to 60s for the CRIS integration to reduce startup timeouts and improve stability in slower network conditions.

* **Notes**
  * No functional changes expected beyond improved robustness and fewer initialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->