### PR TITLE
backend/enh: radius-based gate lookup scoped to special location in search

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
@@ -47,6 +47,7 @@ import qualified SharedLogic.External.LocationTrackingService.Types as LT
 import SharedLogic.MerchantPaymentMethod
 import SharedLogic.Ride
 import qualified SharedLogic.RiderDetails as SRD
+import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import SharedLogic.SearchTry
 import Storage.CachedQueries.Merchant as QM
 import qualified Storage.CachedQueries.Merchant.MerchantPaymentMethod as QMPM
@@ -128,6 +129,10 @@ handler merchant req validatedQuote = do
       (ride, _, vehicle) <- initializeRide merchant driver uBooking Nothing (Just req.enableFrequentLocationUpdates) driverQuote.clientId (Just req.enableOtpLessRide) (mFleetOwnerId <&> (.fleetOwnerId) <&> Id)
       void $ deactivateExistingQuotes booking.merchantOperatingCityId merchant.id driver.id driverQuote.searchTryId (mkPrice (Just driverQuote.currency) driverQuote.estimatedFare) Nothing
       uBooking2 <- QRB.findById booking.id >>= fromMaybeM (BookingNotFound booking.id.getId)
+      -- Booking confirmed: decrement demand at this pickup gate AND complete any
+      -- Accepted pickup-zone request for this driver (supply -1). Idempotent with StartRide.
+      fork "specialZoneCompletePickupZoneOnConfirm" $
+        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driver.id uBooking2.id.getId uBooking2.pickupGateId (show uBooking2.vehicleServiceTier)
       mkDConfirmResp (Just $ RideInfo {ride, driver, vehicle}) uBooking2 riderDetails
 
     handleRideOtpFlow isNewRider _ booking riderDetails = do
@@ -150,6 +155,8 @@ handler merchant req validatedQuote = do
       mFleetOwnerId <- QFDA.findByDriverId driver.id True
       (ride, _, vehicle) <- initializeRide merchant driver uBooking dynamicReferralCode (Just req.enableFrequentLocationUpdates) Nothing (Just req.enableOtpLessRide) (mFleetOwnerId <&> (.fleetOwnerId) <&> Id)
       uBooking2 <- QRB.findById booking.id >>= fromMaybeM (BookingNotFound booking.id.getId)
+      fork "specialZoneCompletePickupZoneOnMeterConfirm" $
+        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driver.id uBooking2.id.getId uBooking2.pickupGateId (show uBooking2.vehicleServiceTier)
       mkDConfirmResp (Just $ RideInfo {ride, driver, vehicle}) uBooking2 riderDetails
 
     generateUniqueOTPCode merchantOperatingCityId cnt = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -78,7 +78,7 @@ import Kernel.Types.Id
 import Kernel.Types.Version (CloudType, Device, Version)
 import Kernel.Utils.CalculateDistance (distanceBetweenInMeters)
 import Kernel.Utils.Common
-import Lib.Queries.GateInfo (findGateInfoByLatLongWithoutGeoJson)
+import Lib.Queries.GateInfo (findGateInfoByLatLongWithinRadius)
 import qualified Lib.Types.SpecialLocation as SL
 import qualified Lib.Yudhishthira.Tools.DebugLog as LYDL
 import Lib.Yudhishthira.Types
@@ -312,7 +312,10 @@ handler ValidatedDSearchReq {..} sReq = do
   mbVehicleServiceTier <- getVehicleServiceTierForMeterRideSearch isMeterRideSearch driverIdForSearch configVersionMap
   let farePolicies = selectFarePolicy (fromMaybe 0 mbDistance) (fromMaybe 0 mbDuration) mbIsAutoRickshawAllowed mbIsTwoWheelerAllowed mbVehicleServiceTier allFarePoliciesProduct.farePolicies
   now <- getCurrentTime
-  (mbPickupGateId, mbSpecialZoneGateId, mbDefaultDriverExtra) <- getSpecialPickupZoneInfo allFarePoliciesProduct.specialLocationTag fromLocation
+  (mbPickupGateId, mbSpecialZoneGateId, mbDefaultDriverExtra) <-
+    getSpecialPickupZoneInfo
+      (fromMaybe allFarePoliciesProduct.area allFarePoliciesProduct.mbPickupDropArea)
+      fromLocation
   logDebug $ "Pickingup Gate info result : " <> show (mbPickupGateId, mbSpecialZoneGateId, mbDefaultDriverExtra)
   let spcllocationTag = maybe allFarePoliciesProduct.specialLocationTag (\_ -> allFarePoliciesProduct.specialLocationTag <&> (<> "_PickupZone")) mbSpecialZoneGateId
       specialLocName = allFarePoliciesProduct.specialLocationName
