### PR TITLE
backend/enhc: handled Tds application on independent drivers, fleet linked drivers for subscription purchases, rides and cancellations

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -920,6 +920,7 @@ TransporterConfig:
       defaultTdsRate: Maybe Double
       subscriptionTdsRate: Maybe Double
       invalidPanTdsRate: Double
+      independentDriverTdsDeductionThreshold: Maybe HighPrecMoney
       derive': Generic, Show, ToJSON, FromJSON, Read, Eq
     FeedbackNotificationConfig:
       enableFeedbackNotification: Bool

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/TransporterConfig.hs
@@ -419,6 +419,7 @@ data SubscriptionConfig = SubscriptionConfig
 data TaxConfig = TaxConfig
   { airportEntryFeeGst :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.GstBreakup,
     defaultTdsRate :: Kernel.Prelude.Maybe Kernel.Prelude.Double,
+    independentDriverTdsDeductionThreshold :: Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecMoney,
     invalidPanTdsRate :: Kernel.Prelude.Double,
     rideGst :: Domain.Types.TransporterConfig.GstBreakup,
     securityDepositGst :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.GstBreakup,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
@@ -676,13 +676,33 @@ processSubscriptionPurchasePayment merchantId person subscriptionPurchase = do
                     igstAmount = Nothing
                   }
         mbPanCard <- QPanCard.findByDriverId person.id
+        shouldApplyTdsToPayment <-
+          shouldApplyTds
+            (not isFleetOwner)
+            person.id
+            transporterConfig
+        mbCustomTdsRate <- do
+          if isFleetOwner
+            then do
+              mbFleetInfo <- QFOI.findByPrimaryKey person.id
+              pure $ mbFleetInfo >>= (.tdsRate)
+            else do
+              mbDriverInfo <- QDI.findById person.id
+              pure $ mbDriverInfo >>= (.tdsRate)
+        let mbSubscriptionEffectiveTdsRate =
+              computeEffectiveTdsRate
+                mbPanCard
+                mbCustomTdsRate
+                transporterConfig.taxConfig.subscriptionTdsRate
+                transporterConfig.taxConfig.invalidPanTdsRate
+            mbTdsRateToApply = if shouldApplyTdsToPayment then mbSubscriptionEffectiveTdsRate else Nothing
         (_newBalance, mbInvoiceId) <-
           creditPrepaidBalance
             counterpartyType
             person.id.getId
             creditAmount
             paidAmount
-            transporterConfig.taxConfig.subscriptionTdsRate
+            mbTdsRateToApply
             subscriptionGstBreakdown
             currency
             merchantId.getId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -94,6 +94,7 @@ import qualified Storage.Queries.DriverInformation as QDI
 import qualified Storage.Queries.DriverPanCard as QPanCard
 import qualified Storage.Queries.DriverQuote as QDQ
 import qualified Storage.Queries.DriverStats as QDriverStats
+import qualified Storage.Queries.FleetOwnerInformation as QFOI
 import qualified Storage.Queries.Person as QPerson
 import qualified Storage.Queries.Ride as QRide
 import qualified Storage.Queries.RiderDetails as QRiderDetails
@@ -298,14 +299,31 @@ cancelRideTransaction booking ride bookingCReason merchant rideEndedBy cancellat
               [ (baseCancellation, walletReferenceCustomerCancellationCharges, OwnerLiability),
                 (gstOnCancellation, walletReferenceCustomerCancellationGST, GovtIndirect)
               ]
-            -- TDS on cancellation charges (same rate as ride)
-            mbTdsRate = transporterConfig.taxConfig.defaultTdsRate
-            mbTdsAmount = do
-              rate <- mbTdsRate
-              let amount = baseCancellation * realToFrac rate
-              if amount > 0 then Just amount else Nothing
-        mbPanCard <- QPanCard.findByDriverId ride.driverId
         mbDriverInfo <- QDI.findById (cast ride.driverId)
+        mbCustomTdsRate <- case ride.fleetOwnerId of
+          Just fleetOwnerId -> do
+            mbFleetInfo <- QFOI.findByPrimaryKey (cast fleetOwnerId)
+            let currentRate = mbFleetInfo >>= (.tdsRate)
+            pure currentRate
+          Nothing -> do
+            let currentRate = mbDriverInfo >>= (.tdsRate)
+            pure currentRate
+        shouldApplyTdsToCancellation <- shouldApplyTds (isNothing ride.fleetOwnerId) (cast ride.driverId) transporterConfig
+        let driverOrFleetPersonId = fromMaybe ride.driverId ride.fleetOwnerId
+        mbPanCard <- QPanCard.findByDriverId driverOrFleetPersonId
+        let mbTdsAmount =
+              if shouldApplyTdsToCancellation
+                then do
+                  let effectiveTdsRate =
+                        computeEffectiveTdsRate
+                          mbPanCard
+                          mbCustomTdsRate
+                          transporterConfig.taxConfig.defaultTdsRate
+                          transporterConfig.taxConfig.invalidPanTdsRate
+                  rate <- effectiveTdsRate
+                  let amount = baseCancellation * realToFrac rate
+                  if amount > 0 then Just amount else Nothing
+                else Nothing
         ctx <- buildFinanceCtx booking ride (Just driver) mbPanCard mbDriverInfo transporterConfig
         result <- runFinance ctx $ do
           mapM_

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -499,7 +499,7 @@ createDriverWalletTransaction ride booking fareParams driverInfo transporterConf
     let driverOrFleetPersonId = fromMaybe ride.driverId ride.fleetOwnerId
 
     let configTdsRate = transporterConfig.taxConfig.defaultTdsRate
