### PR TITLE
Adding new client configs in backend, and moving FCM configs there

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -319,6 +319,7 @@ library
       Domain.Types.Extra.DriverPlan
       Domain.Types.Extra.Feedback
       Domain.Types.Extra.Location
+      Domain.Types.Extra.MerchantClientConfig
       Domain.Types.Extra.MerchantMessage
       Domain.Types.Extra.MerchantPaymentMethod
       Domain.Types.Extra.MerchantServiceConfig
@@ -643,6 +644,7 @@ library
       Storage.Queries.LocationMappingExtra
       Storage.Queries.MandateExtra
       Storage.Queries.MediaFileDocumentExtra
+      Storage.Queries.MerchantClientConfigExtra
       Storage.Queries.MerchantExtra
       Storage.Queries.MerchantPaymentMethodExtra
       Storage.Queries.MerchantServiceConfigExtra
@@ -690,6 +692,7 @@ library
       Storage.Queries.Transformers.FleetOwnerInformation
       Storage.Queries.Transformers.Invoice
       Storage.Queries.Transformers.Location
+      Storage.Queries.Transformers.MerchantClientConfig
       Storage.Queries.Transformers.MerchantMessage
       Storage.Queries.Transformers.MerchantPaymentMethod
       Storage.Queries.Transformers.MerchantServiceConfig
@@ -963,6 +966,7 @@ library
       Domain.Types.Mandate
       Domain.Types.MediaFileDocument
       Domain.Types.Merchant
+      Domain.Types.MerchantClientConfig
       Domain.Types.MerchantMessage
       Domain.Types.MerchantOperatingCity
       Domain.Types.MerchantPaymentMethod
@@ -1118,6 +1122,7 @@ library
       Storage.Beam.Mandate
       Storage.Beam.MediaFileDocument
       Storage.Beam.Merchant
+      Storage.Beam.MerchantClientConfig
       Storage.Beam.MerchantMessage
       Storage.Beam.MerchantOperatingCity
       Storage.Beam.MerchantPaymentMethod
@@ -1277,6 +1282,7 @@ library
       Storage.Queries.Mandate
       Storage.Queries.MediaFileDocument
       Storage.Queries.Merchant
+      Storage.Queries.MerchantClientConfig
       Storage.Queries.MerchantMessage
       Storage.Queries.MerchantOperatingCity
       Storage.Queries.MerchantPaymentMethod
@@ -1340,6 +1346,7 @@ library
       Storage.Queries.OrphanInstances.Mandate
       Storage.Queries.OrphanInstances.MediaFileDocument
       Storage.Queries.OrphanInstances.Merchant
+      Storage.Queries.OrphanInstances.MerchantClientConfig
       Storage.Queries.OrphanInstances.MerchantPaymentMethod
       Storage.Queries.OrphanInstances.MerchantServiceConfig
       Storage.Queries.OrphanInstances.Message

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -47,6 +47,7 @@ imports:
   ServiceName: Domain.Types.Extra.MerchantServiceConfig
   GatewayAndRegistryService: Domain.Types
   Role: Domain.Types.Person
+  Version: Kernel.Types.Version
 Merchant:
   derives: Generic,Show,'UsageSafety
   types:
@@ -1615,6 +1616,38 @@ MerchantServiceConfig:
     configJSON: getConfigJSON
   fromTType:
     serviceConfig: Storage.Queries.Transformers.MerchantServiceConfig.mkServiceConfig configJSON serviceName|EM
