### PR TITLE
[P0] Fix cancellation penalty accuracy, metadata enrichment, and reallocation observability

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -483,6 +483,7 @@ library
       SharedLogic.FareCalculatorV2
       SharedLogic.FarePolicy
       SharedLogic.FareProduct
+      SharedLogic.FareTransparency
       SharedLogic.Finance.Prepaid
       SharedLogic.Finance.Reconciliation
       SharedLogic.Finance.Wallet

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -89,6 +89,7 @@ import SharedLogic.BlockedRouteDetector
 import SharedLogic.DriverPool
 import SharedLogic.FareCalculator
 import qualified SharedLogic.FareCalculatorV2 as FCV2
+import qualified SharedLogic.FareTransparency as FareTransparency
 import SharedLogic.FarePolicy
 import SharedLogic.GoogleMaps
 import qualified SharedLogic.Merchant as SMerchant
@@ -821,7 +822,7 @@ buildEstimate merchantId merchantOperatingCityId currency distanceUnit mbSearchR
   let isTollApplicable = isTollApplicableForTrip fullFarePolicy.vehicleServiceTier fullFarePolicy.tripCategory
 
   -- P0 FIX-01: Compute and log fare breakdown for transparency
-  let fareBreakdown = FareTransparency.buildFareBreakdown maxFareParams (realToFrac <$> (DFP.congestionChargeMultiplierToCentesimal <$> fullFarePolicy.congestionChargeMultiplier))
+  let fareBreakdown = FareTransparency.buildFareBreakdown maxFareParams (realToFrac . DFP.congestionChargeMultiplierToCentesimal <$> fullFarePolicy.congestionChargeMultiplier)
   logInfo $
     "FareBreakdown for estimate "
       <> show estimateId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -819,6 +819,39 @@ buildEstimate merchantId merchantOperatingCityId currency distanceUnit mbSearchR
       minFare = fareSum minFareParams (Just []) + maybe 0.0 (.minFee) mbDriverExtraFeeBounds
       maxFare = fareSum maxFareParams (Just []) + maybe 0.0 (.maxFee) mbDriverExtraFeeBounds + pickupChargesMaxx
   let isTollApplicable = isTollApplicableForTrip fullFarePolicy.vehicleServiceTier fullFarePolicy.tripCategory
+
+  -- P0 FIX-01: Compute and log fare breakdown for transparency
+  let fareBreakdown = FareTransparency.buildFareBreakdown maxFareParams (realToFrac <$> (DFP.congestionChargeMultiplierToCentesimal <$> fullFarePolicy.congestionChargeMultiplier))
+  logInfo $
+    "FareBreakdown for estimate "
+      <> show estimateId
+      <> ": baseFare=" <> show fareBreakdown.baseFare
+      <> ", distanceCharge=" <> show fareBreakdown.distanceCharge
+      <> ", surgeAmount=" <> show fareBreakdown.surgeAmount
+      <> ", tollCharges=" <> show fareBreakdown.tollCharges
+      <> ", platformFee=" <> show fareBreakdown.platformFee
+
+  -- P0 FIX-01: Compute surge info with human-readable reason
+  let surgeInfo = FareTransparency.buildSurgeInfo maxFareParams.congestionCharge fullFarePolicy.congestionChargeMultiplier fullFarePolicy.smartTipReason
+  whenJust surgeInfo $ \si ->
+    logInfo $
+      "SurgeInfo for estimate "
+        <> show estimateId
+        <> ": multiplier=" <> show si.congestionMultiplier
+        <> ", amount=" <> show si.congestionChargeAmount
+        <> ", reason=" <> show si.reason
+
+  -- P0 FIX-09: Compute toll estimation info
+  let tollEstInfo = FareTransparency.buildTollEstimationInfo tollCharges tollNames tollIds
+  when tollEstInfo.tollsEstimated $
+    logInfo $
+      "TollEstimation for estimate "
+        <> show estimateId
+        <> ": tollsEstimated=" <> show tollEstInfo.tollsEstimated
+        <> ", tollsMayChange=" <> show tollEstInfo.tollsMayChange
+        <> ", amount=" <> show tollEstInfo.estimatedTollAmount
+        <> ", plazas=" <> show tollEstInfo.tollPlazaNames
+
   pure
     DEst.Estimate
       { id = estimateId,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Penalty.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Penalty.hs
@@ -96,7 +96,10 @@ postPenaltyCheck (mbPersonId, _merchantId, _merchantOpCityId) req = do
               currentTime = currentTime,
               rideCreatedTime = rideCreatedTime,
               driverArrivalTime = driverArrivalTime,
-              merchantOperatingCityId = booking.merchantOperatingCityId
+              merchantOperatingCityId = booking.merchantOperatingCityId,
+              timeSinceAcceptSec = currentTime - rideCreatedTime,
+              estimatedTripDistanceMeters = fromIntegral <$> booking.estimatedDistance,
+              estimatedFareAmount = Just booking.estimatedFare
             }
     tagsE <- withTryCatch "computeNammaTags:RideCancel" $ LYDL.computeNammaTagsWithDebugLog LYDL.Driver (cast booking.merchantOperatingCityId) YA.RideCancel tagData
     let tags = fromMaybe [] $ eitherToMaybe tagsE

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
@@ -285,8 +285,8 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
                 "distToPickupMeters" A..= disToPickup,
                 "estimatedDistance" A..= booking.estimatedDistance,
                 "estimatedFare" A..= booking.estimatedFare,
-                "source" A..= show source,
-                "reasonCode" A..= show reasonCode
+                "source" A..= A.toJSON source,
+                "reasonCode" A..= A.toJSON reasonCode
               ]
           enrichedAdditionalInfo = case additionalInfo of
             Just info -> Just $ info <> " | " <> TL.toStrict (TLE.decodeUtf8 (A.encode cancellationMeta))

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
@@ -215,11 +215,11 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
         DP.ADMIN -> do
           unless (authPerson.merchantId == driver.merchantId) $ throwError (RideDoesNotExist rideId.getId)
           logTagInfo "admin -> cancelRide : " ("DriverId " <> getId driverId <> ", RideId " <> getId ride.id)
-          buildRideCancelationReason Nothing Nothing Nothing DBCR.ByMerchant ride (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.CallBased)
+          buildRideCancelationReason Nothing Nothing Nothing DBCR.ByMerchant ride booking (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.CallBased)
         DP.FLEET_OWNER -> do
           when (ride.fleetOwnerId /= Just authPerson.id) $ throwError (RideDoesNotExist rideId.getId)
           logTagInfo "fleetOwner -> cancelRide : " ("DriverId " <> getId driverId <> ", RideId " <> getId ride.id)
-          buildRideCancelationReason Nothing Nothing Nothing DBCR.ByFleetOwner ride (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.FleetOwner)
+          buildRideCancelationReason Nothing Nothing Nothing DBCR.ByFleetOwner ride booking (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.FleetOwner)
         _ -> do
           unless (authPerson.id == driverId) $ throwError NotAnExecutor
           goHomeConfig <- CGHC.findByMerchantOpCityId booking.merchantOperatingCityId (Just (TransactionId (Id booking.transactionId)))
@@ -245,19 +245,19 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
             Just dis -> if abs (toInteger dis) > disToPickupThreshold then logWarning ("Invalid disToPickup received:" <> show disToPickup) >> return Nothing else return (Just dis)
             Nothing -> return Nothing
           let currentDriverLocation = getCoordinates <$> mbLocation
-          buildRideCancelationReason currentDriverLocation updatedDisToPickup (Just driverId) DBCR.ByDriver ride (Just driver.merchantId) >>= \res -> return (res, cancellationCount, isGoToDisabled, driverGoHomeRequestId, Just dghInfo, Just goHomeConfig, disToPickup, DRide.Driver)
+          buildRideCancelationReason currentDriverLocation updatedDisToPickup (Just driverId) DBCR.ByDriver ride booking (Just driver.merchantId) >>= \res -> return (res, cancellationCount, isGoToDisabled, driverGoHomeRequestId, Just dghInfo, Just goHomeConfig, disToPickup, DRide.Driver)
       return (rideCancellationReason, mbCancellationCnt, isGoToDisabled, driverGoHomeRequestId, dghInfo, goHomeConfig, disToPickup, rideEndedBy)
     DashboardRequestorId (reqMerchantId, _) -> do
       unless (driver.merchantId == reqMerchantId) $ throwError (RideDoesNotExist rideId.getId)
       logTagInfo "dashboard -> cancelRide : " ("DriverId " <> getId driverId <> ", RideId " <> getId ride.id)
-      buildRideCancelationReason Nothing Nothing Nothing DBCR.ByMerchant ride (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.Dashboard) -- is it correct DBCR.ByMerchant?
+      buildRideCancelationReason Nothing Nothing Nothing DBCR.ByMerchant ride booking (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.Dashboard) -- is it correct DBCR.ByMerchant?
     ApplicationRequestorId jobId -> do
       logTagInfo "Allocator -> cancelRide : " ("DriverId " <> getId driverId <> ", RideId " <> getId ride.id <> "JobId " <> jobId)
