### PR TITLE
feat: add refund handling to purchased pass transactions

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/Pass.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/Pass.yaml
@@ -17,6 +17,8 @@ imports:
   Day: Data.Time
   Language: Kernel.External.Types
   CumulativeOfferResp: SharedLogic.Offer
+  Refunds: Lib.Payment.Domain.Types.Refunds
+  RefundStatus: Kernel.External.Payment.Interface
   VerificationStatus: Domain.Types.PassDetails
   Value: Data.Aeson
   MediaFile: IssueManagement.Domain.Types.MediaFile
@@ -118,6 +120,16 @@ types:
     passDetails: PassAPIEntity
     derive: "Show"
 
+  RefundAPIEntity:
+    id: Id Refunds
+    amount: HighPrecMoney
+    status: RefundStatus
+    arn: Maybe Text
+    completedAt: Maybe UTCTime
+    updatedAt: UTCTime
+    createdAt: UTCTime
+    derive: "Show"
+
   PurchasedPassTransactionAPIEntity:
     id: Id PurchasedPassPayment
     passName: Maybe Text
@@ -128,6 +140,7 @@ types:
     amount: HighPrecMoney
     status: StatusType
     passType: Maybe PassEnum
+    refunds: "[RefundAPIEntity]"
     derive: "Show"
 
   SetPassPrefSrcAndDestReq:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/Pass.hs
@@ -15,11 +15,13 @@ import qualified Domain.Types.PassType
 import qualified Domain.Types.PurchasedPass
 import qualified Domain.Types.PurchasedPassPayment
 import EulerHS.Prelude hiding (id)
+import qualified Kernel.External.Payment.Interface
 import qualified IssueManagement.Domain.Types.MediaFile
 import qualified Kernel.External.Payment.Juspay.Types.CreateOrder
 import qualified Kernel.Prelude
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
+import qualified Lib.Payment.Domain.Types.Refunds
 import Servant
 import qualified SharedLogic.Offer
 import Tools.Auth
@@ -133,8 +135,21 @@ data PurchasedPassTransactionAPIEntity = PurchasedPassTransactionAPIEntity
     passCode :: Data.Text.Text,
     passName :: Data.Maybe.Maybe Data.Text.Text,
     passType :: Data.Maybe.Maybe Domain.Types.PassType.PassEnum,
+    refunds :: [RefundAPIEntity],
     startDate :: Data.Time.Day,
     status :: Domain.Types.PurchasedPass.StatusType
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+data RefundAPIEntity = RefundAPIEntity
+  { amount :: Kernel.Types.Common.HighPrecMoney,
+    arn :: Data.Maybe.Maybe Data.Text.Text,
+    completedAt :: Data.Maybe.Maybe Kernel.Prelude.UTCTime,
+    createdAt :: Kernel.Prelude.UTCTime,
+    id :: Kernel.Types.Id.Id Lib.Payment.Domain.Types.Refunds.Refunds,
+    status :: Kernel.External.Payment.Interface.RefundStatus,
+    updatedAt :: Kernel.Prelude.UTCTime
   }
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -30,6 +30,7 @@ import qualified Data.Aeson as A
 import qualified Data.Aeson.Key as AKey
 import qualified Data.Aeson.KeyMap as AKeyMap
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Time as DT
 import qualified Domain.Types.IntegratedBPPConfig as DIBC
@@ -75,6 +76,9 @@ import qualified Lib.JourneyModule.Utils as JLU
 import qualified Lib.Payment.Domain.Action as DPayment
 import qualified Lib.Payment.Domain.Types.Common as DPayment
 import qualified Lib.Payment.Domain.Types.PaymentOrder as DOrder
+import qualified Lib.Payment.Domain.Types.Refunds as DRefunds
+import qualified Lib.Payment.Storage.Queries.PaymentOrder as QPaymentOrder
+import qualified Lib.Payment.Storage.Queries.Refunds as QRefunds
 import Lib.SessionizerMetrics.Types.Event (EventStreamFlow)
 import qualified SharedLogic.External.Nandi.Types
 import qualified SharedLogic.IntegratedBPPConfig as SIBC
@@ -723,6 +727,7 @@ buildPurchasedPassAPIEntity mbLanguage person mbDeviceId today purchasedPass = d
   mbLastVerified <- QPassVerifyTransaction.findLastVerifiedVehicleNumberByPurchasePassId purchasedPass.id
   let lastVerifiedVehicleNumber = fmap fst mbLastVerified
   let isAutoVerified = (mbLastVerified >>= snd) == Just True
+  futureRenewalEntities <- buildPurchasedPassPaymentAPIEntities futureRenewals
   return $
     PassAPI.PurchasedPassAPIEntity
       { id = purchasedPass.id,
@@ -741,7 +746,7 @@ buildPurchasedPassAPIEntity mbLanguage person mbDeviceId today purchasedPass = d
         purchaseDate = DT.utctDay purchasedPass.createdAt,
         expiryDate = purchasedPass.endDate,
         isPreferredSourceAndDestinationSet = isJust purchasedPass.preferredDestination && isJust purchasedPass.preferredSource,
-        futureRenewals = buildPurchasedPassPaymentAPIEntity <$> futureRenewals
+        futureRenewals = futureRenewalEntities
       }
 
 -- Webhook Handler for Pass Payment Status Updates