+  extraOperations:
+    - EXTRA_DOMAIN_TYPE_FILE
+    - EXTRA_QUERY_FILE
+
+MerchantClientConfig:
+  derives: Generic,Show
+  fields:
+    packageId: Text
+    clientOS: Maybe Kernel.Types.Version.DeviceType
+    clientServiceConfig: Domain.Types.Extra.MerchantClientConfig.ClientServiceConfig
+    updatedAt: UTCTime
+    createdAt: UTCTime
+  beamFields:
+    clientServiceConfig:
+      serviceName: Domain.Types.MerchantClientConfig.ClientService
+      configJSON: Value
+  constraints:
+    packageId: PrimaryKey
+    serviceName: PrimaryKey
+  excludedDefaultQueries:
+    - findByPrimaryKey
+    - updateByPrimaryKey
+  beamInstance:
+    - MakeTableInstances
+  sqlType:
+    serviceName: character varying(50)
+    configJSON: json
+  toTType:
+    serviceName: getServiceName
+    configJSON: getConfigJSON
+  fromTType:
+    clientServiceConfig: Storage.Queries.Transformers.MerchantClientConfig.mkServiceConfig configJSON serviceName|EM
   extraOperations:
     - EXTRA_DOMAIN_TYPE_FILE
     - EXTRA_QUERY_FILE

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/MerchantClientConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/MerchantClientConfig.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Domain.Types.MerchantClientConfig (module Domain.Types.MerchantClientConfig, module ReExport) where
+
+import Data.Aeson
+import Domain.Types.Extra.MerchantClientConfig as ReExport
+import qualified Domain.Types.Extra.MerchantClientConfig
+import qualified Domain.Types.Merchant
+import qualified Domain.Types.MerchantOperatingCity
+import Kernel.Prelude
+import qualified Kernel.Types.Id
+import qualified Kernel.Types.Version
+import qualified Tools.Beam.UtilsTH
+
+data MerchantClientConfig = MerchantClientConfig
+  { clientOS :: Kernel.Prelude.Maybe Kernel.Types.Version.DeviceType,
+    clientServiceConfig :: Domain.Types.Extra.MerchantClientConfig.ClientServiceConfig,
+    createdAt :: Kernel.Prelude.UTCTime,
+    packageId :: Kernel.Prelude.Text,
+    updatedAt :: Kernel.Prelude.UTCTime,
+    merchantId :: Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Merchant.Merchant),
+    merchantOperatingCityId :: Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity)
+  }
+  deriving (Generic, Show)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/MerchantClientConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/MerchantClientConfig.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Beam.MerchantClientConfig where
+
+import qualified Data.Aeson
+import qualified Database.Beam as B
+import Domain.Types.Common ()
+import qualified Domain.Types.MerchantClientConfig
+import Kernel.External.Encryption
+import Kernel.Prelude
+import qualified Kernel.Prelude
+import qualified Kernel.Types.Version
+import Tools.Beam.UtilsTH
+
+data MerchantClientConfigT f = MerchantClientConfigT
+  { clientOS :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.Version.DeviceType)),
+    configJSON :: (B.C f Data.Aeson.Value),
+    serviceName :: (B.C f Domain.Types.MerchantClientConfig.ClientService),
+    createdAt :: (B.C f Kernel.Prelude.UTCTime),
+    packageId :: (B.C f Kernel.Prelude.Text),
+    updatedAt :: (B.C f Kernel.Prelude.UTCTime),
+    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
+    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text)))
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table MerchantClientConfigT where
+  data PrimaryKey MerchantClientConfigT f = MerchantClientConfigId (B.C f Domain.Types.MerchantClientConfig.ClientService) (B.C f Kernel.Prelude.Text) deriving (Generic, B.Beamable)
+  primaryKey = MerchantClientConfigId <$> serviceName <*> packageId
+
+type MerchantClientConfig = MerchantClientConfigT Identity
+
+$(enableKVPG (''MerchantClientConfigT) [('serviceName), ('packageId)] [])
+
+$(mkTableInstances (''MerchantClientConfigT) "merchant_client_config")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/MerchantClientConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/MerchantClientConfig.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Queries.MerchantClientConfig (module Storage.Queries.MerchantClientConfig, module ReExport) where
+
+import qualified Domain.Types.MerchantClientConfig
+import Kernel.Beam.Functions
+import Kernel.External.Encryption
+import Kernel.Prelude
+import Kernel.Types.Error
+import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
+import Storage.Queries.MerchantClientConfigExtra as ReExport
+import Storage.Queries.Transformers.MerchantClientConfig
+
+create :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.MerchantClientConfig.MerchantClientConfig -> m ())
+create = createWithKV
+
+createMany :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => ([Domain.Types.MerchantClientConfig.MerchantClientConfig] -> m ())
+createMany = traverse_ create

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantClientConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantClientConfig.hs
@@ -1,0 +1,43 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Queries.OrphanInstances.MerchantClientConfig where
+
+import qualified Domain.Types.MerchantClientConfig
+import Kernel.Beam.Functions
+import Kernel.External.Encryption
+import Kernel.Prelude
+import Kernel.Types.Error
+import qualified Kernel.Types.Id
+import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
+import qualified Storage.Beam.MerchantClientConfig as Beam
+import Storage.Queries.Transformers.MerchantClientConfig
+import qualified Storage.Queries.Transformers.MerchantClientConfig
+
+instance FromTType' Beam.MerchantClientConfig Domain.Types.MerchantClientConfig.MerchantClientConfig where
+  fromTType' (Beam.MerchantClientConfigT {..}) = do
+    clientServiceConfig' <- Storage.Queries.Transformers.MerchantClientConfig.mkServiceConfig configJSON serviceName
+    pure $
+      Just
+        Domain.Types.MerchantClientConfig.MerchantClientConfig
+          { clientOS = clientOS,
+            clientServiceConfig = clientServiceConfig',
+            createdAt = createdAt,
+            packageId = packageId,
+            updatedAt = updatedAt,
+            merchantId = Kernel.Types.Id.Id <$> merchantId,
+            merchantOperatingCityId = Kernel.Types.Id.Id <$> merchantOperatingCityId
+          }
+
+instance ToTType' Beam.MerchantClientConfig Domain.Types.MerchantClientConfig.MerchantClientConfig where
+  toTType' (Domain.Types.MerchantClientConfig.MerchantClientConfig {..}) = do
+    Beam.MerchantClientConfigT
+      { Beam.clientOS = clientOS,
+        Beam.configJSON = getConfigJSON clientServiceConfig,
+        Beam.serviceName = getServiceName clientServiceConfig,
+        Beam.createdAt = createdAt,
+        Beam.packageId = packageId,
+        Beam.updatedAt = updatedAt,
+        Beam.merchantId = Kernel.Types.Id.getId <$> merchantId,
+        Beam.merchantOperatingCityId = Kernel.Types.Id.getId <$> merchantOperatingCityId
+      }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Call.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Call.hs
@@ -624,7 +624,7 @@ sendFCMToBPPOnFailedCallStatus callStatus idInfo = do
       when (DM.isNothing booking.exotelDeclinedCallStatusReceivingTime) $ do
         driver <- QPerson.findById ride.driverId >>= fromMaybeM (PersonNotFound ride.driverId.getId)
         notification <- setNotificationData booking.merchantOperatingCityId ride.driverId driver.deviceToken
