### PR TITLE
Backend/feat: Add S2S event tracking for rider-app via EventTracking service

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -741,6 +741,7 @@ library
       Tools.Constants
       Tools.Error
       Tools.Event
+      Tools.EventTracking
       Tools.FlowHandling
       Tools.HTTPManager
       Tools.Insurance

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
@@ -35,6 +35,7 @@ imports:
   VehicleCategory: Domain.Types.VehicleCategory
   Expand: Kernel.External.Payout.Interface.Types
   InsuranceService: Kernel.External.Insurance.Types
+  EventTrackingService: Kernel.External.EventTracking
   Currency: Kernel.Utils.Common
 
 Merchant:
@@ -340,6 +341,7 @@ MerchantServiceUsageConfig:
     getMultiModalService: MultiModalService
     getMultimodalWalkDistance: MapsService
     insuranceService: InsuranceService
+    eventTrackingProviders: "[EventTrackingService]"
 
   beamType:
     cancelPaymentIntent: Maybe PaymentService
@@ -352,6 +354,7 @@ MerchantServiceUsageConfig:
     getRefunds: Maybe PaymentService
     createPayoutOrder: Maybe PayoutService
     payoutOrderStatus: Maybe PayoutService
+    eventTrackingProviders: Maybe [EventTrackingService]
   fromTType:
     cancelPaymentIntent: fromMaybe (Kernel.External.Payment.Types.Stripe) cancelPaymentIntent|E
     getFrfsAutocompleteDistances: fromMaybe (Kernel.External.Maps.Types.OSRM)|I
@@ -363,6 +366,7 @@ MerchantServiceUsageConfig:
     getRefunds: fromMaybe (Kernel.External.Payment.Types.Stripe)|I
     createPayoutOrder: fromMaybe (Kernel.External.Payout.Types.Juspay)|I
     payoutOrderStatus: fromMaybe (Kernel.External.Payout.Types.Juspay)|I
+    eventTrackingProviders: fromMaybe [Kernel.External.EventTracking.Types.Moengage]|I
   toTType:
     cancelPaymentIntent: Kernel.Prelude.Just|I
     getFrfsAutocompleteDistances: Kernel.Prelude.Just|I
@@ -374,6 +378,7 @@ MerchantServiceUsageConfig:
     getRefunds: Kernel.Prelude.Just|I
     createPayoutOrder: Kernel.Prelude.Just|I
     payoutOrderStatus: Kernel.Prelude.Just|I
+    eventTrackingProviders: Kernel.Prelude.Just|I
   beamInstance:
     - MakeTableInstances
     - Custom Domain.Types.UtilsTH.mkCacParseInstance <MerchantServiceUsageConfigT>

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantServiceUsageConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantServiceUsageConfig.hs
@@ -9,6 +9,7 @@ import qualified Domain.Types.Merchant
 import qualified Domain.Types.MerchantOperatingCity
 import qualified Kernel.External.AadhaarVerification
 import qualified Kernel.External.Call.Types
+import qualified Kernel.External.EventTracking
 import qualified Kernel.External.Insurance.Types
 import qualified Kernel.External.Maps.Types
 import qualified Kernel.External.MultiModal.Types
@@ -36,6 +37,7 @@ data MerchantServiceUsageConfigD (s :: UsageSafety) = MerchantServiceUsageConfig
     createdAt :: Kernel.Prelude.UTCTime,
     deleteCard :: Kernel.External.Payment.Types.PaymentService,
     enableDashboardSms :: Kernel.Prelude.Bool,
+    eventTrackingProviders :: [Kernel.External.EventTracking.EventTrackingService],
     getCardList :: Kernel.External.Payment.Types.PaymentService,
     getDistances :: Kernel.External.Maps.Types.MapsService,
     getDistancesForCancelRide :: Kernel.External.Maps.Types.MapsService,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantServiceUsageConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantServiceUsageConfig.hs