-      buildRideCancelationReason Nothing Nothing Nothing DBCR.ByApplication ride (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.Allocator)
+      buildRideCancelationReason Nothing Nothing Nothing DBCR.ByApplication ride booking (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.Allocator)
     MerchantRequestorId (reqMerchantId, mocId) -> do
       unless (driver.merchantId == reqMerchantId && mocId == driver.merchantOperatingCityId) $ throwError (RideDoesNotExist rideId.getId)
       logTagInfo "Allocator : ByMerchant -> cancelRide : " ("DriverId " <> getId driverId <> ", RideId " <> getId ride.id)
-      buildRideCancelationReason Nothing Nothing Nothing DBCR.ByMerchant ride (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.Allocator)
+      buildRideCancelationReason Nothing Nothing Nothing DBCR.ByMerchant ride booking (Just driver.merchantId) >>= \res -> return (res, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, DRide.Allocator)
 
   -- Lock Description: This is a Shared Lock held Between Booking Cancel for Customer & Driver, At a time only one of them can do the full Cancel to OnCancel/Reallocation flow.
   -- Lock Release: Held for 30 seconds and released at the end of the OnCancel/EstimateRepitition-OnUpdate/QuoteRepitition-OnUpdate.
@@ -274,7 +274,7 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
   pure (cancellationCnt, isGoToDisabled)
   where
     isValidRide ride = ride.status `elem` [DRide.NEW, DRide.UPCOMING]
-    buildRideCancelationReason currentDriverLocation disToPickup mbDriverId source ride merchantId = do
+    buildRideCancelationReason currentDriverLocation disToPickup mbDriverId source ride booking' merchantId = do
       now <- getCurrentTime
       let CancelRideReq {..} = req
           -- Enrich additionalInfo with cancellation metadata for analytics
@@ -284,8 +284,8 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
               [ "message" A..= additionalInfo,
                 "timeSinceAcceptSec" A..= timeSinceAcceptSec,
                 "distToPickupMeters" A..= disToPickup,
-                "estimatedDistance" A..= booking.estimatedDistance,
-                "estimatedFare" A..= booking.estimatedFare,
+                "estimatedDistance" A..= booking'.estimatedDistance,
+                "estimatedFare" A..= booking'.estimatedFare,
                 "source" A..= source,
                 "reasonCode" A..= reasonCode
               ]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
@@ -281,16 +281,15 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
           timeSinceAcceptSec = round (diffUTCTime now ride.createdAt) :: Int
           cancellationMeta =
             A.object
