### PR TITLE
backend/fix: journey date in bookJourney

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/BookJourney.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/BookJourney.hs
@@ -267,7 +267,7 @@ createOrder config integratedBPPConfig booking quoteCategories = do
     Just oid -> return oid
     Nothing -> getBppOrderId booking
   classCode <- getFRFSVehicleServiceTier quote
-  startTime <- fromMaybeM (CRISError "Start time not found") booking.startTime
+  currentTime <- getCurrentTime
   let tpBookType = if config.enableBookType == Just True && booking.isSingleMode == Just True then 1 else 0
 
   let fareParameters = calculateFareParametersWithBookingFallback (mkCategoryPriceItemFromQuoteCategories quoteCategories) booking
@@ -287,7 +287,7 @@ createOrder config integratedBPPConfig booking quoteCategories = do
             classCode = classCode,
             trainType = trainTypeCode,
             tktType = config.ticketType,
-            journeyDate = T.pack $ formatTime defaultTimeLocale "%m-%d-%Y" (utcToIST startTime),
+            journeyDate = T.pack $ formatTime defaultTimeLocale "%m-%d-%Y" (utcToIST currentTime),
             adult = fromMaybe 0 adultQuantity,
             child = fromMaybe 0 childQuantity,
             seniorMen = 0,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Passing current time instead of booking start time in bookJourney API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved journey booking reliability by using the system's current time when computing booking dates.
  * Ensures journey dates are calculated using the local (IST) converted current time to avoid incorrect timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->