### PR TITLE
Harden image-api-helper paths and remove shell-based S3 execution

### DIFF
--- a/Backend/app/utils/image-api-helper/src/API/DecodeFile.hs
+++ b/Backend/app/utils/image-api-helper/src/API/DecodeFile.hs
@@ -14,14 +14,16 @@
 
 module API.DecodeFile where
 
+import Data.Char (isAlphaNum)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base64 as B64
 import Data.String.Conversions
+import qualified Data.Text as T
 import Environment
 import Kernel.Mock.App hiding (runMock)
 import Kernel.Prelude
 import Kernel.Types.Error (GenericError (InvalidRequest))
-import Kernel.Utils.Common
+import Kernel.Utils.Common (fromEitherM, fromMaybeM)
 import Servant
 
 type DecodeFileAPI =
@@ -37,7 +39,24 @@ data DecodeFileReq = DecodeFileReq
 
 decodeFileHandler :: DecodeFileReq -> MockM AppEnv Text
 decodeFileHandler req = {- apiHandler $ -} do
-  let path = cs req.filePath
+  path <- toSandboxedPath req.filePath & fromMaybeM (InvalidRequest "filePath must be a simple file name")
   raw <- B64.decode (cs req.base64) & fromEitherM (InvalidRequest . cs)
   liftIO $ B.writeFile path raw
   pure "OK"
+
+toSandboxedPath :: Text -> Maybe FilePath
+toSandboxedPath rawName = do
+  let fileName = T.strip rawName
+  guard $ isValidFileName fileName
+  pure $ "/tmp/image-api-helper-" <> T.unpack fileName
+
+isValidFileName :: Text -> Bool
+isValidFileName fileName =
+  not (T.null fileName)
+    && T.length fileName <= 128
+    && fileName /= "."
+    && fileName /= ".."
+    && T.all isSafeFileNameChar fileName
+
+isSafeFileNameChar :: Char -> Bool
+isSafeFileNameChar char = isAlphaNum char || char `elem` ['.', '_', '-']

--- a/Backend/app/utils/image-api-helper/src/API/EncodeFile.hs
+++ b/Backend/app/utils/image-api-helper/src/API/EncodeFile.hs
@@ -14,12 +14,16 @@
 
 module API.EncodeFile where
 
+import Data.Char (isAlphaNum)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base64 as B64
 import Data.String.Conversions
+import qualified Data.Text as T
 import Environment
 import Kernel.Mock.App hiding (runMock)
 import Kernel.Prelude
+import Kernel.Types.Error (GenericError (InvalidRequest))
+import Kernel.Utils.Common (fromMaybeM)
 import Servant
 
 type EncodeFileAPI =
@@ -39,7 +43,24 @@ newtype EncodeFileResp = EncodeFileResp
 
 encodeFileHandler :: EncodeFileReq -> MockM AppEnv EncodeFileResp
 encodeFileHandler req = do
-  let path = req.filePath
-  raw <- liftIO $ B.readFile $ cs path
+  path <- toSandboxedPath req.filePath & fromMaybeM (InvalidRequest "filePath must be a simple file name")
+  raw <- liftIO $ B.readFile path
   let base64 = cs $ B64.encode raw
   pure EncodeFileResp {base64}
+
+toSandboxedPath :: Text -> Maybe FilePath
+toSandboxedPath rawName = do
+  let fileName = T.strip rawName
+  guard $ isValidFileName fileName
+  pure $ "/tmp/image-api-helper-" <> T.unpack fileName
+
+isValidFileName :: Text -> Bool
+isValidFileName fileName =
+  not (T.null fileName)
+    && T.length fileName <= 128
+    && fileName /= "."
+    && fileName /= ".."
+    && T.all isSafeFileNameChar fileName
+
+isSafeFileNameChar :: Char -> Bool
+isSafeFileNameChar char = isAlphaNum char || char `elem` ['.', '_', '-']

--- a/Backend/app/utils/image-api-helper/src/App.hs
+++ b/Backend/app/utils/image-api-helper/src/App.hs
@@ -27,6 +27,7 @@ import Kernel.Utils.Logging
 import Network.Wai.Handler.Warp
   ( defaultSettings,
     runSettings,
+    setHost,
     setPort,
   )
 
@@ -36,7 +37,7 @@ runMock _cfgModifier = do
   withAppEnv appCfg $ \appEnv -> do
     let port = appCfg.port
         settings =
-          defaultSettings & setPort port
+          defaultSettings & setHost "127.0.0.1" & setPort port
         reqRespLogger :: Text -> Text -> IO ()
         reqRespLogger tag info = runReaderT (runMockM $ withLogTag tag $ logOutput INFO info) appEnv
 

