### PR TITLE
fix: add issinglemode field to journeyinforesp

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -63,6 +63,7 @@ types:
     merchantOperatingCityName: Maybe Text
     paymentOrderShortId: Kernel.Prelude.Maybe (Kernel.Types.Id.ShortId Lib.Payment.Domain.Types.PaymentOrder.PaymentOrder)
     result: Maybe Text # for backward compatibility hardcoding to Success in response
+    isSingleMode: Maybe Bool
     derive: "Show"
 
   LegStatus:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -129,6 +129,7 @@ data JourneyInfoResp = JourneyInfoResp
     estimatedDuration :: Kernel.Prelude.Maybe Kernel.Types.Common.Seconds,
     estimatedMaxFare :: Kernel.Types.Common.PriceAPIEntity,
     estimatedMinFare :: Kernel.Types.Common.PriceAPIEntity,
+    isSingleMode :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
     journeyId :: Kernel.Types.Id.Id Domain.Types.Journey.Journey,
     journeyStatus :: Domain.Types.Journey.JourneyStatus,
     legs :: [Lib.JourneyModule.Types.LegInfo],

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Base.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Base.hs
@@ -1356,7 +1356,8 @@ generateJourneyInfoResponse journey legs = do
         merchantOperatingCityName,
         paymentOrderShortId = journey.paymentOrderShortId,
         unifiedQRV2,
-        result = Just "Success"
+        result = Just "Success",
+        isSingleMode = journey.isSingleMode
       }
   where
     getUnifiedQRV2 :: Maybe JL.UnifiedTicketQR -> Maybe JL.UnifiedTicketQRV2


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Journey information responses now include a new `isSingleMode` field indicating whether a journey operates in single-mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->