-        runWithServiceConfigForProviders booking.merchantOperatingCityId notification EulerHS.Prelude.id (clearDeviceToken ride.driverId)
+        runWithServiceConfigForProviders booking.merchantOperatingCityId driver.clientId driver.clientDevice notification EulerHS.Prelude.id (clearDeviceToken ride.driverId)
         QRB.updateExotelCallDeclinedTime booking.id
     else return ()
   where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/MerchantClientConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/MerchantClientConfig.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE ApplicativeDo #-}
+
+module Domain.Types.Extra.MerchantClientConfig where
+
+import Kernel.External.Notification.FCM.Types as FT
+import Kernel.Prelude
+import qualified Text.Show
+import Tools.Beam.UtilsTH (mkBeamInstancesForEnum)
+
+data ClientService
+  = ClientFCMService
+  deriving stock (Eq, Ord, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+$(mkBeamInstancesForEnum ''ClientService)
+
+instance Show ClientService where
+  show ClientFCMService = "FCM"
+
+instance Read ClientService where
+  readsPrec _ s
+    | s == "FCM" = [(ClientFCMService, "")]
+    | otherwise = []
+
+data ClientServiceConfig
+  = ClientFCMServiceConfig FT.FCMConfig
+  deriving (Generic, Eq, Show)
+
+instance FromJSON ClientServiceConfig
+
+instance ToJSON ClientServiceConfig

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/MerchantClientConfigExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/MerchantClientConfigExtra.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Queries.MerchantClientConfigExtra where
+
+import Domain.Types.MerchantClientConfig
+import Kernel.Beam.Functions
+import Kernel.External.Encryption
+import Kernel.Prelude
+import Kernel.Types.Error
+import Kernel.Types.Version
+import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
+import qualified Sequelize as Se
+import qualified Storage.Beam.MerchantClientConfig as BeamMCC
+import Storage.Queries.OrphanInstances.MerchantClientConfig
+
+-- Extra code goes here --
+findByPackageOSAndService :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => ClientService -> Maybe DeviceType -> Text -> m (Maybe MerchantClientConfig)
+findByPackageOSAndService service clientOS packageId =
+  findOneWithKV [Se.And [Se.Is BeamMCC.serviceName $ Se.Eq service, Se.Is BeamMCC.packageId $ Se.Eq packageId, Se.Is BeamMCC.clientOS $ Se.Eq clientOS]]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/MerchantClientConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/MerchantClientConfig.hs
@@ -1,0 +1,25 @@
+module Storage.Queries.Transformers.MerchantClientConfig where
+
+import qualified Data.Aeson
+import qualified Data.Aeson as A
+import qualified Data.Text as T
+import qualified Domain.Types.MerchantClientConfig as Domain
+import Kernel.Prelude as P
+import Kernel.Types.Common
+import Kernel.Types.Error
+import Kernel.Utils.Common
+
+getConfigJSON :: Domain.ClientServiceConfig -> Data.Aeson.Value
+getConfigJSON (Domain.ClientFCMServiceConfig fcmConfig) = toJSON fcmConfig
+
+getServiceName :: Domain.ClientServiceConfig -> Domain.ClientService
+getServiceName (Domain.ClientFCMServiceConfig _) = Domain.ClientFCMService
+
+mkServiceConfig :: (MonadThrow m, Log m) => Data.Aeson.Value -> Domain.ClientService -> m Domain.ClientServiceConfig
+mkServiceConfig configJSON serviceName = either (\err -> throwError $ InternalError ("Unable to decode MerchantServiceConfigT.configJSON: " <> show configJSON <> " Error:" <> err)) return $ case serviceName of
+  Domain.ClientFCMService -> Domain.ClientFCMServiceConfig <$> eitherValue configJSON
+  where
+    eitherValue :: FromJSON a => A.Value -> Either Text a
+    eitherValue value = case A.fromJSON value of
+      A.Success a -> Right a
+      A.Error err -> Left $ T.pack err

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/MarketingEvents.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/MarketingEvents.hs
@@ -13,6 +13,7 @@ import Kernel.Streaming.Kafka.Producer.Types (HasKafkaProducer)
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import Storage.Queries.Person as QPerson
 import Tools.Error
 import Tools.Notifications
 
@@ -40,7 +41,8 @@ notifyMarketingEvents driverId deviceToken marketingEventsType vehicleCategory c
   logDebug $ "the event to be triggered is :" <> events
 
   notification <- setNotificationData events merchantOpCityId driverId eventDestination deviceToken
-  runWithServiceConfigForProviders merchantOpCityId notification EulerHS.Prelude.id (clearDeviceToken driverId)
+  driver <- QPerson.findById driverId
+  runWithServiceConfigForProviders merchantOpCityId (driver >>= (.clientId)) (driver >>= (.clientDevice)) notification EulerHS.Prelude.id (clearDeviceToken driverId)
   where
     splitFirstChars :: T.Text -> T.Text
     splitFirstChars shortId = T.concat $ map (T.take 1) $ T.splitOn "_" shortId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Notifications.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Notifications.hs
@@ -28,6 +28,7 @@ import qualified Domain.Types.BookingUpdateRequest as DBUR
 import Domain.Types.EmptyDynamicParam
 import Domain.Types.Location
 import qualified Domain.Types.Merchant as DM
+import Domain.Types.MerchantClientConfig as DMCC
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.MerchantServiceConfig as DMSC
 import Domain.Types.Message as Message
@@ -44,6 +45,7 @@ import qualified Kernel.External.Notification as Notification
 import qualified Kernel.External.Notification.FCM.Flow as FCM
 import Kernel.External.Notification.FCM.Types as FCM
 import Kernel.External.Notification.Interface.GRPC as GRPC
+import Kernel.External.Notification.Types (NotificationService (..))
 import Kernel.External.Types (Language (..), ServiceFlow)
 import Kernel.Prelude hiding (unwords)
 import Kernel.Types.Error
@@ -60,6 +62,7 @@ import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import qualified Storage.CachedQueries.Merchant.MerchantPushNotification as CPN
 import qualified Storage.CachedQueries.Merchant.MerchantServiceConfig as QMSC
 import qualified Storage.Queries.FleetDriverAssociation as QFDA
+import qualified Storage.Queries.MerchantClientConfig as QMCC
 import qualified Storage.Queries.Person as QPerson
 import Utils.Common.Cac.KeyNameConstants
 
@@ -141,6 +144,14 @@ instance Default FCMReq where
 createFCMReq :: Text -> Text -> FCM.FCMEntityType -> (FCMReq -> FCMReq) -> FCMReq
 createFCMReq notificationKey entityId entityType modifier = modifier $ def {entityId = entityId, notificationKey = notificationKey, entityType = entityType}
 
+findFCMConfigWithFallback :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> Id Person -> m FCMConfig
+findFCMConfigWithFallback merchantOpCityId personId = do
+  driver <- QPerson.findById personId
+  mbClientConfig <- QMCC.findByPackageOSAndService (ClientFCMService) (driver >>= (.clientDevice) <&> (.deviceType)) (fromMaybe "" (driver >>= (.clientId)))
+  case mbClientConfig of
+    Just clientConfig -> let (DMCC.ClientFCMServiceConfig fcmCfg) = clientConfig.clientServiceConfig in pure fcmCfg
+    Nothing -> findByMerchantOpCityId merchantOpCityId (Just (DriverId (cast personId))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId) <&> (.fcmConfig)
+
 dynamicFCMNotifyPerson ::
   ( CacheFlow m r,
     EsqDBFlow m r,
@@ -158,7 +169,7 @@ dynamicFCMNotifyPerson ::
   Maybe [LYT.ConfigVersionMap] ->
   m ()
 dynamicFCMNotifyPerson merchantOpCityId personId mbDeviceToken lang tripCategory fcmReq entityData dynamicParams mbConfigInExperimentVersions = do
-  transporterConfig <- findByMerchantOpCityId merchantOpCityId (Just (DriverId (cast personId))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
+  fcmConfig <- findFCMConfigWithFallback merchantOpCityId personId
   mbMerchantPN <- CPN.findMatchingMerchantPN merchantOpCityId fcmReq.notificationKey tripCategory fcmReq.subCategory (Just lang) mbConfigInExperimentVersions
   when (isNothing mbMerchantPN) $ logError $ "MISSED_FCM - " <> fcmReq.notificationKey
   whenJust mbMerchantPN $ \merchantPN -> do
@@ -175,7 +186,7 @@ dynamicFCMNotifyPerson merchantOpCityId personId mbDeviceToken lang tripCategory
               fcmOverlayNotificationJSON = FCM.createAndroidOverlayNotification <$> fcmReq.overlayReq,
               fcmNotificationId = Nothing
             }
-    FCM.notifyPersonWithPriority transporterConfig.fcmConfig fcmReq.priority (clearDeviceToken personId) notificationData (FCMNotificationRecipient personId.getId mbDeviceToken) EulerHS.Prelude.id
+    FCM.notifyPersonWithPriority fcmConfig fcmReq.priority (clearDeviceToken personId) notificationData (FCMNotificationRecipient personId.getId mbDeviceToken) EulerHS.Prelude.id
 
 notifyOnNewSearchRequestAvailable ::
   ( CacheFlow m r,
@@ -371,7 +382,8 @@ notifyDriverWithProviders ::
   Maybe FCM.FCMRecipientToken ->
   a ->
   m ()
-notifyDriverWithProviders merchantOpCityId category title body driver mbDeviceToken dataSend = runWithServiceConfigForProviders merchantOpCityId notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
+notifyDriverWithProviders merchantOpCityId category title body driver mbDeviceToken dataSend =
+  runWithServiceConfigForProviders merchantOpCityId driver.clientId driver.clientDevice notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
   where
     notificationData =
       Notification.NotificationReq
@@ -401,7 +413,8 @@ driverScheduledRideAcceptanceAlert ::
   Person ->
   Maybe FCM.FCMRecipientToken ->
   m ()
-driverScheduledRideAcceptanceAlert merchantOpCityId category title body driver mbDeviceToken = runWithServiceConfigForProviders merchantOpCityId notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
+driverScheduledRideAcceptanceAlert merchantOpCityId category title body driver mbDeviceToken =
+  runWithServiceConfigForProviders merchantOpCityId driver.clientId driver.clientDevice notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
   where
     notificationData =
       Notification.NotificationReq
@@ -447,9 +460,9 @@ sendNotificationToDriver ::
   Maybe FCM.FCMRecipientToken ->
   m ()
 sendNotificationToDriver merchantOpCityId displayOption priority notificationType notificationTitle message driver mbToken = do
-  let newCityId = cityFallback driver.clientBundleVersion merchantOpCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast driver.id))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig priority (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId mbToken) EulerHS.Prelude.id
+  let newCityId = cityFallback driver.clientBundleVersion merchantOpCityId
+  fcmConfig <- findFCMConfigWithFallback newCityId driver.id -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
+  FCM.notifyPersonWithPriority fcmConfig priority (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId mbToken) EulerHS.Prelude.id
   where
     notificationData =
       FCM.FCMData
@@ -480,9 +493,9 @@ sendMessageToDriver ::
   Id Message.Message ->
   m ()
 sendMessageToDriver merchantOpCityId displayOption priority notificationType notificationTitle message driver messageId = do
-  let newCityId = cityFallback driver.clientBundleVersion merchantOpCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast driver.id))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig priority (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId driver.deviceToken) EulerHS.Prelude.id
+  let newCityId = cityFallback driver.clientBundleVersion merchantOpCityId
+  fcmConfig <- findFCMConfigWithFallback newCityId driver.id -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
+  FCM.notifyPersonWithPriority fcmConfig priority (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId driver.deviceToken) EulerHS.Prelude.id
   where
     notificationData =
       FCM.FCMData
