### PR TITLE
backend/fix: get passes based on status properly

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -509,7 +509,7 @@ getMultimodalPassList (mbCallerPersonId, merchantId) mbLimitParam mbOffsetParam 
   personId <- mbCallerPersonId & fromMaybeM (PersonNotFound "personId")
 
   let mbStatus = case mbStatusParam of
-        Just DPurchasedPass.Active -> Just [DPurchasedPass.Active, DPurchasedPass.PreBooked, DPurchasedPass.Expired]
+        Just DPurchasedPass.Active -> Just [DPurchasedPass.Active, DPurchasedPass.PreBooked]
         Just s -> Just [s]
         Nothing -> Nothing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active pass list now excludes expired passes so only currently active and pre-booked passes are shown, improving accuracy and reducing clutter in your available-pass view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->