### PR TITLE
backend/feat: add app-facing cancellationChargesWaiveOff API

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -232,6 +232,7 @@ library
       Domain.Action.UI.Call
       Domain.Action.UI.CallEvent
       Domain.Action.UI.Cancel
+      Domain.Action.UI.CancellationChargesWaiveOff
       Domain.Action.UI.CancellationReason
       Domain.Action.UI.Conductor.Stats
       Domain.Action.UI.Confirm
@@ -758,6 +759,7 @@ library
       API.Action.UI.AttractionRecommend
       API.Action.UI.BBPS
       API.Action.UI.Cac
+      API.Action.UI.CancellationChargesWaiveOff
       API.Action.UI.CRIS
       API.Action.UI.CustomerReferral
       API.Action.UI.DeletedPerson
@@ -844,6 +846,7 @@ library
       API.Types.UI.AlertWebhook
       API.Types.UI.AttractionRecommend
       API.Types.UI.BBPS
+      API.Types.UI.CancellationChargesWaiveOff
       API.Types.UI.CRIS
       API.Types.UI.CustomerReferral
       API.Types.UI.DeletedPerson

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/CancellationChargesWaiveOff.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/CancellationChargesWaiveOff.yaml
@@ -1,0 +1,20 @@
+imports:
+  Booking: Domain.Types.Booking
+  PriceAPIEntity: Kernel.Types.Common
+
+module: CancellationChargesWaiveOff
+
+types:
+  CancellationChargesWaiveOffRes:
+    waivedOffAmount: Maybe HighPrecMoney
+    waivedOffAmountWithCurrency: Maybe PriceAPIEntity
+    waivedOffSuccess: Bool
+
+apis:
+  - POST:
+      endpoint: /rideBooking/{bookingId}/cancellationChargesWaiveOff
+      auth: TokenAuth
+      params:
+        bookingId: Id Booking
+      response:
+        type: API.Types.UI.CancellationChargesWaiveOff.CancellationChargesWaiveOffRes

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/CancellationChargesWaiveOff.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/CancellationChargesWaiveOff.hs
@@ -1,0 +1,42 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module API.Action.UI.CancellationChargesWaiveOff
+  ( API,
+    handler,
+  )
+where
+
+import qualified API.Types.UI.CancellationChargesWaiveOff
+import qualified Control.Lens
+import qualified Domain.Action.UI.CancellationChargesWaiveOff
+import qualified Domain.Types.Booking
+import qualified Domain.Types.Merchant
+import qualified Domain.Types.Person
+import qualified Environment
+import EulerHS.Prelude
+import qualified Kernel.Prelude
+import qualified Kernel.Types.Id
+import Kernel.Utils.Common
+import Servant
+import Storage.Beam.SystemConfigs ()
+import Tools.Auth
+
+type API =
+  ( TokenAuth :> "rideBooking" :> Capture "bookingId" (Kernel.Types.Id.Id Domain.Types.Booking.Booking) :> "cancellationChargesWaiveOff"
+      :> Post
+           ('[JSON])
+           API.Types.UI.CancellationChargesWaiveOff.CancellationChargesWaiveOffRes
+  )
+
+handler :: Environment.FlowServer API
+handler = postRideBookingCancellationChargesWaiveOff
+
+postRideBookingCancellationChargesWaiveOff ::
+  ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
+      Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
+    ) ->
+    Kernel.Types.Id.Id Domain.Types.Booking.Booking ->
+    Environment.FlowHandler API.Types.UI.CancellationChargesWaiveOff.CancellationChargesWaiveOffRes
+  )
+postRideBookingCancellationChargesWaiveOff a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.CancellationChargesWaiveOff.postRideBookingCancellationChargesWaiveOff (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a2) a1

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/CancellationChargesWaiveOff.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/CancellationChargesWaiveOff.hs
@@ -1,0 +1,18 @@
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module API.Types.UI.CancellationChargesWaiveOff where
+
+import Data.OpenApi (ToSchema)
+import EulerHS.Prelude hiding (id)
+import qualified Kernel.Prelude
+import qualified Kernel.Types.Common
+import Servant
+import Tools.Auth
+
+data CancellationChargesWaiveOffRes = CancellationChargesWaiveOffRes
+  { waivedOffAmount :: Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecMoney,
+    waivedOffAmountWithCurrency :: Kernel.Prelude.Maybe Kernel.Types.Common.PriceAPIEntity,
+    waivedOffSuccess :: Kernel.Prelude.Bool
+  }
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)

--- a/Backend/app/rider-platform/rider-app/Main/src/API/UI.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/UI.hs
@@ -22,6 +22,7 @@ import qualified API.Action.UI.AttractionRecommend as AttractionRecommend
 import qualified API.Action.UI.BBPS as BBPS
 import qualified API.Action.UI.CRIS as CRIS
 import qualified API.Action.UI.Cac as Cac
+import qualified API.Action.UI.CancellationChargesWaiveOff as CancellationChargesWaiveOff
 import qualified API.Action.UI.CustomerReferral as CustomerReferral
 import qualified API.Action.UI.DeletedPerson as DeletedPerson
 import qualified API.Action.UI.Dispatcher as Dispatcher
@@ -115,6 +116,7 @@ type API =
            :<|> MapsProxy.API
            :<|> GoogleTranslateProxy.API
            :<|> CancellationReason.API
