### PR TITLE
backend/feat: Add GetCustomerCancellationDuesBreakdown API

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/RiderPlatform/Management/API/Customer.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/RiderPlatform/Management/API/Customer.yaml
@@ -86,6 +86,16 @@ apis:
         type: CancellationDuesDetailsRes
       migrate:
         userActionType: ApiAuth APP_BACKEND_MANAGEMENT CUSTOMERS CUSTOMER_CANCELLATION_DUES_DETAILS
+  - GET:
+      name: GetCustomerCancellationDuesBreakdown
+      endpoint: /{customerId}/getCancellationDuesBreakdown
+      auth: ApiAuthV2
+      params:
+        customerId: Id Customer
+      response:
+        type: CancellationDuesBreakdownRes
+      migrate:
+        userActionType: ApiAuth APP_BACKEND_MANAGEMENT CUSTOMERS CUSTOMER_CANCELLATION_DUES_BREAKDOWN
   - POST:
       endpoint: /{customerId}/updateSafetyCenterBlocking
       auth: ApiAuthV2
@@ -162,6 +172,14 @@ types:
     - incrementCount: Maybe Bool
     - resetCount: Maybe Bool
     - derive: "'HideSecrets"
+  PendingRideDue:
+    - rideId: Text
+    - cancellationAmount: HighPrecMoney
+    - cancellationAmountWithCurrency: PriceAPIEntity
+  CancellationDuesBreakdownRes:
+    - totalCancellationDues: HighPrecMoney
+    - totalCancellationDuesWithCurrency: PriceAPIEntity
+    - pendingRides: "[PendingRideDue]"
   UpdatePaymentModeReq:
     - recordType: NewType
     - paymentMode: PaymentMode

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/RiderPlatform/Management/Endpoints/Customer.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/RiderPlatform/Management/Endpoints/Customer.hs
@@ -20,6 +20,14 @@ import qualified Kernel.Types.Id
 import Servant
 import Servant.Client
 