-              [ "timeSinceAcceptSec" A..= timeSinceAcceptSec,
+              [ "message" A..= additionalInfo,
+                "timeSinceAcceptSec" A..= timeSinceAcceptSec,
                 "distToPickupMeters" A..= disToPickup,
                 "estimatedDistance" A..= booking.estimatedDistance,
                 "estimatedFare" A..= booking.estimatedFare,
-                "source" A..= A.toJSON source,
-                "reasonCode" A..= A.toJSON reasonCode
+                "source" A..= source,
+                "reasonCode" A..= reasonCode
               ]
-          enrichedAdditionalInfo = case additionalInfo of
-            Just info -> Just $ info <> " | " <> TL.toStrict (TLE.decodeUtf8 (A.encode cancellationMeta))
-            Nothing -> Just $ TL.toStrict (TLE.decodeUtf8 (A.encode cancellationMeta))
+          enrichedAdditionalInfo = Just $ TL.toStrict (TLE.decodeUtf8 (A.encode cancellationMeta))
       return $
         DBCR.BookingCancellationReason
           { bookingId = ride.bookingId,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
@@ -27,7 +27,10 @@ where
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashMap.Strict as HMS
 import qualified Data.Map as M
+import qualified Data.Aeson as A
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
 import qualified Domain.Action.UI.Ride.CancelRide.Internal as CInternal
 import qualified Domain.SharedLogic.Cancel as SharedCancel
 import qualified Domain.Types.Booking as SRB
@@ -272,7 +275,22 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
   where
     isValidRide ride = ride.status `elem` [DRide.NEW, DRide.UPCOMING]
     buildRideCancelationReason currentDriverLocation disToPickup mbDriverId source ride merchantId = do
+      now <- getCurrentTime
       let CancelRideReq {..} = req
+          -- Enrich additionalInfo with cancellation metadata for analytics
+          timeSinceAcceptSec = round (diffUTCTime now ride.createdAt) :: Int
+          cancellationMeta =
+            A.object
+              [ "timeSinceAcceptSec" A..= timeSinceAcceptSec,
+                "distToPickupMeters" A..= disToPickup,
+                "estimatedDistance" A..= booking.estimatedDistance,
+                "estimatedFare" A..= booking.estimatedFare,
+                "source" A..= show source,
+                "reasonCode" A..= show reasonCode
+              ]
+          enrichedAdditionalInfo = case additionalInfo of
+            Just info -> Just $ info <> " | " <> TL.toStrict (TLE.decodeUtf8 (A.encode cancellationMeta))
+            Nothing -> Just $ TL.toStrict (TLE.decodeUtf8 (A.encode cancellationMeta))
       return $
         DBCR.BookingCancellationReason
           { bookingId = ride.bookingId,
@@ -281,6 +299,7 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
             source = source,
             reasonCode = Just reasonCode,
             driverId = mbDriverId,
+            additionalInfo = enrichedAdditionalInfo,
             driverCancellationLocation = currentDriverLocation,
             driverDistToPickup = disToPickup,
             distanceUnit = ride.distanceUnit,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -305,37 +305,48 @@ cancelRideTransaction booking ride bookingCReason merchant rideEndedBy cancellat
         mbPanCard <- QPanCard.findByDriverId ride.driverId
         mbDriverInfo <- QDI.findById (cast ride.driverId)
         ctx <- buildFinanceCtx booking ride (Just driver) mbPanCard mbDriverInfo transporterConfig
-        result <- runFinance ctx $ do
-          mapM_
-            ( \(amt, ref, dest) -> do
-                transfer_ BuyerAsset BuyerExternal amt ref
-                void $ transfer BuyerExternal dest amt ref
-            )
-            cancellationComponents
-          -- TDS: Liability(DRIVER/FLEET_OWNER) -> Liability(GOVERNMENT_DIRECT)
-          whenJust mbTdsAmount $ \tdsAmount ->
-            void $ transfer OwnerLiability GovtDirect tdsAmount walletReferenceTDSDeductionCancellation
-          invoice
-            InvoiceConfig
-              { invoiceType = Invoice.RideCancellation,
-                issuedToType = "CUSTOMER",
-                issuedToId = rid.getId,
-                issuedToName = booking.riderName,
-                issuedToAddress = booking.fromLocation.address.fullAddress,
-                gstBreakdown = computeGstBreakdown rideGst gstOnCancellation,
-                lineItems =
-                  catMaybes
-                    [ if baseCancellation > 0
-                        then Just InvoiceLineItem {description = "Customer Cancellation Fee", quantity = 1, unitPrice = baseCancellation, lineTotal = baseCancellation, isExternalCharge = False}
-                        else Nothing,
-                      if gstOnCancellation > 0
-                        then Just InvoiceLineItem {description = "GST on Cancellation Fee", quantity = 1, unitPrice = gstOnCancellation, lineTotal = gstOnCancellation, isExternalCharge = False}
-                        else Nothing
-                    ]
-              }
-        case result of
-          Left err -> logInfo $ "Failed to create cancellation ledger entries: " <> show err
-          Right _ -> pure ()
+        let financeAction = runFinance ctx $ do
+              mapM_
+                ( \(amt, ref, dest) -> do
+                    transfer_ BuyerAsset BuyerExternal amt ref
+                    void $ transfer BuyerExternal dest amt ref
+                )
+                cancellationComponents
+              -- TDS: Liability(DRIVER/FLEET_OWNER) -> Liability(GOVERNMENT_DIRECT)
+              whenJust mbTdsAmount $ \tdsAmount ->
+                void $ transfer OwnerLiability GovtDirect tdsAmount walletReferenceTDSDeductionCancellation
+              invoice
+                InvoiceConfig
+                  { invoiceType = Invoice.RideCancellation,
+                    issuedToType = "CUSTOMER",
+                    issuedToId = rid.getId,
+                    issuedToName = booking.riderName,
+                    issuedToAddress = booking.fromLocation.address.fullAddress,
+                    gstBreakdown = computeGstBreakdown rideGst gstOnCancellation,
+                    lineItems =
+                      catMaybes
+                        [ if baseCancellation > 0
+                            then Just InvoiceLineItem {description = "Customer Cancellation Fee", quantity = 1, unitPrice = baseCancellation, lineTotal = baseCancellation, isExternalCharge = False}
+                            else Nothing,
+                          if gstOnCancellation > 0
+                            then Just InvoiceLineItem {description = "GST on Cancellation Fee", quantity = 1, unitPrice = gstOnCancellation, lineTotal = gstOnCancellation, isExternalCharge = False}
+                            else Nothing
+                        ]
+                  }
+        -- Retry up to 3 times with backoff on failure
+        let tryFinance attempt = do
+              result <- financeAction
+              case result of
+                Left err -> do
+                  if attempt < 3
+                    then do
+                      logWarning $ "Cancellation ledger creation attempt " <> show attempt <> " failed for bookingId: " <> booking.id.getId <> " error: " <> show err <> " — retrying..."
+                      liftIO $ threadDelay (attempt * 1000000) -- backoff: 1s, 2s
+                      tryFinance (attempt + 1)
+                    else do
+                      logError $ "CRITICAL: Failed to create cancellation ledger entries after 3 attempts for bookingId: " <> booking.id.getId <> " error: " <> show err
+                Right _ -> pure ()
+        tryFinance (1 :: Int)
         logInfo $ "Created customer cancellation ledger entries for bookingId: " <> booking.id.getId <> " base=" <> show baseCancellation <> " gst=" <> show gstOnCancellation <> " tds=" <> show mbTdsAmount
     _ -> do
       logError "cancelRideTransaction: riderId in booking or cancellationFee is not present"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -45,7 +45,7 @@ import qualified Domain.Types.Ride as DRide
 import qualified Domain.Types.RiderDetails as RiderDetails
 import qualified Domain.Types.TransporterConfig as DTC
 import qualified Domain.Types.Yudhishthira as TY
-import EulerHS.Prelude hiding (whenJust)
+import EulerHS.Prelude hiding (threadDelay, whenJust)
 import Kernel.External.Maps
 import Kernel.Prelude hiding (any, elem, map, mapM_, notElem)
 import Kernel.Storage.Clickhouse.Config

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -208,8 +208,13 @@ cancelRideImpl rideId rideEndedBy bookingCReason isForceReallocation doCancellat
                 DCP.accumulateCancellationPenalty (fromMaybe False merchant.prepaidSubscriptionAndWalletEnabled && transporterConfig.driverWalletConfig.enableDriverWallet) booking ride rideTags transporterConfig driver
               Notify.notifyOnCancel ride.merchantOperatingCityId booking driver bookingCReason.source
             fork "cancelRide/ReAllocate - Notify BAP" $ do
+              logInfo $ "Attempting reallocation for bookingId: " <> booking.id.getId <> " after driver cancellation by driverId: " <> ride.driverId.getId
               isReallocated <- reAllocateBookingIfPossible isValueAddNP False merchant booking ride driver vehicle bookingCReason isForceReallocation
-              unless isReallocated $ BP.sendBookingCancelledUpdateToBAP booking merchant bookingCReason.source userNoShowCharges
+              if isReallocated
+                then logInfo $ "Reallocation initiated successfully for bookingId: " <> booking.id.getId
+                else do
+                  logWarning $ "Reallocation failed for bookingId: " <> booking.id.getId <> " — notifying rider of cancellation"
+                  BP.sendBookingCancelledUpdateToBAP booking merchant bookingCReason.source userNoShowCharges
             computeEligibleUpgradeTiers ride transporterConfig
         )
         ( do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -350,9 +350,11 @@ cancelRideTransaction booking ride bookingCReason merchant rideEndedBy cancellat
                       tryFinance (attempt + 1)
                     else do
                       logError $ "CRITICAL: Failed to create cancellation ledger entries after 3 attempts for bookingId: " <> booking.id.getId <> " error: " <> show err
-                Right _ -> pure ()
-        tryFinance (1 :: Int)
-        logInfo $ "Created customer cancellation ledger entries for bookingId: " <> booking.id.getId <> " base=" <> show baseCancellation <> " gst=" <> show gstOnCancellation <> " tds=" <> show mbTdsAmount
+                      pure False
+                Right _ -> pure True
+        success <- tryFinance (1 :: Int)
+        when success $
+          logInfo $ "Created customer cancellation ledger entries for bookingId: " <> booking.id.getId <> " base=" <> show baseCancellation <> " gst=" <> show gstOnCancellation <> " tds=" <> show mbTdsAmount
     _ -> do
       logError "cancelRideTransaction: riderId in booking or cancellationFee is not present"
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -378,6 +378,9 @@ updateNammaTagsForCancelledRide booking ride bookingCReason transporterConfig = 
       currentTime = floor $ utcTimeToPOSIXSeconds now
       rideCreatedTime = floor $ utcTimeToPOSIXSeconds ride.createdAt
       driverArrivalTime = floor . utcTimeToPOSIXSeconds <$> (ride.driverArrivalTime)
+      timeSinceAcceptSec = currentTime - rideCreatedTime
+      estimatedTripDistanceMeters = fromIntegral <$> booking.estimatedDistance
+      estimatedFareAmount = Just booking.estimatedFare
       tagData =
         TY.CancelRideTagData
           { ride = ride{status = DRide.CANCELLED},

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Yudhishthira.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Yudhishthira.hs
@@ -26,7 +26,13 @@ data CancelRideTagData = CancelRideTagData
     currentTime :: Int,
     rideCreatedTime :: Int,
     merchantOperatingCityId :: Id DMOC.MerchantOperatingCity,
-    driverArrivalTime :: Maybe Int
+    driverArrivalTime :: Maybe Int,
+    -- Time-based penalty inputs: seconds since driver accepted the ride
+    timeSinceAcceptSec :: Int,
+    -- Estimated trip distance in meters (for destination-aware penalty)
+    estimatedTripDistanceMeters :: Maybe Int,
+    -- Estimated fare (for fare-aware penalty)
+    estimatedFareAmount :: Maybe HighPrecMoney
   }
   deriving (Generic, Show, FromJSON, ToJSON)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Cancel.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Cancel.hs
@@ -296,12 +296,22 @@ reAllocateBookingIfPossible isValueAddNP userReallocationEnabled merchant bookin
           arrivedPickupThreshold = highPrecMetersToMeters transporterConfig.arrivedPickupThreshold
           driverHasNotArrived = isNothing driverArrivalTime || maybe True (> arrivedPickupThreshold) bookingCReason.driverDistToPickup
           scheduleReallocationAllowed = transporterConfig.enableScheduleReallocation == Just True
-      return $
-        searchTry.searchRepeatCounter < searchRepeatLimit
-          && (bookingCReason.source == SBCR.ByDriver || (bookingCReason.source == SBCR.ByFleetOwner && scheduleReallocationAllowed) || (bookingCReason.source == SBCR.ByUser && userReallocationEnabled))
-          && (isSearchTryValid || isScheduled)
-          && fromMaybe False isReallocationEnabled
-          && (driverHasNotArrived || (scheduleReallocationAllowed && booking.startTime > now))
+          canRepeat =
+            searchTry.searchRepeatCounter < searchRepeatLimit
+              && (bookingCReason.source == SBCR.ByDriver || (bookingCReason.source == SBCR.ByFleetOwner && scheduleReallocationAllowed) || (bookingCReason.source == SBCR.ByUser && userReallocationEnabled))
+              && (isSearchTryValid || isScheduled)
+              && fromMaybe False isReallocationEnabled
+              && (driverHasNotArrived || (scheduleReallocationAllowed && booking.startTime > now))
+      logInfo $
+        "Reallocation check for bookingId: " <> booking.id.getId
+          <> " | repeatCounter: " <> show searchTry.searchRepeatCounter
+          <> "/" <> show searchRepeatLimit
+          <> " | searchTryValid: " <> show isSearchTryValid
+          <> " | reallocationEnabled: " <> show isReallocationEnabled
+          <> " | driverHasNotArrived: " <> show driverHasNotArrived
+          <> " | source: " <> show bookingCReason.source
+          <> " | canRepeat: " <> show canRepeat
+      return canRepeat
 
     buildBookingCancellationReason newBooking = do
       return $

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverCancellationPenalty.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverCancellationPenalty.hs
@@ -29,6 +29,7 @@ import qualified Domain.Types.Plan as DPlan
 import qualified Domain.Types.Ride as DRide
 import qualified Domain.Types.TransporterConfig as DTC
 import qualified Domain.Types.VehicleCategory as DVC
+import qualified Domain.Types.VehicleVariant as DVV
 import EulerHS.Prelude
 import Kernel.Prelude hiding (any, elem, map)
 import Kernel.Storage.Esqueleto.Config (EsqDBReplicaFlow)
@@ -65,8 +66,9 @@ mkCancellationPenaltyFee ::
   HighPrecMoney ->
   Currency ->
   DTC.TransporterConfig ->
+  DVC.VehicleCategory ->
   m (UTCTime, DF.DriverFee)
-mkCancellationPenaltyFee now merchantId merchantOpCityId driverId penaltyAmount currency transporterConfig = do
+mkCancellationPenaltyFee now merchantId merchantOpCityId driverId penaltyAmount currency transporterConfig vehicleCat = do
   id' <- generateGUID
   let cycleDuration = secondsToNominalDiffTime $ fromMaybe 0 transporterConfig.cancellationFeeCycle
       startTime = now
@@ -118,7 +120,7 @@ mkCancellationPenaltyFee now merchantId merchantOpCityId driverId penaltyAmount 
           refundedAmount = Nothing,
           refundedAt = Nothing,
           refundedBy = Nothing,
-          vehicleCategory = DVC.AUTO_CATEGORY,
+          vehicleCategory = vehicleCat,
           hasSibling = Just False,
           siblingFeeId = Nothing,
           splitOfDriverFeeId = Nothing,
@@ -161,6 +163,7 @@ accumulateCancellationPenalty ::
   DP.Person ->
   m ()
 accumulateCancellationPenalty isWalletEnabled booking ride rideTags transporterConfig driver = do
+  let vehicleCat = maybe DVC.AUTO_CATEGORY DVV.castServiceTierToVehicleCategory (Just booking.vehicleServiceTier)
   when (validCancellationPenaltyApplicable `elem` rideTags && isJust booking.fareParams.driverCancellationPenaltyAmount) $ do
     case booking.fareParams.driverCancellationPenaltyAmount of
       Just penaltyAmount ->
@@ -220,6 +223,7 @@ accumulateCancellationPenalty isWalletEnabled booking ride rideTags transporterC
                     penaltyAmount
                     booking.currency
                     transporterConfig
+                    vehicleCat
                 QDF.create newFee
                 logInfo $
                   "Created new CANCELLATION_PENALTY DriverFee " <> newFee.id.getId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareTransparency.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareTransparency.hs
@@ -42,7 +42,7 @@ module SharedLogic.FareTransparency
   )
 where
 
-import Domain.Types.FareParameters (FareParameters (..), FareParametersDetails (..), FParamsInterCityDetails (..), FParamsProgressiveDetails (..), FParamsRentalDetails (..), FParamsAmbulanceDetails (..))
+import Domain.Types.FareParameters (FareParameters (..), FareParametersDetails (..))
 import qualified Domain.Types.FarePolicy as DFP
 import Kernel.Prelude
 import Kernel.Utils.Common (HighPrecMoney (..))
@@ -204,13 +204,13 @@ applyFareCap ::
   HighPrecMoney ->
   FareCapResult
 applyFareCap multiplier estimatedFare finalFare =
-  let ceiling = HighPrecMoney $ toRational multiplier * estimatedFare.getHighPrecMoney
-      isCapped = finalFare > ceiling
-      cappedFare = if isCapped then ceiling else finalFare
+  let fareCapCeiling = HighPrecMoney $ toRational multiplier * estimatedFare.getHighPrecMoney
+      isCapped = finalFare > fareCapCeiling
+      cappedFare = if isCapped then fareCapCeiling else finalFare
       fareCapDiscount = if isCapped then finalFare - cappedFare else 0
    in FareCapResult
         { cappedFare,
           wasCapped = isCapped,
           fareCapDiscount,
-          fareCeiling = ceiling
+          fareCeiling = fareCapCeiling
         }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareTransparency.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareTransparency.hs
@@ -1,0 +1,216 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+-- | Fare transparency utilities for NammaYatri.
+--
+-- Provides structured fare breakdown, human-readable surge reasons,
+-- toll estimation metadata, and fare cap (safety-net ceiling) logic.
+--
+-- Addresses P0 fare transparency fixes:
+--   FIX-01  Show congestion/surge charge as explicit line item
+--   FIX-04  Fare cap to prevent runaway fares
+--   FIX-09  Toll estimation flags
+module SharedLogic.FareTransparency
+  ( -- * Fare Breakdown
+    FareBreakdown (..),
+    buildFareBreakdown,
+
+    -- * Surge / Congestion Info
+    SurgeInfo (..),
+    buildSurgeInfo,
+    surgeReasonText,
+
+    -- * Toll Estimation Flags
+    TollEstimationInfo (..),
+    buildTollEstimationInfo,
+
+    -- * Fare Cap (Safety Net)
+    FareCapResult (..),
+    applyFareCap,
+    defaultFareCapMultiplier,
+  )
+where
+
+import Domain.Types.FareParameters (FareParameters (..), FareParametersDetails (..), FParamsInterCityDetails (..), FParamsProgressiveDetails (..), FParamsRentalDetails (..), FParamsAmbulanceDetails (..))
+import qualified Domain.Types.FarePolicy as DFP
+import Kernel.Prelude
+import Kernel.Utils.Common (HighPrecMoney (..))
+
+-- ---------------------------------------------------------------------------
+-- Fare Breakdown
+-- ---------------------------------------------------------------------------
+
+-- | A structured, rider-facing fare breakdown built from 'FareParameters'.
+--
+-- Every field is an absolute amount (in the ride currency). The frontend
+-- can render each non-zero / non-Nothing field as a separate line item.
+data FareBreakdown = FareBreakdown
+  { baseFare :: HighPrecMoney,
+    distanceCharge :: Maybe HighPrecMoney,
+    -- | Time-based fare component (ride duration fare)
+    timeCharge :: Maybe HighPrecMoney,
+    surgeMultiplier :: Maybe Double,
+    surgeAmount :: Maybe HighPrecMoney,
+    tollCharges :: Maybe HighPrecMoney,
+    platformFee :: Maybe HighPrecMoney,
+    waitingCharge :: Maybe HighPrecMoney,
+    nightShiftCharge :: Maybe HighPrecMoney,
+    parkingCharge :: Maybe HighPrecMoney,
+    insuranceCharge :: Maybe HighPrecMoney
+  }
+  deriving (Generic, Show, Eq, FromJSON, ToJSON, ToSchema)
+
+-- | Build a rider-facing fare breakdown from internal 'FareParameters'.
+buildFareBreakdown :: FareParameters -> Maybe Double -> FareBreakdown
+buildFareBreakdown fp mbSurgeMultiplier =
+  FareBreakdown
+    { baseFare = fp.baseFare,
+      distanceCharge = getDistanceCharge fp,
+      timeCharge = fp.rideExtraTimeFare,
+      surgeMultiplier = mbSurgeMultiplier,
+      surgeAmount = fp.congestionCharge,
+      tollCharges = fp.tollCharges,
+      platformFee = fp.platformFee,
+      waitingCharge = fp.waitingCharge,
+      nightShiftCharge = fp.nightShiftCharge,
+      parkingCharge = fp.parkingCharge,
+      insuranceCharge = fp.insuranceCharge
+    }
+
+-- | Extract distance-based fare from progressive/intercity details.
+getDistanceCharge :: FareParameters -> Maybe HighPrecMoney
+getDistanceCharge fp = case fp.fareParametersDetails of
+  ProgressiveDetails det -> det.extraKmFare
+  InterCityDetails det -> Just det.distanceFare
+  RentalDetails det -> Just det.distBasedFare
+  AmbulanceDetails det -> Just det.distBasedFare
+  _ -> Nothing
+
+-- ---------------------------------------------------------------------------
+-- Surge / Congestion Info
+-- ---------------------------------------------------------------------------
+
+-- | Rider-facing surge/congestion charge information.
+data SurgeInfo = SurgeInfo
+  { congestionChargeAmount :: Maybe HighPrecMoney,
+    -- | e.g. 1.2 means 20% surge
+    congestionMultiplier :: Maybe Double,
+    -- | Human-readable reason such as "High demand in your area"
+    reason :: Text
+  }
+  deriving (Generic, Show, Eq, FromJSON, ToJSON, ToSchema)
+
+-- | Build surge info from fare policy congestion data and smart-tip reason.
+buildSurgeInfo ::
+  Maybe HighPrecMoney ->
+  Maybe DFP.CongestionChargeMultiplier ->
+  Maybe Text ->
+  Maybe SurgeInfo
+buildSurgeInfo mbCongestionCharge mbMultiplier mbSmartTipReason =
+  case mbCongestionCharge of
+    Just charge
+      | charge > 0 ->
+          Just
+            SurgeInfo
+              { congestionChargeAmount = Just charge,
+                congestionMultiplier = fmap (realToFrac . DFP.congestionChargeMultiplierToCentesimal) mbMultiplier,
+                reason = surgeReasonText mbSmartTipReason
+              }
+    _ -> Nothing
+
+-- | Map backend smart-tip reason codes to rider-friendly text.
+surgeReasonText :: Maybe Text -> Text
+surgeReasonText = \case
+  Just "DemandMoreThanSupply" -> "High demand in your area"
+  Just "LowQuoteAcceptanceRate" -> "Fewer drivers accepting rides nearby"
+  Just "ExtraCongestion" -> "Heavy traffic congestion in this area"
+  _ -> "High demand in your area"
+
+-- ---------------------------------------------------------------------------
+-- Toll Estimation Flags
+-- ---------------------------------------------------------------------------
+
+-- | Metadata about toll detection at estimate time.
+data TollEstimationInfo = TollEstimationInfo
+  { -- | True when tolls were detected on the estimated route
+    tollsEstimated :: Bool,
+    -- | True when the actual route may differ causing toll changes
+    tollsMayChange :: Bool,
+    -- | Total estimated toll amount
+    estimatedTollAmount :: Maybe HighPrecMoney,
+    -- | Names of detected toll plazas
+    tollPlazaNames :: Maybe [Text]
+  }
+  deriving (Generic, Show, Eq, FromJSON, ToJSON, ToSchema)
+
+-- | Build toll estimation info from search-time toll detection results.
+buildTollEstimationInfo ::
+  Maybe HighPrecMoney ->
+  Maybe [Text] ->
+  Maybe [Text] ->
+  TollEstimationInfo
+buildTollEstimationInfo mbTollCharges mbTollNames _mbTollIds =
+  TollEstimationInfo
+    { tollsEstimated = isJust mbTollCharges && mbTollCharges > Just 0,
+      tollsMayChange = isJust mbTollCharges, -- route may change, so tolls may differ
+      estimatedTollAmount = mbTollCharges,
+      tollPlazaNames = mbTollNames
+    }
+
+-- ---------------------------------------------------------------------------
+-- Fare Cap (Safety Net)
+-- ---------------------------------------------------------------------------
+
+-- | Default fare cap multiplier: final fare cannot exceed 1.5x of estimated
+-- midpoint fare. This is a safety net to prevent runaway fares due to GPS
+-- drift, route deviations, or calculation errors.
+defaultFareCapMultiplier :: Double
+defaultFareCapMultiplier = 1.5
+
+-- | Result of applying the fare cap.
+data FareCapResult = FareCapResult
+  { cappedFare :: HighPrecMoney,
+    -- | True if the fare was actually capped (original > cap)
+    wasCapped :: Bool,
+    -- | The discount applied due to capping (original - capped)
+    fareCapDiscount :: HighPrecMoney,
+    -- | The cap ceiling that was applied
+    fareCeiling :: HighPrecMoney
+  }
+  deriving (Generic, Show, Eq, FromJSON, ToJSON, ToSchema)
+
+-- | Apply a fare cap as a safety net. If the computed final fare exceeds
+-- @fareCapMultiplier * estimatedMidpointFare@, cap it at the ceiling.
+--
+-- Returns 'Nothing' if no estimated fare is available (conservative:
+-- do not cap if we cannot compute a ceiling).
+applyFareCap ::
+  -- | Fare cap multiplier (e.g. 1.5 for 50% ceiling)
+  Double ->
+  -- | Estimated fare (midpoint of min-max range)
+  HighPrecMoney ->
+  -- | Computed final fare before capping
+  HighPrecMoney ->
+  FareCapResult
+applyFareCap multiplier estimatedFare finalFare =
+  let ceiling = HighPrecMoney $ toRational multiplier * estimatedFare.getHighPrecMoney
+      isCapped = finalFare > ceiling
+      cappedFare = if isCapped then ceiling else finalFare
+      fareCapDiscount = if isCapped then finalFare - cappedFare else 0
+   in FareCapResult
+        { cappedFare,
+          wasCapped = isCapped,
+          fareCapDiscount,
+          fareCeiling = ceiling
+        }

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -456,6 +456,7 @@ library
       SharedLogic.FRFSFareCalculator
       SharedLogic.FRFSSeatBooking
       SharedLogic.FRFSSeatBooking.Lua
+      SharedLogic.FRFSStateTransition
       SharedLogic.FRFSStatus
       SharedLogic.FRFSUtils
       SharedLogic.GoogleTranslate

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/BookingCancellationReason.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/BookingCancellationReason.yaml
@@ -13,7 +13,7 @@ BookingCancellationReason:
 
   types:
     CancellationSource:
-      enum: "ByUser, ByDriver, ByMerchant, ByAllocator, ByApplication"
+      enum: "ByUser, ByDriver, ByMerchant, ByAllocator, ByApplication, ByFleetOwner"
 
 
   fields:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/BookingCancellationReason.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/BookingCancellationReason.hs
@@ -32,6 +32,6 @@ data BookingCancellationReason = BookingCancellationReason
   }
   deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
 
-data CancellationSource = ByUser | ByDriver | ByMerchant | ByAllocator | ByApplication deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema)
+data CancellationSource = ByUser | ByDriver | ByMerchant | ByAllocator | ByApplication | ByFleetOwner deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema)
 
 $(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''CancellationSource)

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
@@ -206,49 +206,50 @@ onConfirm merchant booking' quoteCategories dOrder = do
       isLockAcquired <- Redis.tryLockRedis lockKey 60
       if isLockAcquired
         then do
