### PR TITLE
fix: call otp in routeServiceability based on params

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -343,11 +343,21 @@ types:
     schedules: [ScheduledVehicleInfo]
     alternateRouteInfo: Maybe [AlternateRouteDetails]
 
+  LegRouteWithLiveVehicle:
+    legOrder: Int
+    routeWithLiveVehicles: [RouteWithLiveVehicle]
+
   RouteServiceabilityResp:
-    enum: "LiveRouteInfo RouteWithLiveVehicle, AlternateLiveRoutesInfo [RouteWithLiveVehicle]"
+    legs: [LegRouteWithLiveVehicle]
+
+  RouteCodesWithLeg:
+    legOrder: Int
+    routeCodes: [Text]
+    derive: "Show"
 
   RouteServiceabilityReq:
-    routeCode: Maybe Text
+    routeCodes: Maybe [RouteCodesWithLeg]
+    callOtp: Maybe Bool
     onlySelectedRoute: Maybe Bool
     sourceStopCode: Maybe Text
     destinationStopCode: Maybe Text

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -184,6 +184,10 @@ data KafKaPacket = KafKaPacket
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
+data LegRouteWithLiveVehicle = LegRouteWithLiveVehicle {legOrder :: Kernel.Prelude.Int, routeWithLiveVehicles :: [RouteWithLiveVehicle]}
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data LegServiceTierOptionsResp = LegServiceTierOptionsResp {options :: [Domain.Types.RouteDetails.AvailableRoutesByTier]}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -302,19 +306,22 @@ data RouteAvailabilityResp = RouteAvailabilityResp {availableRoutes :: [Availabl
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
+data RouteCodesWithLeg = RouteCodesWithLeg {legOrder :: Kernel.Prelude.Int, routeCodes :: [Kernel.Prelude.Text]}
+  deriving stock (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data RouteServiceabilityReq = RouteServiceabilityReq
-  { destinationStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+  { callOtp :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
+    destinationStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     onlySelectedRoute :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
-    routeCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    routeCodes :: Kernel.Prelude.Maybe [RouteCodesWithLeg],
     serviceTierType :: Kernel.Prelude.Maybe BecknV2.FRFS.Enums.ServiceTierType,
     sourceStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text
   }
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data RouteServiceabilityResp
-  = LiveRouteInfo RouteWithLiveVehicle
-  | AlternateLiveRoutesInfo [RouteWithLiveVehicle]
+data RouteServiceabilityResp = RouteServiceabilityResp {legs :: [LegRouteWithLiveVehicle]}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Error.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Error.hs
@@ -1039,6 +1039,7 @@ data MultimodalError
   | StopDoesNotHaveLocation Text
   | CategoriesAndTotalPriceMismatch Text Text
   | NoSelectedCategoryFound Text
+  | NoValidBusRoute Text Text
   deriving (Eq, Show, IsBecknAPIError)
 
 instanceExceptionWithParent 'HTTPException ''MultimodalError
@@ -1063,12 +1064,14 @@ instance IsBaseError MultimodalError where
     StopDoesNotHaveLocation reason -> Just $ "Stop does not have location: " <> reason
     CategoriesAndTotalPriceMismatch categoriesTotalPrice totalPrice -> Just $ "Categories and total price mismatch: " <> categoriesTotalPrice <> " and " <> totalPrice
     NoSelectedCategoryFound quoteId -> Just $ "No selected category found in quote categories, quoteId : " <> quoteId
+    NoValidBusRoute source dest -> Just $ "No valid bus route found between " <> source <> " and " <> dest
 
 instance IsHTTPError MultimodalError where
   toErrorCode = \case
     InvalidStationChange _ _ -> "INVALID_STATION_CHANGE"
     NoValidMetroRoute _ _ -> "NO_VALID_METRO_ROUTE"
     MetroLegNotFound _ -> "METRO_LEG_NOT_FOUND"
+    NoValidBusRoute _ _ -> "NO_VALID_BUS_ROUTE"
     NoValidSubwayRoute _ _ -> "NO_VALID_SUBWAY_ROUTE"
     SubwayLegNotFound _ -> "SUBWAY_LEG_NOT_FOUND"
     InvalidLegOrder _ -> "INVALID_LEG_ORDER"
@@ -1090,6 +1093,7 @@ instance IsHTTPError MultimodalError where
     NoValidMetroRoute _ _ -> E400
     MetroLegNotFound _ -> E400
     NoValidSubwayRoute _ _ -> E400
+    NoValidBusRoute _ _ -> E400
     SubwayLegNotFound _ -> E400
     InvalidLegOrder _ -> E400
     OSRMFailure _ -> E500


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multimodal routing now returns per-leg results with live vehicle details and route codes.
  * Added an option to request routing with or without OTP verification (callOtp).
  * Requests can include per-leg route code selections.

* **Refactor**
  * Routing flow reorganized to produce a consistent response shape across OTP and non-OTP paths.

* **Bug Fixes**
  * Improved user-facing error for "no valid bus route" between source and destination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->