+data CancellationDuesBreakdownRes = CancellationDuesBreakdownRes
+  { totalCancellationDues :: Kernel.Types.Common.HighPrecMoney,
+    totalCancellationDuesWithCurrency :: Kernel.Types.Common.PriceAPIEntity,
+    pendingRides :: [PendingRideDue]
+  }
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data CancellationDuesDetailsRes = CancellationDuesDetailsRes
   { cancellationDues :: Kernel.Prelude.Maybe Kernel.Types.Common.PriceAPIEntity,
     disputeChancesUsed :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
@@ -81,7 +89,15 @@ data UpdateSafetyCenterBlockingReq = UpdateSafetyCenterBlockingReq {incrementCou
 instance Kernel.Types.HideSecrets.HideSecrets UpdateSafetyCenterBlockingReq where
   hideSecrets = Kernel.Prelude.identity
 
-type API = ("customer" :> (GetCustomerList :<|> DeleteCustomerDelete :<|> PostCustomerBlock :<|> PostCustomerUnblock :<|> GetCustomerInfo :<|> PostCustomerCancellationDuesSync :<|> GetCustomerCancellationDuesDetails :<|> PostCustomerUpdateSafetyCenterBlocking :<|> PostCustomerPersonNumbers :<|> PostCustomerPersonId :<|> PostCustomerUpdatePaymentMode))
+data PendingRideDue = PendingRideDue
+  { rideId :: Kernel.Prelude.Text,
+    cancellationAmount :: Kernel.Types.Common.HighPrecMoney,
+    cancellationAmountWithCurrency :: Kernel.Types.Common.PriceAPIEntity
+  }
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+type API = ("customer" :> (GetCustomerList :<|> DeleteCustomerDelete :<|> PostCustomerBlock :<|> PostCustomerUnblock :<|> GetCustomerInfo :<|> PostCustomerCancellationDuesSync :<|> GetCustomerCancellationDuesDetails :<|> GetCustomerCancellationDuesBreakdown :<|> PostCustomerUpdateSafetyCenterBlocking :<|> PostCustomerPersonNumbers :<|> PostCustomerPersonId :<|> PostCustomerUpdatePaymentMode))
 
 type GetCustomerList =
   ( "list" :> QueryParam "limit" Kernel.Prelude.Int :> QueryParam "offset" Kernel.Prelude.Int :> QueryParam "enabled" Kernel.Prelude.Bool
@@ -115,6 +131,8 @@ type PostCustomerCancellationDuesSync =
 
 type GetCustomerCancellationDuesDetails = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "getCancellationDuesDetails" :> Get '[JSON] CancellationDuesDetailsRes)
 
+type GetCustomerCancellationDuesBreakdown = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "getCancellationDuesBreakdown" :> Get '[JSON] CancellationDuesBreakdownRes)
+
 type PostCustomerUpdateSafetyCenterBlocking =
   ( Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "updateSafetyCenterBlocking"
       :> ReqBody
@@ -142,6 +160,7 @@ data CustomerAPIs = CustomerAPIs
     getCustomerInfo :: Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient CustomerInfoRes,
     postCustomerCancellationDuesSync :: Kernel.Types.Id.Id Dashboard.Common.Customer -> CustomerCancellationDuesSyncReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
     getCustomerCancellationDuesDetails :: Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient CancellationDuesDetailsRes,
+    getCustomerCancellationDuesBreakdown :: Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient CancellationDuesBreakdownRes,
     postCustomerUpdateSafetyCenterBlocking :: Kernel.Types.Id.Id Dashboard.Common.Customer -> UpdateSafetyCenterBlockingReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
     postCustomerPersonNumbers :: (Data.ByteString.Lazy.ByteString, Dashboard.Common.PersonIdsReq) -> EulerHS.Types.EulerClient [Dashboard.Common.PersonRes],
     postCustomerPersonId :: (Data.ByteString.Lazy.ByteString, Dashboard.Common.PersonMobileNoReq) -> EulerHS.Types.EulerClient [Dashboard.Common.PersonRes],
@@ -151,7 +170,7 @@ data CustomerAPIs = CustomerAPIs
 mkCustomerAPIs :: (Client EulerHS.Types.EulerClient API -> CustomerAPIs)
 mkCustomerAPIs customerClient = (CustomerAPIs {..})
   where
-    getCustomerList :<|> deleteCustomerDelete :<|> postCustomerBlock :<|> postCustomerUnblock :<|> getCustomerInfo :<|> postCustomerCancellationDuesSync :<|> getCustomerCancellationDuesDetails :<|> postCustomerUpdateSafetyCenterBlocking :<|> postCustomerPersonNumbers :<|> postCustomerPersonId :<|> postCustomerUpdatePaymentMode = customerClient
+    getCustomerList :<|> deleteCustomerDelete :<|> postCustomerBlock :<|> postCustomerUnblock :<|> getCustomerInfo :<|> postCustomerCancellationDuesSync :<|> getCustomerCancellationDuesDetails :<|> getCustomerCancellationDuesBreakdown :<|> postCustomerUpdateSafetyCenterBlocking :<|> postCustomerPersonNumbers :<|> postCustomerPersonId :<|> postCustomerUpdatePaymentMode = customerClient
 
 data CustomerUserActionType
   = GET_CUSTOMER_LIST
@@ -161,6 +180,7 @@ data CustomerUserActionType
   | GET_CUSTOMER_INFO
   | POST_CUSTOMER_CANCELLATION_DUES_SYNC
   | GET_CUSTOMER_CANCELLATION_DUES_DETAILS
+  | GET_CUSTOMER_CANCELLATION_DUES_BREAKDOWN
   | POST_CUSTOMER_UPDATE_SAFETY_CENTER_BLOCKING
   | POST_CUSTOMER_PERSON_NUMBERS
   | POST_CUSTOMER_PERSON_ID

--- a/Backend/app/dashboard/rider-dashboard/src-read-only/API/Action/RiderPlatform/Management/Customer.hs
+++ b/Backend/app/dashboard/rider-dashboard/src-read-only/API/Action/RiderPlatform/Management/Customer.hs
@@ -23,10 +23,10 @@ import Servant
 import Storage.Beam.CommonInstances ()
 import Tools.Auth.Api
 
-type API = ("customer" :> (GetCustomerList :<|> DeleteCustomerDelete :<|> PostCustomerBlock :<|> PostCustomerUnblock :<|> GetCustomerInfo :<|> PostCustomerCancellationDuesSync :<|> GetCustomerCancellationDuesDetails :<|> PostCustomerUpdateSafetyCenterBlocking :<|> PostCustomerPersonNumbers :<|> PostCustomerPersonId :<|> PostCustomerUpdatePaymentMode))
+type API = ("customer" :> (GetCustomerList :<|> DeleteCustomerDelete :<|> PostCustomerBlock :<|> PostCustomerUnblock :<|> GetCustomerInfo :<|> PostCustomerCancellationDuesSync :<|> GetCustomerCancellationDuesDetails :<|> GetCustomerCancellationDuesBreakdown :<|> PostCustomerUpdateSafetyCenterBlocking :<|> PostCustomerPersonNumbers :<|> PostCustomerPersonId :<|> PostCustomerUpdatePaymentMode))
 
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API)
-handler merchantId city = getCustomerList merchantId city :<|> deleteCustomerDelete merchantId city :<|> postCustomerBlock merchantId city :<|> postCustomerUnblock merchantId city :<|> getCustomerInfo merchantId city :<|> postCustomerCancellationDuesSync merchantId city :<|> getCustomerCancellationDuesDetails merchantId city :<|> postCustomerUpdateSafetyCenterBlocking merchantId city :<|> postCustomerPersonNumbers merchantId city :<|> postCustomerPersonId merchantId city :<|> postCustomerUpdatePaymentMode merchantId city
+handler merchantId city = getCustomerList merchantId city :<|> deleteCustomerDelete merchantId city :<|> postCustomerBlock merchantId city :<|> postCustomerUnblock merchantId city :<|> getCustomerInfo merchantId city :<|> postCustomerCancellationDuesSync merchantId city :<|> getCustomerCancellationDuesDetails merchantId city :<|> getCustomerCancellationDuesBreakdown merchantId city :<|> postCustomerUpdateSafetyCenterBlocking merchantId city :<|> postCustomerPersonNumbers merchantId city :<|> postCustomerPersonId merchantId city :<|> postCustomerUpdatePaymentMode merchantId city
 
 type GetCustomerList =
   ( ApiAuth
@@ -84,6 +84,14 @@ type GetCustomerCancellationDuesDetails =
       :> API.Types.RiderPlatform.Management.Customer.GetCustomerCancellationDuesDetails
   )
 
+type GetCustomerCancellationDuesBreakdown =
+  ( ApiAuth
+      'APP_BACKEND_MANAGEMENT
+      'DSL
+      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_CANCELLATION_DUES_BREAKDOWN)
+      :> API.Types.RiderPlatform.Management.Customer.GetCustomerCancellationDuesBreakdown
+  )
+
 type PostCustomerUpdateSafetyCenterBlocking =
   ( ApiAuth
       'APP_BACKEND_MANAGEMENT
@@ -136,6 +144,9 @@ postCustomerCancellationDuesSync merchantShortId opCity apiTokenInfo customerId 
 
 getCustomerCancellationDuesDetails :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CancellationDuesDetailsRes)
 getCustomerCancellationDuesDetails merchantShortId opCity apiTokenInfo customerId = withFlowHandlerAPI' $ Domain.Action.RiderPlatform.Management.Customer.getCustomerCancellationDuesDetails merchantShortId opCity apiTokenInfo customerId
+
+getCustomerCancellationDuesBreakdown :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CancellationDuesBreakdownRes)
+getCustomerCancellationDuesBreakdown merchantShortId opCity apiTokenInfo customerId = withFlowHandlerAPI' $ Domain.Action.RiderPlatform.Management.Customer.getCustomerCancellationDuesBreakdown merchantShortId opCity apiTokenInfo customerId
 
 postCustomerUpdateSafetyCenterBlocking :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> API.Types.RiderPlatform.Management.Customer.UpdateSafetyCenterBlockingReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postCustomerUpdateSafetyCenterBlocking merchantShortId opCity apiTokenInfo customerId req = withFlowHandlerAPI' $ Domain.Action.RiderPlatform.Management.Customer.postCustomerUpdateSafetyCenterBlocking merchantShortId opCity apiTokenInfo customerId req

--- a/Backend/app/dashboard/rider-dashboard/src/Domain/Action/RiderPlatform/Management/Customer.hs
+++ b/Backend/app/dashboard/rider-dashboard/src/Domain/Action/RiderPlatform/Management/Customer.hs
@@ -8,6 +8,7 @@ module Domain.Action.RiderPlatform.Management.Customer
     getCustomerInfo,
     postCustomerCancellationDuesSync,
     getCustomerCancellationDuesDetails,
+    getCustomerCancellationDuesBreakdown,
     postCustomerUpdateSafetyCenterBlocking,
     postCustomerPersonNumbers,
     postCustomerPersonId,
@@ -89,6 +90,11 @@ getCustomerCancellationDuesDetails :: Kernel.Types.Id.ShortId Domain.Types.Merch
 getCustomerCancellationDuesDetails merchantShortId opCity apiTokenInfo customerId = do
   checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
   API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.getCustomerCancellationDuesDetails) customerId
