### PR TITLE
backend/enhc: added AC warning overlay before downgrading to non-AC

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Overlay/SendOverlay.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Overlay/SendOverlay.hs
@@ -36,11 +36,17 @@ acUsageRestrictionKey = "AC_USAGE_RESTRICTED"
 acUsageRestrictionLiftedKey :: Text
 acUsageRestrictionLiftedKey = "AC_USAGE_RESTRICTION_LIFTED"
 
+acUsageWarningKey :: Text
+acUsageWarningKey = "AC_USAGE_WARNING"
+
 sendACUsageRestrictionLiftedOverlay :: (CacheFlow m r, EsqDBFlow m r) => DP.Person -> m ()
 sendACUsageRestrictionLiftedOverlay = sendACOverlay acUsageRestrictionLiftedKey
 
 sendACUsageRestrictionOverlay :: (CacheFlow m r, EsqDBFlow m r) => DP.Person -> m ()
 sendACUsageRestrictionOverlay = sendACOverlay acUsageRestrictionKey
+
+sendACUsageWarningOverlay :: (CacheFlow m r, EsqDBFlow m r) => DP.Person -> m ()
+sendACUsageWarningOverlay = sendACOverlay acUsageWarningKey
 
 sendACOverlay :: (CacheFlow m r, EsqDBFlow m r) => Text -> DP.Person -> m ()
 sendACOverlay overlayKey person = do

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0402-ac-checks.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0402-ac-checks.sql
@@ -92,6 +92,52 @@ INSERT INTO
     from atlas_driver_offer_bpp.merchant_operating_city
     );
 
+INSERT INTO
+  atlas_driver_offer_bpp.merchant_overlay
+    (id,
+    merchant_id,
+    language,
+    overlay_key,
+    udf1,
+    image_url,
+    title,
+    description,
+    ok_button_text,
+    cancel_button_text,
+    req_body,
+    end_point,
+    method,
+    delay,
+    contact_support_number,
+    toast_message,
+    secondary_actions,
+    social_media_links,
+    show_push_notification,
+    merchant_operating_city_id
+    )
+    (select
+    atlas_driver_offer_bpp.uuid_generate_v4() as id,
+    merchant_id,
+    'ENGLISH' as language,
+    'AC_USAGE_WARNING' as overlay_key,
+    null as udf1,
+    'https://raw.githubusercontent.com/witcher-shailesh/github-asset-store/main/uploads/img-ny_ic_ac_warning-1760509546890.jpg' as image_url,
+    'Multiple AC-related complaints' as title,
+    'You may be downgraded to Non-AC rides if this continues' as description,
+    'Okay' as ok_button_text,
+    '' as cancel_button_text,
+    json_build_object() as req_body,
+    null as end_point,
+    null as method,
+    0 as delay,
+    null as contact_support_number,
+    null as toast_message,
+    null as secondary_actions,
+    null as social_media_links,
+    true as show_push_notification,
+    id as merchant_operating_city_id
+    from atlas_driver_offer_bpp.merchant_operating_city
+    );
 
 insert into atlas_driver_offer_bpp.translations(created_at, id, language, message, message_key, updated_at) VALUES (now(), atlas_driver_offer_bpp.uuid_generate_v4() ,'ENGLISH' , 'You have been downgraded to only Non-AC rides due to multiple customer complaints', 'AC_RESTRICTION_MESSAGE', now());
 insert into atlas_driver_offer_bpp.translations(created_at, id, language, message, message_key, updated_at) VALUES (now(), atlas_driver_offer_bpp.uuid_generate_v4() ,'ENGLISH' , 'For uninterrupted service, please ensure that the AC is turned ON on AC rides', 'AC_WORKING_MESSAGE', now());


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduces an AC Usage Warning overlay that is automatically sent when a driver’s AC score approaches the usage limit (within 1 point or at threshold).
  - Push notifications enabled for the warning to improve visibility.
  - Localized content (EN) with title, description, image, and an “Okay” action.

- Chores
  - Database migration to create and configure the AC Usage Warning overlay and associate it with operating cities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->