### PR TITLE
backend/new-error-type-added

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/VehicleRegistrationCertificate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/VehicleRegistrationCertificate.hs
@@ -719,7 +719,7 @@ checkIfVehicleAlreadyExists person rc merchantOpCityId rideThresholdLastXDays = 
               maybeRide <- RDE.findByCreatedAtAndVehicleNumber fromDate rcNumber -- finding if there is a ride in the past threshold number of days.
               case maybeRide of
                 Just _ -> do
-                  throwError RCActiveOnOtherAccount -- if ride exists, do not let the new driver add the RC
+                  throwError RCBlockedByAnotherAccount -- if ride exists, do not let the new driver add the RC
                 Nothing -> do
                   driverInfo <- DIQuery.findById (cast driverId) >>= fromMaybeM (PersonNotFound driverId.getId)
                   activateRC driverInfo person.merchantId merchantOpCityId now rc -- otherwise add the RC

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
@@ -1241,6 +1241,7 @@ data DriverOnboardingError
   | DocumentNotFound Text
   | DuplicateWebhookReceived
   | WebhookAuthFailed
+  | RCBlockedByAnotherAccount
   deriving (Show, Eq, Read, Ord, Generic, FromJSON, ToJSON, ToSchema, IsBecknAPIError)
 
 instance IsBaseError DriverOnboardingError where
@@ -1297,6 +1298,7 @@ instance IsBaseError DriverOnboardingError where
     DocumentNotFound docId -> Just $ "Document not found with id: " <> docId
     DuplicateWebhookReceived -> Just "Multiple webhooks received for same request id."
     WebhookAuthFailed -> Just "Auth header data mismatch ocurred!!!!!!"
+    RCBlockedByAnotherAccount -> Just "RC is Blocked By another Account"
 
 instance IsHTTPError DriverOnboardingError where
   toErrorCode = \case
@@ -1352,6 +1354,7 @@ instance IsHTTPError DriverOnboardingError where
     DocumentNotFound _ -> "DOCUMENT_NOT_FOUND"
     DuplicateWebhookReceived -> "DUPLICATE_WEBHOOK_RECEIVED"
     WebhookAuthFailed -> "WEBHOOK_AUTH_FAILED"
+    RCBlockedByAnotherAccount -> "RC_BLOCKED_BY_ANOTHER_ACCOUNT"
   toHttpCode = \case
     ImageValidationExceedLimit _ -> E429
     ImageValidationFailed -> E400
@@ -1405,6 +1408,7 @@ instance IsHTTPError DriverOnboardingError where
     DocumentNotFound _ -> E404
     DuplicateWebhookReceived -> E400
     WebhookAuthFailed -> E401
+    RCBlockedByAnotherAccount -> E400
 
 instance IsAPIError DriverOnboardingError
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver onboarding error handling for Vehicle Registration Certificate checks. Users now receive a clear “RC is Blocked By another Account” message when a certificate is associated with another account.
  * Standardized API response with a dedicated error code “RC_BLOCKED_BY_ANOTHER_ACCOUNT” and HTTP 400 status for this scenario, ensuring consistent client behavior and easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->