### PR TITLE
[4/8] ops: connection pool alerts & Kafka topic documentation

### DIFF
--- a/Backend/monitoring/alerts/connection_pool_alerts.yml
+++ b/Backend/monitoring/alerts/connection_pool_alerts.yml
@@ -47,6 +47,7 @@ groups:
             New requests may block waiting for a connection.
 
       # Pool metrics not being reported (monitor thread may have died)
+      # Note: absent() without label selectors won't detect per-pod outages in multi-replica deployments
       - alert: PgPoolMetricsAbsent
         expr: absent(db_pool_size)
         for: 5m

--- a/Backend/monitoring/alerts/connection_pool_alerts.yml
+++ b/Backend/monitoring/alerts/connection_pool_alerts.yml
@@ -1,5 +1,9 @@
 # Prometheus alerting rules for connection pool health monitoring.
 # Deploy alongside your Prometheus configuration.
+#
+# DEPENDENCY: Metrics (db_pool_size, db_pool_in_use, db_pool_idle,
+# db_pool_utilization_ratio) are emitted by Utils.ConnectionPoolMetrics
+# in dynamic-offer-driver-app (PR #13977).
 
 groups:
   - name: connection_pool_health
@@ -42,14 +46,14 @@ groups:
             All {{ $labels.service }}/{{ $labels.pool }} pool connections are in use.
             New requests may block waiting for a connection.
 
-      # Pool size unexpectedly at zero (misconfiguration or pool destroyed)
-      - alert: PgPoolEmpty
-        expr: db_pool_size == 0
-        for: 1m
+      # Pool metrics not being reported (monitor thread may have died)
+      - alert: PgPoolMetricsAbsent
+        expr: absent(db_pool_size)
+        for: 5m
         labels:
-          severity: critical
+          severity: warning
         annotations:
-          summary: "PostgreSQL pool size is zero ({{ $labels.service }}/{{ $labels.pool }})"
+          summary: "PostgreSQL pool metrics are not being reported"
           description: >
-            Pool {{ $labels.service }}/{{ $labels.pool }} reports size 0.
-            This indicates a misconfiguration or pool destruction.
+            No db_pool_size metric received for 5+ minutes.
+            The pool monitoring thread may have crashed or the service may be down.

--- a/Backend/monitoring/alerts/connection_pool_alerts.yml
+++ b/Backend/monitoring/alerts/connection_pool_alerts.yml
@@ -1,0 +1,55 @@
+# Prometheus alerting rules for connection pool health monitoring.
+# Deploy alongside your Prometheus configuration.
+
+groups:
+  - name: connection_pool_health
+    rules:
+      # PostgreSQL pool utilization > 80% for 5 minutes
+      - alert: PgPoolHighUtilization
+        expr: db_pool_utilization_ratio > 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL pool utilization high ({{ $labels.service }}/{{ $labels.pool }})"
+          description: >
+            Pool utilization is {{ $value | humanizePercentage }} for
+            {{ $labels.service }}/{{ $labels.pool }}.
+            Consider increasing connectionPoolCount or investigating slow queries.
+
+      # PostgreSQL pool utilization > 95% for 2 minutes (critical)
+      - alert: PgPoolNearExhaustion
+        expr: db_pool_utilization_ratio > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "PostgreSQL pool near exhaustion ({{ $labels.service }}/{{ $labels.pool }})"
+          description: >
+            Pool utilization is {{ $value | humanizePercentage }} for
+            {{ $labels.service }}/{{ $labels.pool }}.
+            Connection exhaustion imminent — requests will start blocking.
+
+      # No idle connections for 5 minutes
+      - alert: PgPoolNoIdleConnections
+        expr: db_pool_idle == 0 and db_pool_size > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No idle PostgreSQL connections ({{ $labels.service }}/{{ $labels.pool }})"
+          description: >
+            All {{ $labels.service }}/{{ $labels.pool }} pool connections are in use.
+            New requests may block waiting for a connection.
+
+      # Pool size unexpectedly at zero (misconfiguration or pool destroyed)
+      - alert: PgPoolEmpty
+        expr: db_pool_size == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "PostgreSQL pool size is zero ({{ $labels.service }}/{{ $labels.pool }})"
+          description: >
+            Pool {{ $labels.service }}/{{ $labels.pool }} reports size 0.
+            This indicates a misconfiguration or pool destruction.