@@ -603,7 +616,7 @@ notifyDriverClearedFare ::
   m ()
 notifyDriverClearedFare merchantOpCityId driver sReqId _ = do
   notificationData <- buildClearedFareNotificationData merchantOpCityId driver.id driver.deviceToken sReqId
-  runWithServiceConfigForProviders merchantOpCityId notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
+  runWithServiceConfigForProviders merchantOpCityId driver.clientId driver.clientDevice notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
 
 buildClearedFareNotificationData ::
   ( ServiceFlow m r,
@@ -653,7 +666,7 @@ notifyOnCancelSearchRequest ::
   m ()
 notifyOnCancelSearchRequest merchantOpCityId driver searchTryId tripCategory = do
   notificationData <- buildCancelSearchNotificationData merchantOpCityId driver.id driver.deviceToken searchTryId tripCategory
-  runWithServiceConfigForProviders merchantOpCityId notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
+  runWithServiceConfigForProviders merchantOpCityId driver.clientId driver.clientDevice notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
 
 buildCancelSearchNotificationData ::
   ( ServiceFlow m r,
@@ -887,8 +900,8 @@ sendOverlay ::
   m ()
 sendOverlay merchantOpCityId person req@FCM.FCMOverlayReq {..} = do
   let newCityId = cityFallback person.clientBundleVersion merchantOpCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast person.id))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback newCityId person.id