@@ -378,10 +381,17 @@ handler ValidatedDSearchReq {..} sReq = do
   buildDSearchResp sReq.pickupLocation sReq.dropLocation (stopsLatLong sReq.stops) spcllocationTag searchMetricsMVar driverInfoQuotes driverInfoEstimates specialLocName specialLocationSupportNumber now possibleTripOption.schedule sReq.fareParametersInRateCard sReq.isMultimodalSearch
   where
     stopsLatLong = map (.gps)
-    getSpecialPickupZoneInfo :: Maybe Text -> DLoc.Location -> Flow (Maybe Text, Maybe Text, Maybe HighPrecMoney)
-    getSpecialPickupZoneInfo Nothing _ = pure (Nothing, Nothing, Nothing)
-    getSpecialPickupZoneInfo (Just _) fromLocation = do
-      mbPickupZone <- Esq.runInReplica $ findGateInfoByLatLongWithoutGeoJson (LatLong fromLocation.lat fromLocation.lon)
+    getSpecialPickupZoneInfo :: SL.Area -> DLoc.Location -> Flow (Maybe Text, Maybe Text, Maybe HighPrecMoney)
+    getSpecialPickupZoneInfo SL.Default _ = pure (Nothing, Nothing, Nothing)
+    getSpecialPickupZoneInfo area fromLocation = do
+      let pickupLatLong = LatLong fromLocation.lat fromLocation.lon
+          mbSlId = case area of
+            SL.Pickup slId -> Just slId
+            SL.PickupDrop slId _ -> Just slId
+            _ -> Nothing
+      mbPickupZone <- case mbSlId of
+        Just slId -> Esq.runInReplica $ findGateInfoByLatLongWithinRadius slId pickupLatLong 20.0
+        Nothing -> pure Nothing
       if ((.canQueueUpOnGate) <$> mbPickupZone) == Just True
         then -- Demand counter is now bumped at Select time (per chosen variant) rather than at Search,
         -- because at Search we don't yet know which estimate the customer will pick.

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -81,6 +81,7 @@ import SharedLogic.Finance.Wallet
 import SharedLogic.GoogleTranslate (TranslateFlow)
 import SharedLogic.Ride (releaseLien, updateOnRideStatusWithAdvancedRideCheck)
 import SharedLogic.RuleBasedTierUpgrade
+import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import qualified SharedLogic.UserCancellationDues as UserCancellationDues
 import qualified Storage.Cac.TransporterConfig as CCT
 import qualified Storage.CachedQueries.Driver.GoHomeRequest as CQDGR
@@ -193,6 +194,15 @@ cancelRideImpl rideId rideEndedBy bookingCReason isForceReallocation doCancellat
             unless (isValidRide ride) $ throwError (InternalError "Ride is not valid for cancellation")
             cancelRideTransaction booking ride bookingCReason merchant rideEndedBy userNoShowCharges transporterConfig driver
             logTagInfo ("rideId-" <> getId rideId) ("Cancellation reason " <> show bookingCReason.source)
+            -- Demand decrement: customer cancelled before ride start → demand retracted.
+            -- Only applies to pickup-gate bookings cancelled by the user (ByDriver cancels keep demand live).
+            when (bookingCReason.source == SBCR.ByUser && isJust booking.pickupGateId) $
+              fork "specialZoneDemandDecrementOnCancel" $
+                SpecialZoneDriverDemand.runDemandDecrementForBooking booking.id.getId booking.pickupGateId (show booking.vehicleServiceTier)
+            -- Supply decrement: driver cancelled pre-start ride → retract the pickup-zone commitment.
+            when (bookingCReason.source == SBCR.ByDriver) $
+              fork "specialZoneSupplyDecrementOnDriverCancel" $
+                SpecialZoneDriverDemand.cancelPickupZoneRequestsForDriver ride.driverId
 
             fork "DriverRideCancelledCoin Event : " $ do
               mbLocation <- do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
@@ -224,7 +224,8 @@ startRide ServiceHandle {..} rideId req = withLogTag ("rideId-" <> rideId.getId)
 
       fork "notify customer for ride start" $ notifyBAPRideStarted booking updatedRide (Just point)
       fork "startRide - Notify driver" $ Notify.notifyOnRideStarted ride booking