--- a/Backend/monitoring/alerts/drainer_alerts.yml
+++ b/Backend/monitoring/alerts/drainer_alerts.yml
@@ -1,57 +1,44 @@
 # Prometheus alerting rules for drainer health monitoring.
 # Covers both rider-app-drainer and dynamic-offer-driver-drainer.
+#
+# Actual metrics emitted by drainers:
+#   Rider:  query_execution_failure_error, drainer_stop_status,
+#           peek_db_command_error, drop_db_command_error, parse_db_command_error,
+#           query_drain_latency, drainer_query_executes
+#   Driver: driver_query_execution_failure_error, driver_drainer_stop_status,
+#           driver_peek_db_command_error, driver_drop_db_command_error,
+#           driver_parse_db_command_error, driver_query_drain_latency,
+#           driver_drainer_query_executes
 
 groups:
   - name: drainer_health
     rules:
-      # Drainer lag exceeds 30 seconds
-      - alert: DrainerLagHigh
-        expr: drainer_lag_seconds > 30 or driver_drainer_lag_seconds > 30
-        for: 2m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Drainer lag exceeds 30 seconds"
-          description: >
-            Drainer lag is {{ $value | humanize }}s.
-            Data in Redis is not being written to PostgreSQL in a timely manner.
-            Check DB connection health and query performance.
-
-      # Drainer lag exceeds 120 seconds (critical)
-      - alert: DrainerLagCritical
-        expr: drainer_lag_seconds > 120 or driver_drainer_lag_seconds > 120
-        for: 1m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Drainer lag exceeds 2 minutes — risk of data loss"
-          description: >
-            Drainer lag is {{ $value | humanize }}s.
-            Redis stream is growing faster than drainer can process.
-            Immediate investigation required.
-
-      # Any drainer errors occurring
-      - alert: DrainerErrorsDetected
-        expr: rate(drainer_errors_total[5m]) > 0 or rate(driver_drainer_errors_total[5m]) > 0
+      # Query execution failures detected
+      - alert: DrainerQueryFailures
+        expr: >
+          rate(query_execution_failure_error[5m]) > 0
+          or rate(driver_query_execution_failure_error[5m]) > 0
         for: 1m
         labels:
           severity: warning
         annotations:
-          summary: "Drainer is experiencing errors"
+          summary: "Drainer DB query execution failures"
           description: >
-            Drainer error rate is {{ $value | humanize }}/s over the last 5 minutes.
-            Check logs for PeekDBCommandError, QueryExecutionFailure, or ParseDBCommandError.
+            Database query failures detected in drainer.
+            Check PostgreSQL connectivity and schema compatibility.
 
-      # High error rate (sustained)
-      - alert: DrainerErrorRateHigh
-        expr: rate(drainer_errors_total[5m]) > 0.1 or rate(driver_drainer_errors_total[5m]) > 0.1
+      # Sustained high query failure rate
+      - alert: DrainerQueryFailureRateHigh
+        expr: >
+          sum(rate(query_execution_failure_error[5m])) > 0.1
+          or sum(rate(driver_query_execution_failure_error[5m])) > 0.1
         for: 5m
         labels:
           severity: critical
         annotations:
-          summary: "Sustained high drainer error rate"
+          summary: "Sustained high drainer query failure rate"
           description: >
-            Drainer error rate has been {{ $value | humanize }}/s for 5+ minutes.
+            Drainer query failure rate has been {{ $value | humanize }}/s for 5+ minutes.
             Drainer may be stuck in a failure loop. Check DB and Redis connectivity.
 
       # Drainer is stopped (dead man's switch)
@@ -81,28 +68,34 @@ groups:
             The drainer process may have crashed or failed to start.
             Check pod/container status.
 
