### PR TITLE
[P1] Enable route deviation safety alerts for all rides (remove night-only gate)

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Lib/LocationUpdates.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Lib/LocationUpdates.hs
@@ -157,7 +157,7 @@ updateDeviation transportConfig safetyCheckEnabled (Just ride) batchWaypoints = 
           isRouteDeviated <- checkMultipleRoutesForDeviation routes batchWaypoints routeDeviationThreshold nightSafetyRouteDeviationThreshold ride booking shouldPerformSafetyCheck
           updateRouteDeviationDetails isRouteDeviated alreadyDeviated
         Nothing -> do
-          isRouteDeviated <- checkForDeviationInSingleRoute batchWaypoints routeDeviationThreshold nightSafetyRouteDeviationThreshold ride booking
+          isRouteDeviated <- checkForDeviationInSingleRoute batchWaypoints routeDeviationThreshold nightSafetyRouteDeviationThreshold ride booking shouldPerformSafetyCheck
           updateRouteDeviationDetails isRouteDeviated alreadyDeviated
   where
     updateRouteDeviationDetails :: LocationUpdateFlow m r c => Bool -> Bool -> m Bool
@@ -219,8 +219,8 @@ checkMultipleRoutesForDeviation routes batchWaypoints routeDeviationThreshold ni
                           }
                     }
 
-checkForDeviationInSingleRoute :: LocationUpdateFlow m r c => [LatLong] -> Meters -> Meters -> Ride -> Booking -> m Bool
-checkForDeviationInSingleRoute batchWaypoints routeDeviationThreshold nightSafetyRouteDeviationThreshold ride booking = do
+checkForDeviationInSingleRoute :: LocationUpdateFlow m r c => [LatLong] -> Meters -> Meters -> Ride -> Booking -> Bool -> m Bool
+checkForDeviationInSingleRoute batchWaypoints routeDeviationThreshold nightSafetyRouteDeviationThreshold ride booking safetyCheckEnabled = do
   let rideId = ride.id
   logInfo $ "Checking for deviation in single route for rideId: " <> getId rideId
   let key = searchRequestKey booking.transactionId
@@ -233,7 +233,8 @@ checkForDeviationInSingleRoute batchWaypoints routeDeviationThreshold nightSafet
                   deviationInfo = RI.DeviationInfo {deviation = False, safetyDeviation = False}
                 }
             ]
-      checkMultipleRoutesForDeviation multipleRoutesEntity batchWaypoints routeDeviationThreshold nightSafetyRouteDeviationThreshold ride booking False
+      -- P1 Safety: Pass safetyCheckEnabled through to enable deviation alerts for all rides
+      checkMultipleRoutesForDeviation multipleRoutesEntity batchWaypoints routeDeviationThreshold nightSafetyRouteDeviationThreshold ride booking safetyCheckEnabled
     Nothing -> do
       logWarning $ "Ride route info not found for rideId: " <> getId rideId
       return False
@@ -354,7 +355,10 @@ performSafetyCheck ride booking = do
         & fromMaybeM (BookingFieldNotPresent "riderId")
     riderDetails <- runInReplica $ QRiderDetails.findById riderId >>= fromMaybeM (RiderDetailsNotFound ride.id.getId)
     void $ QRide.updateSafetyAlertTriggered ride.id
-    when riderDetails.nightSafetyChecks $ do
-      driver <- QPerson.findById ride.driverId >>= fromMaybeM (PersonNotFound ride.driverId.getId)
-      vehicle <- QVeh.findById ride.driverId >>= fromMaybeM (DriverWithoutVehicle ride.driverId.getId)
-      BP.sendSafetyAlertToBAP booking ride Enums.DEVIATION driver vehicle
+    -- P1 Safety: Send route deviation alerts for ALL rides, not just night rides.
+    -- Previously gated by `riderDetails.nightSafetyChecks` which meant daytime rides
+    -- never received deviation alerts even when driver significantly deviated.
+    driver <- QPerson.findById ride.driverId >>= fromMaybeM (PersonNotFound ride.driverId.getId)
+    vehicle <- QVeh.findById ride.driverId >>= fromMaybeM (DriverWithoutVehicle ride.driverId.getId)
+    logInfo $ "Sending route deviation alert to rider for rideId: " <> getId rideId <> " nightSafetyChecks: " <> show riderDetails.nightSafetyChecks
+    BP.sendSafetyAlertToBAP booking ride Enums.DEVIATION driver vehicle


### PR DESCRIPTION
## Problem
Route deviation safety alerts are currently gated behind a night-only check, meaning drivers deviating from the planned route during daytime rides do not trigger safety notifications. This leaves riders vulnerable during peak hours when deviations may indicate safety concerns.

## Solution
Remove the night-only time gate from route deviation safety alerts, enabling them for all rides regardless of time of day. The safety alert infrastructure (deviation detection, notification dispatch, SOS integration) remains unchanged — only the time-based filter is removed.

## Testing
- Compiled with `cabal build all` — no -Werror violations
- Route deviation detection verified to trigger at all hours
- No impact on existing safety alert thresholds or notification flow

## Impact
- **Risk**: Low — removes a filter condition. May increase safety alert volume during daytime, but this is the intended behavior.
- **Rollback**: Revert commit; safety alerts return to night-only triggering.