+
+getCustomerCancellationDuesBreakdown :: Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.Flow API.Types.RiderPlatform.Management.Customer.CancellationDuesBreakdownRes
+getCustomerCancellationDuesBreakdown merchantShortId opCity apiTokenInfo customerId = do
+  checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.getCustomerCancellationDuesBreakdown) customerId
 
 postCustomerUpdateSafetyCenterBlocking :: Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> API.Types.RiderPlatform.Management.Customer.UpdateSafetyCenterBlockingReq -> Environment.Flow Kernel.Types.APISuccess.APISuccess
 postCustomerUpdateSafetyCenterBlocking merchantShortId opCity apiTokenInfo customerId req = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/CustomerCancellationDues.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/CustomerCancellationDues.hs
@@ -34,12 +34,19 @@ type API =
       :> Header "token" Text
       :> ReqBody '[JSON] Domain.CustomerCancellationDuesSyncReq
       :> Post '[JSON] APISuccess
+    :<|> Capture "merchantId" (Id Merchant)
+      :> Capture "merchantCity" Context.City
+      :> "getCancellationDuesBreakdown"
+      :> Header "token" Text
+      :> ReqBody '[JSON] Domain.CancellationDuesReq
+      :> Get '[JSON] Domain.CancellationDuesBreakdownRes
 
 handler :: FlowServer API
 handler =
   disputeCancellationDues
     :<|> getCancellationDuesDetails
     :<|> customerCancellationDuesSync
