### PR TITLE
feat: add eligible pass ids for fleet

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -269,6 +269,7 @@ types:
     ss: [TransportStation]
     rsm: [TransportRouteStopMapping]
     ptcv: Text
+    eligiblePassIds: Maybe [Text]
     derive': "Generic, ToSchema"
 
   UpdatePaymentOrderReq:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -271,7 +271,7 @@ data PaymentOrder = PaymentOrder {sdkPayload :: Kernel.Prelude.Maybe Kernel.Exte
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data PublicTransportData = PublicTransportData {ptcv :: Kernel.Prelude.Text, rs :: [TransportRoute], rsm :: [TransportRouteStopMapping], ss :: [TransportStation]}
+data PublicTransportData = PublicTransportData {eligiblePassIds :: Kernel.Prelude.Maybe [Kernel.Prelude.Text], ptcv :: Kernel.Prelude.Text, rs :: [TransportRoute], rsm :: [TransportRouteStopMapping], ss :: [TransportStation]}
   deriving stock (Generic)
   deriving anyclass (ToSchema)
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -910,6 +910,11 @@ getPublicTransportDataImpl (mbPersonId, merchantId) mbCity mbEnableSwitchRoute _
           Nothing -> getVehicleLiveRouteInfo vehicleNumber integratedBPPConfigs
       Nothing -> return Nothing
 
+  -- eligiblePassIds are vehicle-level data.
+  -- They must be present only when live vehicle info exists.
+  let mbEligiblePassIds =
+        mbVehicleLiveRouteInfo >>= (JMU.eligiblePassIds . snd)
+
   let mbOppositeTripDetails :: Maybe [NandiTypes.BusScheduleTrip] =
         case (mbEnableSwitchRoute, isPublicVehicleData) of
           (Just True, False) -> do
@@ -987,7 +992,8 @@ getPublicTransportDataImpl (mbPersonId, merchantId) mbCity mbEnableSwitchRoute _
                         }
                   )
                   routeStops,
-              ptcv = gtfsVersion
+              ptcv = gtfsVersion,
+              eligiblePassIds = Nothing
             }
 
   let fetchData mbRouteCodeAndServiceType bppConfig = do
@@ -1058,7 +1064,8 @@ getPublicTransportDataImpl (mbPersonId, merchantId) mbCity mbEnableSwitchRoute _
           { ss = concatMap (.ss) transportDataList,
             rs = concatMap (.rs) transportDataList,
             rsm = concatMap (.rsm) transportDataList,
-            ptcv = T.intercalate (T.pack "#") gtfsVersion <> (maybe "" (\version -> "#" <> show version) (riderConfig >>= (.domainPublicTransportDataVersion)))
+            ptcv = T.intercalate (T.pack "#") gtfsVersion <> (maybe "" (\version -> "#" <> show version) (riderConfig >>= (.domainPublicTransportDataVersion))),
+            eligiblePassIds = mbEligiblePassIds
           }
   return transportData
   where

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
@@ -1412,7 +1412,8 @@ data VehicleLiveRouteInfo = VehicleLiveRouteInfo
     remaining_trip_details :: Maybe [NandiTypes.BusScheduleTrip],
     isActuallyValid :: Maybe Bool,
     busConductorId :: Maybe Text,
-    busDriverId :: Maybe Text
+    busDriverId :: Maybe Text,
+    eligiblePassIds :: Maybe [Text]
   }
   deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
 
@@ -1457,7 +1458,7 @@ getVehicleLiveRouteInfoUnsafe integratedBPPConfigs vehicleNumber mbPassVerifyReq
         mbResult
           <&> ( \result ->
                   ( integratedBPPConfig,
-                    VehicleLiveRouteInfo {routeNumber = result.route_number, vehicleNumber = vehicleNumber, routeCode = result.route_id, serviceType = result.service_type, waybillId = result.waybill_id, scheduleNo = result.schedule_no, depot = result.depot, isActuallyValid = result.is_actually_valid, remaining_trip_details = result.remaining_trip_details, tripNumber = result.trip_number, busConductorId = result.conductor_id, busDriverId = result.driver_id}
+                    VehicleLiveRouteInfo {routeNumber = result.route_number, vehicleNumber = vehicleNumber, routeCode = result.route_id, serviceType = result.service_type, waybillId = result.waybill_id, scheduleNo = result.schedule_no, depot = result.depot, isActuallyValid = result.is_actually_valid, remaining_trip_details = result.remaining_trip_details, tripNumber = result.trip_number, busConductorId = result.conductor_id, busDriverId = result.driver_id, eligiblePassIds = result.eligible_pass_ids}
                   )
               )
 

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Types.hs
@@ -88,7 +88,8 @@ data VehicleServiceTypeResponse = VehicleServiceTypeResponse
     remaining_trip_details :: Maybe [BusScheduleTrip],
     is_actually_valid :: Maybe Bool,
     driver_id :: Maybe Text,
-    conductor_id :: Maybe Text
+    conductor_id :: Maybe Text,
+    eligible_pass_ids :: Maybe [Text]
   }
   deriving (Generic, FromJSON, ToJSON, ToSchema, Show)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multimodal confirmation now surfaces optional eligible pass IDs for public-transport trips.

* **Updates**
  * Eligible pass IDs are propagated from vehicle/route data through to the multimodal public-transport response and API schema.
  * External service payloads and internal route representations now include an optional list of eligible pass IDs to support journey confirmations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->