-    mbTdsRate <- case ride.fleetOwnerId of
+    mbCustomTdsRate <- case ride.fleetOwnerId of
       Just fleetOwnerId -> do
         mbFleetInfo <- QFOI.findByPrimaryKey (cast fleetOwnerId)
         let currentRate = mbFleetInfo >>= (.tdsRate)
@@ -507,21 +507,25 @@ createDriverWalletTransaction ride booking fareParams driverInfo transporterConf
           when (isNothing currentRate) $
             whenJust configTdsRate $ \rate ->
               QFOI.updateTdsRate (Just rate) (cast fleetOwnerId)
-        pure (currentRate <|> configTdsRate)
+        pure currentRate
       Nothing -> do
         let currentRate = driverInfo.tdsRate
         when (isNothing currentRate) $
           whenJust configTdsRate $ \rate ->
             QDI.updateTdsRate (Just rate) ride.driverId
-        pure (currentRate <|> configTdsRate)
+        pure currentRate
 
+    shouldApplyTdsToRide <- shouldApplyTds (isNothing ride.fleetOwnerId) (cast ride.driverId) transporterConfig
     mbPanCard <- QPanCard.findByDriverId driverOrFleetPersonId
-    let effectiveTdsRate = computeEffectiveTdsRate mbPanCard mbTdsRate (transporterConfig.taxConfig.defaultTdsRate) (transporterConfig.taxConfig.invalidPanTdsRate)
-        baseFareForTds = max 0 baseFare
-        mbTdsAmount = do
-          rate <- effectiveTdsRate
-          let amount = baseFareForTds * realToFrac rate -- tdsRate is already decimal (0.01 = 1%)
-          if amount > 0 then Just amount else Nothing
+    let baseFareForTds = max 0 baseFare
+        mbTdsAmount =
+          if shouldApplyTdsToRide
+            then do
+              let effectiveTdsRate = computeEffectiveTdsRate mbPanCard mbCustomTdsRate (transporterConfig.taxConfig.defaultTdsRate) (transporterConfig.taxConfig.invalidPanTdsRate)
+              rate <- effectiveTdsRate
+              let amount = baseFareForTds * realToFrac rate -- tdsRate is already decimal (0.01 = 1%)
+              if amount > 0 then Just amount else Nothing
+            else Nothing
 
     ctx <- buildFinanceCtx booking ride mbDriver mbPanCard (Just driverInfo) transporterConfig
     let invoiceConfig =

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Finance/Wallet.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Finance/Wallet.hs
@@ -35,6 +35,7 @@ module SharedLogic.Finance.Wallet
     getPayoutEligibilityData,
     computeTdsRateReason,
     computeEffectiveTdsRate,
+    shouldApplyTds,
     estimateWalletDeductions,
   )
 where
@@ -57,6 +58,7 @@ import qualified Lib.Finance.Domain.Types.LedgerEntry
 import Lib.Finance.Storage.Beam.BeamFlow (BeamFlow)
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import qualified Storage.Queries.DailyStatsExtra as QDailyStatsExtra
 import Storage.Queries.FleetOwnerInformation as QFOI
 
 -- Reference type constants (PascalCase, abbreviations in all caps)
@@ -455,16 +457,49 @@ computeEffectiveTdsRate ::
   Maybe Double -- effective rate
 computeEffectiveTdsRate mbPanCard mbCustomRate configDefaultTdsRate invalidPanTdsRate_ =
   let hasValidPan = maybe False (\pan -> pan.verificationStatus == Documents.VALID) mbPanCard
-      panType = mbPanCard >>= (.docType)
-      panTypeEligible = case panType of
-        Just DPanCard.BUSINESS -> True
-        _ -> True
-      isPanValid = hasValidPan && panTypeEligible
-   in if isPanValid
+      panAadhaarLinked = maybe False (\pan -> pan.panAadhaarLinkage == Just DPanCard.PAN_AADHAAR_LINKED) mbPanCard
+      isPanValidForStandardRate = hasValidPan && panAadhaarLinked
+   in if isPanValidForStandardRate
         then case mbCustomRate of
           Just _ -> mbCustomRate
           Nothing -> configDefaultTdsRate
         else Just invalidPanTdsRate_
