### PR TITLE
backend/enh/added-flag-for-device-check-during-searchreq

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Select.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Select.hs
@@ -236,7 +236,10 @@ select2 personId estimateId req@DSelectReq {..} = do
       _ -> pure Nothing
   let lastUsedVehicleServiceTiers = insertVehicleServiceTierAndCategory (maybe 5 (.noOfRideRequestsConfig) riderConfig) estimate.vehicleServiceTierType person.lastUsedVehicleServiceTiers
   let lastUsedVehicleCategories = insertVehicleServiceTierAndCategory (maybe 5 (.noOfRideRequestsConfig) riderConfig) (fromMaybe DVCT.AUTO_RICKSHAW estimate.vehicleCategory) person.lastUsedVehicleCategories
-  let toUpdateDeviceIdInfo = (fromMaybe 0 person.totalRidesCount) == 0
+  let toUpdateDeviceIdInfo =
+        if fromMaybe False (riderConfig >>= (.isDeviceIdCheckDisabled))
+          then False
+          else (fromMaybe 0 person.totalRidesCount) == 0
   isMultipleOrNoDeviceIdExist <-
     maybe
       (return Nothing)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configuration to disable device ID checks for selected environments or cohorts.
  - When disabled, riders won’t be prompted for device verification, reducing friction.
  - When enabled, existing behavior remains (device check on first ride only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->