### PR TITLE
backend/feat: populate createdAt field in PurchasedPassAPIEntity resp…

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/Pass.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/Pass.yaml
@@ -94,6 +94,7 @@ types:
     lastVerifiedVehicleNumber: Maybe Text
     isAutoVerified: Bool
     status: StatusType
+    createdAt: UTCTime
     purchaseDate: Day
     daysToExpire: Int
     startDate: Day

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/Pass.hs
@@ -95,7 +95,8 @@ data PassVerifyReq = PassVerifyReq
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data PurchasedPassAPIEntity = PurchasedPassAPIEntity
-  { daysToExpire :: Kernel.Prelude.Int,
+  { createdAt :: Kernel.Prelude.UTCTime,
+    daysToExpire :: Kernel.Prelude.Int,
     deviceMismatch :: Kernel.Prelude.Bool,
     deviceSwitchAllowed :: Kernel.Prelude.Bool,
     expiryDate :: Data.Time.Day,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -629,6 +629,7 @@ buildPurchasedPassAPIEntity mbLanguage person mbDeviceId today purchasedPass = d
         deviceSwitchAllowed = purchasedPass.deviceSwitchCount < maxSwitchCount,
         profilePicture = purchasedPass.profilePicture <|> person.profilePicture,
         daysToExpire = daysToExpire,
+        createdAt = purchasedPass.createdAt,
         purchaseDate = DT.utctDay purchasedPass.createdAt,
         expiryDate = purchasedPass.endDate,
         isPreferredSourceAndDestinationSet = isJust purchasedPass.preferredDestination && isJust purchasedPass.preferredSource,


### PR DESCRIPTION
…onse

The createdAt field was defined on the API type but never set in the builder, causing the frontend to receive null. This is needed for correct recency-based sorting of passes alongside journey tickets.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Purchased pass responses now include a creation timestamp ("createdAt") alongside existing expiry information, so pass records show both when the pass was created and its days-to-expire.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->