+  FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
   where
     notifType = FCM.DRIVER_NOTIFY
     notificationData =
@@ -915,9 +928,10 @@ sendUpdateLocOverlay ::
   UpdateLocationNotificationReq ->
   m ()
 sendUpdateLocOverlay merchantOpCityId person req@FCM.FCMOverlayReq {..} entityData = do
-  let newCityId = cityFallback person.clientBundleVersion merchantOpCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast person.id))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
+  let newCityId = cityFallback person.clientBundleVersion merchantOpCityId
+  -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
+  fcmConfig <- findFCMConfigWithFallback newCityId person.id
+  FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
   where
     notifType = FCM.DRIVER_NOTIFY_LOCATION_UPDATE
     notificationData =
@@ -944,8 +958,8 @@ sendPickupLocationChangedOverlay ::
   m ()
 sendPickupLocationChangedOverlay person req entityData = do
   let newCityId = cityFallback person.clientBundleVersion person.merchantOperatingCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast person.id))) >>= fromMaybeM (TransporterConfigNotFound person.merchantOperatingCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback newCityId person.id
+  FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
   where
     notifType = FCM.EDIT_LOCATION
     notificationData =
@@ -973,8 +987,8 @@ sendCancellationRateNudgeOverlay ::
   CancellationRateBaseNudgeData ->
   m ()
 sendCancellationRateNudgeOverlay mOpCityId person fcmType req entityData = do
-  transporterConfig <- findByMerchantOpCityId mOpCityId (Just (DriverId (cast person.id))) >>= fromMaybeM (TransporterConfigNotFound person.merchantOperatingCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback mOpCityId person.id
+  FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
   where
     notificationData =
       FCM.FCMData
@@ -1000,8 +1014,8 @@ drunkAndDriveViolationWarningOverlay ::
   DrunkAndDriveViolationWarningData ->
   m ()
 drunkAndDriveViolationWarningOverlay mOpCityId person req entityData = do
-  transporterConfig <- findByMerchantOpCityId mOpCityId (Just (DriverId (cast person.id))) >>= fromMaybeM (TransporterConfigNotFound person.merchantOperatingCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback mOpCityId person.id
+  FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
   where
     notificationData =
       FCM.FCMData
@@ -1030,7 +1044,8 @@ driverStopDetectionAlert ::
   Person ->
   Maybe FCM.FCMRecipientToken ->
   m ()
-driverStopDetectionAlert merchantOpCityId category title body driver mbDeviceToken = runWithServiceConfigForProviders merchantOpCityId notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
+driverStopDetectionAlert merchantOpCityId category title body driver mbDeviceToken =
+  runWithServiceConfigForProviders merchantOpCityId driver.clientId driver.clientDevice notificationData EulerHS.Prelude.id (clearDeviceToken driver.id)
   where
     notificationData =
       Notification.NotificationReq
@@ -1117,7 +1132,8 @@ sendSearchRequestToDriverNotification ::
   m ()
 sendSearchRequestToDriverNotification _merchantId merchantOpCityId driverId req = do
   --logDebug $ "DFCM - NEW_RIDE_AVAILABLE  Title -> " <> show req.title <> " body - " <> show req.body
-  runWithServiceConfigForProviders merchantOpCityId req iosModifier (clearDeviceToken driverId)
+  driver <- QPerson.findById driverId
+  runWithServiceConfigForProviders merchantOpCityId (driver >>= (.clientId)) (driver >>= (.clientDevice)) req iosModifier (clearDeviceToken driverId)
   where
     iosModifier (iosFCMdata :: (FCM.FCMData SearchRequestForDriverAPIEntity)) = iosFCMdata {fcmEntityData = modifyEntity iosFCMdata.fcmEntityData}
     modifyEntity SearchRequestForDriverAPIEntity {..} = IOSSearchRequestForDriverAPIEntity {..}
@@ -1142,7 +1158,7 @@ notifyStopModification rideStatus person entityData tripCategory = do
   let newCityId = cityFallback person.clientBundleVersion person.merchantOperatingCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
   if rideStatus == DRide.NEW
     then do
-      transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast person.id))) >>= fromMaybeM (TransporterConfigNotFound person.merchantOperatingCityId.getId)
+      fcmConfig <- findFCMConfigWithFallback newCityId person.id
       let notificationType = if entityData.isEdit then FCM.EDIT_STOP else FCM.ADD_STOP
           titleText = if entityData.isEdit then "Stop Edited" else "Stop Added"
           bodyText = if entityData.isEdit then "Customer has edited the stop." else "Customer has added a new stop."