-      # Items pending growing (backlog building up)
-      - alert: DrainerBacklogGrowing
-        expr: drainer_items_pending > 10000 or driver_drainer_items_pending > 10000
+      # Peek/drop/parse errors indicate stream corruption or schema drift
+      - alert: DrainerStreamErrors
+        expr: >
+          rate(peek_db_command_error[5m]) > 0
+          or rate(drop_db_command_error[5m]) > 0
+          or rate(parse_db_command_error[5m]) > 0
+          or rate(driver_peek_db_command_error[5m]) > 0
+          or rate(driver_drop_db_command_error[5m]) > 0
+          or rate(driver_parse_db_command_error[5m]) > 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Drainer stream read/parse errors detected"
+          description: >
+            Drainer is encountering errors reading or parsing commands from Redis.
+            Check for schema drift (schema_variation_alert) or Redis connectivity issues.
+
+      # High drain latency indicates DB slowness
+      - alert: DrainerHighLatency
+        expr: >
+          histogram_quantile(0.95, rate(query_drain_latency_bucket[5m])) > 5
+          or histogram_quantile(0.95, rate(driver_query_drain_latency_bucket[5m])) > 5
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "Drainer backlog exceeds 10,000 items"
+          summary: "Drainer query drain latency is high (p95 > 5s)"
           description: >
-            {{ $value | humanize }} items pending in Redis stream shard.
-            Drainer may be unable to keep up with write volume.
-
-      # Query execution failures
-      - alert: DrainerQueryFailures
-        expr: >
-          rate(query_execution_failure_error[5m]) > 0
-          or rate(driver_query_execution_failure_error[5m]) > 0
-        for: 1m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Drainer DB query execution failures"
-          description: >
-            Database query failures detected in drainer.
-            Check PostgreSQL connectivity and schema compatibility.
+            95th percentile drain latency is {{ $value | humanize }}s.
+            Database may be under heavy load or queries may need optimization.

--- a/Backend/monitoring/alerts/drainer_alerts.yml
+++ b/Backend/monitoring/alerts/drainer_alerts.yml
@@ -30,8 +30,8 @@ groups:
       # Sustained high query failure rate
       - alert: DrainerQueryFailureRateHigh
         expr: >
-          sum(rate(query_execution_failure_error[5m])) > 0.1
-          or sum(rate(driver_query_execution_failure_error[5m])) > 0.1
+          sum by (job, instance)(rate(query_execution_failure_error[5m])) > 0.1
+          or sum by (job, instance)(rate(driver_query_execution_failure_error[5m])) > 0.1
         for: 5m
         labels:
           severity: critical
@@ -55,16 +55,31 @@ groups:
             Check RIDER_DRAINER_STOP / DRIVER_DRAINER_STOP Redis keys
             and drainer logs for the root cause.
 
-      # Drainer not emitting any metrics (process completely dead)
-      - alert: DrainerAbsent
-        expr: absent(drainer_stop_status) or absent(driver_drainer_stop_status)
+      # Rider drainer not emitting any metrics (process completely dead)
+      # Note: absent() without label selectors won't detect per-pod outages in multi-replica deployments
+      - alert: RiderDrainerAbsent
+        expr: absent(drainer_stop_status)
         for: 5m
         labels:
           severity: critical
         annotations:
-          summary: "Drainer process is not running"
+          summary: "rider-app-drainer process is not running"
           description: >
-            No metrics received from drainer for 5+ minutes.
+            No metrics received from rider-app-drainer for 5+ minutes.
+            The drainer process may have crashed or failed to start.
+            Check pod/container status.
+
+      # Driver drainer not emitting any metrics (process completely dead)
+      # Note: absent() without label selectors won't detect per-pod outages in multi-replica deployments
+      - alert: DriverDrainerAbsent
+        expr: absent(driver_drainer_stop_status)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "dynamic-offer-driver-drainer process is not running"
+          description: >
+            No metrics received from dynamic-offer-driver-drainer for 5+ minutes.
             The drainer process may have crashed or failed to start.
             Check pod/container status.
 
@@ -89,8 +104,8 @@ groups:
       # High drain latency indicates DB slowness
       - alert: DrainerHighLatency
         expr: >
