### PR TITLE
backend/fix: disable probe for singlemode subway

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Fare.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Fare.hs
@@ -138,7 +138,7 @@ getFares riderId merchantId merchantOperatingCityId integratedBPPConfig fareRout
           -- Cached fares available: fork probing calls in background
           let probeWindow = fromMaybe 60 (apiConfig <&> (.canaryWindowSeconds))
           probeCount <- CB.getProbeCounter ptMode CB.FareAPI merchantOperatingCityId
-          when (alwaysProbe || probeCount < probeLimit) $ do
+          when (not isSingleMode && (alwaysProbe || probeCount < probeLimit)) $ do
             -- Fork a background probe request for circuit breaker tracking
             fork "probe-fare-api" $ do
               unless alwaysProbe $ void $ CB.incrementProbeCounter ptMode CB.FareAPI merchantOperatingCityId probeWindow


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Disable probe api calls for single mode subway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized background fare probing to better respect single-mode configurations, improving system reliability and reducing unnecessary background processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->