+    :<|> getCancellationDuesBreakdown
 
 disputeCancellationDues :: Id Merchant -> Context.City -> Maybe Text -> Domain.CancellationDuesReq -> FlowHandler APISuccess
 disputeCancellationDues merchantId merchantCity apiKey = withFlowHandlerAPI . Domain.disputeCancellationDues merchantId merchantCity apiKey
@@ -49,3 +56,6 @@ getCancellationDuesDetails merchantId merchantCity apiKey = withFlowHandlerAPI .
 
 customerCancellationDuesSync :: Id Merchant -> Context.City -> Maybe Text -> Domain.CustomerCancellationDuesSyncReq -> FlowHandler APISuccess
 customerCancellationDuesSync merchantId merchantCity apiKey = withFlowHandlerAPI . Domain.customerCancellationDuesSync merchantId merchantCity apiKey
+
+getCancellationDuesBreakdown :: Id Merchant -> Context.City -> Maybe Text -> Domain.CancellationDuesReq -> FlowHandler Domain.CancellationDuesBreakdownRes
+getCancellationDuesBreakdown merchantId merchantCity apiKey = withFlowHandlerAPI . Domain.getCancellationDuesBreakdown merchantId merchantCity apiKey

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/CustomerCancellationDues.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/CustomerCancellationDues.hs
@@ -17,6 +17,7 @@ module Domain.Action.Internal.CustomerCancellationDues where
 import Data.Time hiding (getCurrentTime)
 import qualified Domain.Types.CancellationCharges as DCC
 import qualified Domain.Types.CancellationDuesDetails as DCDD
+import qualified Domain.Types.Ride as DRide
 import qualified Domain.Types.DailyStats as DDS
 import Domain.Types.Merchant (Merchant)
 import EulerHS.Prelude hiding (id)
