### PR TITLE
perf/refactor: cache otp indirect resolved routes

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Location.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Location.hs
@@ -5,7 +5,7 @@ import Domain.Types.Location
 makeLocationAPIEntity :: Location -> LocationAPIEntity
 makeLocationAPIEntity Location {..} =
   let LocationAddress {..} = address
-  in LocationAPIEntity
-    { door = door,
-      ..
-    }
+   in LocationAPIEntity
+        { door = door,
+          ..
+        }

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -345,7 +345,6 @@ types:
     routeShortName: Text
     liveVehicles: [LiveVehicleInfo]
     schedules: [ScheduledVehicleInfo]
-    alternateRouteInfo: Maybe [AlternateRouteDetails]
 
   LegRouteWithLiveVehicle:
     legOrder: Int
@@ -356,8 +355,8 @@ types:
     requestedDestinationStop: Text
     effectiveSourceStop: Text
     effectiveDestinationStop: Text
-    sourceChanged: Bool
-    destinationChanged: Bool
+    sourceStopNameChanged: Bool
+    destStopNameChanged: Bool
 
   RouteServiceabilityResp:
     legs: [LegRouteWithLiveVehicle]
@@ -370,11 +369,8 @@ types:
 
   RouteServiceabilityReq:
     routeCodes: Maybe [RouteCodesWithLeg]
-    callOtp: Maybe Bool
-    onlySelectedRoute: Maybe Bool
     sourceStopCode: Maybe Text
     destinationStopCode: Maybe Text
-    serviceTierType: Maybe ServiceTierType
     derive: "Show"
 
   AvailableRoute:
@@ -386,7 +382,6 @@ types:
     routeShortName: Text
     routeLongName: Text
     routeTimings: "[Seconds]"
-    serviceSubTypes: "Maybe [ServiceSubType]"
 
   SwitchRouteReq:
     journeyId: Id Journey

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -71,12 +71,12 @@ data ChangeStopsResp = ChangeStopsResp {stationsChanged :: Kernel.Prelude.Bool}
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data EffectiveStops = EffectiveStops
-  { destinationChanged :: Kernel.Prelude.Bool,
+  { destStopNameChanged :: Kernel.Prelude.Bool,
     effectiveDestinationStop :: Kernel.Prelude.Text,
     effectiveSourceStop :: Kernel.Prelude.Text,
     requestedDestinationStop :: Kernel.Prelude.Text,
     requestedSourceStop :: Kernel.Prelude.Text,
-    sourceChanged :: Kernel.Prelude.Bool
+    sourceStopNameChanged :: Kernel.Prelude.Bool
   }
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -323,11 +323,8 @@ data RouteCodesWithLeg = RouteCodesWithLeg {legOrder :: Kernel.Prelude.Int, rout
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data RouteServiceabilityReq = RouteServiceabilityReq
-  { callOtp :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
-    destinationStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
-    onlySelectedRoute :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
+  { destinationStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     routeCodes :: Kernel.Prelude.Maybe [RouteCodesWithLeg],
-    serviceTierType :: Kernel.Prelude.Maybe BecknV2.FRFS.Enums.ServiceTierType,
     sourceStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text
   }
   deriving stock (Generic, Show)
@@ -341,13 +338,7 @@ data RouteStopMapping = RouteStopMapping {code :: Kernel.Prelude.Text, lat :: Ke
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data RouteWithLiveVehicle = RouteWithLiveVehicle
-  { alternateRouteInfo :: Kernel.Prelude.Maybe [AlternateRouteDetails],
-    liveVehicles :: [LiveVehicleInfo],
-    routeCode :: Kernel.Prelude.Text,
-    routeShortName :: Kernel.Prelude.Text,
-    schedules :: [ScheduledVehicleInfo]
-  }
+data RouteWithLiveVehicle = RouteWithLiveVehicle {liveVehicles :: [LiveVehicleInfo], routeCode :: Kernel.Prelude.Text, routeShortName :: Kernel.Prelude.Text, schedules :: [ScheduledVehicleInfo]}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster OTP-based route resolution via caching for quicker multimodal responses and fewer repeated lookups.
  * Effective stop-change detection added to compute and expose when source/destination stop names differ.

* **API Changes**
  * Simplified multimodal routing payloads by removing several unused/optional fields.
  * Renamed stop-change fields to explicitly indicate stop-name changes.

* **Schema**
  * Route leg/resolution data now includes expanded serialization and schema support for more consistent API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->