### PR TITLE
backend/fix: use driver location's special location for queue skip count

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
@@ -13,6 +13,7 @@ import qualified Domain.Types.MerchantOperatingCity
 import qualified Domain.Types.Person
 import qualified Domain.Types.SpecialZoneQueueRequest
 import qualified Environment
+import Data.List (partition)
 import EulerHS.Prelude hiding (id)
 import Kernel.External.Maps.Types (LatLong (..))
 import qualified Kernel.Prelude
@@ -30,6 +31,7 @@ import SharedLogic.SpecialZoneDriverDemand (mkQueueSkipCountKey)
 import Storage.Beam.SchedulerJob ()
 import qualified Storage.Queries.SpecialZoneQueueRequest as QSZQR
 import Tools.Error
+import qualified Lib.Queries.SpecialLocation as LQSL
 
 getSpecialZoneQueueRequest ::
   ( ( Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person),
@@ -41,27 +43,28 @@ getSpecialZoneQueueRequest ::
 getSpecialZoneQueueRequest (mbPersonId, _merchantId, _merchantOpCityId) = do
   personId <- mbPersonId & fromMaybeM (PersonNotFound "No person id")
   now <- getCurrentTime
-  -- Fetch both Active and Accepted requests
-  activeRequests <- QSZQR.findActiveByDriverId personId Domain.Types.SpecialZoneQueueRequest.Active
-  acceptedRequests <- QSZQR.findActiveByDriverId personId Domain.Types.SpecialZoneQueueRequest.Accepted
+  -- Fetch both Active and Accepted requests in one query, then split
+  allReqs <- QSZQR.findActiveByStasusListAndDriverId personId [Domain.Types.SpecialZoneQueueRequest.Active, Domain.Types.SpecialZoneQueueRequest.Accepted]
+  let (activeRequests, acceptedRequests) = partition (\request -> request.status == Domain.Types.SpecialZoneQueueRequest.Active) allReqs
   -- Lazy-expire Active requests past validTill
   validActiveRequests <- collectValidActive now activeRequests
   -- Accepted requests are always returned (they're waiting for arrival/ride)
   let acceptedRes = map mkRes acceptedRequests
-      allRequests = validActiveRequests ++ acceptedRes
-  -- Get skip count from driver's current location (which gate they're in)
+      responseRequests = validActiveRequests ++ acceptedRes
+  -- Get skip count from driver's current location's special location
   mbDriverLoc <- LTSFlow.driversLocation [personId]
-  mbCurrentGate <- case mbDriverLoc of
-    (loc : _) -> Esq.runInReplica $ QGI.findGateInfoByLatLongWithoutGeoJson (LatLong loc.lat loc.lon)
+  mbSpecialLoc <- case mbDriverLoc of
+    (loc : _) -> Esq.runInReplica $ LQSL.findSpecialLocationByLatLongFull (LatLong loc.lat loc.lon)
     [] -> pure Nothing
-  (skipCount, maxSkips) <- case mbCurrentGate of
-    Just gate -> do
-      mbSkipCount <- Redis.withCrossAppRedis $ Redis.get @Int (mkQueueSkipCountKey gate.specialLocationId.getId personId.getId)
-      pure (fromMaybe 0 mbSkipCount, gate.maxRideSkipsBeforeQueueRemoval)
+  (skipCount, maxSkips) <- case mbSpecialLoc of
+    Just specialLoc -> do
+      mbSkipCount <- Redis.withCrossAppRedis $ Redis.get @Int (mkQueueSkipCountKey specialLoc.id.getId personId.getId)
+      let mbMaxSkips = Kernel.Prelude.listToMaybe specialLoc.gatesInfo >>= (.maxRideSkipsBeforeQueueRemoval)
+      pure (fromMaybe 0 mbSkipCount, mbMaxSkips)
     Nothing -> pure (0, Nothing)
   pure $
     API.Types.UI.SpecialZoneQueue.SpecialZoneQueueRequestListRes
-      { requests = allRequests,
+      { requests = responseRequests,
         currentSkipCount = skipCount,
         maxSkipsBeforeQueueRemoval = maxSkips
       }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SpecialZoneQueueRequestExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SpecialZoneQueueRequestExtra.hs
@@ -3,11 +3,23 @@
 
 module Storage.Queries.SpecialZoneQueueRequestExtra where
 
+import qualified Domain.Types.Person
+import qualified Domain.Types.SpecialZoneQueueRequest
 import Kernel.Beam.Functions
 import Kernel.External.Encryption
 import Kernel.Prelude
+import qualified Kernel.Types.Id
 import Kernel.Types.Error
 import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
+import qualified Sequelize as Se
+import qualified Storage.Beam.SpecialZoneQueueRequest as Beam
 import Storage.Queries.OrphanInstances.SpecialZoneQueueRequest
 
 -- Extra code goes here --
+findActiveByStasusListAndDriverId ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  Kernel.Types.Id.Id Domain.Types.Person.Person ->
+  [Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequestStatus] ->
+  m [Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest]
+findActiveByStasusListAndDriverId driverId statusList =
+  findAllWithKV [Se.And [Se.Is Beam.driverId $ Se.Eq (Kernel.Types.Id.getId driverId), Se.Is Beam.status $ Se.In statusList]]


### PR DESCRIPTION
## Summary
- Fetch Active and Accepted queue requests in a single query and split via \`partition\`.
- Resolve skip count and max-skips from the driver's current special location (geospatial match on driver's live location) instead of depending on a stale request's gate context.
- Fix \`findActiveByStasusListAndDriverId\` query signature (now accepts a status list) and add missing imports.

## Test plan
- [ ] Driver in a special zone with no active/accepted requests — GET returns correct skip count from current location
- [ ] Driver with both Active and Accepted requests — both returned, partition works
- [ ] Driver outside any special zone — skipCount 0, maxSkips null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized special zone queue request handling with streamlined data retrieval processes for improved overall performance and system responsiveness
  * Enhanced accuracy of location-based queue operations with an updated driver location resolution mechanism
  * Refined queue skip limit computation to provide better consistency and reliability in driver queue handling across different zones

<!-- end of auto-generated comment: release notes by coderabbit.ai -->