@@ -1327,20 +1332,96 @@ getMultimodalPassTransactions (mbCallerPersonId, _) mbLimitParam mbOffsetParam m
   allPurchasedPassTransactions <- case statuses of
     [] -> QPurchasedPassPayment.findAllWithPersonId (Just limit) (Just offset) personId
     _ -> QPurchasedPassPayment.findAllByPersonIdAndStatuses (Just limit) (Just offset) personId statuses
-  return $ map buildPurchasedPassPaymentAPIEntity allPurchasedPassTransactions
+  buildPurchasedPassPaymentAPIEntities allPurchasedPassTransactions
 
-buildPurchasedPassPaymentAPIEntity :: DPurchasedPassPayment.PurchasedPassPayment -> PassAPI.PurchasedPassTransactionAPIEntity
-buildPurchasedPassPaymentAPIEntity purchasedPassPayment =
+buildPurchasedPassPaymentAPIEntities ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  [DPurchasedPassPayment.PurchasedPassPayment] ->
+  m [PassAPI.PurchasedPassTransactionAPIEntity]
+buildPurchasedPassPaymentAPIEntities payments = do
+  refundMap <- fetchRefundsForPayments payments
+  return $ map (mkPurchasedPassPaymentAPIEntity refundMap) payments
+
+mkPurchasedPassPaymentAPIEntity ::
+  Map.Map (Id.Id DOrder.PaymentOrder) [PassAPI.RefundAPIEntity] ->
+  DPurchasedPassPayment.PurchasedPassPayment ->
   PassAPI.PurchasedPassTransactionAPIEntity
-    { id = purchasedPassPayment.id,
-      startDate = purchasedPassPayment.startDate,
-      endDate = purchasedPassPayment.endDate,
-      status = purchasedPassPayment.status,
-      amount = purchasedPassPayment.amount,
-      passName = purchasedPassPayment.passName,
-      passCode = purchasedPassPayment.passCode,
-      passType = purchasedPassPayment.passEnum,
-      createdAt = purchasedPassPayment.createdAt
+mkPurchasedPassPaymentAPIEntity refundMap purchasedPassPayment =
+  let refunds = Map.findWithDefault [] purchasedPassPayment.orderId refundMap
+      computedStatus = computePassStatusFromRefunds purchasedPassPayment.status refunds
+   in PassAPI.PurchasedPassTransactionAPIEntity
+        { id = purchasedPassPayment.id,
+          startDate = purchasedPassPayment.startDate,
+          endDate = purchasedPassPayment.endDate,
+          status = computedStatus,
+          amount = purchasedPassPayment.amount,
+          passName = purchasedPassPayment.passName,
+          passCode = purchasedPassPayment.passCode,
+          passType = purchasedPassPayment.passEnum,
+          createdAt = purchasedPassPayment.createdAt,
+          refunds = refunds
+        }
+
+-- Derives status from the most-recently-updated refund row. Retries land as
+-- new refund rows, so the latest row supersedes earlier failed attempts.
+computePassStatusFromRefunds :: DPurchasedPass.StatusType -> [PassAPI.RefundAPIEntity] -> DPurchasedPass.StatusType
+computePassStatusFromRefunds originalStatus refunds
+  | null refunds = originalStatus
+  | otherwise =
+      let latest = foldr1 pickLatest refunds
+       in mapStatus latest.status
+  where
+    pickLatest r acc = if r.updatedAt >= acc.updatedAt then r else acc
+    mapStatus PaymentInterface.REFUND_PENDING = DPurchasedPass.RefundPending
+    mapStatus PaymentInterface.REFUND_SUCCESS = DPurchasedPass.Refunded
+    mapStatus PaymentInterface.REFUND_FAILURE = DPurchasedPass.RefundFailed
+    mapStatus PaymentInterface.MANUAL_REVIEW = DPurchasedPass.RefundInitiated
+    mapStatus _ = originalStatus
+
+isRefundStatus :: DPurchasedPass.StatusType -> Bool
+isRefundStatus DPurchasedPass.RefundInitiated = True
+isRefundStatus DPurchasedPass.RefundPending = True
+isRefundStatus DPurchasedPass.Refunded = True
+isRefundStatus DPurchasedPass.RefundFailed = True
+isRefundStatus _ = False
+
+fetchRefundsForPayments ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  [DPurchasedPassPayment.PurchasedPassPayment] ->
+  m (Map.Map (Id.Id DOrder.PaymentOrder) [PassAPI.RefundAPIEntity])
+fetchRefundsForPayments payments = do
+  let refundPayments = filter (isRefundStatus . (.status)) payments
+      orderIds = map (.orderId) refundPayments
+  if null orderIds
+    then return Map.empty
+    else do
+      paymentOrders <- QPaymentOrder.findAllByIds orderIds
+      let foundOrderIds = map (.id) paymentOrders
+          missingOrderIds = filter (`notElem` foundOrderIds) orderIds
+      forM_ missingOrderIds $ \missingId ->
+        logError $ "Missing payment order for pass payment, paymentOrderId: " <> missingId.getId
+      let shortIdMap = Map.fromList $ map (\po -> (po.shortId, po.id)) paymentOrders
+          allShortIds = map (.shortId) paymentOrders
+      if null allShortIds
+        then return Map.empty
+        else do
+          allRefunds <- QRefunds.findAllByOrderIds allShortIds
+          let refundsByOrderId = foldl' (\acc refund -> case Map.lookup refund.orderId shortIdMap of
+                  Just payOrderId -> Map.insertWith (++) payOrderId [buildRefundAPIEntity refund] acc
+                  Nothing -> acc
+                ) Map.empty allRefunds
+          return refundsByOrderId
+
+buildRefundAPIEntity :: DRefunds.Refunds -> PassAPI.RefundAPIEntity
+buildRefundAPIEntity refund =
+  PassAPI.RefundAPIEntity
+    { id = refund.id,
+      amount = refund.refundAmount,
+      status = refund.status,
+      arn = refund.arn,
+      completedAt = refund.completedAt,
+      updatedAt = refund.updatedAt,
+      createdAt = refund.createdAt
     }
 
 getDeviceId :: DP.Person -> Maybe Text -> Maybe Text -> Environment.Flow Text

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Payment.hs
@@ -472,6 +472,14 @@ refundStatusHandler paymentOrder paymentServiceType = do
           QPurchasedPassPayment.updateStatusByOrderId DPurchasedPass.RefundFailed paymentOrder.id
           when (purchasedPass.status == DPurchasedPass.Pending && purchasedPass.startDate == purchasedPassPayment.startDate && purchasedPass.endDate == purchasedPassPayment.endDate) $ do
             QPurchasedPass.updateStatusById DPurchasedPass.RefundFailed purchasedPass.id