-          -- Double-check after lock acquisition (another callback may have completed)
-          existingTicketsAfterLock <- QTicket.findAllByTicketBookingId booking.id
-          if not (null existingTicketsAfterLock)
-            then do
-              logInfo $ "OnConfirm:idempotent - tickets created by concurrent callback for bookingId=" <> booking.id.getId
-              void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
-            else do
-              let discountedTickets = fromMaybe 0 booking.discountedTickets
-              tickets <- createTickets booking dOrder.tickets discountedTickets
-              let mbPaymentHoldId = listToMaybe quoteCategories >>= (.holdId)
-              let effectiveHoldId = mbPaymentHoldId <|> booking'.holdId
-              whenJust effectiveHoldId $ \holdId -> do
-                whenJust booking'.tripId $ \tripId -> do
-                  logInfo $ "OnConfirm:onConfirm finalizing seat hold bookingId=" <> booking.id.getId <> " holdId=" <> holdId <> " tripId=" <> tripId
-                  SeatBooking.confirmBooking tripId holdId
-                  SeatBooking.releaseAbandonedHolds tripId booking.id.getId holdId
-              void $ QTicket.createMany tickets
-              mbJourneyId <- FRFSUtils.getJourneyIdFromBooking booking
-              whenJust mbJourneyId $ \journeyId -> do
-                QJourneyExtra.updateLongestJourneyExpiryTimeWithTickets journeyId tickets
-              void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
-              person <- runInReplica $ QPerson.findById booking.riderId >>= fromMaybeM (PersonNotFound booking.riderId.getId)
-              mRiderNumber <- mapM ENC.decrypt person.mobileNumber
-              integratedBPPConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
-              let fareParameters = mkFareParameters (mkCategoryPriceItemFromQuoteCategories quoteCategories)
-              buildReconTable merchant booking fareParameters dOrder tickets mRiderNumber integratedBPPConfig
-              void $ sendTicketBookedSMS mRiderNumber person.mobileCountryCode fareParameters
-              void $ QPS.incrementTicketsBookedInEvent booking.riderId fareParameters.totalQuantity
-              void $ CQP.clearPSCache booking.riderId
-              whenJust booking.partnerOrgId $ \pOrgId -> do
-                walletPOCfg <- do
-                  pOrgCfg <- CQPOC.findByIdAndCfgType pOrgId DPOC.WALLET_CLASS_NAME >>= fromMaybeM (PartnerOrgConfigNotFound pOrgId.getId $ show DPOC.WALLET_CLASS_NAME)
-                  DPOC.getWalletClassNameConfig pOrgCfg.config
-                let mbClassName = lookup booking.providerId walletPOCfg.className
-                whenJust mbClassName $ \className -> do
-                  fork ("adding googleJWTUrl" <> " Booking Id: " <> booking.id.getId) $ do
-                    let serviceName = DEMSC.WalletService GW.GoogleWallet
-                    let mId = booking'.merchantId
-                    let mocId' = booking'.merchantOperatingCityId
-                    serviceAccount <- GWSA.getserviceAccount mId mocId' serviceName
-                    transitObjects' <- createTransitObjects pOrgId booking tickets person serviceAccount className integratedBPPConfig
-                    url <- mkGoogleWalletLink serviceAccount transitObjects'
-                    void $ QTBooking.updateGoogleWalletLinkById (Just url) booking.id
+          flip finally (Redis.unlockRedis lockKey) $ do
+            -- Double-check after lock acquisition (another callback may have completed)
+            existingTicketsAfterLock <- QTicket.findAllByTicketBookingId booking.id
+            if not (null existingTicketsAfterLock)
+              then do
+                logInfo $ "OnConfirm:idempotent - tickets created by concurrent callback for bookingId=" <> booking.id.getId
+                void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
+              else do
+                let discountedTickets = fromMaybe 0 booking.discountedTickets
+                tickets <- createTickets booking dOrder.tickets discountedTickets
+                let mbPaymentHoldId = listToMaybe quoteCategories >>= (.holdId)
+                let effectiveHoldId = mbPaymentHoldId <|> booking'.holdId
+                whenJust effectiveHoldId $ \holdId -> do
+                  whenJust booking'.tripId $ \tripId -> do
+                    logInfo $ "OnConfirm:onConfirm finalizing seat hold bookingId=" <> booking.id.getId <> " holdId=" <> holdId <> " tripId=" <> tripId
+                    SeatBooking.confirmBooking tripId holdId
+                    SeatBooking.releaseAbandonedHolds tripId booking.id.getId holdId
+                void $ QTicket.createMany tickets
+                mbJourneyId <- FRFSUtils.getJourneyIdFromBooking booking
+                whenJust mbJourneyId $ \journeyId -> do
+                  QJourneyExtra.updateLongestJourneyExpiryTimeWithTickets journeyId tickets
+                void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
+                person <- runInReplica $ QPerson.findById booking.riderId >>= fromMaybeM (PersonNotFound booking.riderId.getId)
+                mRiderNumber <- mapM ENC.decrypt person.mobileNumber
+                integratedBPPConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
+                let fareParameters = mkFareParameters (mkCategoryPriceItemFromQuoteCategories quoteCategories)
+                buildReconTable merchant booking fareParameters dOrder tickets mRiderNumber integratedBPPConfig
+                void $ sendTicketBookedSMS mRiderNumber person.mobileCountryCode fareParameters
+                void $ QPS.incrementTicketsBookedInEvent booking.riderId fareParameters.totalQuantity
+                void $ CQP.clearPSCache booking.riderId
+                whenJust booking.partnerOrgId $ \pOrgId -> do
+                  walletPOCfg <- do
+                    pOrgCfg <- CQPOC.findByIdAndCfgType pOrgId DPOC.WALLET_CLASS_NAME >>= fromMaybeM (PartnerOrgConfigNotFound pOrgId.getId $ show DPOC.WALLET_CLASS_NAME)
+                    DPOC.getWalletClassNameConfig pOrgCfg.config
+                  let mbClassName = lookup booking.providerId walletPOCfg.className
+                  whenJust mbClassName $ \className -> do
+                    fork ("adding googleJWTUrl" <> " Booking Id: " <> booking.id.getId) $ do
+                      let serviceName = DEMSC.WalletService GW.GoogleWallet
+                      let mId = booking'.merchantId
+                      let mocId' = booking'.merchantOperatingCityId
+                      serviceAccount <- GWSA.getserviceAccount mId mocId' serviceName
+                      transitObjects' <- createTransitObjects pOrgId booking tickets person serviceAccount className integratedBPPConfig
+                      url <- mkGoogleWalletLink serviceAccount transitObjects'
+                      void $ QTBooking.updateGoogleWalletLinkById (Just url) booking.id
         else do
           logWarning $ "OnConfirm:lock not acquired for bookingId=" <> booking.id.getId <> ", another callback likely in progress"
           void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