@@ -1159,7 +1175,7 @@ notifyStopModification rideStatus person entityData tripCategory = do
                 fcmOverlayNotificationJSON = Nothing,
                 fcmNotificationId = Nothing
               }
-      FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
+      FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken person.id) notificationData (FCMNotificationRecipient person.id.getId person.deviceToken) EulerHS.Prelude.id
     else do
       let notificationKey = if entityData.isEdit then "EDIT_STOP" else "ADD_STOP"
       dynamicFCMNotifyPerson
@@ -1272,8 +1288,8 @@ notifyDriverOnEvents ::
   FCM.FCMNotificationType ->
   m ()
 notifyDriverOnEvents merchantOpCityId personId mbDeviceToken entityData notifType = do
-  transporterConfig <- findByMerchantOpCityId merchantOpCityId (Just (DriverId (cast personId))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken personId) notificationData (FCMNotificationRecipient personId.getId mbDeviceToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback merchantOpCityId personId
+  FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken personId) notificationData (FCMNotificationRecipient personId.getId mbDeviceToken) EulerHS.Prelude.id
   where
     notificationData =
       FCM.FCMData
@@ -1365,11 +1381,13 @@ runWithServiceConfigForProviders ::
     HasFlowEnv m r '["maxNotificationShards" ::: Int]
   ) =>
   Id DMOC.MerchantOperatingCity ->
