### PR TITLE
added multiple routes buses to tracking

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/TrackRoute.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/TrackRoute.yaml
@@ -47,7 +47,8 @@ apis:
         integratedBppConfigId: Id IntegratedBPPConfig
         currentLat: Double
         currentLon: Double
-        selectedStopId: Text
+        selectedSourceStopCode: Text
+        selectedDestinationStopCode: Text
         maxBuses: Int
       params:
         routeCode: Text

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/TrackRoute.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/TrackRoute.hs
@@ -38,13 +38,16 @@ type API =
            "platformType"
            Domain.Types.IntegratedBPPConfig.PlatformType
       :> QueryParam
-           "selectedStopId"
+           "selectedDestinationStopCode"
+           Kernel.Prelude.Text
+      :> QueryParam
+           "selectedSourceStopCode"
            Kernel.Prelude.Text
       :> QueryParam
            "vehicleType"
            BecknV2.FRFS.Enums.VehicleCategory
       :> Get
-           '[JSON]
+           ('[JSON])
            API.Types.UI.TrackRoute.TrackingResp
   )
 
@@ -56,13 +59,14 @@ getTrackVehicles ::
       Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
     ) ->
     Kernel.Prelude.Text ->
-    Kernel.Prelude.Maybe Kernel.Prelude.Double ->
-    Kernel.Prelude.Maybe Kernel.Prelude.Double ->
+    Kernel.Prelude.Maybe (Kernel.Prelude.Double) ->
+    Kernel.Prelude.Maybe (Kernel.Prelude.Double) ->
     Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.IntegratedBPPConfig.IntegratedBPPConfig) ->
-    Kernel.Prelude.Maybe Kernel.Prelude.Int ->
-    Kernel.Prelude.Maybe Domain.Types.IntegratedBPPConfig.PlatformType ->
-    Kernel.Prelude.Maybe Kernel.Prelude.Text ->
-    Kernel.Prelude.Maybe BecknV2.FRFS.Enums.VehicleCategory ->
+    Kernel.Prelude.Maybe (Kernel.Prelude.Int) ->
+    Kernel.Prelude.Maybe (Domain.Types.IntegratedBPPConfig.PlatformType) ->
+    Kernel.Prelude.Maybe (Kernel.Prelude.Text) ->
+    Kernel.Prelude.Maybe (Kernel.Prelude.Text) ->
+    Kernel.Prelude.Maybe (BecknV2.FRFS.Enums.VehicleCategory) ->
     Environment.FlowHandler API.Types.UI.TrackRoute.TrackingResp
   )
-getTrackVehicles a9 a8 a7 a6 a5 a4 a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.TrackRoute.getTrackVehicles (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a9) a8 a7 a6 a5 a4 a3 a2 a1
+getTrackVehicles a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.TrackRoute.getTrackVehicles (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a10) a9 a8 a7 a6 a5 a4 a3 a2 a1

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/OTPRest/OTPRest.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/OTPRest/OTPRest.hs
@@ -391,7 +391,7 @@ getNandiTripInfo ::
   IntegratedBPPConfig ->
   Text ->
   m (Maybe TripInfoResponse)
-getNandiTripInfo integratedBPPConfig tripId = do
+getNandiTripInfo integratedBPPConfig tripId = IM.withInMemCache ["NandiTripInfo", integratedBPPConfig.id.getId, tripId] 3600 $ do
   baseUrl <- MM.getOTPRestServiceReq integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
   let updatedTripId = integratedBPPConfig.feedKey <> ":" <> tripId
   Flow.getNandiTripInfo baseUrl updatedTripId


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
In the `/track/{routeCode}/vehicles` API, we previously returned buses for a single specified route.
In this PR, we’ve added support for specifying source and destination stop IDs. Using these stops, the API now fetches all routes that include both stops and returns buses running on any of those routes, instead of limiting results to just one route.

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