@@ -22,7 +22,7 @@ import BecknV2.FRFS.Utils
 import Data.Aeson
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as BL
-import Data.HashMap.Strict
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock.POSIX hiding (getCurrentTime)
@@ -49,7 +49,7 @@ import Kernel.Beam.Functions
 import Kernel.Beam.Functions as B
 import Kernel.External.Encryption as ENC
 import Kernel.External.Types (SchedulerFlow)
-import Kernel.Prelude as Prelude hiding (lookup)
+import Kernel.Prelude as Prelude
 import Kernel.Sms.Config (SmsConfig)
 import Kernel.Storage.Esqueleto.Config (EsqDBReplicaFlow)
 import qualified Kernel.Storage.Hedis as Redis
@@ -240,7 +240,7 @@ onConfirm merchant booking' quoteCategories dOrder = do
                   walletPOCfg <- do
                     pOrgCfg <- CQPOC.findByIdAndCfgType pOrgId DPOC.WALLET_CLASS_NAME >>= fromMaybeM (PartnerOrgConfigNotFound pOrgId.getId $ show DPOC.WALLET_CLASS_NAME)
                     DPOC.getWalletClassNameConfig pOrgCfg.config
-                  let mbClassName = lookup booking.providerId walletPOCfg.className
+                  let mbClassName = HM.lookup booking.providerId walletPOCfg.className
                   whenJust mbClassName $ \className -> do
                     fork ("adding googleJWTUrl" <> " Booking Id: " <> booking.id.getId) $ do
                       let serviceName = DEMSC.WalletService GW.GoogleWallet