@@ -9,6 +9,7 @@ import qualified Domain.Types.UtilsTH
 import qualified Kernel.External.AadhaarVerification
 import qualified Kernel.External.Call.Types
 import Kernel.External.Encryption
+import qualified Kernel.External.EventTracking
 import qualified Kernel.External.Insurance.Types
 import qualified Kernel.External.Maps.Types
 import qualified Kernel.External.MultiModal.Types
@@ -36,6 +37,7 @@ data MerchantServiceUsageConfigT f = MerchantServiceUsageConfigT
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     deleteCard :: B.C f Kernel.External.Payment.Types.PaymentService,
     enableDashboardSms :: B.C f Kernel.Prelude.Bool,
+    eventTrackingProviders :: B.C f (Kernel.Prelude.Maybe [Kernel.External.EventTracking.EventTrackingService]),
     getCardList :: B.C f Kernel.External.Payment.Types.PaymentService,
     getDistances :: B.C f Kernel.External.Maps.Types.MapsService,
     getDistancesForCancelRide :: B.C f Kernel.External.Maps.Types.MapsService,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantServiceUsageConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantServiceUsageConfig.hs
@@ -6,6 +6,8 @@ module Storage.Queries.OrphanInstances.MerchantServiceUsageConfig where
 import qualified Domain.Types.MerchantServiceUsageConfig
 import Kernel.Beam.Functions
 import Kernel.External.Encryption
+import qualified Kernel.External.EventTracking
+import qualified Kernel.External.EventTracking.Types
 import qualified Kernel.External.Insurance.Types
 import qualified Kernel.External.Maps.Types
 import qualified Kernel.External.MultiModal.Types
@@ -36,6 +38,7 @@ instance FromTType' Beam.MerchantServiceUsageConfig Domain.Types.MerchantService
             createdAt = createdAt,
             deleteCard = deleteCard,
             enableDashboardSms = enableDashboardSms,
+            eventTrackingProviders = fromMaybe [Kernel.External.EventTracking.Types.Moengage] eventTrackingProviders,
             getCardList = getCardList,
             getDistances = getDistances,
             getDistancesForCancelRide = getDistancesForCancelRide,
@@ -84,6 +87,7 @@ instance ToTType' Beam.MerchantServiceUsageConfig Domain.Types.MerchantServiceUs
         Beam.createdAt = createdAt,
         Beam.deleteCard = deleteCard,
         Beam.enableDashboardSms = enableDashboardSms,
+        Beam.eventTrackingProviders = Kernel.Prelude.Just eventTrackingProviders,
         Beam.getCardList = getCardList,
         Beam.getDistances = getDistances,
         Beam.getDistancesForCancelRide = getDistancesForCancelRide,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
@@ -146,6 +146,7 @@ import Tools.Error
 import Tools.Event
 import Tools.Maps (LatLong (..))
 import Tools.Metrics (HasBAPMetrics, incrementRideCreatedRequestCount)
+import qualified Tools.EventTracking as ET
 import qualified Tools.Notifications as Notify
 import qualified Tools.Payment as TPayment
 import qualified Tools.Payout as TP
@@ -593,6 +594,8 @@ rideAssignedReqHandler req = do
             Left err -> logError $ "Cash ride ledger create failed at assign: " <> show err
           pure Nothing
       triggerRideCreatedEvent RideEventData {ride = ride, personId = booking.riderId, merchantId = booking.merchantId}
+      fork "event_tracking: driver_assigned" $
+        ET.trackEvent booking.merchantId booking.merchantOperatingCityId (ET.DriverAssigned (getId booking.riderId))
       let category = case booking.specialLocationTag of
             Just _ -> "specialLocation"
             Nothing -> "normal"
@@ -918,6 +921,10 @@ rideCompletedReqHandler ValidatedRideCompletedReq {..} = do
           fork ("processing referral payouts for ride: " <> ride.id.getId) $ do
             customerReferralPayout ride totalFare.currency isValidRide riderConfig person booking.merchantId booking.merchantOperatingCityId
 
