### PR TITLE
fix: pass truly non-live routes to findByRouteCodeAndStopCode

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
@@ -232,11 +232,14 @@ fetchLiveBusTimings routeCodes stopCode currentTime integratedBppConfig mid moci
     if useLiveBusData
       then do
         allRouteWithBuses <- MultiModalBus.getBusesForRoutes routeCodes
-        let routesWithoutBuses = map (.routeId) $ filter (\route -> null route.buses) allRouteWithBuses
         liveRouteStopTimes <- mapConcurrently processRoute allRouteWithBuses
         let flattenedLiveRouteStopTimes = concat liveRouteStopTimes
+        let liveRouteCodes = nub $ map (.routeCode) flattenedLiveRouteStopTimes
+        -- Pass only routeCodes which don't have route.buses and also don't serve our source stop
+        let routesWithoutBuses = map (.routeId) $ filter (\route -> null route.buses) allRouteWithBuses
+        let routesWithoutLiveTimings = filter (`notElem` liveRouteCodes) routeCodes
         logDebug $ "allRouteWithBuses: " <> show (length allRouteWithBuses) <> " flattenedLiveRouteStopTimes: " <> show (length flattenedLiveRouteStopTimes)
-        return (flattenedLiveRouteStopTimes, routesWithoutBuses)
+        return (flattenedLiveRouteStopTimes, nub $ routesWithoutLiveTimings ++ routesWithoutBuses)
       else do
         return ([], routeCodes)
   staticRouteStopTimes <- measureLatency (GRSM.findByRouteCodeAndStopCode integratedBppConfig mid mocid routesWithoutBuses stopCode False False) "fetch route stop timing through graphql"


### PR DESCRIPTION
This fix passes routeCodes which are having null buses in live data and
also are filtered out for not having eta for source sto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of live timings and route availability: the app now more accurately identifies routes lacking live timing and combines them with routes that have no active buses, removes duplicates, and refines filtering so route availability shown to users is more consistent and up-to-date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->