+  Maybe Text ->
+  Maybe Version.Device ->
   Notification.NotificationReq a b ->
   (FCMData a -> FCMData c) ->
   m () ->
   m ()
-runWithServiceConfigForProviders merchantOpCityId req iosModifier = Notification.notifyPersonWithAllProviders handler req Nothing
+runWithServiceConfigForProviders merchantOpCityId clientId clientDevice req iosModifier = Notification.notifyPersonWithAllProviders handler req Nothing
   where
     handler = Notification.NotficationServiceHandler {..}
 
@@ -1379,6 +1397,17 @@ runWithServiceConfigForProviders merchantOpCityId req iosModifier = Notification
       when (null sendSearchReqNotificationList) $ throwError $ InternalError ("No notification service provider configured for the merchant Op city : " <> merchantOpCityId.getId)
       pure sendSearchReqNotificationList
 
+    getServiceConfig FCM = do
+      mbClientConfig <- QMCC.findByPackageOSAndService (ClientFCMService) (clientDevice <&> (.deviceType)) (fromMaybe "" clientId)
+      case mbClientConfig of
+        Just clientConfig -> let (DMCC.ClientFCMServiceConfig fcmCfg) = clientConfig.clientServiceConfig in pure $ Notification.FCMConfig fcmCfg
+        Nothing -> do
+          merchantNotificationServiceConfig <-
+            QMSC.findByServiceAndCity (DMSC.NotificationService FCM) merchantOpCityId
+              >>= fromMaybeM (MerchantServiceConfigNotFound merchantOpCityId.getId "Notification" (show FCM))
+          case merchantNotificationServiceConfig.serviceConfig of
+            DMSC.NotificationServiceConfig nsc -> pure nsc
+            _ -> throwError $ InternalError "Unknow Service Config"
     getServiceConfig service = do
       merchantNotificationServiceConfig <-
         QMSC.findByServiceAndCity (DMSC.NotificationService service) merchantOpCityId