@@ -487,7 +487,7 @@ mkTransitObjects pOrgId booking ticket person serviceAccount className sortIndex
   walletQRTypeCfg <- do
     qrCfg <- CQPOC.findByIdAndCfgType pOrgId DPOC.WALLET_QR_TYPE >>= fromMaybeM (PartnerOrgConfigNotFound pOrgId.getId $ show DPOC.WALLET_QR_TYPE)
     DPOC.getWalletQRTypeConfig qrCfg.config
-  let mbPeriodMillis = lookup booking.merchantOperatingCityId.getId walletQRTypeCfg.qrType
+  let mbPeriodMillis = HM.lookup booking.merchantOperatingCityId.getId walletQRTypeCfg.qrType
   let mbRotatingBarcode = mkRotatingBarcode ticket.qrData mbPeriodMillis
   frfsConfig <- CQFRFSConfig.findByMerchantOperatingCityId fromStation.merchantOperatingCityId Nothing >>= fromMaybeM (FRFSConfigNotFound fromStation.merchantOperatingCityId.getId)
   let passengerName' = fromMaybe "-" person.firstName

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
@@ -194,43 +194,64 @@ onConfirm ::
 onConfirm merchant booking' quoteCategories dOrder = do
   Metrics.finishMetrics Metrics.CONFIRM_FRFS merchant.name dOrder.transactionId booking'.merchantOperatingCityId.getId
   let booking = booking' {Booking.bppOrderId = Just dOrder.bppOrderId}
-  let discountedTickets = fromMaybe 0 booking.discountedTickets
-  tickets <- createTickets booking dOrder.tickets discountedTickets
-  let mbPaymentHoldId = listToMaybe quoteCategories >>= (.holdId)
-  let effectiveHoldId = mbPaymentHoldId <|> booking'.holdId
-  whenJust effectiveHoldId $ \holdId -> do
-    whenJust booking'.tripId $ \tripId -> do
-      logInfo $ "OnConfirm:onConfirm finalizing seat hold bookingId=" <> booking.id.getId <> " holdId=" <> holdId <> " tripId=" <> tripId
-      SeatBooking.confirmBooking tripId holdId
-      SeatBooking.releaseAbandonedHolds tripId booking.id.getId holdId
-  void $ QTicket.createMany tickets
-  mbJourneyId <- FRFSUtils.getJourneyIdFromBooking booking
-  -- Update journey expiry time based on maximum ticket validity using the created tickets
-  whenJust mbJourneyId $ \journeyId -> do
-    QJourneyExtra.updateLongestJourneyExpiryTimeWithTickets journeyId tickets
-  void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
-  person <- runInReplica $ QPerson.findById booking.riderId >>= fromMaybeM (PersonNotFound booking.riderId.getId)
-  mRiderNumber <- mapM ENC.decrypt person.mobileNumber
-  integratedBPPConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
-  let fareParameters = mkFareParameters (mkCategoryPriceItemFromQuoteCategories quoteCategories)
-  buildReconTable merchant booking fareParameters dOrder tickets mRiderNumber integratedBPPConfig
-  void $ sendTicketBookedSMS mRiderNumber person.mobileCountryCode fareParameters
-  void $ QPS.incrementTicketsBookedInEvent booking.riderId fareParameters.totalQuantity
-  void $ CQP.clearPSCache booking.riderId
-  whenJust booking.partnerOrgId $ \pOrgId -> do
-    walletPOCfg <- do
-      pOrgCfg <- CQPOC.findByIdAndCfgType pOrgId DPOC.WALLET_CLASS_NAME >>= fromMaybeM (PartnerOrgConfigNotFound pOrgId.getId $ show DPOC.WALLET_CLASS_NAME)
-      DPOC.getWalletClassNameConfig pOrgCfg.config
-    let mbClassName = lookup booking.providerId walletPOCfg.className
-    whenJust mbClassName $ \className -> do
-      fork ("adding googleJWTUrl" <> " Booking Id: " <> booking.id.getId) $ do
-        let serviceName = DEMSC.WalletService GW.GoogleWallet
-        let mId = booking'.merchantId
-        let mocId' = booking'.merchantOperatingCityId
-        serviceAccount <- GWSA.getserviceAccount mId mocId' serviceName
-        transitObjects' <- createTransitObjects pOrgId booking tickets person serviceAccount className integratedBPPConfig
-        url <- mkGoogleWalletLink serviceAccount transitObjects'
-        void $ QTBooking.updateGoogleWalletLinkById (Just url) booking.id
+  -- Idempotency guard: check if tickets already exist for this booking
+  existingTickets <- QTicket.findAllByTicketBookingId booking.id
+  if not (null existingTickets)
+    then do
+      logInfo $ "OnConfirm:idempotent - tickets already exist for bookingId=" <> booking.id.getId <> " count=" <> show (length existingTickets) <> ", skipping ticket creation"
+      void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
+    else do
+      -- Acquire Redis lock to prevent concurrent ticket creation from duplicate callbacks
+      let lockKey = "onConfirm:ticketCreation:" <> booking.id.getId
+      isLockAcquired <- Redis.tryLockRedis lockKey 60
+      if isLockAcquired
+        then do
+          -- Double-check after lock acquisition (another callback may have completed)
+          existingTicketsAfterLock <- QTicket.findAllByTicketBookingId booking.id
+          if not (null existingTicketsAfterLock)
+            then do
+              logInfo $ "OnConfirm:idempotent - tickets created by concurrent callback for bookingId=" <> booking.id.getId
+              void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
+            else do
+              let discountedTickets = fromMaybe 0 booking.discountedTickets
+              tickets <- createTickets booking dOrder.tickets discountedTickets
+              let mbPaymentHoldId = listToMaybe quoteCategories >>= (.holdId)
+              let effectiveHoldId = mbPaymentHoldId <|> booking'.holdId
+              whenJust effectiveHoldId $ \holdId -> do
+                whenJust booking'.tripId $ \tripId -> do
+                  logInfo $ "OnConfirm:onConfirm finalizing seat hold bookingId=" <> booking.id.getId <> " holdId=" <> holdId <> " tripId=" <> tripId
+                  SeatBooking.confirmBooking tripId holdId
+                  SeatBooking.releaseAbandonedHolds tripId booking.id.getId holdId
+              void $ QTicket.createMany tickets
+              mbJourneyId <- FRFSUtils.getJourneyIdFromBooking booking
+              whenJust mbJourneyId $ \journeyId -> do
+                QJourneyExtra.updateLongestJourneyExpiryTimeWithTickets journeyId tickets
+              void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
+              person <- runInReplica $ QPerson.findById booking.riderId >>= fromMaybeM (PersonNotFound booking.riderId.getId)
+              mRiderNumber <- mapM ENC.decrypt person.mobileNumber
+              integratedBPPConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
+              let fareParameters = mkFareParameters (mkCategoryPriceItemFromQuoteCategories quoteCategories)
+              buildReconTable merchant booking fareParameters dOrder tickets mRiderNumber integratedBPPConfig
+              void $ sendTicketBookedSMS mRiderNumber person.mobileCountryCode fareParameters
+              void $ QPS.incrementTicketsBookedInEvent booking.riderId fareParameters.totalQuantity
+              void $ CQP.clearPSCache booking.riderId
+              whenJust booking.partnerOrgId $ \pOrgId -> do
+                walletPOCfg <- do
+                  pOrgCfg <- CQPOC.findByIdAndCfgType pOrgId DPOC.WALLET_CLASS_NAME >>= fromMaybeM (PartnerOrgConfigNotFound pOrgId.getId $ show DPOC.WALLET_CLASS_NAME)
+                  DPOC.getWalletClassNameConfig pOrgCfg.config
+                let mbClassName = lookup booking.providerId walletPOCfg.className
+                whenJust mbClassName $ \className -> do
+                  fork ("adding googleJWTUrl" <> " Booking Id: " <> booking.id.getId) $ do
+                    let serviceName = DEMSC.WalletService GW.GoogleWallet
+                    let mId = booking'.merchantId
+                    let mocId' = booking'.merchantOperatingCityId
+                    serviceAccount <- GWSA.getserviceAccount mId mocId' serviceName
+                    transitObjects' <- createTransitObjects pOrgId booking tickets person serviceAccount className integratedBPPConfig
+                    url <- mkGoogleWalletLink serviceAccount transitObjects'
+                    void $ QTBooking.updateGoogleWalletLinkById (Just url) booking.id
+        else do
+          logWarning $ "OnConfirm:lock not acquired for bookingId=" <> booking.id.getId <> ", another callback likely in progress"
+          void $ QTBooking.updateBPPOrderIdAndStatusById (Just dOrder.bppOrderId) Booking.CONFIRMED booking.id
   return ()
   where
     sendTicketBookedSMS mRiderNumber mRiderMobileCountryCode fareParameters =

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Ride.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Ride.hs
@@ -480,6 +480,7 @@ castCancellationSource = \case
   DBCReason.ByMerchant -> Common.ByMerchant
   DBCReason.ByAllocator -> Common.ByAllocator
   DBCReason.ByApplication -> Common.ByApplication
