### PR TITLE
feat: extend onboarding API response status enum with PULL_REQUIRED a…

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Fleet/API/Onboarding.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Fleet/API/Onboarding.yaml
@@ -166,7 +166,7 @@ types:
     verificationMessage: Maybe Text
     verificationUrl: Maybe BaseUrl
   ResponseStatus:
-    enum: "NO_DOC_AVAILABLE,PENDING,VALID,FAILED,INVALID,LIMIT_EXCEED,MANUAL_VERIFICATION_REQUIRED,UNAUTHORIZED"
+    enum: "NO_DOC_AVAILABLE,PENDING,VALID,FAILED,INVALID,LIMIT_EXCEED,MANUAL_VERIFICATION_REQUIRED,UNAUTHORIZED,PULL_REQUIRED,CONSENT_DENIED"
   VehicleDocumentItem:
     registrationNo: Text
     userSelectedVehicleCategory: VehicleCategory

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Fleet/Endpoints/Onboarding.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Fleet/Endpoints/Onboarding.hs
@@ -110,6 +110,8 @@ data ResponseStatus
   | LIMIT_EXCEED
   | MANUAL_VERIFICATION_REQUIRED
   | UNAUTHORIZED
+  | PULL_REQUIRED
+  | CONSENT_DENIED
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Onboarding.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Onboarding.hs
@@ -210,5 +210,5 @@ castResponseStatus = \case
   SStatus.LIMIT_EXCEED -> CommonOnboarding.LIMIT_EXCEED
   SStatus.MANUAL_VERIFICATION_REQUIRED -> CommonOnboarding.MANUAL_VERIFICATION_REQUIRED
   SStatus.UNAUTHORIZED -> CommonOnboarding.UNAUTHORIZED
-  SStatus.PULL_REQUIRED -> CommonOnboarding.PENDING -- Map to PENDING until Fleet API supports PULL_REQUIRED
-  SStatus.CONSENT_DENIED -> CommonOnboarding.FAILED -- Map to FAILED as consent was denied
+  SStatus.PULL_REQUIRED -> CommonOnboarding.PULL_REQUIRED
+  SStatus.CONSENT_DENIED -> CommonOnboarding.CONSENT_DENIED


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now includes two additional statuses: PULL_REQUIRED and CONSENT_DENIED, enabling more specific verification outcomes to be reported.
  * Internal status handling updated so these new statuses are surfaced consistently in onboarding responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->