@@ -1406,8 +1435,8 @@ sendCoinsNotification ::
   m ()
 sendCoinsNotification merchantOpCityId notificationTitle message driver mbToken entityData = do
   let newCityId = cityFallback driver.clientBundleVersion merchantOpCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast driver.id))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig Nothing (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId mbToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback newCityId driver.id
+  FCM.notifyPersonWithPriority fcmConfig Nothing (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId mbToken) EulerHS.Prelude.id
   where
     notificationData =
       FCM.FCMData
@@ -1437,8 +1466,8 @@ requestRejectionNotification ::
   m ()
 requestRejectionNotification merchantOpCityId notificationTitle message driver mbToken entityData = do
   let newCityId = cityFallback driver.clientBundleVersion merchantOpCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast driver.id))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig Nothing (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId mbToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback newCityId driver.id
+  FCM.notifyPersonWithPriority fcmConfig Nothing (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId mbToken) EulerHS.Prelude.id
   where
     notificationData =
       FCM.FCMData
@@ -1471,8 +1500,8 @@ sendCoinsNotificationV3 ::
 sendCoinsNotificationV3 merchantOpCityId notificationTitle message driver mbToken entityData metroRideType = do
   logDebug $ "We are in metro notification"
   let newCityId = cityFallback driver.clientBundleVersion merchantOpCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast driver.id))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig Nothing (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId mbToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback newCityId driver.id
+  FCM.notifyPersonWithPriority fcmConfig Nothing (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId mbToken) EulerHS.Prelude.id
   where
     fcmNotificationType = case metroRideType of
       ToMetro -> FCM.TO_METRO_COINS
@@ -1527,8 +1556,8 @@ notifyEditDestination ::
   m ()
 notifyEditDestination merchantOpCityId personId mbDeviceToken = do
   logDebug $ "We are in edit destination when driver accepted edited location"
-  transporterConfig <- findByMerchantOpCityId merchantOpCityId (Just (DriverId (cast personId))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken personId) notificationData (FCMNotificationRecipient personId.getId mbDeviceToken) EulerHS.Prelude.id
+  fcmConfig <- findFCMConfigWithFallback merchantOpCityId personId
+  FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken personId) notificationData (FCMNotificationRecipient personId.getId mbDeviceToken) EulerHS.Prelude.id
   where
     notificationData =
       FCM.FCMData
@@ -1561,7 +1590,7 @@ sendPickupInstructionNotification ::
   m ()
 sendPickupInstructionNotification merchantOpCityId driver entityData = do
   let newCityId = cityFallback driver.clientBundleVersion merchantOpCityId -- TODO: Remove this fallback once YATRI_PARTNER_APP is updated To Newer Version
-  transporterConfig <- findByMerchantOpCityId newCityId (Just (DriverId (cast driver.id))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
+  fcmConfig <- findFCMConfigWithFallback newCityId driver.id
   -- Build notification data
   let notificationData =
         FCM.FCMData
@@ -1578,4 +1607,4 @@ sendPickupInstructionNotification merchantOpCityId driver entityData = do
       body = FCMNotificationBody $ fromMaybe "You have received pickup instructions" entityData.instruction
   logInfo $ "PickupInstructionNotification: Notification data: " <> show notificationData
   -- Send notification
-  FCM.notifyPersonWithPriority transporterConfig.fcmConfig (Just FCM.HIGH) (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId driver.deviceToken) EulerHS.Prelude.id
+  FCM.notifyPersonWithPriority fcmConfig (Just FCM.HIGH) (clearDeviceToken driver.id) notificationData (FCMNotificationRecipient driver.id.getId driver.deviceToken) EulerHS.Prelude.id

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/merchant_client_config.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/merchant_client_config.sql
@@ -1,0 +1,17 @@
+CREATE TABLE atlas_driver_offer_bpp.merchant_client_config ();
+
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD COLUMN config_json json NOT NULL;
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD COLUMN service_name character varying(50) NOT NULL;
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD COLUMN created_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD COLUMN package_id character varying(36) NOT NULL;
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD COLUMN updated_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD COLUMN merchant_id character varying(36) ;
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD COLUMN merchant_operating_city_id character varying(36) ;
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD PRIMARY KEY ( service_name, package_id);
+
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ALTER COLUMN package_id TYPE text;
+ALTER TABLE atlas_driver_offer_bpp.merchant_client_config ADD COLUMN client_os text ;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Since we are hitting the limit on the number of apps in firebase acct, we have to have a new account and the new apps added there (They will have different FCM configs).

We now fetch the FCM configs by merchant city; instead we will fetch them by the package/ client id (frontend identifier) and OS, and the notifications sent using that.

So a new config table has been created, that will serve configs based on package id (instead of conventional merchant op city). We will get FCM configs from here, and fallback to the current config tables if we dont find. 

Also made refactorings to get all FCM configs from one place (currently the same config is there in multiple tables and is fetched differently)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced client-aware service configuration for notifications that selects settings based on driver client context (device/app version) with fallback to merchant-level defaults.

* **Chores**
  * Database migration to support merchant client configuration storage with composite key and client device tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->