-      fork "startRide - Complete pickup zone request" $ SpecialZoneDriverDemand.completePickupZoneRequestOnRideStart driverId
+      fork "startRide - Complete pickup zone request" $
+        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driverId booking.id.getId booking.pickupGateId (show booking.vehicleServiceTier)
       if isInterCityTrip booking.tripCategory || isRentalTrip booking.tripCategory
         then logTagInfo "IffcoTokio driver insurance skipped" ("tripCategory=" <> show booking.tripCategory <> ", rideId=" <> ride.id.getId)
         else fork "IffcoTokio driver insurance" $ IffcoInsurance.triggerIffcoTokioInsurance driverId booking.providerId ride.merchantOperatingCityId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
@@ -29,6 +29,7 @@ import Lib.Scheduler.JobStorageType.SchedulerType (createJobIn)
 import SharedLogic.Allocator (AllocatorJobType (..), CheckPickupZoneArrivalJobData (..))
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTSFlow
 import SharedLogic.SpecialZoneDriverDemand (mkQueueSkipCountKey)
+import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import Storage.Beam.SchedulerJob ()
 import qualified Storage.Queries.SpecialZoneQueueRequest as QSZQR
 import Tools.Error
@@ -113,6 +114,9 @@ postSpecialZoneQueueRequestRespond (mbPersonId, _merchantId, _merchantOpCityId) 
   case actualResponse of
     Domain.Types.SpecialZoneQueueRequest.Accept -> do
       QSZQR.updateResponse (Just Domain.Types.SpecialZoneQueueRequest.Accept) Domain.Types.SpecialZoneQueueRequest.Accepted requestId
+      -- Supply increment: driver has committed to this gate for this variant.
+      fork "specialZoneSupplyIncrementOnAccept" $
+        SpecialZoneDriverDemand.runSupplyIncrementForRequest requestId.getId request.gateId request.vehicleType
       mbGate <- Esq.runInReplica $ QGI.findById (Kernel.Types.Id.Id request.gateId)
       let timeoutSec = maybe 1200 (fromMaybe 1200 . (.pickupZoneArrivalTimeoutInSec)) mbGate
       createJobIn @_ @'CheckPickupZoneArrival
@@ -146,4 +150,7 @@ postSpecialZoneQueueRequestCancel (mbPersonId, _merchantId, _merchantOpCityId) r
   unless (request.driverId == personId) $ throwError (InvalidRequest "Request does not belong to this driver")
   unless (request.status == Domain.Types.SpecialZoneQueueRequest.Accepted) $ throwError (InvalidRequest "Only accepted requests can be cancelled")
   QSZQR.updateResponse (Just Domain.Types.SpecialZoneQueueRequest.Cancelled) Domain.Types.SpecialZoneQueueRequest.Expired requestId
+  -- Supply decrement: driver retracted their pickup-zone commitment.
+  fork "specialZoneSupplyDecrementOnRequestCancel" $
+    SpecialZoneDriverDemand.runSupplyDecrementForRequest requestId.getId request.gateId request.vehicleType
   pure Kernel.Types.APISuccess.Success

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SpecialZoneQueue/CheckPickupZoneArrival.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SpecialZoneQueue/CheckPickupZoneArrival.hs
@@ -14,6 +14,7 @@ import Lib.Scheduler
 import SharedLogic.Allocator (AllocatorJobType (..))
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTSFlow
 import SharedLogic.External.LocationTrackingService.Types (HasLocationService)
+import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import qualified Storage.Queries.SpecialZoneQueueRequest as QSZQR
 import qualified Tools.Notifications as Notify
 