--- a/Backend/lib/beckn-services/src/AWS/S3/Flow.hs
+++ b/Backend/lib/beckn-services/src/AWS/S3/Flow.hs
@@ -61,7 +61,7 @@ import qualified System.Directory as Dir
 import System.FilePath.Posix as Path
 import qualified System.Posix.Files as Posix
 import qualified System.Posix.IO as Posix
-import System.Process
+import System.Process (callProcess)
 
 type S3GetAPI = Get '[S3ImageData] Text
 
@@ -164,8 +164,10 @@ get'' ::
   m Text
 get'' bucketName path = withLogTag "S3" $ do
   let tmpPath = getTmpPath path
-  let cmd = "aws s3api get-object --bucket " <> T.unpack bucketName <> " --key " <> path <> " " <> tmpPath
-  liftIO $ callCommand cmd
+  liftIO $
+    callProcess
+      "aws"
+      ["s3api", "get-object", "--bucket", T.unpack bucketName, "--key", path, tmpPath]
   result <- liftIO $ readFile tmpPath
   liftIO $ removeFile tmpPath
   return result
@@ -181,8 +183,10 @@ put'' ::
 put'' bucketName path img = withLogTag "S3" $ do
   let tmpPath = getTmpPath path
   liftIO $ writeFile_ tmpPath img
-  let cmd = "aws s3api put-object --bucket " <> T.unpack bucketName <> " --key " <> path <> " --body " <> tmpPath
-  liftIO $ callCommand cmd
+  liftIO $
+    callProcess
+      "aws"
+      ["s3api", "put-object", "--bucket", T.unpack bucketName, "--key", path, "--body", tmpPath]
   liftIO $ removeFile tmpPath
   where
     writeFile_ path_ img_ = do
@@ -202,8 +206,10 @@ putRaw'' ::
 putRaw'' bucketName path bs _contentType = withLogTag "S3" $ do
   let tmpPath = getTmpPath path
   liftIO $ BS.writeFile tmpPath bs
-  let cmd = "aws s3api put-object --bucket " <> T.unpack bucketName <> " --key " <> path <> " --body " <> tmpPath <> " --content-type " <> _contentType
-  liftIO $ callCommand cmd
+  liftIO $
+    callProcess
+      "aws"
+      ["s3api", "put-object", "--bucket", T.unpack bucketName, "--key", path, "--body", tmpPath, "--content-type", _contentType]
   liftIO $ removeFile tmpPath
 
 delete'' ::
@@ -214,8 +220,10 @@ delete'' ::
   String ->
   m ()
 delete'' bucketName path = withLogTag "S3" $ do
-  let cmd = "aws s3api delete-object --bucket " <> T.unpack bucketName <> " --key " <> path
-  liftIO $ callCommand cmd
+  liftIO $
+    callProcess
+      "aws"
+      ["s3api", "delete-object", "--bucket", T.unpack bucketName, "--key", path]
 
 getTmpPath :: String -> String
 getTmpPath = (<>) "/tmp/" . T.unpack . DL.last . T.split (== '/') . T.pack


### PR DESCRIPTION
## Summary
- harden image-api-helper so requests can no longer read or write arbitrary filesystem paths
- bind image-api-helper to 127.0.0.1 by default to avoid accidental network exposure
- replace shell-built aws s3api invocations with argument-based process execution to remove command injection risk

## Vulnerabilities addressed
- image-api-helper previously accepted a client-controlled file path and passed it directly to readFile/writeFile, which allowed arbitrary file read and write if the helper was reachable
- the S3 wrapper previously built aws CLI commands via string concatenation and executed them through the shell, which allowed command injection when untrusted values reached S3 keys or content types

## Fix details
- image-api-helper now accepts only simple file names, validates them with an allowlist, and maps them into /tmp/image-api-helper-<name>
- invalid file names are rejected with InvalidRequest
- the helper now binds only to localhost
- AWS.S3.Flow now uses callProcess with explicit argv lists for get/put/delete operations instead of callCommand

## Validation
- confirmed in source that AWS.S3.Flow no longer uses callCommand and now uses callProcess
- confirmed in source that EncodeFile/DecodeFile route file access through sandboxed path helpers
- confirmed in source that the helper binds to 127.0.0.1
- full project build could not be completed in this Windows environment because the repo depends on external Haskell packages not present in the checkout, and beckn-services also depends on unix which is not buildable here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file path validation and sanitization to prevent unauthorized access during file upload and download operations.
  * Restricted server binding to localhost for improved security posture.

* **Security**
  * Replaced shell-based operations with direct process calls for AWS S3 interactions to eliminate command injection vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->