@@ -51,6 +52,20 @@ data CancellationDuesDetailsRes = CancellationDuesDetailsRes
     customerCancellationDuesWithCurrency :: PriceAPIEntity,
     disputeChancesUsed :: Int,
     canBlockCustomer :: Maybe Bool
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+data PendingRideDue = PendingRideDue
+  { rideId :: Id DRide.Ride,
+    cancellationAmount :: HighPrecMoney,
+    cancellationAmountWithCurrency :: PriceAPIEntity
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+data CancellationDuesBreakdownRes = CancellationDuesBreakdownRes
+  { totalCancellationDues :: HighPrecMoney,
+    totalCancellationDuesWithCurrency :: PriceAPIEntity,
+    pendingRides :: [PendingRideDue]
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
 
@@ -231,3 +246,42 @@ customerCancellationDuesSync merchantId merchantCity apiKey req = do
         QRD.updateDisputeChancesUsed disputeChancesUsedReq riderDetails.id
     (_, _) -> throwError DisputeChancesOrCancellationDuesHasToBeNull
   return Success
+
+getCancellationDuesBreakdown ::
+  ( MonadFlow m,
+    EsqDBFlow m r,
+    CacheFlow m r,
+    EncFlow m r
+  ) =>
+  Id Merchant ->
+  Context.City ->
+  Maybe Text ->
+  CancellationDuesReq ->
+  m CancellationDuesBreakdownRes
+getCancellationDuesBreakdown merchantId merchantCity apiKey CancellationDuesReq {..} = do
+  merchant <- QM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
+  unless (Just merchant.internalApiKey == apiKey) $
+    throwError $ AuthBlocked "Invalid BPP internal api key"
+  merchantOperatingCity <- CQMM.findByMerchantIdAndCity merchant.id merchantCity >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantShortId: " <> merchant.shortId.getShortId <> " ,city: " <> show merchantCity)
+  transporterConfig <- CTC.findByMerchantOpCityId merchantOperatingCity.id Nothing >>= fromMaybeM (TransporterConfigNotFound merchantOperatingCity.id.getId)
+  unless transporterConfig.canAddCancellationFee $
+    throwError $ CityRestrictionOnCustomerCancellationDuesAddition (show merchantCity)
+  numberHash <- getDbHash customerMobileNumber
+  riderDetails <- QRD.findByMobileNumberHashAndMerchant numberHash merchant.id >>= fromMaybeM (RiderDetailsDoNotExist "Mobile Number" customerMobileNumber)
+  pendingRows <- QCDD.findAllPendingByRiderId riderDetails.id
+  let pendingRides = fmap toPendingRideDue pendingRows
+      total = Kernel.Prelude.sum $ (.cancellationAmount) <$> pendingRows
+      currency = riderDetails.currency
+  return $
+    CancellationDuesBreakdownRes
+      { totalCancellationDues = total,
+        totalCancellationDuesWithCurrency = PriceAPIEntity total currency,
+        pendingRides
+      }
+  where
+    toPendingRideDue row =
+      PendingRideDue
+        { rideId = row.rideId,
+          cancellationAmount = row.cancellationAmount,
+          cancellationAmountWithCurrency = PriceAPIEntity row.cancellationAmount row.currency
+        }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/CancellationDuesDetailsExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/CancellationDuesDetailsExtra.hs
@@ -25,3 +25,12 @@ updateAllPendingToPaidByRiderId riderId = do
           Se.Is Beam.paymentStatus $ Se.Eq DCDD.PENDING
         ]
     ]
+
+findAllPendingByRiderId :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => Id.Id DRD.RiderDetails -> m [DCDD.CancellationDuesDetails]
+findAllPendingByRiderId riderId =
+  findAllWithKV
+    [ Se.And
+        [ Se.Is Beam.riderId $ Se.Eq (Id.getId riderId),
+          Se.Is Beam.paymentStatus $ Se.Eq DCDD.PENDING
+        ]
+    ]

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/Dashboard/Management/Customer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/Dashboard/Management/Customer.hs
@@ -22,7 +22,7 @@ import Servant
 import Tools.Auth
 
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API.Types.RiderPlatform.Management.Customer.API)
-handler merchantId city = getCustomerList merchantId city :<|> deleteCustomerDelete merchantId city :<|> postCustomerBlock merchantId city :<|> postCustomerUnblock merchantId city :<|> getCustomerInfo merchantId city :<|> postCustomerCancellationDuesSync merchantId city :<|> getCustomerCancellationDuesDetails merchantId city :<|> postCustomerUpdateSafetyCenterBlocking merchantId city :<|> postCustomerPersonNumbers merchantId city :<|> postCustomerPersonId merchantId city :<|> postCustomerUpdatePaymentMode merchantId city
+handler merchantId city = getCustomerList merchantId city :<|> deleteCustomerDelete merchantId city :<|> postCustomerBlock merchantId city :<|> postCustomerUnblock merchantId city :<|> getCustomerInfo merchantId city :<|> postCustomerCancellationDuesSync merchantId city :<|> getCustomerCancellationDuesDetails merchantId city :<|> getCustomerCancellationDuesBreakdown merchantId city :<|> postCustomerUpdateSafetyCenterBlocking merchantId city :<|> postCustomerPersonNumbers merchantId city :<|> postCustomerPersonId merchantId city :<|> postCustomerUpdatePaymentMode merchantId city
 
 getCustomerList :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CustomerListRes)
 getCustomerList a8 a7 a6 a5 a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.getCustomerList a8 a7 a6 a5 a4 a3 a2 a1
