### PR TITLE
backend/feat: add pn for payment fullfillment status

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
@@ -1568,8 +1568,8 @@ notifyAboutScheduledRide booking title body = do
           }
   notifyPerson person.merchantId person.merchantOperatingCityId person.id notificationData Nothing
 
-notifyRefundNotification :: (ServiceFlow m r) => Notification.Category -> Id DOrder.PaymentOrder -> Id Person -> DOrder.PaymentServiceType -> m ()
-notifyRefundNotification notifCategory paymentOrderId personId paymentServiceType = do
+notifyPaymentFulfillment :: (ServiceFlow m r) => Notification.Category -> Id DOrder.PaymentOrder -> Id Person -> DOrder.PaymentServiceType -> m ()
+notifyPaymentFulfillment notifCategory paymentOrderId personId paymentServiceType = do
   person <- Person.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
   notificationSoundFromConfig <- SQNSC.findByNotificationType notifCategory person.merchantOperatingCityId
   mbMerchantPN <- CPN.findMatchingMerchantPN person.merchantOperatingCityId (mkRefundNotificationKey) Nothing Nothing person.language Nothing


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unify refund-related notifications into payment-fulfillment flow; added fulfillment-pending and fulfillment-succeeded handling so pending/success transitions produce correct alerts.
  * Compare prior vs. refreshed payment status (including fallback path) to avoid duplicate or incorrect pending notifications.

* **New Features**
  * Notifications now respect merchant-configured templates and trigger rules, building templated title/body and applying a default sound when configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->