### PR TITLE
backend/fix: made exo_phone_country_code nullable and a default value

### DIFF
--- a/Backend/dev/migrations/dynamic-offer-driver-app/0700-drop-not-null-exo-phone-country-code.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0700-drop-not-null-exo-phone-country-code.sql
@@ -1,0 +1,4 @@
+ALTER TABLE atlas_driver_offer_bpp.merchant
+    ALTER COLUMN exo_phone_country_code DROP NOT NULL;
+ALTER TABLE atlas_driver_offer_bpp.merchant
+    ALTER COLUMN exo_phone_country_code SET DEFAULT '+91';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merchant phone country code now defaults to +91 when not specified.
  * The phone country code field is now optional during merchant onboarding and profile updates, reducing friction from strict validation.

* **Chores**
  * Database migration to support optional phone country code and set a default for new entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->