+        Payment.REFUND_PENDING -> do
+          QPurchasedPassPayment.updateStatusByOrderId DPurchasedPass.RefundPending paymentOrder.id
+          when (purchasedPass.status == DPurchasedPass.Pending && purchasedPass.startDate == purchasedPassPayment.startDate && purchasedPass.endDate == purchasedPassPayment.endDate) $ do
+            QPurchasedPass.updateStatusById DPurchasedPass.RefundPending purchasedPass.id
+        Payment.MANUAL_REVIEW -> do
+          QPurchasedPassPayment.updateStatusByOrderId DPurchasedPass.RefundInitiated paymentOrder.id
+          when (purchasedPass.status == DPurchasedPass.Pending && purchasedPass.startDate == purchasedPassPayment.startDate && purchasedPass.endDate == purchasedPassPayment.endDate) $ do
+            QPurchasedPass.updateStatusById DPurchasedPass.RefundInitiated purchasedPass.id
         _ ->
           case refund.isApiCallSuccess of
             Nothing -> do

--- a/Backend/lib/payment/src/Lib/Payment/Storage/Queries/PaymentOrder.hs
+++ b/Backend/lib/payment/src/Lib/Payment/Storage/Queries/PaymentOrder.hs
@@ -30,6 +30,9 @@ import qualified Sequelize as Se
 findById :: BeamFlow m r => Id DOrder.PaymentOrder -> m (Maybe DOrder.PaymentOrder)
 findById (Id paymentOrder) = findOneWithKV [Se.Is BeamPO.id $ Se.Eq paymentOrder]
 
+findAllByIds :: BeamFlow m r => [Id DOrder.PaymentOrder] -> m [DOrder.PaymentOrder]
+findAllByIds ids = findAllWithKV [Se.Is BeamPO.id $ Se.In (map getId ids)]
+
 findByShortId :: BeamFlow m r => ShortId DOrder.PaymentOrder -> m (Maybe DOrder.PaymentOrder)
 findByShortId (ShortId shortId) = findOneWithKV [Se.Is BeamPO.shortId $ Se.Eq shortId]
 

--- a/Backend/lib/payment/src/Lib/Payment/Storage/Queries/RefundsExtra.hs
+++ b/Backend/lib/payment/src/Lib/Payment/Storage/Queries/RefundsExtra.hs
@@ -12,6 +12,16 @@ import qualified Sequelize as Se
 
 -- Extra code goes here --
 
+findAllByOrderIds ::
+  BeamFlow m r =>
+  [ShortId DPaymentOrder.PaymentOrder] ->
+  m [DRefunds.Refunds]
+findAllByOrderIds shortIds
+  | null ids = pure []
+  | otherwise = findAllWithKV [Se.Is BeamR.orderId $ Se.In ids]
+  where
+    ids = map getShortId shortIds
+
 findLatestByOrderId ::
   BeamFlow m r =>
   ShortId DPaymentOrder.PaymentOrder ->


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Purchased pass transaction responses now include refund history (refund id, amount, status, optional ARN, completion timestamp, created/updated timestamps) so users can see refunds alongside pass transactions.
* **Bug Fixes**
  * Pass and payment statuses now reflect refund lifecycle states (e.g., pending or manual-review) so displayed pass statuses align with refund progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->