### PR TITLE
backend/fix: add single mode bus expiry

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI.hs
@@ -245,8 +245,9 @@ confirm ::
   (Maybe Text, Maybe Text) ->
   DBooking.FRFSTicketBooking ->
   [DFRFSQuoteCategory.FRFSQuoteCategory] ->
+  Maybe Bool ->
   m ()
-confirm onConfirmHandler merchant merchantOperatingCity bapConfig (mRiderName, mRiderNumber) booking quoteCategories = do
+confirm onConfirmHandler merchant merchantOperatingCity bapConfig (mRiderName, mRiderNumber) booking quoteCategories mbIsSingleMode = do
   Metrics.startMetrics Metrics.CONFIRM_FRFS merchant.name booking.searchId.getId merchantOperatingCity.id.getId
   integratedBPPConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
   case integratedBPPConfig.providerConfig of
@@ -269,7 +270,7 @@ confirm onConfirmHandler merchant merchantOperatingCity bapConfig (mRiderName, m
           frfsConfig <-
             CQFRFSConfig.findByMerchantOperatingCityIdInRideFlow merchantOperatingCity.id []
               >>= fromMaybeM (InternalError $ "FRFS config not found for merchant operating city Id " <> merchantOperatingCity.id.getId)
-          onConfirmReq <- Flow.confirm merchant merchantOperatingCity frfsConfig integratedBPPConfig bapConfig (mRiderName, mRiderNumber) booking quoteCategories
+          onConfirmReq <- Flow.confirm merchant merchantOperatingCity frfsConfig integratedBPPConfig bapConfig (mRiderName, mRiderNumber) booking quoteCategories mbIsSingleMode
           onConfirmHandler onConfirmReq
         case result of
           Left err -> do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation flow now distinguishes single‑mode vs multi‑modal bus journeys for improved accuracy.
  * Added a configurable single‑mode bus station TTL (default 1800s).
  * Search now better supports multimodal search requests and related metadata.

* **Chores**
  * Database schema updated to store single‑mode TTL and multimodal search metadata to improve search and booking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->