+           :<|> CancellationChargesWaiveOff.API
            :<|> SavedReqLocation.API
            :<|> Frontend.API
            :<|> Whatsapp.API
@@ -188,6 +190,7 @@ handler =
     :<|> MapsProxy.handler
     :<|> GoogleTranslateProxy.handler
     :<|> CancellationReason.handler
+    :<|> CancellationChargesWaiveOff.handler
     :<|> SavedReqLocation.handler
     :<|> Frontend.handler
     :<|> Whatsapp.handler

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/CancellationChargesWaiveOff.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/CancellationChargesWaiveOff.hs
@@ -1,0 +1,59 @@
+{-# OPTIONS_GHC -Wwarn=unused-imports #-}
+
+module Domain.Action.UI.CancellationChargesWaiveOff (postRideBookingCancellationChargesWaiveOff) where
+
+import qualified API.Types.UI.CancellationChargesWaiveOff
+import qualified Domain.Types.Booking
+import qualified Domain.Types.Merchant
+import qualified Domain.Types.Person
+import qualified Environment
+import EulerHS.Prelude hiding (id)
+import qualified Kernel.Prelude
+import qualified Kernel.Types.Common
+import qualified Kernel.Types.Id
+import Kernel.Utils.Common
+import qualified SharedLogic.CallBPPInternal as CallBPPInternal
+import qualified Storage.CachedQueries.Merchant as CQM
+import qualified Storage.Queries.Booking as QRB
+import qualified Storage.Queries.Ride as QRide
+import Tools.Error
+
+postRideBookingCancellationChargesWaiveOff ::
+  ( ( Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person),
+      Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
+    ) ->
+    Kernel.Types.Id.Id Domain.Types.Booking.Booking ->
+    Environment.Flow API.Types.UI.CancellationChargesWaiveOff.CancellationChargesWaiveOffRes
+  )
+postRideBookingCancellationChargesWaiveOff (mbPersonId, _merchantId) bookingId = do
+  booking <- QRB.findById bookingId >>= fromMaybeM (BookingDoesNotExist bookingId.getId)
+  whenJust mbPersonId $ \personId ->
+    unless (booking.riderId == personId) $ throwError (BookingDoesNotExist bookingId.getId)
+  merchant <- CQM.findById booking.merchantId >>= fromMaybeM (MerchantNotFound booking.merchantId.getId)
+  ride <- QRide.findOneByBookingId bookingId >>= fromMaybeM (RideDoesNotExist bookingId.getId)
+  case ride.cancellationChargesOnCancel of
+    Just charges | charges > 0 -> do
+      case booking.bppBookingId of
+        Just bppBookingId -> do
+          logInfo $ "CancellationChargesWaiveOff: Trying to waive off cancellation charges for bookingId: " <> bookingId.getId <> " with amount: " <> show charges
+          result <- withTryCatch "customerCancellationDuesWaiveOff" $ CallBPPInternal.customerCancellationDuesWaiveOff merchant.driverOfferApiKey merchant.driverOfferBaseUrl merchant.driverOfferMerchantId bppBookingId.getId ride.bppRideId.getId charges
+          case result of
+            Right _ -> do
+              logInfo $ "CancellationChargesWaiveOff: Successfully waived off cancellation charges for bookingId: " <> bookingId.getId
+              pure $ mkRes (Just charges) True
+            Left err -> do
+              logError $ "CancellationChargesWaiveOff: Failed to waive off cancellation charges for bookingId: " <> bookingId.getId <> " with error: " <> show err
+              pure $ mkRes Nothing False
+        Nothing -> do
+          logInfo $ "CancellationChargesWaiveOff: No bppBookingId found for bookingId: " <> bookingId.getId
+          pure $ mkRes Nothing False
+    _ -> do
+      logInfo $ "CancellationChargesWaiveOff: No non-zero cancellation charges found for bookingId: " <> bookingId.getId
+      pure $ mkRes Nothing False
+  where
+    mkRes mbAmt success =
+      API.Types.UI.CancellationChargesWaiveOff.CancellationChargesWaiveOffRes
+        { waivedOffAmount = mbAmt,
+          waivedOffAmountWithCurrency = fmap (\a -> Kernel.Types.Common.PriceAPIEntity {amount = a, currency = Kernel.Types.Common.INR}) mbAmt,
+          waivedOffSuccess = success
+        }


### PR DESCRIPTION
## Summary

- Adds `POST /v2/rideBooking/{bookingId}/cancellationChargesWaiveOff` as a rider-app UI endpoint (app equivalent of the existing dashboard `GET /cancellationChargesWaiveOff/{rideId}`)
- Uses `TokenAuth` (rider authentication) and accepts `bookingId` as the path parameter (consistent with other app-facing Cancel APIs)
- Verifies the booking belongs to the authenticated rider before processing
- Delegates to `CallBPPInternal.customerCancellationDuesWaiveOff` — same BPP internal call as the dashboard version

## Test plan

- [ ] POST `v2/rideBooking/{bookingId}/cancellationChargesWaiveOff` with a valid rider token for a booking that has `cancellationChargesOnCancel` set — expect `waivedOffSuccess: true` and amount returned
- [ ] Same request with a booking belonging to a different rider — expect `BookingDoesNotExist` error
- [ ] Booking with no cancellation charges — expect `waivedOffSuccess: false`, null amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint to request waiver of cancellation charges for ride bookings, returning the waived amount and operation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->