### PR TITLE
backend/fix: remove the preliminary leg from single mode

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
@@ -87,6 +87,7 @@ import Storage.Beam.Payment ()
 import Storage.Beam.SchedulerJob ()
 import Storage.Beam.Yudhishthira ()
 import qualified Storage.CachedQueries.FRFSGtfsStageFare as QFRFSGtfsStageFare
+import Storage.CachedQueries.Merchant.MultiModalBus (utcToIST)
 import qualified Storage.CachedQueries.Merchant.MultiModalBus as CQMMB
 import Storage.CachedQueries.OTPRest.OTPRest as OTPRest
 import qualified Storage.CachedQueries.PartnerOrgStation as CQPOS
@@ -608,7 +609,7 @@ trackVehicles _personId _merchantId merchantOpCityId vehicleType routeCode platf
             return $
               VehicleTracking
                 { nextStop = mbNextStopMapping,
-                  nextStopTravelTime = (\t -> nominalDiffTimeToSeconds $ diffUTCTime t now) <$> (mbNextStop <&> (.arrivalTime)),
+                  nextStopTravelTime = (\t -> Seconds $ getSeconds (nominalDiffTimeToSeconds $ diffUTCTime t (utcToIST now)) `div` 60) <$> (mbNextStop <&> (.arrivalTime)),
                   nextStopTravelDistance = Nothing,
                   upcomingStops = upcomingStops, -- fix it later
                   vehicleId = bus.vehicleNumber,

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Search.hs
@@ -130,7 +130,8 @@ data PublicTransportSearchReq = PublicTransportSearchReq
     vehicleCategory :: Maybe Enums.VehicleCategory,
     platformType :: Maybe DIBPC.PlatformType,
     currentLocation :: Maybe LatLong,
-    busLocationData :: Maybe [RL.BusLocation]
+    busLocationData :: Maybe [RL.BusLocation],
+    firstMileRemoved :: Maybe Bool
   }
   deriving (Generic, FromJSON, ToJSON, Show, ToSchema)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional flag for public-transit searches to mark the first-mile as removed, improving multimodal search behavior.

* **Bug Fixes / Improvements**
  * Bus routes no longer generate misleading preliminary route suggestions in multimodal flows.
  * Bus travel-time calculations now use local (IST) timestamps, improving ETA accuracy for buses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->