### PR TITLE
backend/feat: Add a internal api for quote respond

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -67,6 +67,7 @@ library
       API.Internal.PickupInstruction
       API.Internal.PopulateTipAmount
       API.Internal.ProdLoopStatus
+      API.Internal.QuoteRespond
       API.Internal.ReportACIssue
       API.Internal.ReportIssue
       API.Internal.Ride
@@ -211,6 +212,7 @@ library
       Domain.Action.Internal.PopulateTipAmount
       Domain.Action.Internal.ProcessingChangeOnline
       Domain.Action.Internal.ProdLoopStatus
+      Domain.Action.Internal.QuoteRespond
       Domain.Action.Internal.ReportACIssue
       Domain.Action.Internal.ReportIssue
       Domain.Action.Internal.Ride

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal.hs
@@ -25,6 +25,7 @@ import qualified API.Internal.Multimodal as Multimodal
 import qualified API.Internal.PickupInstruction as PickupInstruction
 import qualified API.Internal.PopulateTipAmount as PopulateTipAmount
 import qualified API.Internal.ProdLoopStatus as ProdLoopStatus
+import qualified API.Internal.QuoteRespond as QuoteRespond
 import qualified API.Internal.ReportACIssue as ReportACIssue
 import qualified API.Internal.ReportIssue as ReportIssue
 import qualified API.Internal.Ride as Ride
@@ -55,6 +56,7 @@ type API =
            :<|> StopDetection.API
            :<|> Multimodal.API
            :<|> DriverReachedDestination.API
+           :<|> QuoteRespond.API
            :<|> ProdLoopStatus.API
            :<|> DriverSourceDeparted.API
            :<|> ViolationDetection.API
@@ -85,6 +87,7 @@ handler =
     :<|> StopDetection.handler
     :<|> Multimodal.handler
     :<|> DriverReachedDestination.handler
+    :<|> QuoteRespond.handler
     :<|> ProdLoopStatus.handler
     :<|> DriverSourceDeparted.handler
     :<|> ViolationDetection.handler

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/QuoteRespond.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/QuoteRespond.hs
@@ -1,0 +1,50 @@
+module API.Internal.QuoteRespond
+  ( API,
+    handler,
+  )
+where
+
+import qualified Domain.Action.UI.Driver as DDriver
+import Domain.Types.Merchant as Merchant
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Person as SP
+import Environment
+import EulerHS.Prelude hiding (id)
+import Kernel.Types.APISuccess
+import Kernel.Types.Id
+import Kernel.Types.Version (Version)
+import Kernel.Utils.Common
+import Servant
+import Storage.Beam.SystemConfigs ()
+import Tools.Auth
+
+type API =
+  ( "driver"
+      :> "quote"
+      :> "respond"
+      :> TokenAuth
+      :> Header "x-package" Text
+      :> Header "x-bundle-version" Version
+      :> Header "x-client-version" Version
+      :> Header "x-config-version" Version
+      :> Header "x-react-bundle-version" Text
+      :> Header "x-device" Text
+      :> ReqBody '[JSON] DDriver.DriverRespondReq
+      :> Post '[JSON] APISuccess
+  )
+
+handler :: FlowServer API
+handler =
+  respondQuote
+
+respondQuote ::
+  (Id SP.Person, Id Merchant.Merchant, Id DMOC.MerchantOperatingCity) ->
+  Maybe Text ->
+  Maybe Version ->
+  Maybe Version ->
+  Maybe Version ->
+  Maybe Text ->
+  Maybe Text ->
+  DDriver.DriverRespondReq ->
+  FlowHandler APISuccess
+respondQuote (personId, driverId, merchantOpCityId) clientId mbBundleVersion mbClientVersion mbConfigVersion mbReactBundleVersion mbDevice = withFlowHandlerAPI . DDriver.respondQuote (personId, driverId, merchantOpCityId) clientId mbBundleVersion mbClientVersion mbConfigVersion mbReactBundleVersion mbDevice

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/QuoteRespond.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/QuoteRespond.hs
@@ -1,0 +1,34 @@
+module Domain.Action.Internal.QuoteRespond where
+
+import qualified Domain.Action.UI.Driver as DDriver
+import Environment
+import EulerHS.Prelude hiding (id)
+import Kernel.Types.APISuccess
+import Kernel.Types.Error
+import Kernel.Types.Version (Version)
+import Kernel.Utils.Common
+import Storage.Beam.SystemConfigs ()
+import Tools.Auth
+
+respondQuote ::
+  Maybe RegToken ->
+  Maybe Text ->
+  Maybe Version ->
+  Maybe Version ->
+  Maybe Version ->
+  Maybe Text ->
+  Maybe Text ->
+  DDriver.DriverRespondReq ->
+  Flow APISuccess
+respondQuote token clientId mbBundleVersion mbClientVersion mbConfigVersion mbReactBundleVersion mbDevice request = do
+  regToken <- fromMaybeM AccessDenied token
+  (personId, driverId, merchantOpCityId) <- verifyPerson regToken
+  DDriver.respondQuote
+    (personId, driverId, merchantOpCityId)
+    clientId
+    mbBundleVersion
+    mbClientVersion
+    mbConfigVersion
+    mbReactBundleVersion
+    mbDevice
+    request


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded API surface with a new driver quote response endpoint, enabling drivers to submit responses to quotes with integrated authentication and client version tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->