### PR TITLE
backend/enh: enrich special zone queue stats dashboard API

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/SpecialZoneQueue.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/SpecialZoneQueue.yaml
@@ -31,12 +31,22 @@ types:
     - totalInQueue: Int
     - inPickupZone: Int
     - outsidePickupZone: Int
+    - pendingDemand: Int
+    - driversCommittedToPickup: Int
+    - acceptedQueueRequests: Int
+    - demandThreshold: Maybe Int
+    - minDriverThreshold: Maybe Int
+    - maxDriverThreshold: Maybe Int
 
   SpecialZoneQueueStatsRes:
     - gateId: Text
     - gateName: Text
     - specialLocationName: Text
+    - canQueueUpOnGate: Bool
     - vehicleStats: "[VehicleQueueStats]"
     - totalDriversInQueue: Int
     - totalInPickupZone: Int
     - totalOutsidePickupZone: Int
+    - totalPendingDemand: Int
+    - totalDriversCommittedToPickup: Int
+    - totalAcceptedQueueRequests: Int

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/SpecialZoneQueue.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/SpecialZoneQueue.hs
@@ -18,10 +18,14 @@ data SpecialZoneQueueStatsRes = SpecialZoneQueueStatsRes
   { gateId :: Kernel.Prelude.Text,
     gateName :: Kernel.Prelude.Text,
     specialLocationName :: Kernel.Prelude.Text,
+    canQueueUpOnGate :: Kernel.Prelude.Bool,
     vehicleStats :: [VehicleQueueStats],
     totalDriversInQueue :: Kernel.Prelude.Int,
     totalInPickupZone :: Kernel.Prelude.Int,
-    totalOutsidePickupZone :: Kernel.Prelude.Int
+    totalOutsidePickupZone :: Kernel.Prelude.Int,
+    totalPendingDemand :: Kernel.Prelude.Int,
+    totalDriversCommittedToPickup :: Kernel.Prelude.Int,
+    totalAcceptedQueueRequests :: Kernel.Prelude.Int
   }
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -33,7 +37,18 @@ data TriggerSpecialZoneQueueNotifyReq = TriggerSpecialZoneQueueNotifyReq {gateId
 instance Kernel.Types.HideSecrets.HideSecrets TriggerSpecialZoneQueueNotifyReq where
   hideSecrets = Kernel.Prelude.identity
 
-data VehicleQueueStats = VehicleQueueStats {vehicleType :: Kernel.Prelude.Text, totalInQueue :: Kernel.Prelude.Int, inPickupZone :: Kernel.Prelude.Int, outsidePickupZone :: Kernel.Prelude.Int}
+data VehicleQueueStats = VehicleQueueStats
+  { vehicleType :: Kernel.Prelude.Text,
+    totalInQueue :: Kernel.Prelude.Int,
+    inPickupZone :: Kernel.Prelude.Int,
+    outsidePickupZone :: Kernel.Prelude.Int,
+    pendingDemand :: Kernel.Prelude.Int,
+    driversCommittedToPickup :: Kernel.Prelude.Int,
+    acceptedQueueRequests :: Kernel.Prelude.Int,
+    demandThreshold :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    minDriverThreshold :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    maxDriverThreshold :: Kernel.Prelude.Maybe Kernel.Prelude.Int
+  }
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/SpecialZoneQueueRequest.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/SpecialZoneQueueRequest.yaml
@@ -22,6 +22,7 @@ SpecialZoneQueueRequest:
     status: SpecialZoneQueueRequestStatus
     response: "Maybe SpecialZoneQueueRequestResponse"
     validTill: UTCTime
+    arrivalDeadlineTime: "Maybe UTCTime"
     gateName: Text
     specialLocationName: Text
     vehicleType: Text

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/SpecialZoneQueueRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/SpecialZoneQueueRequest.hs
@@ -12,7 +12,8 @@ import qualified Kernel.Types.Id
 import qualified Tools.Beam.UtilsTH
 
 data SpecialZoneQueueRequest = SpecialZoneQueueRequest
-  { createdAt :: Kernel.Prelude.UTCTime,
+  { arrivalDeadlineTime :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
+    createdAt :: Kernel.Prelude.UTCTime,
     driverId :: Kernel.Types.Id.Id Domain.Types.Person.Person,
     gateId :: Kernel.Prelude.Text,
     gateName :: Kernel.Prelude.Text,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/SpecialZoneQueueRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/SpecialZoneQueueRequest.hs
@@ -12,7 +12,8 @@ import qualified Kernel.Prelude
 import Tools.Beam.UtilsTH
 
 data SpecialZoneQueueRequestT f = SpecialZoneQueueRequestT
-  { createdAt :: (B.C f Kernel.Prelude.UTCTime),
+  { arrivalDeadlineTime :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
+    createdAt :: (B.C f Kernel.Prelude.UTCTime),
     driverId :: (B.C f Kernel.Prelude.Text),
     gateId :: (B.C f Kernel.Prelude.Text),
     gateName :: (B.C f Kernel.Prelude.Text),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/SpecialZoneQueueRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/SpecialZoneQueueRequest.hs
@@ -17,7 +17,8 @@ instance FromTType' Beam.SpecialZoneQueueRequest Domain.Types.SpecialZoneQueueRe
     pure $
       Just
         Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest
-          { createdAt = createdAt,
+          { arrivalDeadlineTime = arrivalDeadlineTime,
+            createdAt = createdAt,
             driverId = Kernel.Types.Id.Id driverId,
             gateId = gateId,
             gateName = gateName,
@@ -36,7 +37,8 @@ instance FromTType' Beam.SpecialZoneQueueRequest Domain.Types.SpecialZoneQueueRe
 instance ToTType' Beam.SpecialZoneQueueRequest Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest where
   toTType' (Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest {..}) = do
     Beam.SpecialZoneQueueRequestT
-      { Beam.createdAt = createdAt,
+      { Beam.arrivalDeadlineTime = arrivalDeadlineTime,
+        Beam.createdAt = createdAt,
         Beam.driverId = Kernel.Types.Id.getId driverId,
         Beam.gateId = gateId,
         Beam.gateName = gateName,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/SpecialZoneQueueRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/SpecialZoneQueueRequest.hs
@@ -44,7 +44,8 @@ updateByPrimaryKey :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Typ
 updateByPrimaryKey (Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest {..}) = do
   _now <- getCurrentTime
   updateWithKV
-    [ Se.Set Beam.driverId (Kernel.Types.Id.getId driverId),
+    [ Se.Set Beam.arrivalDeadlineTime arrivalDeadlineTime,
+      Se.Set Beam.driverId (Kernel.Types.Id.getId driverId),
       Se.Set Beam.gateId gateId,
       Se.Set Beam.gateName gateName,
       Se.Set Beam.merchantId (Kernel.Types.Id.getId merchantId),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -7,21 +7,28 @@ module Domain.Action.Dashboard.Management.SpecialZoneQueue
 where
 
 import qualified API.Types.ProviderPlatform.Management.SpecialZoneQueue as SZQT
+import Data.List (nub)
+import qualified Data.Map.Strict as Map
+import Data.Time (addUTCTime)
 import qualified Domain.Types.Merchant
+import qualified Domain.Types.SpecialZoneQueueRequest as DSZQR
 import qualified Environment
 import EulerHS.Prelude hiding (id)
 import Kernel.External.Maps.Types (LatLong (..))
 import qualified Kernel.Storage.Esqueleto as Esq
+import qualified Kernel.Storage.Hedis as Redis
 import qualified Kernel.Types.APISuccess
 import qualified Kernel.Types.Beckn.Context
 import qualified Kernel.Types.Id
 import Kernel.Utils.Common
 import qualified Lib.Queries.GateInfo as QGI
 import qualified Lib.Queries.SpecialLocation as QSL
+import qualified Lib.Types.GateInfo as DGI
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTSFlow
 import SharedLogic.Merchant (findMerchantByShortId)
 import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import qualified Storage.Queries.SpecialZoneQueueRequestExtra as QSZQR
 import Tools.Error
 
 postSpecialZoneQueueTriggerNotify :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> SZQT.TriggerSpecialZoneQueueNotifyReq -> Environment.Flow Kernel.Types.APISuccess.APISuccess)
@@ -45,8 +52,17 @@ getSpecialZoneQueueQueueStats merchantShortId opCity gateId = do
   driversNearGate <- LTSFlow.nearBy gate.point.lat gate.point.lon (Just False) Nothing 500 merchant.id Nothing Nothing
   driversInPickupZone <- filterM (isInsideGateGeometry gate.id) driversNearGate
   let pickupZoneDriverIds = map (.driverId) driversInPickupZone
-  -- Get queue stats per vehicle type
-  let vehicleTypes = ["SUV", "SEDAN", "HATCHBACK", "AUTO_RICKSHAW", "BIKE", "AMBULANCE"]
+  -- Compute the queue-request lookback cutoff once, reused across all variants.
+  now <- getCurrentTime
+  let queueRequestCutoff = addUTCTime (negate (2 * 60 * 60)) now
+  -- Base variants + every variant the operator has explicitly configured on the gate
+  -- (via per-variant threshold maps). Without this the hardcoded list silently drops
+  -- custom variants like SUV_PLUS / TAXI_PLUS so their config never reaches the dashboard.
+  let baseVariants = ["SUV", "SEDAN", "HATCHBACK", "AUTO_RICKSHAW", "BIKE", "AMBULANCE"]
+      configuredVariants =
+        concatMap Map.keys $
+          catMaybes [gate.minDriverThresholds, gate.maxDriverThresholds, gate.demandThresholds]
+      vehicleTypes = nub (baseVariants <> configuredVariants)
   vehicleStats <- forM vehicleTypes $ \vt -> do
     queueResp <- LTSFlow.getQueueDrivers specialLocationId vt
     let totalInQueue = queueResp.queueSize
@@ -54,26 +70,44 @@ getSpecialZoneQueueQueueStats merchantShortId opCity gateId = do
         -- Drivers that are both in this vehicle type's queue AND inside the pickup zone
         inPickupZone = length $ filter (`elem` pickupZoneDriverIds) queuedDriverIds
         outsidePickupZone = totalInQueue - inPickupZone
+    -- Live demand (pending customer searches) and committed supply (drivers notified/accepted)
+    mbDemandCount <- Redis.withCrossAppRedis $ Redis.get @Int (SpecialZoneDriverDemand.mkGateSearchDemandKey gateId vt)
+    mbSupplyCount <- Redis.withCrossAppRedis $ Redis.get @Int (SpecialZoneDriverDemand.mkGateSearchSupplyKey gateId vt)
+    -- Drivers who accepted the pickup notification and are en-route to the gate
+    acceptedRequests <- QSZQR.findAllByGateIdStatusAndVehicleType queueRequestCutoff gateId DSZQR.Accepted vt
     pure
       SZQT.VehicleQueueStats
         { vehicleType = vt,
           totalInQueue = totalInQueue,
           inPickupZone = inPickupZone,
-          outsidePickupZone = max 0 outsidePickupZone
+          outsidePickupZone = max 0 outsidePickupZone,
+          pendingDemand = fromMaybe 0 mbDemandCount,
+          driversCommittedToPickup = fromMaybe 0 mbSupplyCount,
+          acceptedQueueRequests = length acceptedRequests,
+          demandThreshold = DGI.demandThresholdFor gate vt,
+          minDriverThreshold = DGI.minDriverThresholdFor gate vt,
+          maxDriverThreshold = DGI.maxDriverThresholdFor gate vt
         }
-  let nonEmptyStats = filter (\s -> s.totalInQueue > 0) vehicleStats
+  let nonEmptyStats = filter (isNonEmpty gate) vehicleStats
       totalDrivers = sum $ map (.totalInQueue) nonEmptyStats
       totalInZone = sum $ map (.inPickupZone) nonEmptyStats
       totalOutside = sum $ map (.outsidePickupZone) nonEmptyStats
+      totalDemand = sum $ map (.pendingDemand) nonEmptyStats
+      totalCommitted = sum $ map (.driversCommittedToPickup) nonEmptyStats
+      totalAccepted = sum $ map (.acceptedQueueRequests) nonEmptyStats
   pure
     SZQT.SpecialZoneQueueStatsRes
       { gateId = gateId,
         gateName = gate.name,
         specialLocationName = specialLocationName,
+        canQueueUpOnGate = gate.canQueueUpOnGate,
         vehicleStats = nonEmptyStats,
         totalDriversInQueue = totalDrivers,
         totalInPickupZone = totalInZone,
-        totalOutsidePickupZone = totalOutside
+        totalOutsidePickupZone = totalOutside,
+        totalPendingDemand = totalDemand,
+        totalDriversCommittedToPickup = totalCommitted,
+        totalAcceptedQueueRequests = totalAccepted
       }
   where
     isInsideGateGeometry gateInfoId driverLoc = do
@@ -81,3 +115,15 @@ getSpecialZoneQueueQueueStats merchantShortId opCity gateId = do
       pure $ case mbGate of
         Just g -> g.id == gateInfoId
         Nothing -> False
+    -- Keep a variant if it has any live activity OR any explicit per-variant config
+    -- (so dashboards can always see what the operator has intentionally configured).
+    hasVariantConfig gate variant =
+      isJust (Map.lookup variant =<< gate.minDriverThresholds)
+        || isJust (Map.lookup variant =<< gate.maxDriverThresholds)
+        || isJust (Map.lookup variant =<< gate.demandThresholds)
+    isNonEmpty gate s =
+      s.totalInQueue > 0
+        || s.pendingDemand > 0
+        || s.driversCommittedToPickup > 0
+        || s.acceptedQueueRequests > 0
+        || hasVariantConfig gate s.vehicleType

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
@@ -74,6 +74,7 @@ import Kernel.Types.Id
 import Kernel.Utils.CalculateDistance (distanceBetweenInMeters)
 import Kernel.Utils.Common
 import Kernel.Utils.Error.BaseError.HTTPError.BecknAPIError
+import qualified SharedLogic.AirportEntryFee as AirportEntryFee
 import qualified SharedLogic.Booking as SBooking
 import qualified SharedLogic.CallBAP as BP
 import qualified SharedLogic.CallBAPInternal as CallBAPInternal
@@ -265,6 +266,10 @@ otpRideCreate driver otpCode booking clientId = do
   unless (driverInfo.enabled || fromMaybe False transporterConfig.allowDisableDriverToTakeSpecialZoneRide) $ throwError DriverAccountDisabled
   when driverInfo.blocked $ throwError (DriverAccountBlocked (BlockErrorPayload driverInfo.blockExpiryTime driverInfo.blockReasonFlag))
   unless booking.isDashboardRequest $ throwErrorOnRide transporterConfig.includeDriverCurrentlyOnRide driverInfo False
+  -- Verify the driver has enough liability balance to cover the airport entry
+  -- fee BEFORE creating the ride entity. Doing it here (instead of at StartRide)
+  -- ensures we don't leave an orphan ride row when the balance is insufficient.
+  unless booking.isDashboardRequest $ AirportEntryFee.checkAirportEntryFeeBalanceBeforeStartRide (fromMaybe False transporterConfig.airportEntryFeeEnabled) driver.id booking
   mFleetOwnerId <- QFDA.findByDriverId driver.id True
   (ride, rideDetails, _) <- initializeRide transporter driver booking (Just otpCode) Nothing clientId Nothing (mFleetOwnerId <&> (.fleetOwnerId) <&> Id)
   uBooking <- runInReplica $ QBooking.findById booking.id >>= fromMaybeM (BookingNotFound booking.id.getId) -- in replica db we can have outdated value

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
@@ -60,7 +60,6 @@ import qualified Lib.Payment.Domain.Types.PayoutRequest as DPR
 import qualified Lib.Payment.Payout.Request as PayoutRequest
 import qualified Lib.Payment.Storage.Queries.PayoutRequest as QPR
 import qualified Lib.Scheduler.JobStorageType.SchedulerType as QAllJ
-import SharedLogic.AirportEntryFee (checkAirportEntryFeeBalanceBeforeStartRide)
 import SharedLogic.Allocator (AllocatorJobType (..), SpecialZonePayoutJobData (..))
 import SharedLogic.CallBAP (sendRideStartedUpdateToBAP)
 import qualified SharedLogic.External.LocationTrackingService.Flow as LF
@@ -184,7 +183,6 @@ startRide ServiceHandle {..} rideId req = withLogTag ("rideId-" <> rideId.getId)
     then pure APISuccess.Success
     else do
       unless (isValidRideStatus (ride.status)) $ throwError $ RideInvalidStatus ("This ride cannot be started" <> Text.pack (show ride.status))
-      checkAirportEntryFeeBalanceBeforeStartRide (fromMaybe False transporterConfig.airportEntryFeeEnabled) driverId booking
       (point, odometer) <- case req of
         DriverReq driverReq -> do
           when (DTC.isOdometerReadingsRequired booking.tripCategory && isNothing driverReq.odometer) $ throwError $ OdometerReadingRequired (show booking.tripCategory)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
@@ -9,6 +9,7 @@ where
 
 import qualified API.Types.UI.SpecialZoneQueue
 import Data.List (partition)
+import Data.Time (addUTCTime)
 import qualified Domain.Types.Merchant
 import qualified Domain.Types.MerchantOperatingCity
 import qualified Domain.Types.Person
@@ -27,6 +28,7 @@ import qualified Lib.Queries.GateInfo as QGI
 import qualified Lib.Queries.SpecialLocation as LQSL
 import Lib.Scheduler.JobStorageType.SchedulerType (createJobIn)
 import SharedLogic.Allocator (AllocatorJobType (..), CheckPickupZoneArrivalJobData (..))
+import qualified SharedLogic.Allocator.Jobs.SpecialZoneQueue.CheckPickupZoneArrival as ArrivalCheck
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTSFlow
 import SharedLogic.SpecialZoneDriverDemand (mkQueueSkipCountKey)
 import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
@@ -49,8 +51,26 @@ getSpecialZoneQueueRequest (mbPersonId, _merchantId, _merchantOpCityId) = do
   let (activeRequests, acceptedRequests) = partition (\request -> request.status == Domain.Types.SpecialZoneQueueRequest.Active) allReqs
   -- Lazy-expire Active requests past validTill
   validActiveRequests <- collectValidActive now activeRequests
-  -- Accepted requests are always returned (they're waiting for arrival/ride)
-  let acceptedRes = map mkRes acceptedRequests
+  -- Accepted requests carry an arrivalDeadlineTime (stamped at Accept time).
+  -- If it's in the past, fire the (lock-guarded, idempotent) arrival check in
+  -- the background and drop the row from the response — matches what the
+  -- scheduled CheckPickupZoneArrival job would do, but eagerly so the driver
+  -- UI stays in sync without waiting for the job to fire.
+  let isStaleAccepted r = case r.arrivalDeadlineTime of
+        Just deadline -> deadline < now
+        Nothing -> False
+      (staleAccepted, freshAccepted) = partition isStaleAccepted acceptedRequests
+  forM_ staleAccepted $ \req ->
+    fork ("specialZoneArrivalCheck-" <> req.id.getId) $
+      ArrivalCheck.runArrivalCheckForRequest
+        req.id
+        req.driverId
+        req.gateId
+        req.specialLocationId
+        req.vehicleType
+        req.merchantId
+        req.merchantOperatingCityId
+  let acceptedRes = map mkRes freshAccepted
       responseRequests = validActiveRequests ++ acceptedRes
   -- Get skip count from driver's current location's special location
   mbDriverLoc <- LTSFlow.driversLocation [personId]
@@ -113,12 +133,15 @@ postSpecialZoneQueueRequestRespond (mbPersonId, _merchantId, _merchantOpCityId) 
           else req.response
   case actualResponse of
     Domain.Types.SpecialZoneQueueRequest.Accept -> do
-      QSZQR.updateResponse (Just Domain.Types.SpecialZoneQueueRequest.Accept) Domain.Types.SpecialZoneQueueRequest.Accepted requestId
+      mbGate <- Esq.runInReplica $ QGI.findById (Kernel.Types.Id.Id request.gateId)
+      let timeoutSec = maybe 1200 (fromMaybe 1200 . (.pickupZoneArrivalTimeoutInSec)) mbGate
+          arrivalDeadline = addUTCTime (fromIntegral timeoutSec) now
+      -- Persist the arrival deadline so the GET handler can lazily detect a
+      -- missed-arrival NoShow without waiting for the scheduled job.
+      QSZQR.updateToAcceptedWithArrivalDeadline requestId arrivalDeadline
       -- Supply increment: driver has committed to this gate for this variant.
       fork "specialZoneSupplyIncrementOnAccept" $
         SpecialZoneDriverDemand.runSupplyIncrementForRequest requestId.getId request.gateId request.vehicleType
-      mbGate <- Esq.runInReplica $ QGI.findById (Kernel.Types.Id.Id request.gateId)
-      let timeoutSec = maybe 1200 (fromMaybe 1200 . (.pickupZoneArrivalTimeoutInSec)) mbGate
       createJobIn @_ @'CheckPickupZoneArrival
         (Just request.merchantId)
         (Just request.merchantOperatingCityId)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SpecialZoneQueue/CheckPickupZoneArrival.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SpecialZoneQueue/CheckPickupZoneArrival.hs
@@ -1,12 +1,17 @@
 module SharedLogic.Allocator.Jobs.SpecialZoneQueue.CheckPickupZoneArrival
   ( checkPickupZoneArrival,
+    runArrivalCheckForRequest,
   )
 where
 
+import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Person as DP
 import qualified Domain.Types.SpecialZoneQueueRequest as DSZQR
 import Kernel.External.Maps.Types (LatLong (..))
 import Kernel.Prelude
 import qualified Kernel.Storage.Esqueleto as Esq
+import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import qualified Lib.Queries.GateInfo as QGI
@@ -18,78 +23,104 @@ import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import qualified Storage.Queries.SpecialZoneQueueRequest as QSZQR
 import qualified Tools.Notifications as Notify
 
+-- | Idempotency lock key for the arrival check. Both the scheduled job and the
+-- driver-facing GET handler may try to run this for the same request — the lock
+-- ensures only one execution actually performs the side-effects (DB transition,
+-- LTS queue removal, notification, supply decrement).
+mkArrivalCheckLockKey :: Text -> Text
+mkArrivalCheckLockKey requestId = "PickupZoneArrivalCheck:Lock:" <> requestId
+
 checkPickupZoneArrival ::
   ( CacheFlow m r,
     EsqDBFlow m r,
     Esq.EsqDBReplicaFlow m r,
     MonadFlow m,
+    MonadMask m,
     HasLocationService m r,
     HasShortDurationRetryCfg r c,
     HasRequestId r
   ) =>
   Job 'CheckPickupZoneArrival ->
   m ExecutionResult
-checkPickupZoneArrival Job {id = jobId, jobInfo} = withLogTag ("JobId-" <> jobId.getId) do
+checkPickupZoneArrival Job {id = jobId, jobInfo} = withLogTag ("JobId-" <> jobId.getId) $ do
   let jobData = jobInfo.jobData
-      driverId = jobData.driverId
-      gateId = jobData.gateId
-      specialLocationId = jobData.specialLocationId
-      vehicleType = jobData.vehicleType
-      merchantId = jobData.merchantId
-      merchantOpCityId = jobData.merchantOperatingCityId
-  mbRequest <- QSZQR.findByPrimaryKey (Id jobData.requestId)
-  case mbRequest of
-    Nothing -> do
-      logInfo $ "Request " <> jobData.requestId <> " not found, skipping"
-      return Complete
-    Just request
-      | request.status == DSZQR.Expired -> do
-        logInfo $ "Request " <> jobData.requestId <> " already expired, skipping"
-        return Complete
-      | request.status == DSZQR.Completed -> do
-        logInfo $ "Request " <> jobData.requestId <> " already completed (ride started), skipping"
-        return Complete
-      | request.response == Just DSZQR.NoShow -> do
-        logInfo $ "Request " <> jobData.requestId <> " already marked NoShow, skipping"
-        return Complete
-      | otherwise -> do
-        mbGate <- Esq.runInReplica $ QGI.findById (Id gateId)
-        case mbGate of
-          Nothing -> do
-            logWarning $ "Gate " <> gateId <> " not found for arrival check, expiring request"
-            QSZQR.updateResponse (Just DSZQR.Ignored) DSZQR.Expired (Id jobData.requestId)
-            return Complete
-          Just gate -> do
-            driversNearGate <- LTSFlow.nearBy gate.point.lat gate.point.lon (Just False) Nothing 500 merchantId Nothing Nothing
-            isInPickupZone <- case find (\d -> d.driverId == driverId) driversNearGate of
-              Just dl -> do
-                mbGateCheck <- Esq.runInReplica $ QGI.findGateInfoIfDriverInsideGatePickupZone (LatLong dl.lat dl.lon)
-                pure $ case mbGateCheck of
-                  Just g -> g.id == gate.id
-                  Nothing -> False
-              Nothing -> pure False
-            if isInPickupZone
-              then do
-                logInfo $ "Driver " <> driverId.getId <> " arrived at pickup zone gate " <> gateId
-                QSZQR.updateResponse (Just DSZQR.Accept) DSZQR.Expired (Id jobData.requestId)
-                return Complete
-              else do
-                logWarning $ "Driver " <> driverId.getId <> " no-show at gate " <> gateId <> ", removing from queue"
-                void $ LTSFlow.manualQueueRemove specialLocationId vehicleType merchantId driverId
-                QSZQR.updateResponse (Just DSZQR.NoShow) DSZQR.Expired (Id jobData.requestId)
-                -- Supply decrement: no-show — driver never honored the commitment.
-                SpecialZoneDriverDemand.runSupplyDecrementForRequest jobData.requestId gateId vehicleType
-                let entityData =
-                      Notify.PickupZoneRequestEntityData
-                        { requestId = jobData.requestId,
-                          gateName = gate.name,
-                          gateAddress = gate.address,
-                          specialLocationName = request.specialLocationName,
-                          specialLocationId = specialLocationId,
-                          gateId = gateId,
-                          vehicleType = vehicleType,
-                          validTill = request.validTill,
-                          requestType = "PICKUP_ZONE_NO_SHOW"
-                        }
-                Notify.notifyPickupNoShow merchantOpCityId driverId entityData
-                return Complete
+  runArrivalCheckForRequest
+    (Id jobData.requestId)
+    jobData.driverId
+    jobData.gateId
+    jobData.specialLocationId
+    jobData.vehicleType
+    jobData.merchantId
+    jobData.merchantOperatingCityId
+  return Complete
+
+-- | Core arrival-check routine. Wrapped in a Redis lock so concurrent invocations
+-- (scheduled job + lazy GET-handler trigger) are mutually exclusive — only the
+-- first one to acquire the lock performs the work; the rest no-op.
+runArrivalCheckForRequest ::
+  ( CacheFlow m r,
+    EsqDBFlow m r,
+    Esq.EsqDBReplicaFlow m r,
+    MonadFlow m,
+    MonadMask m,
+    HasLocationService m r,
+    HasShortDurationRetryCfg r c,
+    HasRequestId r
+  ) =>
+  Id DSZQR.SpecialZoneQueueRequest ->
+  Id DP.Person ->
+  Text -> -- gateId
+  Text -> -- specialLocationId
+  Text -> -- vehicleType
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
+  m ()
+runArrivalCheckForRequest requestId driverId gateId specialLocationId vehicleType merchantId merchantOpCityId = do
+  Redis.whenWithLockRedis (mkArrivalCheckLockKey requestId.getId) 60 $ do
+    mbRequest <- QSZQR.findByPrimaryKey requestId
+    case mbRequest of
+      Nothing -> logInfo $ "Request " <> requestId.getId <> " not found, skipping"
+      Just request
+        | request.status == DSZQR.Expired ->
+          logInfo $ "Request " <> requestId.getId <> " already expired, skipping"
+        | request.status == DSZQR.Completed ->
+          logInfo $ "Request " <> requestId.getId <> " already completed (ride started), skipping"
+        | request.response == Just DSZQR.NoShow ->
+          logInfo $ "Request " <> requestId.getId <> " already marked NoShow, skipping"
+        | otherwise -> do
+          mbGate <- Esq.runInReplica $ QGI.findById (Id gateId)
+          case mbGate of
+            Nothing -> do
+              logWarning $ "Gate " <> gateId <> " not found for arrival check, expiring request"
+              QSZQR.updateResponse (Just DSZQR.Ignored) DSZQR.Expired requestId
+            Just gate -> do
+              driversNearGate <- LTSFlow.nearBy gate.point.lat gate.point.lon (Just False) Nothing 500 merchantId Nothing Nothing
+              isInPickupZone <- case find (\d -> d.driverId == driverId) driversNearGate of
+                Just dl -> do
+                  mbGateCheck <- Esq.runInReplica $ QGI.findGateInfoIfDriverInsideGatePickupZone (LatLong dl.lat dl.lon)
+                  pure $ case mbGateCheck of
+                    Just g -> g.id == gate.id
+                    Nothing -> False
+                Nothing -> pure False
+              if isInPickupZone
+                then do
+                  logInfo $ "Driver " <> driverId.getId <> " arrived at pickup zone gate " <> gateId
+                  QSZQR.updateResponse (Just DSZQR.Accept) DSZQR.Expired requestId
+                else do
+                  logWarning $ "Driver " <> driverId.getId <> " no-show at gate " <> gateId <> ", removing from queue"
+                  void $ LTSFlow.manualQueueRemove specialLocationId vehicleType merchantId driverId
+                  QSZQR.updateResponse (Just DSZQR.NoShow) DSZQR.Expired requestId
+                  SpecialZoneDriverDemand.runSupplyDecrementForRequest requestId.getId gateId vehicleType
+                  let entityData =
+                        Notify.PickupZoneRequestEntityData
+                          { requestId = requestId.getId,
+                            gateName = gate.name,
+                            gateAddress = gate.address,
+                            specialLocationName = request.specialLocationName,
+                            specialLocationId = specialLocationId,
+                            gateId = gateId,
+                            vehicleType = vehicleType,
+                            validTill = request.validTill,
+                            requestType = "PICKUP_ZONE_NO_SHOW"
+                          }
+                  Notify.notifyPickupNoShow merchantOpCityId driverId entityData

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -352,6 +352,7 @@ notifyDrivers merchantOpCityId merchantId gate specialLocationId vehicleType coo
                       gateName = gate.name,
                       specialLocationName = specialLocationName,
                       vehicleType = driverVehicleType,
+                      arrivalDeadlineTime = Nothing,
                       createdAt = now,
                       updatedAt = now
                     }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SpecialZoneQueueRequestExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SpecialZoneQueueRequestExtra.hs
@@ -24,6 +24,49 @@ findActiveByStasusListAndDriverId ::
 findActiveByStasusListAndDriverId driverId statusList =
   findAllWithKV [Se.And [Se.Is Beam.driverId $ Se.Eq (Kernel.Types.Id.getId driverId), Se.Is Beam.status $ Se.In statusList]]
 
+-- | Transition a pickup-zone request to Accepted and stamp the arrival deadline.
+-- The arrival deadline lives on its own column (arrivalDeadlineTime) rather than
+-- repurposing validTill — that way validTill keeps its original "Active window
+-- expiry" meaning, and the GET handler can detect a missed arrival cleanly via
+-- arrivalDeadlineTime < now.
+updateToAcceptedWithArrivalDeadline ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  Kernel.Types.Id.Id Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest ->
+  Kernel.Prelude.UTCTime ->
+  m ()
+updateToAcceptedWithArrivalDeadline requestId arrivalDeadline = do
+  now <- getCurrentTime
+  updateOneWithKV
+    [ Se.Set Beam.response (Just Domain.Types.SpecialZoneQueueRequest.Accept),
+      Se.Set Beam.status Domain.Types.SpecialZoneQueueRequest.Accepted,
+      Se.Set Beam.arrivalDeadlineTime (Just arrivalDeadline),
+      Se.Set Beam.updatedAt now
+    ]
+    [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId requestId)]
+
+-- | Find pickup-zone requests at a given gate filtered by status and vehicle type,
+-- restricted to createdAt >= the passed-in lower bound. Uses conditional-DB fallback
+-- (no KV) because gateId / status / vehicleType are not indexed; the createdAt bound
+-- keeps the scan cheap on the raw table. The caller owns the time cutoff so repeated
+-- calls (e.g. per-variant in a loop) share a single getCurrentTime.
+findAllByGateIdStatusAndVehicleType ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  Kernel.Prelude.UTCTime ->
+  Kernel.Prelude.Text ->
+  Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequestStatus ->
+  Kernel.Prelude.Text ->
+  m [Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest]
+findAllByGateIdStatusAndVehicleType createdAtFrom gateId status vehicleType =
+  findAllWithKVAndConditionalDB
+    [ Se.And
+        [ Se.Is Beam.createdAt $ Se.GreaterThanOrEq createdAtFrom,
+          Se.Is Beam.gateId $ Se.Eq gateId,
+          Se.Is Beam.status $ Se.Eq status,
+          Se.Is Beam.vehicleType $ Se.Eq vehicleType
+        ]
+    ]
+    Nothing
+
 -- | Find the most recent pickup-zone request for a driver where response=Accept,
 -- regardless of its current status. This catches requests that have already
 -- transitioned past Accepted (e.g., Expired after the arrival check) so the

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/special_zone_queue_request.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/special_zone_queue_request.sql
@@ -15,3 +15,9 @@ ALTER TABLE atlas_driver_offer_bpp.special_zone_queue_request ADD COLUMN updated
 ALTER TABLE atlas_driver_offer_bpp.special_zone_queue_request ADD COLUMN valid_till timestamp with time zone NOT NULL;
 ALTER TABLE atlas_driver_offer_bpp.special_zone_queue_request ADD COLUMN vehicle_type text NOT NULL;
 ALTER TABLE atlas_driver_offer_bpp.special_zone_queue_request ADD PRIMARY KEY ( id);
+
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.special_zone_queue_request ADD COLUMN arrival_deadline_time timestamp with time zone ;


### PR DESCRIPTION
## Summary
Enriches the `queueStats/{gateId}` dashboard API with live demand/supply metrics and gate config thresholds so dashboards can see the full picture at a special-zone gate — not just drivers currently queued.

### Per vehicle type (new fields on `VehicleQueueStats`)
- **`pendingDemand`** — live customer searches waiting at this gate (Redis demand counter)
- **`driversCommittedToPickup`** — drivers already notified/committed to come (Redis supply counter)
- **`acceptedQueueRequests`** — count of `SpecialZoneQueueRequest` rows with `status=Accepted` for this gate + variant
- **`demandThreshold`**, **`minDriverThreshold`**, **`maxDriverThreshold`** — per-variant thresholds from `GateInfo`

### Top-level (new fields on `SpecialZoneQueueStatsRes`)
- `canQueueUpOnGate`
- `totalPendingDemand`, `totalDriversCommittedToPickup`, `totalAcceptedQueueRequests`

### Other changes
- Variants are now kept in the response if ANY of queue / demand / supply / accepted is non-zero (previously hidden when only `totalInQueue=0` even though demand was live)
- Adds `findAllByGateIdStatusAndVehicleType` query in `SpecialZoneQueueRequestExtra`

## Test plan
- [ ] Hit `queueStats/{gateId}` for an active special-zone gate and verify the new fields are populated
- [ ] With active customer searches at a gate, confirm `pendingDemand > 0` even when no drivers are queued
- [ ] Dashboard trigger-notify → confirm `driversCommittedToPickup` / `acceptedQueueRequests` reflect the state
- [ ] Gate with `canQueueUpOnGate = false` → verify the flag surfaces correctly
- [ ] Gate with no demand/supply/queue activity → no variants returned, totals all zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue stats now show pending demand, drivers committed to pickup, and accepted requests per vehicle type
  * Dashboard includes optional per-vehicle thresholds for demand and drivers
  * Gate-level indicator shows whether vehicles can queue up
  * New aggregated totals: total pending demand, total committed drivers, and total accepted requests
  * Vehicle-type list now includes types with positive demand, commit, or accepted-request counts or explicit gate config
<!-- end of auto-generated comment: release notes by coderabbit.ai -->