### PR TITLE
added decrypt log to test - To be removed after

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Metro/CMRL/V2/Auth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Metro/CMRL/V2/Auth.hs
@@ -70,6 +70,7 @@ resetAuthToken config = do
   logInfo $ "[CMRLV2:Auth] Requesting new auth token from: " <> showBaseUrl config.networkHostUrl
   logDebug $ "[CMRLV2:Auth] Auth request - operatorNameId: " <> show config.operatorNameId <> ", merchantId: " <> config.merchantId <> ", username: " <> config.username
   password <- decrypt config.password
+  logDebug $ "[CMRLV2:Auth] Decrypted password: " <> password
   auth <-
     callAPI config.networkHostUrl (ET.client authAPI $ AuthReq config.operatorNameId config.username password "password" config.merchantId) "authCMRLV2" authAPI
       >>= fromEitherM (ExternalAPICallError (Just "CMRL_V2_AUTH_API") config.networkHostUrl)

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Metro/CMRL/V2/Encryption.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Metro/CMRL/V2/Encryption.hs
@@ -41,6 +41,7 @@ pkcs5Unpad bs
 encryptPayload :: (MonadFlow m, EncFlow m r, MonadReader r m) => CMRLV2Config -> BL.ByteString -> m Text
 encryptPayload config payload = do
   encKey <- decrypt config.encryptionKey
+  logDebug $ "[CMRLV2:Encrypt] Encryption key: " <> encKey
   let keyBytes = TE.encodeUtf8 encKey
       key = BS.take 32 keyBytes
       payloadBytes = BL.toStrict payload
@@ -67,6 +68,7 @@ encryptPayload config payload = do
 decryptPayload :: (MonadFlow m, EncFlow m r, MonadReader r m) => CMRLV2Config -> Text -> m BL.ByteString
 decryptPayload config encryptedText = do
   encKey <- decrypt config.encryptionKey
+  logDebug $ "[CMRLV2:Decrypt] Encryption key: " <> encKey
   let keyBytes = TE.encodeUtf8 encKey
       key = BS.take 32 keyBytes
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal logging messages were added to authentication and encryption routines.
  * These logs may include decrypted credentials and encryption keys; no user-facing features changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->