### PR TITLE
Backend/feat : Added Purchase Status in subscriptions & handled Subscription exhaustion logic

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/FinanceManagement.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/FinanceManagement.yaml
@@ -137,7 +137,7 @@ apis:
 
 types:
   SubscriptionPurchaseStatus:
-    - enum: "SubscriptionPending, SubscriptionActive, SubscriptionExpired, SubscriptionFailed, SubscriptionExhausted"
+    - enum: "SubscriptionPending, SubscriptionPurchased, SubscriptionActive, SubscriptionExpired, SubscriptionFailed, SubscriptionExhausted"
     - derive: "HttpInstance"
 
   PgGateway:

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/FinanceManagement.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/FinanceManagement.hs
@@ -327,6 +327,7 @@ data SubscriptionPurchaseListRes = SubscriptionPurchaseListRes {totalItems :: Ke
 
 data SubscriptionPurchaseStatus
   = SubscriptionPending
+  | SubscriptionPurchased
   | SubscriptionActive
   | SubscriptionExpired
   | SubscriptionFailed

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/SubscriptionPurchase.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/SubscriptionPurchase.yaml
@@ -18,7 +18,7 @@ SubscriptionPurchase:
 
   types:
     SubscriptionPurchaseStatus:
-      enum: "PENDING,ACTIVE,EXPIRED,FAILED,EXHAUSTED"
+      enum: "PENDING,PURCHASED,ACTIVE,EXPIRED,FAILED,EXHAUSTED"
       derive': "Generic, Show, ToJSON, FromJSON, ToSchema, Ord, Eq, Read, ToParamSchema"
     SubscriptionOwnerType:
       enum: "DRIVER, FLEET_OWNER"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/SubscriptionPurchase.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/SubscriptionPurchase.hs
@@ -50,7 +50,7 @@ data SubscriptionPurchase = SubscriptionPurchase
 
 data SubscriptionOwnerType = DRIVER | FLEET_OWNER deriving (Generic, Show, ToJSON, FromJSON, ToSchema, Ord, Eq, Read, ToParamSchema)
 
-data SubscriptionPurchaseStatus = PENDING | ACTIVE | EXPIRED | FAILED | EXHAUSTED deriving (Generic, Show, ToJSON, FromJSON, ToSchema, Ord, Eq, Read, ToParamSchema)
+data SubscriptionPurchaseStatus = PENDING | PURCHASED | ACTIVE | EXPIRED | FAILED | EXHAUSTED deriving (Generic, Show, ToJSON, FromJSON, ToSchema, Ord, Eq, Read, ToParamSchema)
 
 $(Kernel.Beam.Lib.UtilsTH.mkBeamInstancesForEnumAndList ''SubscriptionPurchaseStatus)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Ride.hs
@@ -46,6 +46,7 @@ import Kernel.Beam.Functions
 import Kernel.External.Maps.Types
 import Kernel.Prelude
 import Kernel.ServantMultipart
+import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Types.APISuccess (APISuccess)
 import Kernel.Types.Id
 import Kernel.Utils.CalculateDistance (distanceBetweenInMeters)
@@ -55,7 +56,6 @@ import Servant hiding (throwError)
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTF
 import SharedLogic.Person (findPerson)
 import Storage.Beam.SystemConfigs ()
-import qualified Kernel.Storage.Hedis as Redis
 import qualified Storage.Cac.TransporterConfig as SCT
 import qualified Storage.Queries.Booking as QBooking
 import qualified Storage.Queries.DriverInformation as QDI

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/FinanceManagement.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/FinanceManagement.hs
@@ -159,6 +159,7 @@ getFinanceManagementSubscriptionPurchaseList merchantShortId opCity mbAmountMax 
     castSubscriptionPurchaseStatus :: API.SubscriptionPurchaseStatus -> DSP.SubscriptionPurchaseStatus
     castSubscriptionPurchaseStatus = \case
       API.SubscriptionPending -> DSP.PENDING
+      API.SubscriptionPurchased -> DSP.PURCHASED
       API.SubscriptionActive -> DSP.ACTIVE
       API.SubscriptionExpired -> DSP.EXPIRED
       API.SubscriptionFailed -> DSP.FAILED
@@ -277,7 +278,7 @@ getFinanceManagementSubscriptionPurchaseList merchantShortId opCity mbAmountMax 
             planValidityDays = planValidityDays,
             planGeography = planGeography,
             planVehicleCategory = Just $ show plan.vehicleCategory,
-            subscriptionStartDate = subscription.startDate <|> Just subscription.purchaseTimestamp,
+            subscriptionStartDate = subscription.startDate,
             subscriptionEndDate = subscription.expiryDate,
             subscriptionStatus = Just $ show subscription.status,
             baseAmount = baseAmount,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/RideBooking/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/RideBooking/Driver.hs
@@ -41,6 +41,7 @@ import qualified Domain.Action.Dashboard.Common as DCommon
 import qualified Domain.Action.Dashboard.Fleet.Driver as Driver
 import qualified Domain.Action.UI.DriverOnboarding.VehicleRegistrationCertificate as DomainRC
 import Domain.Types.AadhaarCard
+import qualified Domain.Types.DocumentVerificationConfig as ODC
 import qualified Domain.Types.DriverBlockTransactions as DTDBT
 import Domain.Types.DriverFee as DDF
 import Domain.Types.DriverInformation
@@ -79,11 +80,10 @@ import qualified Lib.Yudhishthira.Tools.Utils as Yudhishthira
 import SharedLogic.Analytics as Analytics
 import qualified SharedLogic.BehaviourManagement.CancellationRate as SCR
 import qualified SharedLogic.DriverFee as SLDriverFee
-import qualified Domain.Types.DocumentVerificationConfig as ODC
 import SharedLogic.DriverOnboarding
-import SharedLogic.Reminder.Helper (createReminder)
 import qualified SharedLogic.Finance.Wallet as FWallet
 import SharedLogic.Merchant (findMerchantByShortId)
+import SharedLogic.Reminder.Helper (createReminder)
 import Storage.Beam.Yudhishthira ()
 import qualified Storage.Cac.TransporterConfig as CTC
 import qualified Storage.CachedQueries.Merchant as CQM

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Call.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Call.hs
@@ -702,7 +702,7 @@ addCampaignData req merchantOpCityId = do
       case (ozonetelCfg.sosCampaignName, ozonetelCfg.fromTime >>= parseCampaignTime, ozonetelCfg.toTime >>= parseCampaignTime) of
         (Just sosCampaignName, Just fromCampaignTime, Just toCampaignTime)
           | isWithinCampaignWindow currentLocalTimeOfDay fromCampaignTime toCampaignTime ->
-              sosCampaignName
+            sosCampaignName
         _ -> ozonetelCfg.campaignName
 
     isWithinCampaignWindow :: TimeOfDay -> TimeOfDay -> TimeOfDay -> Bool

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
@@ -630,15 +630,13 @@ processSubscriptionPurchasePayment merchantId person subscriptionPurchase = do
             referenceId = latestPurchase.id.getId
             isFleetOwner = DCommon.checkFleetOwnerRole person.role
             counterpartyType = if isFleetOwner then counterpartyFleetOwner else counterpartyDriver
-        -- Check if there are other ACTIVE purchases with expiry already set (deferred FIFO)
         let ownerType = if isFleetOwner then DSP.FLEET_OWNER else DSP.DRIVER
-        existingActive <- QSPE.findAllActiveByOwnerAndServiceName person.id.getId ownerType DP.PREPAID_SUBSCRIPTION
-        let hasActiveWithExpiry = any (\p -> isJust p.expiryDate) existingActive
-            -- Only set expiry if no other active purchase has one (this is the first/only active plan)
+        mbExistingActive <- QSPE.findCurrentActiveByOwnerAndServiceName person.id.getId ownerType DP.PREPAID_SUBSCRIPTION
+        let purchaseStatus = maybe DSP.ACTIVE (const DSP.PURCHASED) mbExistingActive
             expiryDate =
-              if hasActiveWithExpiry
-                then Nothing -- Queued: timer starts when predecessor exhausts/expires
-                else fmap (\days -> addUTCTime (fromIntegral (days * 60 * 60 * 24)) now) plan.validityInDays
+              if purchaseStatus == DSP.ACTIVE
+                then fmap (\days -> addUTCTime (fromIntegral (days * 60 * 60 * 24)) now) plan.validityInDays
+                else Nothing
         -- Fetch merchant for issuedByName and issuedByAddress
         merchant <- CQM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
         -- Fetch operating city for issuedToAddress
@@ -694,14 +692,14 @@ processSubscriptionPurchasePayment merchantId person subscriptionPurchase = do
             >>= fromEitherM (\err -> InternalError ("Failed to credit prepaid balance: " <> show err))
         let updatedPurchase =
               latestPurchase
-                { status = DSP.ACTIVE,
+                { status = purchaseStatus,
                   purchaseTimestamp = now,
                   expiryDate = expiryDate,
-                  startDate = if isJust expiryDate then Just now else Nothing,
+                  startDate = if purchaseStatus == DSP.ACTIVE then Just now else Nothing,
                   financeInvoiceId = mbInvoiceId
                 }
         QSP.updateByPrimaryKey updatedPurchase
-        -- Schedule expiry job only if expiry was set (not queued)
+        -- Schedule expiry job only for the current ACTIVE purchase.
         whenJust expiryDate $ \expiry -> do
           let delay = diffUTCTime expiry now
           createJobIn @_ @'ExpireSubscriptionPurchase
@@ -806,7 +804,7 @@ updatePaymentStatus driverId merchantOpCityId serviceName = do
     DP.PREPAID_SUBSCRIPTION -> do
       person <- QP.findById driverId >>= fromMaybeM (PersonNotFound driverId.getId)
       let (ownerType, ownerId) = if DCommon.checkFleetOwnerRole person.role then (DSP.FLEET_OWNER, person.id.getId) else (DSP.DRIVER, person.id.getId)
-      mbPurchase <- QSPE.findLatestActiveByOwnerAndServiceName handleSubscriptionExpiry ownerId ownerType serviceName
+      mbPurchase <- QSPE.findCurrentActiveByOwnerAndServiceName ownerId ownerType serviceName
       pure $ ADPlan.mkSyntheticDriverPlanFromPurchase <$> mbPurchase
     _ -> findByDriverIdWithServiceName (cast driverId) serviceName -- what if its changed? needed inside lock?
   plan <- getPlan mbDriverPlan serviceName merchantOpCityId Nothing (mbDriverPlan >>= (.vehicleCategory))

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Plan.hs
@@ -57,7 +57,6 @@ import qualified Lib.Payment.Domain.Types.Common as DPayment
 import qualified Lib.Payment.Domain.Types.PaymentOrder as DOrder
 import qualified Lib.Payment.Storage.Queries.PaymentOrder as SOrder
 import SharedLogic.DriverFee (calcNumRides, calculatePlatformFeeAttr, getPaymentModeAndVehicleCategoryKey, getStartTimeAndEndTimeRange, mkCachedKeyTotalRidesByDriverId, roundToHalf)
-import SharedLogic.Finance.Prepaid (handleSubscriptionExpiry)
 import qualified SharedLogic.Merchant as SMerchant
 import SharedLogic.Payment
 import qualified SharedLogic.Payment as SPayment
@@ -414,7 +413,7 @@ getSubcriptionStatusWithPlanPrepaid ::
 getSubcriptionStatusWithPlanPrepaid driverId = do
   person <- QPerson.findById (cast driverId) >>= fromMaybeM (PersonNotFound driverId.getId)
   let (ownerType, ownerId) = if DCommon.checkFleetOwnerRole person.role then (DSP.FLEET_OWNER, person.id.getId) else (DSP.DRIVER, person.id.getId)
-  mbPurchase <- QSPE.findLatestActiveByOwnerAndServiceName handleSubscriptionExpiry ownerId ownerType PREPAID_SUBSCRIPTION
+  mbPurchase <- QSPE.findCurrentActiveByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
   pure (Nothing, mkSyntheticDriverPlanFromPurchase <$> mbPurchase)
 
 updateSubscriptionStatusGeneric ::
@@ -515,7 +514,7 @@ planList (personId, merchantId, merchantOpCityId) serviceName _mbLimit _mbOffset
   mDriverPlan <- case serviceName of
     PREPAID_SUBSCRIPTION -> do
       let (ownerType, ownerId) = if DCommon.checkFleetOwnerRole person.role then (DSP.FLEET_OWNER, person.id.getId) else (DSP.DRIVER, person.id.getId)
-      mbPurchase <- B.runInReplica $ QSPE.findLatestActiveByOwnerAndServiceName handleSubscriptionExpiry ownerId ownerType PREPAID_SUBSCRIPTION
+      mbPurchase <- B.runInReplica $ QSPE.findCurrentActiveByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
       pure $ mkSyntheticDriverPlanFromPurchase <$> mbPurchase
     _ -> B.runInReplica $ QDPlan.findByDriverIdWithServiceName personId serviceName
   transporterConfig <- SCTC.findByMerchantOpCityId merchantOpCityId (Just (DriverId (cast personId))) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
@@ -555,8 +554,9 @@ currentPlan serviceName (driverId, _merchantId, merchantOperatingCityId) = do
   let (ownerType, ownerId) = if DCommon.checkFleetOwnerRole person.role then (DSP.FLEET_OWNER, person.id.getId) else (DSP.DRIVER, person.id.getId)
   latestManualPaymentDate <- case serviceName of
     PREPAID_SUBSCRIPTION -> do
-      purchases <- QSP.findAllByOwnerAndStatus ownerId ownerType DSP.ACTIVE
-      pure $ listToMaybe (sortOn (Down . (.updatedAt)) purchases) <&> (.updatedAt)
+      activePurchases <- QSPE.findAllActiveByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
+      purchasedPlans <- QSPE.findAllPurchasedByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
+      pure $ listToMaybe (sortOn (Down . (.purchaseTimestamp)) (activePurchases <> purchasedPlans)) <&> (.purchaseTimestamp)
     _ -> do
       latestManualPayment <- QDF.findLatestByFeeTypeAndStatusWithServiceName DF.RECURRING_INVOICE [DF.CLEARED, DF.COLLECTED_CASH] driverId serviceName
       pure $ latestManualPayment <&> (.updatedAt)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -57,6 +57,7 @@ import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Streaming.Kafka.Producer.Types (HasKafkaProducer, KafkaProducerTools)
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import qualified Kernel.Utils.Version as Version
 import qualified Lib.DriverCoins.Coins as DC
 import qualified Lib.DriverCoins.Types as DCT
 import qualified Lib.DriverScore as DS
@@ -90,7 +91,6 @@ import qualified Storage.Queries.Booking as QRB
 import qualified Storage.Queries.BookingCancellationReason as QBCR
 import qualified Storage.Queries.CallStatus as QCallStatus
 import qualified Storage.Queries.CancellationDuesDetails as QCDD
-import qualified Kernel.Utils.Version as Version
 import qualified Storage.Queries.DriverInformation as QDI
 import qualified Storage.Queries.DriverPanCard as QPanCard
 import qualified Storage.Queries.DriverQuote as QDQ

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -339,7 +339,7 @@ processEndRideFinance merchant ride booking newFareParams driverId driverInfo th
       if DCommon.checkFleetOwnerRole person.role
         then pure (DSP.FLEET_OWNER, person.id.getId)
         else pure (DSP.DRIVER, person.id.getId)
-  mbPrepaidPurchase <- QSPE.findLatestActiveByOwnerAndServiceName handleSubscriptionExpiry ownerId ownerType PREPAID_SUBSCRIPTION
+  mbPrepaidPurchase <- QSPE.findCurrentActiveByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
   let serviceName = if isJust mbPrepaidPurchase then PREPAID_SUBSCRIPTION else YATRI_SUBSCRIPTION
 
   -- 1. Subscription Flow — route by serviceName
@@ -373,21 +373,19 @@ processEndRideFinance merchant ride booking newFareParams driverId driverInfo th
                 booking.id.getId
                 Nothing
                 >>= fromEitherM (\err -> InternalError ("Failed to debit prepaid balance: " <> show err))
-            (contributingPurchaseIds, anyExhausted) <- checkAndMarkExhaustedSubscriptions counterpartyFleetOwner fleetOwnerId.getId DSP.FLEET_OWNER
+            (contributingPurchaseIds, mbActivatedPurchase) <- checkAndMarkExhaustedSubscriptions counterpartyFleetOwner fleetOwnerId.getId DSP.FLEET_OWNER
             unless (null contributingPurchaseIds) $
               QRide.updateSubscriptionPurchaseIds (Just contributingPurchaseIds) ride.id
-            when anyExhausted $ do
-              mbActivated <- activateNextQueuedPurchaseExpiry fleetOwnerId.getId DSP.FLEET_OWNER
-              whenJust mbActivated $ \(nextPurchaseId, expiry) -> do
-                now <- getCurrentTime
-                let delay = diffUTCTime expiry now
-                createJobIn @_ @'ExpireSubscriptionPurchase
-                  (Just booking.providerId)
-                  (Just booking.merchantOperatingCityId)
-                  delay
-                  $ ExpireSubscriptionPurchaseJobData
-                    { subscriptionPurchaseId = nextPurchaseId
-                    }
+            whenJust mbActivatedPurchase $ \(nextPurchaseId, expiry) -> do
+              now <- getCurrentTime
+              let delay = diffUTCTime expiry now
+              createJobIn @_ @'ExpireSubscriptionPurchase
+                (Just booking.providerId)
+                (Just booking.merchantOperatingCityId)
+                delay
+                $ ExpireSubscriptionPurchaseJobData
+                  { subscriptionPurchaseId = nextPurchaseId
+                  }
             pure ()
         Nothing -> do
           Redis.withWaitOnLockRedisWithExpiry (makeSubscriptionRunningBalanceLockKey ride.driverId.getId) 10 10 $ do
@@ -408,21 +406,19 @@ processEndRideFinance merchant ride booking newFareParams driverId driverInfo th
             let balanceUpdateMessage = "Thank you for taking the ride. Your updated subscription balance is Rs." <> show newBalance
                 balanceUpdatedTitle = "Subscription balance updated!"
             sendNotificationToDriver driver.merchantOperatingCityId FCM.SHOW Nothing FCM.PREPAID_BALANCE_UPDATE balanceUpdatedTitle balanceUpdateMessage driver driver.deviceToken
-            (contributingPurchaseIds, anyExhausted) <- checkAndMarkExhaustedSubscriptions counterpartyDriver ride.driverId.getId DSP.DRIVER
+            (contributingPurchaseIds, mbActivatedPurchase) <- checkAndMarkExhaustedSubscriptions counterpartyDriver ride.driverId.getId DSP.DRIVER
             unless (null contributingPurchaseIds) $
               QRide.updateSubscriptionPurchaseIds (Just contributingPurchaseIds) ride.id
-            when anyExhausted $ do
-              mbActivated <- activateNextQueuedPurchaseExpiry ride.driverId.getId DSP.DRIVER
-              whenJust mbActivated $ \(nextPurchaseId, expiry) -> do
-                now' <- getCurrentTime
-                let delay = diffUTCTime expiry now'
-                createJobIn @_ @'ExpireSubscriptionPurchase
-                  (Just booking.providerId)
-                  (Just booking.merchantOperatingCityId)
-                  delay
-                  $ ExpireSubscriptionPurchaseJobData
-                    { subscriptionPurchaseId = nextPurchaseId
-                    }
+            whenJust mbActivatedPurchase $ \(nextPurchaseId, expiry) -> do
+              now' <- getCurrentTime
+              let delay = diffUTCTime expiry now'
+              createJobIn @_ @'ExpireSubscriptionPurchase
+                (Just booking.providerId)
+                (Just booking.merchantOperatingCityId)
+                delay
+                $ ExpireSubscriptionPurchaseJobData
+                  { subscriptionPurchaseId = nextPurchaseId
+                  }
             let subscriptionConfig = thresholdConfig.subscriptionConfig
             let prepaidSubscriptionThreshold = subscriptionConfig.prepaidSubscriptionThreshold
             when (newBalance < fromMaybe 0 prepaidSubscriptionThreshold) $ do
@@ -439,7 +435,7 @@ processEndRideFinance merchant ride booking newFareParams driverId driverInfo th
           if DCommon.checkFleetOwnerRole person.role
             then pure (DSP.FLEET_OWNER, person.id.getId)
             else pure (DSP.DRIVER, person.id.getId)
-      mbPurchase <- QSPE.findLatestActiveByOwnerAndServiceName handleSubscriptionExpiry ownerId' ownerType' PREPAID_SUBSCRIPTION
+      mbPurchase <- QSPE.findCurrentActiveByOwnerAndServiceName ownerId' ownerType' PREPAID_SUBSCRIPTION
       let mbSyntheticPlan = Plan.mkSyntheticDriverPlanFromPurchase <$> mbPurchase
       plan <- getPlan mbSyntheticPlan PREPAID_SUBSCRIPTION booking.merchantOperatingCityId Nothing Nothing
       case plan of

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SubscriptionTransaction.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SubscriptionTransaction.hs
@@ -91,10 +91,10 @@ getSubscriptionTransactions (mbDriverId, _, _) mbFrom mbLimit mbMaxAmount mbMinA
       entities <- forM paged $ \entry -> do
         transactionType <-
           if
-            | entry.referenceType == prepaidRideDebitReferenceType -> pure RIDE
-            | entry.referenceType == subscriptionCreditReferenceType -> pure PLAN_PURCHASE
-            | entry.referenceType == expiryCreditTransferReferenceType -> pure SUBSCRIPTION_EXPIRY
-            | otherwise -> throwError $ InternalError $ "Unknown reference type: " <> show entry.referenceType
+              | entry.referenceType == prepaidRideDebitReferenceType -> pure RIDE
+              | entry.referenceType == subscriptionCreditReferenceType -> pure PLAN_PURCHASE
+              | entry.referenceType == expiryCreditTransferReferenceType -> pure SUBSCRIPTION_EXPIRY
+              | otherwise -> throwError $ InternalError $ "Unknown reference type: " <> show entry.referenceType
         let (fromLocation, toLocation) =
               if entry.referenceType == prepaidRideDebitReferenceType
                 then case M.lookup (Id entry.referenceId) bookingMap of

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Subscription/ExpireSubscriptionPurchase.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Subscription/ExpireSubscriptionPurchase.hs
@@ -7,12 +7,14 @@ where
 
 import qualified Domain.Types.SubscriptionPurchase as DSP
 import Kernel.Prelude
+import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Utils.Common
 import Lib.Finance.Storage.Beam.BeamFlow (BeamFlow)
 import Lib.Scheduler
 import Lib.Scheduler.JobStorageType.SchedulerType (createJobIn)
 import SharedLogic.Allocator (AllocatorJobType (..), ExpireSubscriptionPurchaseJobData (..))
 import SharedLogic.Finance.Prepaid (activateNextQueuedPurchaseExpiry, handleSubscriptionExpiry)
+import SharedLogic.Ride (makeSubscriptionRunningBalanceLockKey)
 import Storage.Beam.SchedulerJob ()
 import qualified Storage.Queries.SubscriptionPurchase as QSP
 
@@ -36,18 +38,28 @@ expireSubscriptionPurchase Job {id = jobId, jobInfo} = withLogTag ("JobId-" <> j
       logInfo $ "Subscription purchase not found: " <> jobData.subscriptionPurchaseId.getId
       pure Complete
     Just purchase -> do
-      handleSubscriptionExpiry purchase
-      -- After expiry, activate the next queued purchase's expiry timer (deferred FIFO)
-      when (purchase.status == DSP.ACTIVE) $ do
-        mbActivated <- activateNextQueuedPurchaseExpiry purchase.ownerId purchase.ownerType
-        whenJust mbActivated $ \(nextPurchaseId, expiry) -> do
-          now <- getCurrentTime
-          let delay = diffUTCTime expiry now
-          createJobIn @_ @'ExpireSubscriptionPurchase
-            (Just purchase.merchantId)
-            (Just purchase.merchantOperatingCityId)
-            delay
-            $ ExpireSubscriptionPurchaseJobData
-              { subscriptionPurchaseId = nextPurchaseId
-              }
+      Redis.withWaitOnLockRedisWithExpiry (makeSubscriptionRunningBalanceLockKey purchase.ownerId) 60 60 $ do
+        mbLatestPurchase <- QSP.findByPrimaryKey jobData.subscriptionPurchaseId
+        case mbLatestPurchase of
+          Nothing -> do
+            logInfo $ "Subscription purchase not found after lock acquisition: " <> jobData.subscriptionPurchaseId.getId
+            pure ()
+          Just latestPurchase -> do
+            when (latestPurchase.status == DSP.ACTIVE) $ do
+              handleSubscriptionExpiry latestPurchase
+              -- After expiry, activate the next queued purchase's expiry timer.
+              mbActivated <- activateNextQueuedPurchaseExpiry latestPurchase.ownerId latestPurchase.ownerType
+              whenJust mbActivated $ \(nextPurchaseId, expiry) -> do
+                now <- getCurrentTime
+                let delay = diffUTCTime expiry now
+                createJobIn @_ @'ExpireSubscriptionPurchase
+                  (Just latestPurchase.merchantId)
+                  (Just latestPurchase.merchantOperatingCityId)
+                  delay
+                  $ ExpireSubscriptionPurchaseJobData
+                    { subscriptionPurchaseId = nextPurchaseId
+                    }
+            when (latestPurchase.status /= DSP.ACTIVE) $
+              logInfo $ "Skipping expiry for subscription " <> latestPurchase.id.getId <> " in terminal state: " <> show latestPurchase.status
+            pure ()
       pure Complete

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
@@ -125,6 +125,7 @@ import qualified Storage.CachedQueries.VehicleServiceTier as CQVST
 import qualified Storage.Queries.DriverBankAccount as QDBA
 import qualified Storage.Queries.DriverInformation as QDI
 import qualified Storage.Queries.DriverStats as QDriverStats
+import qualified Storage.Queries.FleetDriverAssociation as QFDA
 import qualified Storage.Queries.IdfyVerification as QIV
 import qualified Storage.Queries.Person as QPerson
 import qualified Storage.Queries.RideDetails as QRideDetails
@@ -137,7 +138,6 @@ import qualified Tools.Notifications as Notify
 import TransactionLogs.PushLogs
 import TransactionLogs.Types
 import Utils.Common.Cac.KeyNameConstants
-import qualified Storage.Queries.FleetDriverAssociation as QFDA
 
 callOnSelectV2 ::
   ( HasFlowEnv m r '["nwAddress" ::: BaseUrl],

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Finance/Prepaid.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Finance/Prepaid.hs
@@ -691,16 +691,16 @@ handleSubscriptionExpiry purchase = do
         merchantOperatingCityId = purchase.merchantOperatingCityId.getId
         referenceId = purchase.id.getId
 
-    -- Fetch all other ACTIVE subscriptions (excluding the one being expired)
-    allActive <- QSPE.findAllActiveByOwnerAndServiceName ownerId purchase.ownerType PREPAID_SUBSCRIPTION
-    let otherActive = filter (\p -> p.id /= purchase.id) allActive
-        otherActiveCredits = sum $ map (.planRideCredit) otherActive
+    -- Preserve credits from other paid-but-not-expired purchases.
+    allPaidTracked <- QSPE.findAllActiveAndPurchasedByOwnerAndServiceName ownerId purchase.ownerType PREPAID_SUBSCRIPTION
+    let otherTracked = filter (\p -> p.id /= purchase.id) allPaidTracked
+        retainedCredits = sum $ map (.planRideCredit) otherTracked
 
     -- Get current unified balance
     mbBalance <- getPrepaidBalanceByOwner counterpartyType ownerId
     let currentBalance = fromMaybe 0 mbBalance
         -- Credits attributable to the expiring subscription
-        expiredCredits = max 0 (currentBalance - otherActiveCredits)
+        expiredCredits = max 0 (currentBalance - retainedCredits)
 
     when (expiredCredits > 0) $ do
       -- Calculate proportional revenue amount from planFee
@@ -762,41 +762,64 @@ handleSubscriptionExpiry purchase = do
     QSP.updateStatusById DSP.EXPIRED purchase.id
     logInfo $ "Subscription " <> purchase.id.getId <> " expired. Expired credits: " <> show expiredCredits
 
--- | After a ride debit, check if the oldest ACTIVE subscription should be marked EXHAUSTED.
--- FIFO logic: if the current balance is at or below the sum of newer subscriptions' credits,
--- the oldest subscription's credits are fully used up.
--- Returns (contributing purchase IDs, whether any were exhausted).
--- If any were exhausted, the caller should call activateNextQueuedPurchaseExpiry
--- and schedule follow-up jobs.
+-- | After a ride debit, walk tracked prepaid purchases in FIFO order and determine:
+--   1. which purchases contributed to this ride,
+--   2. which purchases are now exhausted,
+--   3. which purchase should be ACTIVE after this ride.
+-- All paid plans contribute to the pooled balance immediately, so this function infers
+-- contribution/exhaustion boundaries from the remaining pooled balance after the debit.
+-- Returns (contributingPurchaseIds, maybeNewlyActivatedPurchaseWithExpiry).
 checkAndMarkExhaustedSubscriptions ::
   (BeamFlow m r) =>
   CounterpartyType ->
   Text -> -- Owner ID
   DSP.SubscriptionOwnerType ->
-  m ([Id DSP.SubscriptionPurchase], Bool)
+  m ([Id DSP.SubscriptionPurchase], Maybe (Id DSP.SubscriptionPurchase, UTCTime))
 checkAndMarkExhaustedSubscriptions counterpartyType ownerId ownerType = do
-  allActive <- QSPE.findAllActiveByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
+  trackedPurchases <- QSPE.findAllActiveAndPurchasedByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
   mbBalance <- getPrepaidBalanceByOwner counterpartyType ownerId
   let currentBalance = fromMaybe 0 mbBalance
-      -- Sort by purchaseTimestamp ASC (already from query), process FIFO
-      sorted = DL.sortOn (.purchaseTimestamp) allActive
-  go sorted currentBalance [] False
-  where
-    go [] _ acc exhausted = pure (acc, exhausted)
-    go [single] _ acc exhausted = pure (acc <> [single.id], exhausted) -- Last one is always contributing
-    go (oldest : rest) balance acc exhausted = do
-      let restCredits = sum $ map (.planRideCredit) rest
-      if balance <= restCredits
-        then do
-          -- Oldest subscription's credits are fully consumed
-          QSP.updateStatusById DSP.EXHAUSTED oldest.id
-          logInfo $ "Subscription " <> oldest.id.getId <> " marked EXHAUSTED"
-          -- Continue checking (there might be more to exhaust)
-          go rest balance (acc <> [oldest.id]) True
-        else pure (acc <> [oldest.id], exhausted) -- Oldest is partially consumed
+      orderedPurchases = DL.sortOn (.purchaseTimestamp) trackedPurchases
+      (contributingIds, exhaustedPurchases, mbFinalActivePurchase) = classifyTrackedPurchases currentBalance orderedPurchases
 
--- | Activate the expiry timer for the next queued subscription purchase.
--- A queued purchase is ACTIVE but has expiryDate = Nothing (its timer hasn't started).
+  mapM_
+    ( \purchase -> do
+        QSP.updateStatusById DSP.EXHAUSTED purchase.id
+        logInfo $ "Subscription " <> purchase.id.getId <> " marked EXHAUSTED"
+    )
+    exhaustedPurchases
+
+  activatedPurchase <- case mbFinalActivePurchase of
+    Just purchase | purchase.status == DSP.PURCHASED -> do
+      mbPlan <- QPlan.findByPrimaryKey purchase.planId
+      case mbPlan of
+        Just plan -> do
+          now <- getCurrentTime
+          let expiryDate = fmap (\days -> addUTCTime (fromIntegral (days * 60 * 60 * 24)) now) plan.validityInDays
+          QSPE.updateStatusExpiryAndStartDateById DSP.ACTIVE expiryDate (Just now) purchase.id
+          logInfo $ "Activated subscription " <> purchase.id.getId <> " during ride settlement with expiryDate: " <> show expiryDate <> " startDate: " <> show now
+          pure $ (purchase.id,) <$> expiryDate
+        Nothing -> do
+          logInfo $ "Plan not found for activated subscription during ride settlement: " <> purchase.planId.getId
+          pure Nothing
+    _ -> pure Nothing
+
+  pure (contributingIds, activatedPurchase)
+  where
+    classifyTrackedPurchases balance purchases = go purchases (sum $ map (.planRideCredit) purchases) [] []
+      where
+        go [] _ contributing exhausted = (reverse contributing, reverse exhausted, Nothing)
+        go (purchase : rest) suffixCredits contributing exhausted =
+          let laterCredits = suffixCredits - purchase.planRideCredit
+           in if balance <= laterCredits
+                then go rest laterCredits (purchase.id : contributing) (purchase : exhausted)
+                else
+                  if balance < suffixCredits
+                    then (reverse (purchase.id : contributing), reverse exhausted, Just purchase)
+                    else (reverse contributing, reverse exhausted, Just purchase)
+
+-- | Promote the next queued PURCHASED subscription into the current ACTIVE slot.
+-- Callers are expected to hold the owner-level running balance lock.
 -- Called after an exhaustion or expiry event to cascade to the next FIFO purchase.
 -- Returns Just (purchaseId, expiryDate) if a purchase was activated, Nothing otherwise.
 -- The caller is responsible for scheduling the ExpireSubscriptionPurchase job.
@@ -806,21 +829,24 @@ activateNextQueuedPurchaseExpiry ::
   DSP.SubscriptionOwnerType ->
   m (Maybe (Id DSP.SubscriptionPurchase, UTCTime))
 activateNextQueuedPurchaseExpiry ownerId ownerType = do
-  allActive <- QSPE.findAllActiveByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
-  let sorted = DL.sortOn (.purchaseTimestamp) allActive
-      -- Find first ACTIVE purchase with no expiryDate (queued)
-      queued = filter (\p -> isNothing p.expiryDate) sorted
-  case queued of
-    (nextPurchase : _) -> do
-      mbPlan <- QPlan.findByPrimaryKey nextPurchase.planId
-      case mbPlan of
-        Just plan -> do
-          now <- getCurrentTime
-          let expiryDate = fmap (\days -> addUTCTime (fromIntegral (days * 60 * 60 * 24)) now) plan.validityInDays
-          QSPE.updateExpiryAndStartDateById expiryDate (Just now) nextPurchase.id
-          logInfo $ "Activated expiry for queued subscription " <> nextPurchase.id.getId <> " with expiryDate: " <> show expiryDate <> " startDate: " <> show now
-          pure $ (nextPurchase.id,) <$> expiryDate
-        Nothing -> do
-          logInfo $ "Plan not found for queued subscription: " <> nextPurchase.planId.getId
-          pure Nothing
-    [] -> pure Nothing
+  mbActive <- QSPE.findCurrentActiveByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
+  case mbActive of
+    Just activePurchase -> do
+      logInfo $ "Skipping queued activation because ACTIVE subscription already exists: " <> activePurchase.id.getId
+      pure Nothing
+    Nothing -> do
+      purchased <- QSPE.findAllPurchasedByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION
+      case DL.sortOn (.purchaseTimestamp) purchased of
+        (nextPurchase : _) -> do
+          mbPlan <- QPlan.findByPrimaryKey nextPurchase.planId
+          case mbPlan of
+            Just plan -> do
+              now <- getCurrentTime
+              let expiryDate = fmap (\days -> addUTCTime (fromIntegral (days * 60 * 60 * 24)) now) plan.validityInDays
+              QSPE.updateStatusExpiryAndStartDateById DSP.ACTIVE expiryDate (Just now) nextPurchase.id
+              logInfo $ "Activated expiry for queued subscription " <> nextPurchase.id.getId <> " with expiryDate: " <> show expiryDate <> " startDate: " <> show now
+              pure $ (nextPurchase.id,) <$> expiryDate
+            Nothing -> do
+              logInfo $ "Plan not found for queued subscription: " <> nextPurchase.planId.getId
+              pure Nothing
+        [] -> pure Nothing

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SubscriptionPurchaseExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SubscriptionPurchaseExtra.hs
@@ -35,6 +35,53 @@ findAllActiveByOwnerAndServiceName ownerId ownerType serviceName =
     Nothing
     Nothing
 
+findCurrentActiveByOwnerAndServiceName ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  Text ->
+  SubscriptionOwnerType ->
+  ServiceNames ->
+  m (Maybe SubscriptionPurchase)
+findCurrentActiveByOwnerAndServiceName ownerId ownerType serviceName =
+  listToMaybe <$> findAllActiveByOwnerAndServiceName ownerId ownerType serviceName
+
+findAllPurchasedByOwnerAndServiceName ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  Text ->
+  SubscriptionOwnerType ->
+  ServiceNames ->
+  m [SubscriptionPurchase]
+findAllPurchasedByOwnerAndServiceName ownerId ownerType serviceName =
+  findAllWithOptionsKV
+    [ Se.And
+        [ Se.Is Beam.ownerId $ Se.Eq ownerId,
+          Se.Is Beam.ownerType $ Se.Eq ownerType,
+          Se.Is Beam.status $ Se.Eq PURCHASED,
+          Se.Is Beam.serviceName $ Se.Eq serviceName
+        ]
+    ]
+    (Se.Asc Beam.purchaseTimestamp)
+    Nothing
+    Nothing
+
+findAllActiveAndPurchasedByOwnerAndServiceName ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  Text ->
+  SubscriptionOwnerType ->
+  ServiceNames ->
+  m [SubscriptionPurchase]
+findAllActiveAndPurchasedByOwnerAndServiceName ownerId ownerType serviceName =
+  findAllWithOptionsKV
+    [ Se.And
+        [ Se.Is Beam.ownerId $ Se.Eq ownerId,
+          Se.Is Beam.ownerType $ Se.Eq ownerType,
+          Se.Is Beam.status $ Se.In [ACTIVE, PURCHASED],
+          Se.Is Beam.serviceName $ Se.Eq serviceName
+        ]
+    ]
+    (Se.Asc Beam.purchaseTimestamp)
+    Nothing
+    Nothing
+
 -- | Find the latest active, non-expired subscription.
 -- Using the provided expiry handler callback to process any expired subscriptions found.
 findLatestActiveByOwnerAndServiceName ::
@@ -51,8 +98,8 @@ findLatestActiveByOwnerAndServiceName handleExpiry ownerId ownerType serviceName
   let (expired, valid) = partition (isExpired now) allActive
   -- Handle expired subscriptions (fallback for failed scheduler jobs)
   mapM_ handleExpiry expired
-  -- Return latest non-expired (last in ASC-sorted list)
-  pure $ listToMaybe $ reverse valid
+  -- Return the current non-expired ACTIVE purchase.
+  pure $ listToMaybe valid
   where
     isExpired now purchase = case purchase.expiryDate of
       Just expiry -> expiry <= now
@@ -210,18 +257,20 @@ findActiveByDateRange merchantOpCityId startTime endTime =
           ]
       ]
 
--- | Update the expiryDate and startDate for a specific subscription purchase.
--- Used when activating a queued purchase's expiry timer (deferred FIFO logic).
-updateExpiryAndStartDateById ::
+-- | Update status, expiryDate and startDate for a specific subscription purchase.
+-- Used when promoting a PURCHASED subscription into the current ACTIVE slot.
+updateStatusExpiryAndStartDateById ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  SubscriptionPurchaseStatus ->
   Maybe UTCTime ->
   Maybe UTCTime ->
   Id SubscriptionPurchase ->
   m ()
-updateExpiryAndStartDateById newExpiryDate newStartDate purchaseId = do
+updateStatusExpiryAndStartDateById newStatus newExpiryDate newStartDate purchaseId = do
   now <- getCurrentTime
   updateOneWithKV
-    [ Se.Set Beam.expiryDate newExpiryDate,
+    [ Se.Set Beam.status newStatus,
+      Se.Set Beam.expiryDate newExpiryDate,
       Se.Set Beam.startDate newStartDate,
       Se.Set Beam.updatedAt now
     ]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Notifications.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Notifications.hs
@@ -168,7 +168,6 @@ findFCMConfigWithFallback merchantOpCityId personId = do
 --     ]
 --     Nothing
 
-
 dynamicFCMNotifyPerson ::
   ( CacheFlow m r,
     EsqDBFlow m r,

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0784-prepaid-subscription-purchased-status.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0784-prepaid-subscription-purchased-status.sql
@@ -1,0 +1,8 @@
+-- Normalize queued prepaid subscription purchases to PURCHASED so only one ACTIVE remains.
+UPDATE atlas_driver_offer_bpp.subscription_purchase
+SET status = 'PURCHASED',
+    updated_at = CURRENT_TIMESTAMP
+WHERE service_name = 'PREPAID_SUBSCRIPTION'
+  AND status = 'ACTIVE'
+  AND expiry_date IS NULL
+  AND start_date IS NULL;

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0785-add-subscription-purchase-owner-status-service-name-index.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0785-add-subscription-purchase-owner-status-service-name-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_subscription_purchase_owner_status_service_name
+  ON atlas_driver_offer_bpp.subscription_purchase USING btree (owner_id, owner_type, status, service_name);

--- a/Backend/dhall-configs/dev/dynamic-offer-driver-app.dhall
+++ b/Backend/dhall-configs/dev/dynamic-offer-driver-app.dhall
@@ -353,9 +353,7 @@ let jobInfoMapx =
         }
       , { mapKey = AllocatorJobType.Reconciliation, mapValue = True }
       , { mapKey = AllocatorJobType.ScheduledBatchPayout, mapValue = True }
-      , { mapKey = AllocatorJobType.SettlementReportIngestion
-        , mapValue = True
-        }
+      , { mapKey = AllocatorJobType.SettlementReportIngestion, mapValue = True }
       ]
 
 let LocationTrackingeServiceConfig =

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Storage/Queries/PgPaymentSettlementReportExtra.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Storage/Queries/PgPaymentSettlementReportExtra.hs
@@ -93,6 +93,7 @@ findAllByMerchantOpCityIdWithFilters merchantId merchantOpCityId mbFrom mbTo mbS
     (Se.Desc Beam.createdAt)
     mbLimit
     mbOffset
+
 findByOrderIdAndTxnType ::
   (BeamFlow m r) =>
   Text ->

--- a/subscription_fifo_test_cases.txt
+++ b/subscription_fifo_test_cases.txt
@@ -1,0 +1,354 @@
+PREPAID SUBSCRIPTION FIFO TEST CASES
+
+Purpose
+- Validate pooled prepaid balance behavior.
+- Validate FIFO lifecycle behavior for ACTIVE, PURCHASED, EXHAUSTED, EXPIRED.
+- Validate ride.subscriptionPurchaseIds population for rides that span multiple purchases.
+
+Core Invariants
+- Paid prepaid balance is pooled immediately after successful payment.
+- Exactly one subscription_purchase should be ACTIVE at a time.
+- Zero or more subscription_purchase rows may be PURCHASED.
+- Zero or more subscription_purchase rows may be EXHAUSTED or EXPIRED.
+- Rides should be allowed as long as pooled prepaid balance is sufficient.
+- If one ride spans multiple purchases, ride.subscriptionPurchaseIds should include all contributing purchase ids in FIFO order.
+
+Terminology
+- P1, P2, P3... are subscription purchases ordered by purchaseTimestamp ASC.
+- RC means plan ride credit.
+- Balance means pooled prepaid balance after successful purchase credits and ride debits.
+
+==================================================
+1. HAPPY FLOW
+==================================================
+
+TC-H1: Single purchase, single ride, partial debit
+Setup:
+- P1 RC=500
+Expected after purchase:
+- P1 ACTIVE
+- Balance=500
+Action:
+- End one ride with debit=100
+Expected:
+- Balance=400
+- P1 remains ACTIVE
+- ride.subscriptionPurchaseIds=[P1]
+- No activation of another purchase
+
+TC-H2: Single purchase, exact exhaustion
+Setup:
+- P1 RC=500
+Action:
+- End one ride with debit=500
+Expected:
+- Balance=0
+- P1 becomes EXHAUSTED
+- ride.subscriptionPurchaseIds=[P1]
+- No ACTIVE purchase remains
+
+TC-H3: Two purchases, second remains queued
+Setup:
+- P1 RC=500
+- P2 RC=600
+Expected after purchase:
+- P1 ACTIVE
+- P2 PURCHASED
+- Balance=1100
+Action:
+- End one ride with debit=100
+Expected:
+- Balance=1000
+- P1 remains ACTIVE
+- P2 remains PURCHASED
+- ride.subscriptionPurchaseIds=[P1]
+
+==================================================
+2. MULTIPLE DEBIT / MULTI-PURCHASE CONTRIBUTION
+==================================================
+
+TC-M1: Ride crosses one subscription boundary
+Setup:
+- P1 RC=500
+- P2 RC=600
+Expected before ride:
+- P1 ACTIVE
+- P2 PURCHASED
+- Balance=1100
+Action:
+- End one ride with debit=700
+Expected:
+- Balance=400
+- P1 becomes EXHAUSTED
+- P2 becomes ACTIVE
+- ride.subscriptionPurchaseIds=[P1,P2]
+
+TC-M2: Ride crosses multiple boundaries
+Setup:
+- P1 RC=500
+- P2 RC=600
+- P3 RC=4000
+- P4 RC=100
+- P5 RC=10
+Expected before ride:
+- P1 ACTIVE
+- P2,P3,P4,P5 PURCHASED
+- Balance=5210
+Action:
+- End one ride with debit=1200
+Expected:
+- Balance=4010
+- P1 becomes EXHAUSTED
+- P2 becomes EXHAUSTED
+- P3 becomes ACTIVE
+- P4,P5 remain PURCHASED
+- ride.subscriptionPurchaseIds=[P1,P2,P3]
+
+TC-M3: Sequential rides from same balance pool
+Setup:
+- P1 RC=500
+- P2 RC=600
+- P3 RC=4000
+- P4 RC=100
+- P5 RC=10
+Actions:
+- Ride1 debit=1000
+- Ride2 debit=450
+- Ride3 debit=10
+- Ride4 debit=2000
+- Ride5 debit=10
+Expected after each ride:
+- Ride1: ids should include [P1,P2], current ACTIVE should become P2 or P3 depending on exact remaining pooled inference; final post-ride state must not leave more than one ACTIVE
+- Ride2 onward: all debits should be allowed while pooled balance > 0
+- Every exhausted purchase should move to EXHAUSTED in FIFO order
+- The last partially contributing purchase of each ride should remain or become ACTIVE
+- Each ride.subscriptionPurchaseIds should contain all FIFO-contributing purchase ids for that ride
+
+TC-M4: Single large ride consumes all purchases
+Setup:
+- P1 RC=100
+- P2 RC=50
+- P3 RC=25
+Action:
+- End one ride with debit=175
+Expected:
+- Balance=0
+- P1,P2,P3 all become EXHAUSTED
+- ride.subscriptionPurchaseIds=[P1,P2,P3]
+- No ACTIVE purchase remains
+
+==================================================
+3. RIDE CREDITS LESS / MORE CASES
+==================================================
+
+TC-R1: Ride debit less than ACTIVE remaining credit
+Setup:
+- P1 RC=1000
+- P2 RC=500
+Action:
+- Ride debit=200
+Expected:
+- P1 ACTIVE
+- P2 PURCHASED
+- ride.subscriptionPurchaseIds=[P1]
+
+TC-R2: Ride debit more than ACTIVE but less than ACTIVE+next
+Setup:
+- P1 RC=300
+- P2 RC=700
+Action:
+- Ride debit=500
+Expected:
+- P1 EXHAUSTED
+- P2 ACTIVE
+- ride.subscriptionPurchaseIds=[P1,P2]
+
+TC-R3: Ride debit more than total balance
+Setup:
+- P1 RC=300
+- P2 RC=200
+Action:
+- Attempt ride debit=600
+Expected:
+- Ride should be blocked or debit flow should fail based on existing prepaid insufficiency behavior
+- No silent negative pooled balance
+- No incorrect status changes
+
+==================================================
+4. STATUS TRANSITION CASES
+==================================================
+
+TC-S1: Multiple purchases on same day
+Setup:
+- Buy 5 prepaid plans on same day with RC=500,600,4000,100,10
+Expected after purchases:
+- P1 ACTIVE
+- P2,P3,P4,P5 PURCHASED
+- Balance=5210
+
+TC-S2: PURCHASED should not show as started
+Setup:
+- P1 ACTIVE
+- P2 PURCHASED
+Expected:
+- P2 startDate=NULL
+- P2 expiryDate=NULL
+- Dashboard subscriptionStartDate should be NULL for P2
+
+TC-S3: PURCHASED becomes ACTIVE on first actual usage boundary
+Setup:
+- P1 RC=500 ACTIVE
+- P2 RC=600 PURCHASED
+Action:
+- Ride debit consumes P1 and enters P2
+Expected:
+- P2 startDate set
+- P2 expiryDate set
+- P2 ACTIVE
+
+TC-S4: PURCHASED promoted and exhausted in same ride
+Setup:
+- P1 RC=500 ACTIVE
+- P2 RC=100 PURCHASED
+Action:
+- Ride debit=650
+Expected:
+- P1 EXHAUSTED
+- P2 EXHAUSTED
+- ride.subscriptionPurchaseIds=[P1,P2]
+- No ACTIVE purchase remains
+
+==================================================
+5. EXPIRY FLOWS
+==================================================
+
+TC-E1: ACTIVE purchase expires with queued PURCHASED behind it
+Setup:
+- P1 ACTIVE with expiry in past
+- P2 PURCHASED
+Action:
+- Run ExpireSubscriptionPurchase job for P1
+Expected:
+- P1 EXPIRED
+- Expiry revenue recognition/credit transfer executed once
+- P2 becomes ACTIVE
+- P2 startDate set
+- P2 expiryDate set
+
+TC-E2: Expiry job runs after purchase already EXHAUSTED
+Setup:
+- P1 already EXHAUSTED
+Action:
+- Run ExpireSubscriptionPurchase job for P1
+Expected:
+- Job should skip terminal state
+- P1 must remain EXHAUSTED
+- No EXHAUSTED -> EXPIRED regression
+
+TC-E3: Late expiry versus ride debit
+Setup:
+- P1 near expiry
+- Ride debit and expiry job race
+Expected:
+- Owner lock serializes both
+- Final state should have at most one ACTIVE
+- No double activation of next purchase
+- No duplicate expiry processing
+
+==================================================
+6. CONCURRENCY / RACE CASES
+==================================================
+
+TC-C1: Two successful purchases in parallel
+Setup:
+- No active prepaid plan
+Action:
+- Two purchase success flows run nearly together
+Expected:
+- Only one ends ACTIVE
+- Other ends PURCHASED
+
+TC-C2: Ride debit and purchase success in parallel
+Setup:
+- P1 ACTIVE, pooled balance available
+Action:
+- One ride ends while another purchase payment succeeds
+Expected:
+- Owner lock serializes flow
+- No more than one ACTIVE at end
+- New purchase either remains PURCHASED or becomes ACTIVE only if no ACTIVE remains
+
+TC-C3: Ride debit and expiry job in parallel
+Setup:
+- P1 ACTIVE, P2 PURCHASED
+Action:
+- Ride completion and expiry job overlap
+Expected:
+- No duplicate activation of P2
+- No duplicate expiry job scheduling for same promoted purchase
+- No EXHAUSTED -> EXPIRED regression
+
+==================================================
+7. DASHBOARD / API / REPORTING
+==================================================
+
+TC-D1: Subscription purchase list shows PURCHASED distinctly
+Setup:
+- P1 ACTIVE
+- P2 PURCHASED
+Expected:
+- API and dashboard should show P2 as PURCHASED
+
+TC-D2: latestManualPaymentDate should use purchase time
+Setup:
+- P1 bought on Day1
+- P2 bought on Day2 as PURCHASED
+- Later P2 becomes ACTIVE on Day5
+Expected:
+- latestManualPaymentDate should remain Day2
+- It must not jump to Day5 because of activation
+
+TC-D3: subscriptionStartDate in finance dashboard
+Setup:
+- P2 PURCHASED and not yet activated
+Expected:
+- subscriptionStartDate=NULL
+- purchasedAt=purchaseTimestamp
+
+==================================================
+8. LEGACY DATA / MIGRATION
+==================================================
+
+TC-L1: Legacy queued ACTIVE rows normalized by migration
+Setup:
+- Existing prepaid data has multiple ACTIVE rows where only first has startDate/expiryDate and later ones have NULL startDate/expiryDate
+Action:
+- Run migration 0784
+Expected:
+- First real live row stays ACTIVE
+- Queued NULL-timer rows become PURCHASED
+
+TC-L2: Post-migration invariant
+Expected:
+- For each owner/serviceName PREPAID_SUBSCRIPTION:
+  - at most one ACTIVE
+  - remaining queued rows PURCHASED
+
+==================================================
+9. KNOWN LIMITATION TO DISCUSS
+==================================================
+
+Open discussion item:
+- Current implementation restores multi-subscription ride IDs, but it still does not store exact debit amount per purchase for a ride.
+- Example:
+  - P1 contributes 500
+  - P2 contributes 200
+  - ride.subscriptionPurchaseIds can store [P1,P2]
+  - but exact 500/200 split is not persisted yet
+
+Suggested follow-up if needed:
+- Add a dedicated allocation table or ledger metadata for:
+  - ride_id
+  - subscription_purchase_id
+  - debited_amount
+  - sequence_number


### PR DESCRIPTION
Implemented today:
- Added `PURCHASED` as a new `subscription_purchase` status.
- Payment success now creates:
  - one `ACTIVE` prepaid purchase if none exists
  - otherwise new purchases become `PURCHASED`
- Pooled prepaid balance behavior is unchanged.
- Ride allowance still depends only on total prepaid balance.
- FIFO lifecycle is enforced internally:
  - only one `ACTIVE`
  - multiple `PURCHASED` allowed
  - multiple `EXHAUSTED` allowed
- On exhaustion or expiry:
  - only one current `ACTIVE` is transitioned out
  - exactly one oldest `PURCHASED` is promoted to `ACTIVE`
- Added migration to convert old queued `ACTIVE` prepaid rows into `PURCHASED`.
- Updated dashboard/management status enums to surface `PURCHASED`.

Not implemented:
- Exact per-ride split across multiple subscription purchases.
- Exact partial-consumption tracking per purchase.
- Multi-boundary exhaustion in a single ride event.
- Ledger-level or table-level attribution like:
  - ride X consumed 500 from purchase A
  - ride X consumed 200 from purchase B

Current limitation:
- pooled balance is correct
- FIFO lifecycle is mostly correct
- but if one large ride spans multiple purchases, status progression can lag behind actual economic consumption
- reporting can identify which plan was exhausted, but not exact debit split across plans

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "PURCHASED" subscription status to represent queued/prepaid purchases.

* **Improvements**
  * Clarified ACTIVE vs PURCHASED lifecycle: activation, expiry, and purchase selection updated.
  * Safer expiry processing with distributed locking and re-check before acting.
  * Query logic refined to reliably select current and purchased records; payment/plan flows updated accordingly.

* **Chores**
  * Database migrations to mark matching rows as PURCHASED and add an index for faster lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->