+
+assessmentYearEarningsRange :: Time.Day -> (Time.Day, Time.Day)
+assessmentYearEarningsRange day =
+  let (y, m, _) = Time.toGregorian day
+      startYear = if m >= 4 then y else y - 1
+      start = Time.fromGregorian startYear 4 1
+      end = Time.fromGregorian (startYear + 1) 3 31
+   in (start, end)
+
+shouldApplyTds ::
+  (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>
+  Bool ->
+  Id DP.Person -> -- driverId
+  DTC.TransporterConfig ->
+  m Bool
+shouldApplyTds isIndependentDriver driverId transporterConfig =
+  case (isIndependentDriver, transporterConfig.taxConfig.independentDriverTdsDeductionThreshold) of
+    (True, Just minEarningsThreshold) -> do
+      localTime <- getLocalCurrentTime transporterConfig.timeDiffFromUtc
+      let (fromDay, toDay) = assessmentYearEarningsRange (Time.utctDay localTime)
+      dailyStats <- QDailyStatsExtra.findAllInRangeByDriverId_ driverId fromDay toDay
+      let assessmentYearEarnings = sum $ map (.totalEarnings) dailyStats
+      when (assessmentYearEarnings < minEarningsThreshold) $
+        logInfo $
+          "Skipping TDS deduction for independent driver "
+            <> driverId.getId
+            <> " as assessmentYearEarnings "
+            <> show assessmentYearEarnings
+            <> " is below threshold "
+            <> show minEarningsThreshold
+            <> " for range "
+            <> show fromDay
+            <> " to "
+            <> show toDay
+      pure $ assessmentYearEarnings >= minEarningsThreshold
+    _ -> pure True
 
 -- | Estimate wallet deductions (TDS only) for a given baseFare.
 --   GST (govtCharges) comes from fareParams at ride end, not recalculated here.

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DailyStatsExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DailyStatsExtra.hs
@@ -91,6 +91,7 @@ deleteAllByDriverId ::
 deleteAllByDriverId driverId = do
   deleteWithKV [Se.Is Beam.driverId $ Se.Eq (getId driverId)]
 
+
 -- | Update only d2d (driver-to-driver) referral fields for payout. Customer referral uses updateReferralStatsByDriverId.
 updateD2dReferralStatsByDriverId ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/TransporterConfig.hs
@@ -79,7 +79,8 @@ parseTaxConfig merchantOperatingCityId mbVal = do
             securityDepositGst = Nothing,
             defaultTdsRate = Nothing,
             subscriptionTdsRate = Nothing,
-            invalidPanTdsRate = 0
+            invalidPanTdsRate = 0,
+            independentDriverTdsDeductionThreshold = Nothing
           }
   parseFieldWithDefaultM "transporterConfig" "taxConfig" merchantOperatingCityId def parseTaxConfigWithDefault mbVal
 

--- a/Backend/test/src/Mobility/ARDU/NearestDrivers.hs
+++ b/Backend/test/src/Mobility/ARDU/NearestDrivers.hs
@@ -77,7 +77,8 @@ createNearestDriverReq nearestRadius now =
             rideGst = DTC.GstBreakup Nothing Nothing Nothing,
             securityDepositGst = Nothing,
             subscriptionTdsRate = Nothing,
-            airportEntryFeeGst = Nothing
+            airportEntryFeeGst = Nothing,
+            independentDriverTdsDeductionThreshold = Nothing
           },
       minWalletAmountForCashRides = Nothing,
       ..


### PR DESCRIPTION
This is the exact evaluation order the code follows now.

A) Independent driver (no fleetOwnerId)
1) Earnings threshold (assessment year)
If earnings < independentDriverTdsDeductionThreshold ⇒ TDS is skipped (rate resolution is not even evaluated).
2) PAN checks
If PAN is not VALID OR PAN–Aadhaar is not LINKED ⇒ use invalidPanTdsRate
3) Custom vs config rate (only if PAN valid + linked)
If DriverInformation.tdsRate is set ⇒ use this custom tdsRate
Else ⇒ use config rate (defaultTdsRate for ride/cancel, subscriptionTdsRate for subscription)
4) Amount calculation
(tdsAmount = baseAmount \times tdsRate); if (<=0) ⇒ no entry.
B) Fleet-linked (has fleetOwnerId)
1) Skip earnings threshold
2) PAN checks (fleet owner PAN)
If PAN not VALID OR PAN–Aadhaar not LINKED ⇒ use invalidPanTdsRate
3) Custom vs config rate
If FleetOwnerInformation.tdsRate is set ⇒ use fleet custom tdsRate
Else ⇒ use config rate (defaultTdsRate for ride/cancel, subscriptionTdsRate for subscription)
4) Amount calculation as above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable earnings threshold to exempt independent drivers from TDS when annual earnings fall below the threshold.
  * TDS application is now conditional for subscriptions, ride cancellations, and ride settlements based on driver type and earnings.
  * Stronger PAN+Aadhaar linkage checks and support for fleet/driver-specific custom TDS rates when determining effective TDS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->