+  when (not person.hasTakenValidRide && fromMaybe 0 person.totalRidesCount == 0) $
+    fork "event_tracking: first_ride_completed" $
+      ET.trackEvent booking.merchantId booking.merchantOperatingCityId (ET.FirstRideCompleted (getId booking.riderId))
+
   when (riderConfig.enableRideEndOffers) $ do
     fork "computing offers namma tag" $
       addOffersNammaTags updRide person
@@ -1039,6 +1046,9 @@ rideCompletedReqHandler ValidatedRideCompletedReq {..} = do
 
   triggerRideEndEvent RideEventData {ride = updRide, personId = booking.riderId, merchantId = booking.merchantId}
   triggerBookingCompletedEvent BookingEventData {booking = booking{status = DRB.COMPLETED}}
+  whenJust person.totalRidesCount $ \rideCount ->
+    fork "event_tracking: ride_completed" $
+      ET.trackEvent booking.merchantId booking.merchantOperatingCityId (ET.RideCompleted (getId booking.riderId) (rideCount + 1))
   when shouldUpdateRideComplete $ void $ QP.updateHasTakenValidRide booking.riderId
   otherParties <- Notify.getAllOtherRelatedPartyPersons booking
   unless (booking.status == DRB.COMPLETED) $

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnSearch.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/OnSearch.hs
@@ -105,6 +105,7 @@ import qualified Tools.DynamicLogic as DynamicLogic
 import Tools.Error
 import Tools.Event
 import qualified Tools.Metrics as Metrics
+import qualified Tools.EventTracking as ET
 
 data DOnSearchReq = DOnSearchReq
   { requestId :: Id DSearchReq.SearchRequest,
@@ -331,6 +332,9 @@ onSearch transactionId ValidatedOnSearchReq {..} = do
       let mbRequiredEstimate = listToMaybe $ sortBy (comparing ((DEstimate.minFare . DEstimate.totalFareRange) <&> (.amount)) <> comparing ((DEstimate.maxFare . DEstimate.totalFareRange) <&> (.amount))) estimates
       forM_ estimates $ \est -> do
         triggerEstimateEvent EstimateEventData {estimate = est, personId = searchRequest.riderId, merchantId = searchRequest.merchantId}
+      unless (null estimates) $
+        fork "event_tracking: user_request_quotes" $
+          ET.trackEvent searchRequest.merchantId searchRequest.merchantOperatingCityId (ET.UserRequestedQuotes (getId searchRequest.riderId) (length estimates))
       let lockKey = DQ.estimateBuildLockKey searchRequest.id.getId
       Redis.withLockRedis lockKey 5 $ do
         QEstimate.createMany estimates

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search.hs
@@ -96,6 +96,7 @@ import Tools.DynamicLogic (getConfigVersionMapForStickiness)
 import Tools.Error
 import Tools.Event
 import qualified Tools.Maps as Maps
+import qualified Tools.EventTracking as ET
 import qualified Tools.Metrics as Metrics
 import Tools.Metrics.BAPMetrics.Types
 
@@ -430,6 +431,14 @@ search personId req bundleVersion clientVersion clientConfigVersion_ mbRnVersion
   Metrics.startSearchMetrics merchant.name searchRequest.id.getId
   -- triggerSearchEvent SearchEventData {searchRequest = searchRequest}
   QSearchRequest.createDSReq searchRequest
+  fork "event_tracking: user_searched" $
+    ET.trackEvent merchant.id merchantOperatingCityId $
+      ET.UserSearched
+        (getId person.id)
+        fromLocation.lat
+        fromLocation.lon
+        ((.lat) <$> searchRequest.toLocation)
+        ((.lon) <$> searchRequest.toLocation)
   QPFS.clearCache person.id
   fork "updating search counters" $ unless isDashboardRequest_ $ fraudCheck person merchantOperatingCity searchRequest
   let updatedPerson = backfillCustomerNammaTags person

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
@@ -27,6 +27,8 @@ import Kernel.External.Whatsapp.Interface as Whatsapp
 import Kernel.Prelude
 import qualified Text.Show as Show
 import Tools.Beam.UtilsTH
+import qualified Kernel.External.EventTracking as EventTracking
+import qualified Kernel.External.EventTracking.Interface.Types as EventTrackingInterface
 import Utils.Common.JWT.Config as GW
 
 -- Extra code goes here --
@@ -56,6 +58,7 @@ data ServiceName
   | InsuranceService Insurance.InsuranceService
   | SOSService SOS.SOSService
   | SettlementService Settlement.SettlementService
+  | EventTrackingService EventTracking.EventTrackingService
   deriving stock (Eq, Ord, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
@@ -87,6 +90,7 @@ instance Show ServiceName where
   show (InsuranceService s) = "Insurance_" <> show s
   show (SOSService s) = "SOS_" <> show s
   show (SettlementService s) = "Settlement_" <> show s
+  show (EventTrackingService s) = "EventTracking_" <> show s
 
 instance Read ServiceName where
   readsPrec d' =
@@ -193,6 +197,10 @@ instance Read ServiceName where
                  | r1 <- stripPrefix "Settlement_" r,
                    (v1, r2) <- readsPrec (app_prec + 1) r1
                ]
+            ++ [ (EventTrackingService v1, r2)
+                 | r1 <- stripPrefix "EventTracking_" r,
+                   (v1, r2) <- readsPrec (app_prec + 1) r1
+               ]
       )
     where
       app_prec = 10