@@ -76,6 +77,8 @@ checkPickupZoneArrival Job {id = jobId, jobInfo} = withLogTag ("JobId-" <> jobId
                 logWarning $ "Driver " <> driverId.getId <> " no-show at gate " <> gateId <> ", removing from queue"
                 void $ LTSFlow.manualQueueRemove specialLocationId vehicleType merchantId driverId
                 QSZQR.updateResponse (Just DSZQR.NoShow) DSZQR.Expired (Id jobData.requestId)
+                -- Supply decrement: no-show — driver never honored the commitment.
+                SpecialZoneDriverDemand.runSupplyDecrementForRequest jobData.requestId gateId vehicleType
                 let entityData =
                       Notify.PickupZoneRequestEntityData
                         { requestId = jobData.requestId,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -14,16 +14,24 @@
 
 module SharedLogic.SpecialZoneDriverDemand
   ( mkGateSearchDemandKey,
+    mkGateSearchSupplyKey,
     mkGateDriverNotifiedKey,
     mkQueueSkipCountKey,
     incrementGateSearchDemand,
+    decrementGateSearchDemand,
+    runDemandDecrementForBooking,
+    incrementGateSearchSupply,
+    decrementGateSearchSupply,
+    runSupplyIncrementForRequest,
+    runSupplyDecrementForRequest,
     incrementQueueSkipCount,
     resetQueueSkipCount,
     checkAndNotifyDriverDemand,
     runDemandCheckForVariants,
     forceNotifyDriverDemand,
     handleQueueSkipIfApplicable,
-    completePickupZoneRequestOnRideStart,
+    completePickupZoneRequestsForDriver,
+    cancelPickupZoneRequestsForDriver,
   )
 where
 
@@ -33,7 +41,6 @@ import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.Person as DP
 import qualified Domain.Types.SpecialZoneQueueRequest as DSZQR
-import Kernel.External.Maps.Types (LatLong (..))
 import Kernel.Prelude
 import qualified Kernel.Storage.Esqueleto as Esq
 import qualified Kernel.Storage.Hedis as Redis
@@ -52,6 +59,9 @@ import qualified Tools.Notifications as Notify
 
 mkGateSearchDemandKey :: Text -> Text -> Text
 mkGateSearchDemandKey gateId variant = "DriverDemand:Gate:" <> gateId <> ":" <> variant
+
+mkGateSearchSupplyKey :: Text -> Text -> Text
+mkGateSearchSupplyKey gateId variant = "DriverSupply:Gate:" <> gateId <> ":" <> variant
 
 mkGateDriverNotifiedKey :: Text -> Text -> Text
 mkGateDriverNotifiedKey gateId driverId = "DriverDemand:Notified:" <> gateId <> ":" <> driverId
@@ -72,6 +82,93 @@ incrementGateSearchDemand gateId variant = Redis.withCrossAppRedis $ do
   let key = mkGateSearchDemandKey gateId variant
   void $ Redis.incr key
   Redis.expire key 300 -- 5 min sliding window
+
+-- | Decrement the gate demand counter (clamp at 0). Called when demand is fulfilled or retracted.
+decrementGateSearchDemand ::
+  ( Redis.HedisFlow m r,
+    MonadFlow m
+  ) =>
+  Text -> -- gateId
+  Text -> -- vehicleVariant
+  m ()
+decrementGateSearchDemand gateId variant = Redis.withCrossAppRedis $ do
+  let key = mkGateSearchDemandKey gateId variant
+  newVal <- Redis.decr key
+  when (newVal < 0) $ void $ Redis.set key (0 :: Int)
+
+-- | Idempotent demand decrement keyed by bookingId. Prevents double-decrement on retries.
+--   No-op when pickupGateId is Nothing.
+runDemandDecrementForBooking ::
+  ( Redis.HedisFlow m r,
+    MonadFlow m
+  ) =>
+  Text ->       -- bookingId (idempotency key)
+  Maybe Text -> -- pickupGateId
+  Text ->       -- vehicleServiceTier as Text
+  m ()
+runDemandDecrementForBooking _ Nothing _ = pure ()
+runDemandDecrementForBooking bookingId (Just gateId) variant = do
+  let idempotencyKey = "DriverDemand:Decremented:" <> bookingId
+  wasSet <- Redis.withCrossAppRedis $ Redis.setNxExpire idempotencyKey 86400 ("1" :: Text)
+  when wasSet $ decrementGateSearchDemand gateId variant
+
+-- | Increment the gate supply counter. Supply reflects drivers who have accepted a
+--   pickup-zone request at this gate/variant and are committed to the pickup.
+--   24-hour sliding TTL guards against orphaned counters if explicit decrements are missed.
+incrementGateSearchSupply ::
+  ( Redis.HedisFlow m r,
+    MonadFlow m
+  ) =>
+  Text -> -- gateId
+  Text -> -- vehicleVariant
+  m ()
+incrementGateSearchSupply gateId variant = Redis.withCrossAppRedis $ do
+  let key = mkGateSearchSupplyKey gateId variant
+  void $ Redis.incr key
+  Redis.expire key 86400
+
+-- | Decrement the gate supply counter (clamp at 0).
+decrementGateSearchSupply ::
+  ( Redis.HedisFlow m r,
+    MonadFlow m
+  ) =>
+  Text -> -- gateId
+  Text -> -- vehicleVariant
+  m ()
+decrementGateSearchSupply gateId variant = Redis.withCrossAppRedis $ do
+  let key = mkGateSearchSupplyKey gateId variant
+  newVal <- Redis.decr key
+  when (newVal < 0) $ void $ Redis.set key (0 :: Int)
+
+-- | Idempotent supply increment keyed by pickup-zone requestId. Called when a driver accepts.
+runSupplyIncrementForRequest ::
+  ( Redis.HedisFlow m r,
+    MonadFlow m
+  ) =>
+  Text -> -- requestId (idempotency key)
+  Text -> -- gateId
+  Text -> -- vehicleVariant
+  m ()
+runSupplyIncrementForRequest requestId gateId variant = do
+  let idempotencyKey = "DriverSupply:Incremented:" <> requestId
+  wasSet <- Redis.withCrossAppRedis $ Redis.setNxExpire idempotencyKey 86400 ("1" :: Text)
+  when wasSet $ incrementGateSearchSupply gateId variant
+
+-- | Idempotent supply decrement keyed by pickup-zone requestId. Safe to call from any
+--   code path that terminates the commitment (cancel / no-show / booking confirm / ride start
+--   / driver ride cancel) — only the first call decrements the counter.
+runSupplyDecrementForRequest ::
+  ( Redis.HedisFlow m r,
+    MonadFlow m
+  ) =>
+  Text -> -- requestId (idempotency key)
+  Text -> -- gateId
+  Text -> -- vehicleVariant
+  m ()
+runSupplyDecrementForRequest requestId gateId variant = do
+  let idempotencyKey = "DriverSupply:Decremented:" <> requestId
+  wasSet <- Redis.withCrossAppRedis $ Redis.setNxExpire idempotencyKey 86400 ("1" :: Text)
+  when wasSet $ decrementGateSearchSupply gateId variant
 
 incrementQueueSkipCount ::
   ( Redis.HedisFlow m r,
@@ -131,8 +228,9 @@ runDemandCheckForVariants merchantOpCityId merchantId pickupZoneGateId variants 
       checkAndNotifyDriverDemand merchantOpCityId merchantId gate variant
 
 -- | Per-variant demand check. Triggered from Select once an estimate is chosen.
---   Notifies parking-area drivers of this variant to move to the pickup zone
---   when supply is below 'min' for the gate, capped at 'max - currentInZone'.
+--   Compares per-variant demand against the gate's demand threshold; when it's hit and
+--   committed supply (tracked via Redis) is below 'min', notifies top LTS-queue drivers
+--   up to 'max - supply'.
 checkAndNotifyDriverDemand ::
   ( Redis.HedisFlow m r,
     MonadFlow m,
@@ -158,46 +256,18 @@ checkAndNotifyDriverDemand merchantOpCityId merchantId gate variant = do
     let minThreshold = fromMaybe 0 (DGI.minDriverThresholdFor gate variant)
         -- If max isn't configured, fall back to min so we never overshoot the trigger threshold.
         maxThreshold = fromMaybe minThreshold (DGI.maxDriverThresholdFor gate variant)
-    -- Single source of truth: LTS queue for this gate's special location, filtered by variant.
-    queueResp <- LTSFlow.getQueueDrivers specialLocationId variant
-    let sortedDrivers = sortOn (.queuePosition) queueResp.drivers
-        queueDriverIds = map (.driverId) sortedDrivers
-    (insidePickupZone, parkingDrivers) <- partitionInsideGate gate queueDriverIds
-    let pickupZoneCount = length insidePickupZone
-    when (pickupZoneCount < minThreshold) $ do
-      let needed = max 0 (maxThreshold - pickupZoneCount)
+    mbSupplyCount <- Redis.withCrossAppRedis $ Redis.get @Int (mkGateSearchSupplyKey gateId variant)
+    let supplyCount = fromMaybe 0 mbSupplyCount
+    when (supplyCount < minThreshold) $ do
+      let needed = max 0 (maxThreshold - supplyCount)
       when (needed > 0) $ do
         let cooldown = fromMaybe 900 gate.notificationCooldownInSec
-        eligible <- filterEligibleDrivers gate specialLocationId variant merchantId gateId parkingDrivers
+        -- Pull drivers from the LTS queue for this special location, ordered by queue position.
+        queueResp <- LTSFlow.getQueueDrivers specialLocationId variant
+        let sortedDrivers = sortOn (.queuePosition) queueResp.drivers
+            queueDriverIds = map (.driverId) sortedDrivers
+        eligible <- filterEligibleDrivers gate specialLocationId variant merchantId gateId queueDriverIds
         void $ notifyDrivers merchantOpCityId merchantId gate specialLocationId variant cooldown (take needed eligible)
-
--- | Split a list of driver ids into (insidePickupZone, outside) based on driver locations.
---   Batch-fetches locations once; falls back to "outside" for drivers with unknown location.
-partitionInsideGate ::
-  ( MonadFlow m,
-    HasLocationService m r,
-    HasShortDurationRetryCfg r c,
-    HasRequestId r,
-    CacheFlow m r,
-    EsqDBFlow m r,
-    Esq.EsqDBReplicaFlow m r
-  ) =>
-  DGI.GateInfo ->
-  [Id DP.Person] ->
-  m ([Id DP.Person], [Id DP.Person])
-partitionInsideGate _ [] = pure ([], [])
-partitionInsideGate gate driverIds = do
-  locations <- LTSFlow.driversLocation driverIds
-  let locById = Map.fromList $ map (\l -> (l.driverId, l)) locations
-  insideFlags <- forM driverIds $ \dId ->
-    case Map.lookup dId locById of
-      Nothing -> pure (dId, False)
-      Just loc -> do
-        mbDriverGate <- Esq.runInReplica $ QGI.findGateInfoIfDriverInsideGatePickupZone (LatLong loc.lat loc.lon)
-        pure (dId, maybe False (\g -> g.id == gate.id) mbDriverGate)
-  let inside = [d | (d, True) <- insideFlags]
-      outside = [d | (d, False) <- insideFlags]
-  pure (inside, outside)
 
 -- Force notify (dashboard trigger) — uses LTS queue order, skips demand/supply threshold checks
 forceNotifyDriverDemand ::
@@ -333,19 +403,26 @@ filterEligibleDrivers gate specialLocationId vehicleType merchantId gateId drive
         if recentlyNotified
           then pure acc
           else do
-            -- Increment skip count for every request we're about to send
-            shouldInclude <- case maxSkips of
-              Nothing -> pure True
-              Just threshold -> do
-                newCount <- incrementQueueSkipCount specialLocationId driverId 86400
-                if newCount >= threshold
-                  then do
-                    void $ LTSFlow.manualQueueRemove specialLocationId vehicleType merchantId driverId
-                    resetQueueSkipCount specialLocationId driverId
-                    logInfo $ "Driver " <> driverId.getId <> " removed from queue after " <> show newCount <> " requests at gate " <> gateId
-                    pure False
-                  else pure True
-            pure $ if shouldInclude then acc ++ [driverId] else acc
+            -- Skip drivers who already committed to a pickup-zone request; re-notifying
+            -- them wouldn't change supply and would just spam the driver. At most one
+            -- Accepted request per driver by business rule.
+            hasAccepted <- not . null <$> QSZQR.findActiveByDriverId driverId DSZQR.Accepted
+            if hasAccepted
+              then pure acc
+              else do
+                -- Increment skip count for every request we're about to send
+                shouldInclude <- case maxSkips of
+                  Nothing -> pure True
+                  Just threshold -> do
+                    newCount <- incrementQueueSkipCount specialLocationId driverId 86400
+                    if newCount >= threshold
+                      then do
+                        void $ LTSFlow.manualQueueRemove specialLocationId vehicleType merchantId driverId
+                        resetQueueSkipCount specialLocationId driverId
+                        logInfo $ "Driver " <> driverId.getId <> " removed from queue after " <> show newCount <> " requests at gate " <> gateId
+                        pure False
+                      else pure True
+                pure $ if shouldInclude then acc ++ [driverId] else acc
     )
     []
     driverIds
@@ -361,19 +438,60 @@ notRecentlyNotified gId driverId = do
   mbVal <- Redis.withCrossAppRedis $ Redis.get @Text (mkGateDriverNotifiedKey gId driverId.getId)
   pure $ isNothing mbVal
 
--- Mark Accepted pickup zone request as Completed when driver starts a ride
-completePickupZoneRequestOnRideStart ::
+-- | Booking is progressing (Confirm or StartRide fired) for a driver: decrement demand
+--   for the booking's gate/variant and, if the driver had an Accepted pickup-zone request,
+--   mark it Completed and decrement supply. A driver has at most one Accepted request at
+--   a time. Idempotent:
+--     - demand: bookingId-keyed SETNX (runDemandDecrementForBooking)
+--     - supply: requestId-keyed SETNX + DB status transition Accepted → Completed
+--   Safe to call from both Confirm and StartRide: first fire wins, second is a no-op.
+completePickupZoneRequestsForDriver ::
   ( MonadFlow m,
     CacheFlow m r,
-    EsqDBFlow m r
+    EsqDBFlow m r,
+    Redis.HedisFlow m r
+  ) =>
+  Id DP.Person ->
+  Text -> -- bookingId (for demand-decrement idempotency)
+  Maybe Text -> -- booking.pickupGateId
+  Text -> -- booking.vehicleServiceTier (variant)
+  m ()
+completePickupZoneRequestsForDriver driverId bookingId mbPickupGateId variant = do
+  runDemandDecrementForBooking bookingId mbPickupGateId variant
+  -- Look up the last request the driver accepted — not just those still in
+  -- 'Accepted' status. The CheckPickupZoneArrival job moves arrived drivers
+  -- to status=Expired while keeping response=Accept; without this change those
+  -- rows would never be marked Completed and supply would leak.
+  mbReq <- QSZQR.findLastAcceptedByDriverId driverId
+  forM_ mbReq $ \req -> do
+    QSZQR.updateResponse (Just DSZQR.Accept) DSZQR.Completed req.id
+    runSupplyDecrementForRequest req.id.getId req.gateId req.vehicleType
+    logInfo $ "Completed pickup zone request " <> req.id.getId <> " for driver " <> driverId.getId
+
+-- | Driver cancelled the ride that was to fulfill the pickup-zone commitment. Supply
+--   retracts — demand is untouched (customer still wants a ride). A driver has at most
+--   one Accepted request at a time.
+cancelPickupZoneRequestsForDriver ::
+  ( MonadFlow m,
+    CacheFlow m r,
+    EsqDBFlow m r,
+    Redis.HedisFlow m r
   ) =>
   Id DP.Person ->
   m ()
-completePickupZoneRequestOnRideStart driverId = do
-  acceptedRequests <- QSZQR.findActiveByDriverId driverId DSZQR.Accepted
-  forM_ acceptedRequests $ \req -> do
-    QSZQR.updateResponse (Just DSZQR.Accept) DSZQR.Completed req.id
-    logInfo $ "Marked pickup zone request " <> req.id.getId <> " as Completed for driver " <> driverId.getId
+cancelPickupZoneRequestsForDriver driverId = do
+  -- Same rationale as completePickupZoneRequestsForDriver: look up last Accept
+  -- response regardless of current status so post-arrival Expired rows still
+  -- get their supply retracted.
+  mbReq <- QSZQR.findLastAcceptedByDriverId driverId
+  forM_ mbReq $ \req ->
+    -- If the request is already Completed, the pickup-zone commitment was
+    -- already fulfilled (ride confirmed); don't overwrite that history with
+    -- Cancelled/Expired just because the ride was later cancelled.
+    unless (req.status == DSZQR.Completed) $ do
+      QSZQR.updateResponse (Just DSZQR.Cancelled) DSZQR.Expired req.id
+      runSupplyDecrementForRequest req.id.getId req.gateId req.vehicleType
+      logInfo $ "Cancelled pickup zone request " <> req.id.getId <> " after ride cancel by driver " <> driverId.getId
 
 -- Queue skip handling
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SpecialZoneQueueRequestExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SpecialZoneQueueRequestExtra.hs
@@ -23,3 +23,23 @@ findActiveByStasusListAndDriverId ::
   m [Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest]
 findActiveByStasusListAndDriverId driverId statusList =
   findAllWithKV [Se.And [Se.Is Beam.driverId $ Se.Eq (Kernel.Types.Id.getId driverId), Se.Is Beam.status $ Se.In statusList]]
+
+-- | Find the most recent pickup-zone request for a driver where response=Accept,
+-- regardless of its current status. This catches requests that have already
+-- transitioned past Accepted (e.g., Expired after the arrival check) so the
+-- supply decrement still runs in the normal Confirm / StartRide flows.
+findLastAcceptedByDriverId ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  Kernel.Types.Id.Id Domain.Types.Person.Person ->
+  m (Maybe Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest)
+findLastAcceptedByDriverId driverId =
+  findAllWithOptionsKV
+    [ Se.And
+        [ Se.Is Beam.driverId $ Se.Eq (Kernel.Types.Id.getId driverId),
+          Se.Is Beam.response $ Se.Eq (Just Domain.Types.SpecialZoneQueueRequest.Accept)
+        ]
+    ]
+    (Se.Desc Beam.createdAt)
+    (Just 1)
+    Nothing
+    <&> listToMaybe

--- a/Backend/lib/special-zone/src/Lib/Queries/GateInfo.hs
+++ b/Backend/lib/special-zone/src/Lib/Queries/GateInfo.hs
@@ -14,11 +14,14 @@
 
 module Lib.Queries.GateInfo where
 
+import Data.List (sortBy)
+import Data.Ord (comparing)
 import Kernel.External.Maps.Types (LatLong)
 import Kernel.Prelude hiding (isNothing)
 import Kernel.Storage.Esqueleto as Esq
 import qualified Kernel.Storage.Esqueleto.Functions as F
 import Kernel.Types.Id
+import Kernel.Utils.CalculateDistance (distanceBetweenInMeters)
 import Lib.Tabular.GateInfo
 import qualified Lib.Types.GateInfo as D
 import qualified Lib.Types.SpecialLocation as SL
@@ -51,6 +54,23 @@ findGateInfoByLatLongWithoutGeoJson point = do
     gateInfo <- from $ table @GateInfoT
     where_ $ gateInfo ^. GateInfoPoint ==. val point
     return gateInfo
+
+-- | Find the nearest gate info within a given radius (in meters) of the given point,
+-- scoped to a specific special location. Uses Haversine distance since the `point`
+-- column is a serialized LatLong, not PostGIS geometry.
+-- Returns the closest matching gate, or Nothing if none is within the radius.
+findGateInfoByLatLongWithinRadius :: Transactionable m => Id SL.SpecialLocation -> LatLong -> Double -> m (Maybe D.GateInfo)
+findGateInfoByLatLongWithinRadius slId point radiusMeters = do
+  gates <- Esq.findAll $ do
+    gateInfo <- from $ table @GateInfoT
+    where_ $ gateInfo ^. GateInfoSpecialLocationId ==. val (toKey slId)
+    return gateInfo
+  -- Precompute distance once per gate and tie-break by gate id so the
+  -- selection is deterministic when two gates sit at the same distance.
+  let gatesWithDist = map (\g -> (distanceBetweenInMeters point g.point, g)) gates
+      gatesInRadius = filter (\(d, _) -> d <= realToFrac radiusMeters) gatesWithDist
+      sorted = sortBy (comparing (\(d, g) -> (d, g.id))) gatesInRadius
+  return $ snd <$> listToMaybe sorted
 
 deleteById :: Id D.GateInfo -> SqlDB ()
 deleteById = Esq.deleteByKey @GateInfoT


### PR DESCRIPTION
## Summary
- Adds `findGateInfoByLatLongWithinRadius` in `Lib.Queries.GateInfo`: fetches gates scoped to a special location ID, filters by 20m Haversine radius, returns the nearest match
- Replaces the fragile exact lat/long match (`findGateInfoByLatLongWithoutGeoJson`) in the Search handler with the radius-based approach
- Extracts the special location ID directly from `allFarePoliciesProduct.area` (e.g. `Pickup_<uuid>`) — no extra DB call, no dependency on `sReq.fromSpecialLocationId` or `specialLocationTag`

## Test plan
- [ ] Search from a pickup location within 20m of a gate point in a special zone — gate ID should be resolved
- [ ] Search from a pickup location outside 20m — no gate ID returned
- [ ] Search with `area = Default` (non-special zone) — returns `(Nothing, Nothing, Nothing)`
- [ ] Search with `area = PickupDrop` — pickup special location ID extracted correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pickup-zone detection by selecting nearest gate within a radius and skipping lookups when no special pickup area applies.
  * More accurate area-to-special-location mapping for pickup info resolution.

* **New Features**
  * Confirmation, start, cancellation, accept/cancel/no‑show flows now trigger asynchronous, idempotent demand/supply adjustments to maintain availability.
  * Demand eligibility now relies on persisted supply counters and queue ordering to prevent negative counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->