### PR TITLE
backend/fix: add applicablepasses in leginfo

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Base.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Base.hs
@@ -474,7 +474,7 @@ startJourney riderId confirmElements forcedBookedLegOrder journey mbEnableOffer 
             bookLater = fromMaybe False (mElement <&> (.skipBooking))
         let totalTicketQuantity =
               fromMaybe 0 ticketQuantity + fromMaybe 0 childTicketQuantity
-        let bookingAllowed' = leg.bookingAllowed || totalTicketQuantity /= 1
+        let bookingAllowed' = leg.bookingAllowed || ((fromMaybe False leg.hasApplicablePasses) && totalTicketQuantity /= 1)
         let updatedLeg = leg {JL.bookingAllowed = bookingAllowed'}
         let forcedBooking = Just leg.order == forcedBookedLegOrder
         let crisSdkResponse = find (\element -> element.journeyLegOrder == leg.order) confirmElements >>= (.crisSdkResponse)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Booking validation now considers whether a journey leg has applicable passes when determining booking eligibility.

* **Bug Fixes**
  * Adjusted booking eligibility so multi-ticket scenarios require an applicable pass to be allowed, reducing incorrect bookings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->