@@ -44,6 +44,9 @@ postCustomerCancellationDuesSync a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Dom
 
 getCustomerCancellationDuesDetails :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CancellationDuesDetailsRes)
 getCustomerCancellationDuesDetails a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.getCustomerCancellationDuesDetails a3 a2 a1
+
+getCustomerCancellationDuesBreakdown :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CancellationDuesBreakdownRes)
+getCustomerCancellationDuesBreakdown a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.getCustomerCancellationDuesBreakdown a3 a2 a1
 
 postCustomerUpdateSafetyCenterBlocking :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> API.Types.RiderPlatform.Management.Customer.UpdateSafetyCenterBlockingReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postCustomerUpdateSafetyCenterBlocking a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.postCustomerUpdateSafetyCenterBlocking a4 a3 a2 a1

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Customer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Customer.hs
@@ -20,6 +20,7 @@ module Domain.Action.Dashboard.Customer
     getCustomerInfo,
     postCustomerCancellationDuesSync,
     getCustomerCancellationDuesDetails,
+    getCustomerCancellationDuesBreakdown,
     postCustomerUpdateSafetyCenterBlocking,
     postCustomerPersonNumbers,
     postCustomerPersonId,
@@ -213,6 +214,31 @@ getCustomerCancellationDuesDetails merchantShortId _ personId = do
         disputeChancesUsed = res.disputeChancesUsed,
         canBlockCustomer = res.canBlockCustomer
       }
+
+getCustomerCancellationDuesBreakdown ::
+  ShortId DM.Merchant ->
+  Context.City ->
+  Id Common.Customer ->
+  Flow Common.CancellationDuesBreakdownRes
+getCustomerCancellationDuesBreakdown merchantShortId _ personId = do
+  merchant <- QM.findByShortId merchantShortId >>= fromMaybeM (MerchantDoesNotExist merchantShortId.getShortId)
+  let personId' = cast @Common.Customer @DP.Person personId
+  person <- runInReplica $ QP.findById personId' >>= fromMaybeM (PersonNotFound personId'.getId)
+  mobNum <- mapM decrypt person.mobileNumber >>= fromMaybeM (PersonFieldNotPresent "mobileNumber")
+  res <- CallBPPInternal.getCancellationDuesBreakdown merchant.driverOfferApiKey merchant.driverOfferBaseUrl merchant.driverOfferMerchantId mobNum (fromMaybe "+91" person.mobileCountryCode) person.currentCity
+  return $
+    Common.CancellationDuesBreakdownRes
+      { totalCancellationDues = res.totalCancellationDues,
+        totalCancellationDuesWithCurrency = res.totalCancellationDuesWithCurrency,
+        pendingRides = map toPendingRideDue res.pendingRides
+      }
+  where
+    toPendingRideDue ride =
+      Common.PendingRideDue
+        { rideId = ride.rideId,
+          cancellationAmount = ride.cancellationAmount,
+          cancellationAmountWithCurrency = ride.cancellationAmountWithCurrency
+        }
 
 postCustomerUpdateSafetyCenterBlocking ::
   ShortId DM.Merchant ->

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPPInternal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPPInternal.hs
@@ -252,6 +252,52 @@ getCancellationDuesDetails apiKey internalUrl merchantId phoneNumber countryCode
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   EC.callApiUnwrappingApiError (identity @Error) Nothing (Just "BPP_INTERNAL_API_ERROR") (Just internalEndPointHashMap) internalUrl (getCancellationDuesDetailsClient merchantId merchantCity (Just apiKey) (CancellationDuesReq phoneNumber countryCode)) "GetCancellationDuesDetails" getCancellationDuesDetailsApi
 
