### PR TITLE
chore(nix): Exclude vira.hs from treefmt

### DIFF
--- a/Backend/default.nix
+++ b/Backend/default.nix
@@ -48,6 +48,9 @@
         ./nix/pre-commit.nix
       ];
       pre-commit.settings.hooks.treefmt.enable = lib.mkForce false;
+      treefmt.config.settings.formatter.ormolu.excludes = [
+        "vira.hs"
+      ];
 
       haskellProjects.default = {
         projectRoot = ./.;


### PR DESCRIPTION
This is needed to unbreak `, run-generator -- --apply-hint --skip-update`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend build configuration to exclude specific files from automatic formatting checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->