### PR TITLE
backend/fix: added allowNotificationOnEmptyBadge for allowing empyt b…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -880,6 +880,7 @@ TransporterConfig:
       derive': Generic, Show, ToJSON, FromJSON, Read, Eq
     FeedbackNotificationConfig:
       enableFeedbackNotification: Bool
+      allowNotificationOnEmptyBadge: Bool
       feedbackNotificationDelayInSec: Int
       derive': Generic, Show, ToJSON, FromJSON, Read,Eq
   beamInstance:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/TransporterConfig.hs
@@ -381,7 +381,7 @@ data DriverWalletConfig = DriverWalletConfig
   }
   deriving (Generic, Show, ToJSON, FromJSON, Read, Eq)
 
-data FeedbackNotificationConfig = FeedbackNotificationConfig {enableFeedbackNotification :: Kernel.Prelude.Bool, feedbackNotificationDelayInSec :: Kernel.Prelude.Int}
+data FeedbackNotificationConfig = FeedbackNotificationConfig {allowNotificationOnEmptyBadge :: Kernel.Prelude.Bool, enableFeedbackNotification :: Kernel.Prelude.Bool, feedbackNotificationDelayInSec :: Kernel.Prelude.Int}
   deriving (Generic, Show, ToJSON, FromJSON, Read, Eq)
 
 data SlabType = SlabType {minBookingsRange :: [Kernel.Prelude.Int], penalityForCancellation :: Domain.Types.TransporterConfig.CancellationRateSlab}

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0721-feedback-notification-config.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0721-feedback-notification-config.sql
@@ -1,11 +1,11 @@
 -- QUERIES FOR MASTER
 UPDATE atlas_driver_offer_bpp.transporter_config
-SET feedback_notification_config = '{"enableFeedbackNotification":true,"feedbackNotificationDelayInSec":60}'
+SET feedback_notification_config = '{"enableFeedbackNotification":true,"allowNotificationOnEmptyBadge":true,"feedbackNotificationDelayInSec":60}'
 WHERE feedback_notification_config IS NULL;
 
 -- QUERIES FOR PROD
 -- UPDATE atlas_driver_offer_bpp.transporter_config
--- SET feedback_notification_config = '{"enableFeedbackNotification":false,"feedbackNotificationDelayInSec":7200}'
+-- SET feedback_notification_config = '{"enableFeedbackNotification":false,"enableFeedbackNotification":false,"feedbackNotificationDelayInSec":7200}'
 -- WHERE feedback_notification_config IS NULL;
 
 -- Insert FEEDBACK_BADGE_PN notification for ENGLISH


### PR DESCRIPTION
…adge notification

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control feedback notifications when no badges are present, providing finer control over notification delivery scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->