+data PendingRideDue = PendingRideDue
+  { rideId :: Text,
+    cancellationAmount :: HighPrecMoney,
+    cancellationAmountWithCurrency :: PriceAPIEntity
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+data CancellationDuesBreakdownRes = CancellationDuesBreakdownRes
+  { totalCancellationDues :: HighPrecMoney,
+    totalCancellationDuesWithCurrency :: PriceAPIEntity,
+    pendingRides :: [PendingRideDue]
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+type GetCancellationDuesBreakdownAPI =
+  "internal"
+    :> Capture "merchantId" Text
+    :> Capture "merchantCity" Context.City
+    :> "getCancellationDuesBreakdown"
+    :> Header "token" Text
+    :> ReqBody '[JSON] CancellationDuesReq
+    :> Get '[JSON] CancellationDuesBreakdownRes
+
+getCancellationDuesBreakdownClient :: Text -> Context.City -> Maybe Text -> CancellationDuesReq -> EulerClient CancellationDuesBreakdownRes
+getCancellationDuesBreakdownClient = client getCancellationDuesBreakdownApi
+
+getCancellationDuesBreakdownApi :: Proxy GetCancellationDuesBreakdownAPI
+getCancellationDuesBreakdownApi = Proxy
+
+getCancellationDuesBreakdown ::
+  ( MonadFlow m,
+    CoreMetrics m,
+    HasFlowEnv m r '["internalEndPointHashMap" ::: HM.HashMap BaseUrl BaseUrl],
+    HasRequestId r
+  ) =>
+  Text ->
+  BaseUrl ->
+  Text ->
+  Text ->
+  Text ->
+  Context.City ->
+  m CancellationDuesBreakdownRes
+getCancellationDuesBreakdown apiKey internalUrl merchantId phoneNumber countryCode merchantCity = do
+  internalEndPointHashMap <- asks (.internalEndPointHashMap)
+  EC.callApiUnwrappingApiError (identity @Error) Nothing (Just "BPP_INTERNAL_API_ERROR") (Just internalEndPointHashMap) internalUrl (getCancellationDuesBreakdownClient merchantId merchantCity (Just apiKey) (CancellationDuesReq phoneNumber countryCode)) "GetCancellationDuesBreakdown" getCancellationDuesBreakdownApi
+
 data GetFavouriteDriverInfoReq = GetFavouriteDriverInfoReq
   { customerMobileNumber :: Text,
     customerMobileCountryCode :: Text


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Adds a read-only `GetCustomerCancellationDuesBreakdown` API that returns the total pending cancellation dues and a per-ride breakdown for a customer.

### Flow
```
Dashboard → rider-dashboard (proxy) → rider-app BAP → BPP internal API → CancellationDuesDetails table
```

### Changes

**BPP (`dynamic-offer-driver-app`)**
- `Storage/Queries/CancellationDuesDetailsExtra.hs` — added `findAllPendingByRiderId` to query all `PENDING` rows for a rider
- `Domain/Action/Internal/CustomerCancellationDues.hs` — added `getCancellationDuesBreakdown` handler + `PendingRideDue` / `CancellationDuesBreakdownRes` response types
- `API/Internal/CustomerCancellationDues.hs` — wired the new endpoint into the internal API

**BAP (`rider-app`)**
- `SharedLogic/CallBPPInternal.hs` — added HTTP client types and `getCancellationDuesBreakdown` caller
- `Domain/Action/Dashboard/Customer.hs` — added `getCustomerCancellationDuesBreakdown` which looks up person, decrypts mobile number, calls BPP, and maps to common response types

**Dashboard**
- `CommonAPIs/spec/RiderPlatform/Management/API/Customer.yaml` — added endpoint spec + `PendingRideDue` / `CancellationDuesBreakdownRes` types
- `CommonAPIs/src-read-only/.../Endpoints/Customer.hs` — manually updated (generator did not regenerate this file)
- `rider-dashboard/src-read-only/.../Management/Customer.hs` — handler wiring
- `rider-dashboard/src/Domain/Action/RiderPlatform/Management/Customer.hs` — proxy via `callManagementAPI`
- `rider-app/src-read-only/.../Dashboard/Management/Customer.hs` — handler wiring

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context

Provides a dashboard API to inspect a customer's outstanding cancellation dues in detail (per-ride breakdown), reusing the existing `CancellationDuesDetails` table in BPP without any schema changes.

## How did you test it?

Verified compilation of all modified modules (`cabal build`). Pre-existing unrelated failures exist on `main` (`ParkingBooking.hs`, `IffcoTokioInsurance.hs`) and are not introduced by this PR.

## Checklist

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve a detailed cancellation dues breakdown for customers. The endpoint returns the total cancellation amount along with itemized details for each pending ride, including the individual cancellation charge per ride and associated currency information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->