+  DBCReason.ByFleetOwner -> Common.ByMerchant
 
 bookingCancel ::
   (CacheFlow m r, EsqDBFlow m r) =>

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
@@ -558,7 +558,7 @@ juspayWebhookHandler merchantShortId mbCity mbServiceType mbPlaceId authData val
           -- Store in Redis dead-letter queue for monitoring and manual replay
           now <- getCurrentTime
           let deadLetterEntry = orderShortId <> "|" <> show status <> "|" <> show now <> "|" <> show err
-          Redis.rPush "juspay:webhook:dead-letter" [deadLetterEntry]
+          Redis.rPush "juspay:webhook:dead-letter" (deadLetterEntry :| [])
         Right _ -> pure ()
   pure Ack
   where
@@ -708,7 +708,7 @@ stripeWebhookHandler' serviceName merchantShortId mbCity mbServiceType mbPlaceId
   (paymentServiceConfig, merchantOperatingCity) <- fetchPaymentServiceConfig merchantShortId mbCity mbServiceType mbPlaceId serviceName
   -- P0 Fix: Implement Stripe webhook deduplication using atomic setNxExpire
   let checkDuplicatedEvent eventId = do
-        let dedupKey = "stripe:webhook:eventId:" <> eventId
+        let dedupKey = "stripe:webhook:eventId:" <> eventId.getId
         isNew <- Redis.setNxExpire dedupKey 86400 ("1" :: Text)
         pure (not isNew)
   Stripe.serviceEventWebhook paymentServiceConfig checkDuplicatedEvent (stripeWebhookAction merchantOperatingCity.id) mbSigHeader rawBytes

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
@@ -706,15 +706,11 @@ stripeWebhookHandler' ::
   Flow AckResponse
 stripeWebhookHandler' serviceName merchantShortId mbCity mbServiceType mbPlaceId mbSigHeader rawBytes = do
   (paymentServiceConfig, merchantOperatingCity) <- fetchPaymentServiceConfig merchantShortId mbCity mbServiceType mbPlaceId serviceName
-  -- P0 Fix: Implement Stripe webhook deduplication (was: pure False -- FIXME)
+  -- P0 Fix: Implement Stripe webhook deduplication using atomic setNxExpire
   let checkDuplicatedEvent eventId = do
         let dedupKey = "stripe:webhook:eventId:" <> eventId
-        mbProcessed <- Redis.get @Text dedupKey
-        case mbProcessed of
-          Just _ -> pure True
-          Nothing -> do
-            Redis.setExp dedupKey ("1" :: Text) 86400
-            pure False
+        isNew <- Redis.setNxExpire dedupKey 86400 ("1" :: Text)
+        pure (not isNew)
   Stripe.serviceEventWebhook paymentServiceConfig checkDuplicatedEvent (stripeWebhookAction merchantOperatingCity.id) mbSigHeader rawBytes
 
 stripeWebhookAction ::

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
@@ -537,17 +537,29 @@ juspayWebhookHandler merchantShortId mbCity mbServiceType mbPlaceId authData val
   logDebug $ "order short Id from Response bap webhook: " <> show orderShortId
   whenJust mbServiceType $ \paymentServiceType -> do
     Redis.whenWithLockRedis (mkOrderStatusCheckKey orderShortId status) 60 $ do
-      paymentOrder <- QOrder.findByShortId (ShortId orderShortId) >>= fromMaybeM (PaymentOrderNotFound orderShortId)
-      mocId <- paymentOrder.merchantOperatingCityId & fromMaybeM (InternalError "MerchantOperatingCityId not found in payment order")
-      person <- QP.findById (cast paymentOrder.personId) >>= fromMaybeM (InvalidRequest "Person not found")
-      ticketPlaceId <-
-        case paymentServiceType of
-          Payment.Normal -> do
-            ticketBooking <- QTB.findById (cast paymentOrder.id)
-            return $ ticketBooking <&> (.ticketPlaceId)
-          _ -> return Nothing
-      let orderStatusCall = Payment.orderStatus (cast paymentOrder.merchantId) (cast mocId) ticketPlaceId paymentServiceType (Just paymentOrder.personId.getId) person.clientSdkVersion paymentOrder.isMockPayment
-      void $ callWebhookHandlerWithOrderStatus merchantOperatingCity paymentServiceType (ShortId orderShortId) orderStatusCall
+      -- P0 Fix: Wrap webhook processing with error handling and dead-letter queue.
+      -- On failure, store the webhook data in Redis for manual replay/investigation.
+      -- Always return Ack to Juspay to prevent infinite retries on transient errors.
+      result <- withTryCatch "juspayWebhookHandler:processWebhook" $ do
+        paymentOrder <- QOrder.findByShortId (ShortId orderShortId) >>= fromMaybeM (PaymentOrderNotFound orderShortId)
+        mocId <- paymentOrder.merchantOperatingCityId & fromMaybeM (InternalError "MerchantOperatingCityId not found in payment order")
+        person <- QP.findById (cast paymentOrder.personId) >>= fromMaybeM (InvalidRequest "Person not found")
+        ticketPlaceId <-
+          case paymentServiceType of
+            Payment.Normal -> do
+              ticketBooking <- QTB.findById (cast paymentOrder.id)
+              return $ ticketBooking <&> (.ticketPlaceId)
+            _ -> return Nothing
+        let orderStatusCall = Payment.orderStatus (cast paymentOrder.merchantId) (cast mocId) ticketPlaceId paymentServiceType (Just paymentOrder.personId.getId) person.clientSdkVersion paymentOrder.isMockPayment
+        void $ callWebhookHandlerWithOrderStatus merchantOperatingCity paymentServiceType (ShortId orderShortId) orderStatusCall
+      case result of
+        Left err -> do
+          logError $ "Juspay webhook processing failed for order " <> orderShortId <> ": " <> show err
+          -- Store in Redis dead-letter queue for monitoring and manual replay
+          now <- getCurrentTime
+          let deadLetterEntry = orderShortId <> "|" <> show status <> "|" <> show now <> "|" <> show err
+          Redis.rPush "juspay:webhook:dead-letter" [deadLetterEntry]
+        Right _ -> pure ()
   pure Ack
   where
     getOrderData osr = case osr of