-          histogram_quantile(0.95, rate(query_drain_latency_bucket[5m])) > 5
-          or histogram_quantile(0.95, rate(driver_query_drain_latency_bucket[5m])) > 5
+          histogram_quantile(0.95, rate(query_drain_latency_bucket[5m])) > 5 # Unit: seconds
+          or histogram_quantile(0.95, rate(driver_query_drain_latency_bucket[5m])) > 5 # Unit: seconds
         for: 5m
         labels:
           severity: warning

--- a/Backend/monitoring/alerts/drainer_alerts.yml
+++ b/Backend/monitoring/alerts/drainer_alerts.yml
@@ -1,0 +1,108 @@
+# Prometheus alerting rules for drainer health monitoring.
+# Covers both rider-app-drainer and dynamic-offer-driver-drainer.
+
+groups:
+  - name: drainer_health
+    rules:
+      # Drainer lag exceeds 30 seconds
+      - alert: DrainerLagHigh
+        expr: drainer_lag_seconds > 30 or driver_drainer_lag_seconds > 30
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Drainer lag exceeds 30 seconds"
+          description: >
+            Drainer lag is {{ $value | humanize }}s.
+            Data in Redis is not being written to PostgreSQL in a timely manner.
+            Check DB connection health and query performance.
+
+      # Drainer lag exceeds 120 seconds (critical)
+      - alert: DrainerLagCritical
+        expr: drainer_lag_seconds > 120 or driver_drainer_lag_seconds > 120
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Drainer lag exceeds 2 minutes — risk of data loss"
+          description: >
+            Drainer lag is {{ $value | humanize }}s.
+            Redis stream is growing faster than drainer can process.
+            Immediate investigation required.
+
+      # Any drainer errors occurring
+      - alert: DrainerErrorsDetected
+        expr: rate(drainer_errors_total[5m]) > 0 or rate(driver_drainer_errors_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Drainer is experiencing errors"
+          description: >
+            Drainer error rate is {{ $value | humanize }}/s over the last 5 minutes.
+            Check logs for PeekDBCommandError, QueryExecutionFailure, or ParseDBCommandError.
+
+      # High error rate (sustained)
+      - alert: DrainerErrorRateHigh
+        expr: rate(drainer_errors_total[5m]) > 0.1 or rate(driver_drainer_errors_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Sustained high drainer error rate"
+          description: >
+            Drainer error rate has been {{ $value | humanize }}/s for 5+ minutes.
+            Drainer may be stuck in a failure loop. Check DB and Redis connectivity.
+
+      # Drainer is stopped (dead man's switch)
+      - alert: DrainerNotRunning
+        expr: drainer_stop_status == 1 or driver_drainer_stop_status == 1
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Drainer is stopped — data is accumulating in Redis"
+          description: >
+            Drainer has been in stopped state for 2+ minutes.
+            No data is being moved from Redis to PostgreSQL.
+            Check RIDER_DRAINER_STOP / DRIVER_DRAINER_STOP Redis keys
+            and drainer logs for the root cause.
+
+      # Drainer not emitting any metrics (process completely dead)
+      - alert: DrainerAbsent
+        expr: absent(drainer_stop_status) or absent(driver_drainer_stop_status)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Drainer process is not running"
+          description: >
+            No metrics received from drainer for 5+ minutes.
+            The drainer process may have crashed or failed to start.
+            Check pod/container status.
+
+      # Items pending growing (backlog building up)
+      - alert: DrainerBacklogGrowing
+        expr: drainer_items_pending > 10000 or driver_drainer_items_pending > 10000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Drainer backlog exceeds 10,000 items"
+          description: >
+            {{ $value | humanize }} items pending in Redis stream shard.
+            Drainer may be unable to keep up with write volume.
+
+      # Query execution failures
+      - alert: DrainerQueryFailures
+        expr: >
+          rate(query_execution_failure_error[5m]) > 0
+          or rate(driver_query_execution_failure_error[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Drainer DB query execution failures"
+          description: >
+            Database query failures detected in drainer.
+            Check PostgreSQL connectivity and schema compatibility.

--- a/Backend/monitoring/kafka-topic-configurations.md
+++ b/Backend/monitoring/kafka-topic-configurations.md
@@ -1,7 +1,7 @@
 # Kafka Topic Configuration Reference
 
 Recommended partition counts, retention, and compression settings for all
-Namma Yatri Kafka topics. These are enforced in the dev environment via
+Namma Yatri Kafka topics. These are recommended in the dev environment via
 `nix/services/nammayatri.nix` init script and should be mirrored in
 production Kafka cluster configuration.
 
@@ -21,7 +21,7 @@ production Kafka cluster configuration.
 
 | Topic                | Partitions | Retention | Compression | Consumer Groups                                          | Notes                                           |
 |----------------------|------------|-----------|-------------|----------------------------------------------------------|-------------------------------------------------|
-| `location-updates`   | 12         | 24h       | lz4         | `location-update-consumer`, `driver-availability-consumer` | Continuous driver location pings; highest volume |
+| `location-updates`   | 12         | 24h       | lz4         | `location-update-consumer`, `driver-availability-consumer` | Continuous driver location pings; highest volume. Note: Dev configs use placeholder group IDs; consult prod dhall configs for actual values. |
 
 ### Medium Throughput
 
@@ -37,15 +37,17 @@ production Kafka cluster configuration.
 
 | Topic                          | Partitions | Retention      | Compression | Notes                          |
 |--------------------------------|------------|----------------|-------------|--------------------------------|
-| `ExophoneData`                 | 1          | 72h (default)  | lz4         | Call tracking events           |
+| `ExophoneData`                 | 1          | 72h (default)  | lz4         | Call tracking events. Producers: rider-app, dynamic-offer-driver-app |
 | `AutoCompleteData`             | 1          | 72h (default)  | lz4         | Search autocomplete analytics  |
 | `RouteCollection`              | 1          | 72h (default)  | lz4         | Route data events              |
 | `EventTracker`                 | 1          | 72h (default)  | lz4         | Driver event tracking metrics  |
-| `MarketingParamsData`          | 1          | 72h (default)  | lz4         | Marketing attribution          |
-| `MarketingParamsPreLoginData`  | 1          | 72h (default)  | lz4         | Pre-login marketing params     |
+| `MarketingParamsData`          | 1          | 72h (default)  | lz4         | Marketing attribution. Producers: rider-app, dynamic-offer-driver-app |
+| `MarketingParamsPreLoginData`  | 1          | 72h (default)  | lz4         | Pre-login marketing params. Producers: rider-app, dynamic-offer-driver-app |
 | `metro-webview-events`         | 1          | 72h (default)  | lz4         | Metro webview telemetry        |
 
 ## Consumer Group Reference
+
+> **Note:** Dev configs use placeholder group IDs; consult prod dhall configs for actual values.
 
 | Consumer Group                  | Topic(s)                          | Consumer Type       | Config File                           |
 |---------------------------------|-----------------------------------|---------------------|---------------------------------------|

--- a/Backend/monitoring/kafka-topic-configurations.md
+++ b/Backend/monitoring/kafka-topic-configurations.md
@@ -1,0 +1,65 @@
+# Kafka Topic Configuration Reference
+
+Recommended partition counts, retention, and compression settings for all
+Namma Yatri Kafka topics. These are enforced in the dev environment via
+`nix/services/nammayatri.nix` init script and should be mirrored in
+production Kafka cluster configuration.
+
+## Broker-Level Defaults (dev)
+
+| Setting                              | Value      | Rationale                                      |
+|--------------------------------------|------------|-------------------------------------------------|
+| `num.partitions`                     | 6          | Sane default; high-throughput topics override   |
+| `compression.type`                   | `producer` | Preserves client-side LZ4 end-to-end           |
+| `log.retention.hours`                | 72         | 3 days; overridden per-topic where needed       |
+| `log.segment.bytes`                  | 256 MB     | Granular cleanup without excessive small files  |
+| `offsets.topic.replication.factor`   | 1          | Dev only (single broker); prod should be >= 3   |
+
+## Topic Configurations
+
+### High Throughput
+
+| Topic                | Partitions | Retention | Compression | Consumer Groups                                          | Notes                                           |
+|----------------------|------------|-----------|-------------|----------------------------------------------------------|-------------------------------------------------|
+| `location-updates`   | 12         | 24h       | lz4         | `location-update-consumer`, `driver-availability-consumer` | Continuous driver location pings; highest volume |
+
+### Medium Throughput
+
+| Topic                                   | Partitions | Retention | Compression | Consumer Groups             | Notes                                     |
+|-----------------------------------------|------------|-----------|-------------|-----------------------------|-------------------------------------------|
+| `dynamic-offer-driver-events-updates`   | 6          | 72h       | lz4         | (ClickHouse sink)           | 10 event types: ride/booking lifecycle     |
+| `rider-app-events-updates`              | 6          | 72h       | lz4         | `person-stats-compute`      | 10 event types: ride/booking lifecycle     |
+| `broadcast-messages`                    | 3          | 48h       | lz4         | `broadcast-messages-compute` | Driver broadcast notifications             |
+| `rider-sdk-events`                      | 3          | 48h       | lz4         | (SDK event pipeline)        | Mobile SDK telemetry                       |
+| `driver-sdk-events`                     | 3          | 48h       | lz4         | (SDK event pipeline)        | Mobile SDK telemetry                       |
+
+### Low Throughput
+
+| Topic                          | Partitions | Retention      | Compression | Notes                          |
+|--------------------------------|------------|----------------|-------------|--------------------------------|
+| `ExophoneData`                 | 1          | 72h (default)  | lz4         | Call tracking events           |
+| `AutoCompleteData`             | 1          | 72h (default)  | lz4         | Search autocomplete analytics  |
+| `RouteCollection`              | 1          | 72h (default)  | lz4         | Route data events              |
+| `EventTracker`                 | 1          | 72h (default)  | lz4         | Driver event tracking metrics  |
+| `MarketingParamsData`          | 1          | 72h (default)  | lz4         | Marketing attribution          |
+| `MarketingParamsPreLoginData`  | 1          | 72h (default)  | lz4         | Pre-login marketing params     |
+| `metro-webview-events`         | 1          | 72h (default)  | lz4         | Metro webview telemetry        |
+
+## Consumer Group Reference
+
+| Consumer Group                  | Topic(s)                          | Consumer Type       | Config File                           |
+|---------------------------------|-----------------------------------|---------------------|---------------------------------------|
+| `location-update-consumer`      | `location-updates`                | `LOCATION_UPDATE`   | `dhall-configs/dev/location-update.dhall`            |
+| `driver-availability-consumer`  | `location-updates`                | `AVAILABILITY_TIME` | `dhall-configs/dev/driver-availability-calculator.dhall` |
+| `broadcast-messages-compute`    | `broadcast-messages`              | `BROADCAST_MESSAGE` | `dhall-configs/dev/broadcast-message.dhall`          |
+| `person-stats-compute`          | `rider-app-events-updates`        | `PERSON_STATS`      | `dhall-configs/dev/person-stats.dhall`               |
+
+## Production Scaling Notes
+
+- **Partition count rule of thumb**: `max(consumer_instances * 2, expected_MB_per_sec * 2)`.
+  For `location-updates` in prod with ~50k concurrent drivers at 1 update/3s, target 24-48 partitions.
+- **Replication factor**: All topics should use RF=3 in production.
+- **Retention**: Production retention may differ based on compliance requirements.
+  ClickHouse-sunk topics can use shorter retention (24-48h) since data is durably stored downstream.
+- **Consumer lag monitoring**: Set up alerts on consumer group lag via `kafka_consumergroup_lag`
+  Prometheus metric. Threshold: > 10k messages for high-throughput topics, > 1k for others.


### PR DESCRIPTION
## Problem
Connection pool exhaustion and Kafka drainer lag are not monitored — production incidents from these failure modes are only detected when user-facing errors appear.

## Solution
- **Connection pool alerts**: Prometheus alert rules for pool utilization, wait time, and exhaustion
- **Kafka drainer alerts**: Alert rules for drainer lag, error rates, and backlog growth
- **Documentation**: Kafka topic documentation for operational reference

## Testing
- Alert rule YAML syntax validated
- Note: Alert files need to be referenced in Prometheus config for activation (tracked as follow-up)

## Impact
- **Risk**: Low — monitoring infrastructure only.
- **Rollback**: Remove alert rule files.