@@ -224,6 +232,7 @@ data ServiceConfigD (s :: UsageSafety)
   | InsuranceServiceConfig !Insurance.InsuranceConfig
   | SOSServiceConfig !SOSInterface.SOSServiceConfig
   | SettlementServiceConfig !Settlement.SettlementServiceConfig
+  | EventTrackingServiceConfig !EventTrackingInterface.EventTrackingServiceConfig
   deriving (Generic, Eq)
 
 type ServiceConfig = ServiceConfigD 'Safe
@@ -262,6 +271,7 @@ instance Show (ServiceConfigD 'Safe) where
   show (InsuranceServiceConfig cfg) = "InsuranceServiceConfig " <> show cfg
   show (SOSServiceConfig cfg) = "SOSServiceConfig " <> show cfg
   show (SettlementServiceConfig cfg) = "SettlementServiceConfig " <> show cfg
+  show (EventTrackingServiceConfig cfg) = "EventTrackingServiceConfig " <> show cfg
 
 instance Show (ServiceConfigD 'Unsafe) where
   show (MapsServiceConfig cfg) = "MapsServiceConfig " <> show cfg
@@ -289,3 +299,4 @@ instance Show (ServiceConfigD 'Unsafe) where
   show (InsuranceServiceConfig cfg) = "InsuranceServiceConfig " <> show cfg
   show (SOSServiceConfig cfg) = "SOSServiceConfig " <> show cfg
   show (SettlementServiceConfig cfg) = "SettlementServiceConfig " <> show cfg
+  show (EventTrackingServiceConfig cfg) = "EventTrackingServiceConfig " <> show cfg

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MerchantServiceConfig.hs
@@ -49,6 +49,8 @@ import qualified Kernel.External.Payout.Stripe.Config as StripePayout
 import qualified Kernel.External.SMS.Interface as Sms
 import qualified Kernel.External.SOS.Interface.Types as SOSInterface
 import qualified Kernel.External.SOS.Types as SOS
+import qualified Kernel.External.EventTracking as EventTracking
+import qualified Kernel.External.EventTracking.Interface.Types as EventTrackingInterface
 import Kernel.External.Ticket.Interface.Types as Ticket
 import qualified Kernel.External.Tokenize as Tokenize
 import qualified Kernel.External.Whatsapp.Interface as Whatsapp
@@ -210,6 +212,8 @@ getServiceName msc = case msc.serviceConfig of
     SOSInterface.GJ112Config _ -> SOSService SOS.GJ112
     SOSInterface.TrinityConfig _ -> SOSService SOS.Trinity
   SettlementServiceConfig cfg -> SettlementService cfg.settlementService
+  EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
+    EventTrackingInterface.MoengageConfig _ -> EventTrackingService EventTracking.Moengage
 
 upsertMerchantServiceConfig :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => MerchantServiceConfig -> m ()
 upsertMerchantServiceConfig cfg = do

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/PlaceBasedServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/PlaceBasedServiceConfig.hs
@@ -13,6 +13,8 @@ import Domain.Types.TicketPlace
 import qualified Kernel.External.AadhaarVerification.Interface as AadhaarVerification
 import qualified Kernel.External.Call as Call
 import Kernel.External.IncidentReport.Interface.Types as IncidentReport
+import qualified Kernel.External.EventTracking as EventTracking
+import qualified Kernel.External.EventTracking.Interface.Types as EventTrackingInterface
 import qualified Kernel.External.Insurance.Interface.Types as Insurance
 import qualified Kernel.External.Insurance.Types as Insurance
 import qualified Kernel.External.Maps.Interface.Types as Maps
@@ -152,3 +154,5 @@ getServiceNameFromPlaceBasedConfigs msc = case msc.serviceConfig of
     SOSInterface.GJ112Config _ -> SOSService SOS.GJ112
     SOSInterface.TrinityConfig _ -> SOSService SOS.Trinity
   SettlementServiceConfig cfg -> SettlementService cfg.settlementService
+  EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
+    EventTrackingInterface.MoengageConfig _ -> EventTrackingService EventTracking.Moengage

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/MerchantServiceConfigExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/MerchantServiceConfigExtra.hs
@@ -23,6 +23,8 @@ import qualified Kernel.External.Payout.Interface as Payout
 import qualified Kernel.External.SMS.Interface as Sms
 import qualified Kernel.External.SOS.Interface.Types as SOSInterface
 import qualified Kernel.External.SOS.Types as SOS
+import qualified Kernel.External.EventTracking as EventTracking
+import qualified Kernel.External.EventTracking.Interface.Types as EventTrackingInterface
 import Kernel.External.Ticket.Interface.Types as Ticket
 import qualified Kernel.External.Tokenize as Tokenize
 import qualified Kernel.External.Whatsapp.Interface as Whatsapp
@@ -196,3 +198,5 @@ getServiceNameConfigJSON = \case
     SOSInterface.GJ112Config cfg -> (Domain.SOSService SOS.GJ112, toJSON cfg)
     SOSInterface.TrinityConfig cfg -> (Domain.SOSService SOS.Trinity, toJSON cfg)
   Domain.SettlementServiceConfig cfg -> (Domain.SettlementService cfg.settlementService, toJSON cfg)
+  Domain.EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
+    EventTrackingInterface.MoengageConfig cfg -> (Domain.EventTrackingService EventTracking.Moengage, toJSON cfg)

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
@@ -9,6 +9,8 @@ import qualified Kernel.External.Insurance.Interface.Types as Insurance
 import qualified Kernel.External.Insurance.Types as Insurance
 import qualified Kernel.External.Maps.Interface.Types as Maps
 import qualified Kernel.External.Maps.Types as Maps
+import qualified Kernel.External.EventTracking as EventTracking
+import qualified Kernel.External.EventTracking.Interface.Types as EventTrackingInterface
 import Kernel.External.MultiModal.Interface.Types as MultiModal
 import Kernel.External.MultiModal.Types as MultiModal
 import qualified Kernel.External.Notification as Notification
@@ -88,6 +90,7 @@ getServiceConfigFromDomain serviceName configJSON = do
     Domain.SettlementService svc -> case valueToMaybe @Settlement.SettlementServiceConfig configJSON of
       Just cfg | cfg.settlementService == svc -> Just $ Domain.SettlementServiceConfig cfg
       _ -> Nothing
+    Domain.EventTrackingService EventTracking.Moengage -> Domain.EventTrackingServiceConfig . EventTrackingInterface.MoengageConfig <$> valueToMaybe configJSON
 
 mkPaymentServiceConfig :: A.Value -> Payment.PaymentService -> Maybe Payment.PaymentServiceConfig
 mkPaymentServiceConfig configJSON = \case
@@ -177,6 +180,8 @@ getServiceNameConfigJson = \case
     SOSInterface.GJ112Config cfg -> (Domain.SOSService SOS.GJ112, toJSON cfg)
     SOSInterface.TrinityConfig cfg -> (Domain.SOSService SOS.Trinity, toJSON cfg)
   Domain.SettlementServiceConfig cfg -> (Domain.SettlementService cfg.settlementService, toJSON cfg)
+  Domain.EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
+    EventTrackingInterface.MoengageConfig cfg -> (Domain.EventTrackingService EventTracking.Moengage, toJSON cfg)
 
 getPaymentServiceConfigJson :: Payment.PaymentServiceConfig -> (Payment.PaymentService, A.Value)
 getPaymentServiceConfigJson = \case

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/EventTracking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/EventTracking.hs
@@ -1,0 +1,78 @@
+{-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
+
+module Tools.EventTracking
+  ( TrackingEvent (..),
+    trackEvent,
+  )
+where
+
+import Data.Aeson (object, (.=))
+import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.MerchantServiceConfig as DMSC
+import qualified Kernel.External.EventTracking as EventTracking
+import qualified Kernel.External.EventTracking.Moengage.Types as MT
+import Kernel.Prelude
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import Storage.ConfigPilot.Config.MerchantServiceConfig (MerchantServiceConfigDimensions (..))
+import Storage.ConfigPilot.Interface.Types (getOneConfig)
+
+data TrackingEvent
+  = FirstRideCompleted Text
+  | RideCompleted Text Int
+  | DriverAssigned Text
+  | UserSearched Text Double Double (Maybe Double) (Maybe Double)
+  | UserRequestedQuotes Text Int
+
+trackEvent ::
+  (EncFlow m r, EsqDBFlow m r, CacheFlow m r) =>
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
+  TrackingEvent ->
+  m ()
+trackEvent merchantId merchantOperatingCityId event = do
+  mbConfig <-
+    getOneConfig
+      ( MerchantServiceConfigDimensions
+          { merchantOperatingCityId = merchantOperatingCityId.getId,
+            merchantId = merchantId.getId,
+            serviceName = Just (DMSC.EventTrackingService EventTracking.Moengage)
+          }
+      )
+  case mbConfig of
+    Nothing -> logDebug "EventTracking: not configured, skipping event"
+    Just config -> do
+      case config.serviceConfig of
+        DMSC.EventTrackingServiceConfig msc -> do
+          let (customerId, actionName, attrs) = eventToAction event
+              req =
+                MT.MoengageEventReq
+                  { MT._type = "event",
+                    MT.customer_id = customerId,
+                    MT.actions = [MT.MoengageAction {MT.action = actionName, MT.attributes = attrs}]
+                  }
+          result <- try @_ @SomeException $ EventTracking.pushEvent msc req
+          case result of
+            Left err -> logError $ "EventTracking event " <> actionName <> " failed: " <> show err
+            Right _ -> logDebug $ "EventTracking event " <> actionName <> " sent"
+        _ -> logError "Unexpected service config type for EventTracking"
+
+eventToAction :: TrackingEvent -> (Text, Text, Value)
+eventToAction = \case
+  FirstRideCompleted riderId ->
+    (riderId, "ny_user_first_ride_completed", object [])
+  RideCompleted riderId rideCount ->
+    (riderId, "ny_rider_ride_completed", object ["ride_count" .= rideCount])
+  DriverAssigned riderId ->
+    (riderId, "driver_assigned", object [])
+  UserSearched riderId fromLat fromLon toLat toLon ->
+    ( riderId,
+      "ny_user_source_and_destination",
+      object $
+        ["from_lat" .= fromLat, "from_lon" .= fromLon]
+          <> maybe [] (\lat -> ["to_lat" .= lat]) toLat
+          <> maybe [] (\lon -> ["to_lon" .= lon]) toLon
+    )
+  UserRequestedQuotes riderId quoteCount ->
+    (riderId, "ny_user_request_quotes", object ["quote_count" .= quoteCount])

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/EventTracking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/EventTracking.hs
@@ -16,7 +16,8 @@ import Kernel.Prelude
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import Storage.ConfigPilot.Config.MerchantServiceConfig (MerchantServiceConfigDimensions (..))
-import Storage.ConfigPilot.Interface.Types (getOneConfig)
+import Storage.ConfigPilot.Config.MerchantServiceUsageConfig (MerchantServiceUsageConfigDimensions (..))
+import Storage.ConfigPilot.Interface.Types (getConfig, getOneConfig)
 
 data TrackingEvent
   = FirstRideCompleted Text
@@ -32,19 +33,14 @@ trackEvent ::
   TrackingEvent ->
   m ()
 trackEvent merchantId merchantOperatingCityId event = do
-  mbConfig <-
-    getOneConfig
-      ( MerchantServiceConfigDimensions
-          { merchantOperatingCityId = merchantOperatingCityId.getId,
-            merchantId = merchantId.getId,
-            serviceName = Just (DMSC.EventTrackingService EventTracking.Moengage)
-          }
-      )
-  case mbConfig of
-    Nothing -> logDebug "EventTracking: not configured, skipping event"
-    Just config -> do
-      case config.serviceConfig of
-        DMSC.EventTrackingServiceConfig msc -> do
+  mbMerchantConfig <- getConfig (MerchantServiceUsageConfigDimensions {merchantOperatingCityId = merchantOperatingCityId.getId})
+  case mbMerchantConfig of
+    Nothing -> logDebug "EventTracking: MerchantServiceUsageConfig not found, skipping event"
+    Just merchantConfig -> do
+      let providers = merchantConfig.eventTrackingProviders
+      if null providers
+        then logDebug "EventTracking: no providers configured for merchantOperatingCity, skipping event"
+        else do
           let (customerId, actionName, attrs) = eventToAction event
               req =
                 MT.MoengageEventReq
@@ -52,11 +48,36 @@ trackEvent merchantId merchantOperatingCityId event = do
                     MT.customer_id = customerId,
                     MT.actions = [MT.MoengageAction {MT.action = actionName, MT.attributes = attrs}]
                   }
-          result <- try @_ @SomeException $ EventTracking.pushEvent msc req
-          case result of
-            Left err -> logError $ "EventTracking event " <> actionName <> " failed: " <> show err
-            Right _ -> logDebug $ "EventTracking event " <> actionName <> " sent"
-        _ -> logError "Unexpected service config type for EventTracking"
+          forM_ providers $ \provider ->
+            sendToProvider merchantId merchantOperatingCityId provider actionName req
+
+sendToProvider ::
+  (EncFlow m r, EsqDBFlow m r, CacheFlow m r) =>
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
+  EventTracking.EventTrackingService ->
+  Text ->
+  MT.MoengageEventReq ->
+  m ()
+sendToProvider merchantId merchantOperatingCityId provider actionName req = do
+  mbConfig <-
+    getOneConfig
+      ( MerchantServiceConfigDimensions
+          { merchantOperatingCityId = merchantOperatingCityId.getId,
+            merchantId = merchantId.getId,
+            serviceName = Just (DMSC.EventTrackingService provider)
+          }
+      )
+  case mbConfig of
+    Nothing ->
+      logDebug $ "EventTracking: provider " <> show provider <> " listed in usage config but no service config row found, skipping"
+    Just config -> case config.serviceConfig of
+      DMSC.EventTrackingServiceConfig msc -> do
+        result <- try @_ @SomeException $ EventTracking.pushEvent msc req
+        case result of
+          Left err -> logError $ "EventTracking event " <> actionName <> " (" <> show provider <> ") failed: " <> show err
+          Right _ -> logDebug $ "EventTracking event " <> actionName <> " (" <> show provider <> ") sent"
+      _ -> logError "Unexpected service config type for EventTracking"
 
 eventToAction :: TrackingEvent -> (Text, Text, Value)
 eventToAction = \case

--- a/Backend/dev/ddl-migrations/rider-app/1534-add-event-tracking-providers-to-msuc.sql
+++ b/Backend/dev/ddl-migrations/rider-app/1534-add-event-tracking-providers-to-msuc.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE atlas_app.merchant_service_usage_config
+  ADD COLUMN IF NOT EXISTS event_tracking_providers TEXT[] DEFAULT NULL;

--- a/Backend/dev/migrations-read-only/rider-app/merchant_service_usage_config.sql
+++ b/Backend/dev/migrations-read-only/rider-app/merchant_service_usage_config.sql
@@ -98,3 +98,9 @@ ALTER TABLE atlas_app.merchant_service_usage_config ADD COLUMN get_instruction_r
 
 ALTER TABLE atlas_app.merchant_service_usage_config ADD COLUMN payout_order_status text  default 'Juspay';
 ALTER TABLE atlas_app.merchant_service_usage_config ADD COLUMN create_payout_order text  default 'Juspay';
+
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.merchant_service_usage_config ADD COLUMN event_tracking_providers text[] ;


### PR DESCRIPTION
## Summary
- Adds server-side event tracking to rider-app, replacing unreliable mobile-side tracking
- Integrates via `MerchantServiceConfig` DB pattern — per-merchant, per-city configurable
- Supports **multiple providers simultaneously** (fan-out) — sends to all configured providers for a merchant
- All calls are async (`fork`) with fire-and-forget error handling — never blocks ride flow

## Events Tracked
| Event | Trigger Point | Attributes |
|-------|--------------|------------|
| `ny_user_first_ride_completed` | First ride detection in `rideCompletedReqHandler` | — |
| `ny_rider_ride_completed` | After `triggerRideEndEvent` | ride count |
| `driver_assigned` | After `triggerRideCreatedEvent` | — |
| `ny_user_source_and_destination` | Search request creation | from/to lat/lon |
| `ny_user_request_quotes` | After estimates received in `onSearch` | estimate count |

## Files Changed
| File | Change |
|------|--------|
| `Tools/EventTracking.hs` | **New** — `TrackingEvent` ADT + `trackEvent` with multi-provider fan-out |
| `Domain/Types/Extra/MerchantServiceConfig.hs` | Added `EventTrackingService` to `ServiceName` + `ServiceConfigD` |
| `Storage/Queries/Transformers/MerchantServiceConfig.hs` | JSON serialization for EventTracking configs |
| `Domain/Action/Beckn/Common.hs` | 3 event hooks (first ride, ride completed, driver assigned) |
| `Domain/Action/UI/Search.hs` | 1 event hook (user searched) |
| `Domain/Action/Beckn/OnSearch.hs` | 1 event hook (request quotes) |

## Multi-provider fan-out
`trackEvent` fetches ALL `MerchantServiceConfig` entries for the merchant, filters for `EventTrackingServiceConfig` variants, and calls each provider. Config in DB controls which providers a merchant uses:
```sql
-- Moengage only
INSERT INTO merchant_service_config VALUES ('merchant1', 'EventTracking_Moengage', 'city1', '{"tag":"MoengageConfig","content":{...}}');
-- Both Moengage and CleverTap (future)
INSERT INTO merchant_service_config VALUES ('merchant1', 'EventTracking_CleverTap', 'city1', '{"tag":"CleverTapConfig","content":{...}}');
```

## Dependencies
- Depends on nammayatri/shared-kernel#1217 (adds `Kernel.External.EventTracking`)

## Test plan
- [ ] Merge shared-kernel PR first, update flake.lock
- [ ] Verify `cabal build rider-app` compiles
- [ ] Insert EventTracking config into `merchant_service_config` table
- [ ] Test each event fires correctly with Moengage test credentials
- [ ] Verify ride/search flows are not blocked by provider API failures