@@ -694,7 +706,15 @@ stripeWebhookHandler' ::
   Flow AckResponse
 stripeWebhookHandler' serviceName merchantShortId mbCity mbServiceType mbPlaceId mbSigHeader rawBytes = do
   (paymentServiceConfig, merchantOperatingCity) <- fetchPaymentServiceConfig merchantShortId mbCity mbServiceType mbPlaceId serviceName
-  let checkDuplicatedEvent _eventId = pure False -- FIXME
+  -- P0 Fix: Implement Stripe webhook deduplication (was: pure False -- FIXME)
+  let checkDuplicatedEvent eventId = do
+        let dedupKey = "stripe:webhook:eventId:" <> eventId
+        mbProcessed <- Redis.get @Text dedupKey
+        case mbProcessed of
+          Just _ -> pure True
+          Nothing -> do
+            Redis.setExp dedupKey ("1" :: Text) 86400
+            pure False
   Stripe.serviceEventWebhook paymentServiceConfig checkDuplicatedEvent (stripeWebhookAction merchantOperatingCity.id) mbSigHeader rawBytes
 
 stripeWebhookAction ::

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStateTransition.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStateTransition.hs
@@ -1,0 +1,31 @@
+module SharedLogic.FRFSStateTransition where
+
+import Domain.Types.FRFSTicketBookingStatus
+import qualified Domain.Types.FRFSTicketBooking as DFRFSTicketBooking
+import Kernel.Prelude
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import qualified Storage.Queries.FRFSTicketBooking as QFRFSTicketBooking
+
+-- | Safe status update that validates the transition before persisting.
+-- Logs a warning and skips if the transition is invalid, preventing state corruption.
+safeUpdateBookingStatus ::
+  (MonadFlow m, CacheFlow m r, EsqDBFlow m r, Log m) =>
+  FRFSTicketBookingStatus ->
+  FRFSTicketBookingStatus ->
+  Id DFRFSTicketBooking.FRFSTicketBooking ->
+  m Bool
+safeUpdateBookingStatus currentStatus newStatus bookingId = do
+  if isValidTransition currentStatus newStatus
+    then do
+      QFRFSTicketBooking.updateStatusById newStatus bookingId
+      pure True
+    else do
+      logWarning $
+        "FRFS State Transition Rejected: "
+          <> show currentStatus
+          <> " -> "
+          <> show newStatus
+          <> " for bookingId: "
+          <> bookingId.getId
+      pure False

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
@@ -774,6 +774,7 @@ cancellationSourceToSubCategory = \case
   SBCR.ByUser -> Notification.ByUser
   SBCR.ByMerchant -> Notification.ByMerchant
   SBCR.ByDriver -> Notification.ByDriver
+  SBCR.ByFleetOwner -> Notification.ByDriver
   SBCR.ByAllocator -> Notification.ByAllocator
   SBCR.ByApplication -> Notification.ByApplication
 

--- a/Backend/lib/beckn-spec/src/Domain/Types/FRFSTicketBookingStatus.hs
+++ b/Backend/lib/beckn-spec/src/Domain/Types/FRFSTicketBookingStatus.hs
@@ -51,8 +51,10 @@ isValidTransition from to
       -- All other transitions are invalid
       _ -> False
 
--- | Checks if a status represents a completed/terminal state (no further transitions expected).
--- Named to align with 'isValidTransition' for consistency.
+-- | Checks if a status represents a completed/resolved booking outcome.
+-- Note: CONFIRMED bookings can still be cancelled, and FAILED bookings
+-- can retry via PAYMENT_PENDING. "Completion" here means the primary
+-- booking workflow has reached an outcome, not that no transitions remain.
 isCompletionStatus :: FRFSTicketBookingStatus -> Bool
 isCompletionStatus CONFIRMED = True
 isCompletionStatus FAILED = True

--- a/Backend/lib/beckn-spec/src/Domain/Types/FRFSTicketBookingStatus.hs
+++ b/Backend/lib/beckn-spec/src/Domain/Types/FRFSTicketBookingStatus.hs
@@ -51,11 +51,12 @@ isValidTransition from to
       -- All other transitions are invalid
       _ -> False
 
--- | Checks if a status is terminal (no further transitions expected)
-isTerminalStatus :: FRFSTicketBookingStatus -> Bool
-isTerminalStatus CONFIRMED = True
-isTerminalStatus FAILED = True
-isTerminalStatus CANCELLED = True
-isTerminalStatus COUNTER_CANCELLED = True
-isTerminalStatus TECHNICAL_CANCEL_REJECTED = True
-isTerminalStatus _ = False
+-- | Checks if a status represents a completed/terminal state (no further transitions expected).
+-- Named to align with 'isValidTransition' for consistency.
+isCompletionStatus :: FRFSTicketBookingStatus -> Bool
+isCompletionStatus CONFIRMED = True
+isCompletionStatus FAILED = True
+isCompletionStatus CANCELLED = True
+isCompletionStatus COUNTER_CANCELLED = True
+isCompletionStatus TECHNICAL_CANCEL_REJECTED = True
+isCompletionStatus _ = False

--- a/Backend/lib/beckn-spec/src/Domain/Types/FRFSTicketBookingStatus.hs
+++ b/Backend/lib/beckn-spec/src/Domain/Types/FRFSTicketBookingStatus.hs
@@ -18,3 +18,44 @@ data FRFSTicketBookingStatus
   | CANCEL_INITIATED
   | TECHNICAL_CANCEL_REJECTED
   deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema)
+
+-- | Validates whether a state transition is legal in the FRFS booking state machine.
+-- Returns True if the transition from the first status to the second is allowed.
+isValidTransition :: FRFSTicketBookingStatus -> FRFSTicketBookingStatus -> Bool
+isValidTransition from to
+  | from == to = True -- Identity transitions are always valid (idempotent)
+  | otherwise = case (from, to) of
+      -- Forward flow
+      (NEW, APPROVED) -> True
+      (NEW, PAYMENT_PENDING) -> True
+      (APPROVED, PAYMENT_PENDING) -> True
+      (PAYMENT_PENDING, CONFIRMING) -> True
+      (CONFIRMING, CONFIRMED) -> True
+      -- Failure transitions (any non-terminal state can fail)
+      (NEW, FAILED) -> True
+      (APPROVED, FAILED) -> True
+      (PAYMENT_PENDING, FAILED) -> True
+      (CONFIRMING, FAILED) -> True
+      -- Cancellation transitions
+      (NEW, CANCEL_INITIATED) -> True
+      (APPROVED, CANCEL_INITIATED) -> True
+      (PAYMENT_PENDING, CANCEL_INITIATED) -> True
+      (CONFIRMING, CANCEL_INITIATED) -> True
+      (CONFIRMED, CANCEL_INITIATED) -> True
+      (CANCEL_INITIATED, CANCELLED) -> True
+      (CANCEL_INITIATED, COUNTER_CANCELLED) -> True
+      (CANCELLED, COUNTER_CANCELLED) -> True
+      (CANCEL_INITIATED, TECHNICAL_CANCEL_REJECTED) -> True
+      -- Recovery transitions
+      (FAILED, PAYMENT_PENDING) -> True -- Retry after failure
+      -- All other transitions are invalid
+      _ -> False
+
+-- | Checks if a status is terminal (no further transitions expected)
+isTerminalStatus :: FRFSTicketBookingStatus -> Bool
+isTerminalStatus CONFIRMED = True
+isTerminalStatus FAILED = True
+isTerminalStatus CANCELLED = True
+isTerminalStatus COUNTER_CANCELLED = True
+isTerminalStatus TECHNICAL_CANCEL_REJECTED = True
+isTerminalStatus _ = False


### PR DESCRIPTION
## Problem
Cancellation handling has three P0 issues:
1. Cancellation penalty calculations use incorrect metadata, leading to wrong penalty amounts
2. Cancellation reason metadata is not enriched with context (source, vehicle type, ride stage)
3. Reallocation after cancellation lacks observability — no metrics or logging for retry attempts

## Solution
- **Penalty accuracy**: Fix cancellation penalty calculation to use correct ride metadata and vehicle category
- **Metadata enrichment**: Add cancellation source, reason code, and ride context to cancellation events using proper JSON serialization
- **Reallocation observability**: Add logging and metrics for post-cancellation driver reallocation attempts
- **State machine consistency**: Fix FRFS ticket booking status transition definitions

## Testing
- Compiled with `cabal build all` — no -Werror violations  
- HLint suggestions addressed (functor law)
- Cancellation metadata verified to serialize correctly via ToJSON

## Impact
- **Risk**: Medium — touches cancellation penalty path. Penalty calculation changes affect driver billing.
- **Rollback**: Revert commit; cancellation penalties return to previous (potentially incorrect) calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rider-facing fare transparency: detailed breakdown, surge and toll metadata
  * Fare cap protection to limit unexpected price increases
  * Fleet owner added as a cancellation source
  * Idempotent booking confirmation to prevent duplicate ticket creation

* **Improvements**
  * Richer cancellation analytics captured (time/distance/fare context)
  * Vehicle-aware cancellation penalty calculations
  * More robust webhook processing (error capture + deduplication)
  * Safer booking-state updates and clearer reallocation/cancellation logging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->