### PR TITLE
backend/fix: move special zone demand pipeline from Select to Init

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
@@ -44,6 +44,8 @@ import Lib.SessionizerMetrics.Types.Event
 import qualified Lib.Yudhishthira.Types as LYT
 import SharedLogic.Booking
 import SharedLogic.Cancel
+import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
+import SharedLogic.External.LocationTrackingService.Types (HasLocationService)
 import qualified SharedLogic.FareCalculatorV2 as FCV2
 import qualified SharedLogic.FarePolicy as SFP
 import qualified SharedLogic.RiderDetails as SRD
@@ -119,8 +121,12 @@ data InitRes = InitRes
 handler ::
   ( CacheFlow m r,
     EsqDBFlow m r,
+    Esq.EsqDBReplicaFlow m r,
     EventStreamFlow m r,
-    EncFlow m r
+    EncFlow m r,
+    HasLocationService m r,
+    HasShortDurationRetryCfg r c,
+    HasRequestId r
   ) =>
   Id DM.Merchant ->
   InitReq ->
@@ -149,6 +155,25 @@ handler merchantId req validatedReq = do
         QRB.createBooking booking
         when booking.isScheduled $ void $ addScheduledBookingInRedis booking
         return (booking, Nothing, Nothing)
+  -- Special zone driver demand pipeline: fires for BOTH estimate-based (normal Select → Init)
+  -- and quote-based (special zone OTP direct Init) flows. Moved here from Select.hs because
+  -- special zone OTP rides skip Select entirely — the customer confirms a quote from on_search.
+  logDebug $
+    "Init pickupZoneGateId=" <> show searchRequest.pickupZoneGateId
+      <> " pickupGateId=" <> show searchRequest.pickupGateId
+      <> " vehicleServiceTier=" <> show booking.vehicleServiceTier
+      <> " searchRequestId=" <> searchRequest.id.getId
+  whenJust searchRequest.pickupZoneGateId $ \pickupZoneGateId -> do
+    logInfo $
+      "Firing special zone demand pipeline from Init for gateId=" <> pickupZoneGateId
+        <> " variant=" <> show booking.vehicleServiceTier
+        <> " searchRequestId=" <> searchRequest.id.getId
+    fork "specialZoneDriverDemandPipeline" $
+      SpecialZoneDriverDemand.runDemandCheckForVariants
+        searchRequest.merchantOperatingCityId
+        merchantId
+        pickupZoneGateId
+        [show booking.vehicleServiceTier]
   fork "Updating Demand Hotspots on booking" $ do
     let lat = searchRequest.fromLocation.lat
         lon = searchRequest.fromLocation.lon

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -394,9 +394,15 @@ handler ValidatedDSearchReq {..} sReq = do
       mbPickupZone <- case mbSlId of
         Just slId -> Esq.runInReplica $ findGateInfoByLatLongWithinRadius slId pickupLatLong 20.0
         Nothing -> pure Nothing
+      logDebug $
+        "getSpecialPickupZoneInfo area=" <> show area
+          <> " pickupLatLong=" <> show pickupLatLong
+          <> " slId=" <> show mbSlId
+          <> " gateFound=" <> show (isJust mbPickupZone)
+          <> " canQueueUp=" <> show ((.canQueueUpOnGate) <$> mbPickupZone)
       if ((.canQueueUpOnGate) <$> mbPickupZone) == Just True
-        then -- Demand counter is now bumped at Select time (per chosen variant) rather than at Search,
-        -- because at Search we don't yet know which estimate the customer will pick.
+        then -- Demand counter is bumped at Init time (per chosen variant) for both
+        -- estimate-based and quote-based (special zone OTP) flows.
           pure $ ((.id.getId) <$> mbPickupZone, (.id.getId) <$> mbPickupZone, fmap (toHighPrecMoney . Money) . (.defaultDriverExtra) =<< mbPickupZone) -- FIXME
         else pure ((.id.getId) <$> mbPickupZone, Nothing, Nothing)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Select.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Select.hs
@@ -19,7 +19,7 @@ module Domain.Action.Beckn.Select
 where
 
 import Data.Either.Extra (eitherToMaybe)
-import qualified Data.List as DL
+
 import Data.Text as Text hiding (find)
 import qualified Domain.Action.UI.SearchRequestForDriver as USRD
 import qualified Domain.Types.ConditionalCharges as DAC
@@ -43,7 +43,6 @@ import SharedLogic.Allocator.Jobs.SendSearchRequestToDrivers (sendSearchRequestT
 import SharedLogic.DriverPool
 import qualified SharedLogic.RiderDetails as SRD
 import SharedLogic.SearchTry
-import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import qualified SharedLogic.Type as SLT
 import qualified Storage.CachedQueries.Merchant as QMerch
 import qualified Storage.Queries.DriverQuote as QDQ
@@ -139,17 +138,9 @@ handler merchant sReq searchReq estimates = do
             driverPreference = sReq.driverPreference
           }
   void $ initiateDriverSearchBatch driverSearchBatchInput
-  -- Special zone driver demand pipeline (gate lookup + counter increment + threshold
-  -- check + notifications) is fully forked here. It is independent of the booking
-  -- flow — if it fails or is slow, Select must not be affected.
-  whenJust searchReq.pickupZoneGateId $ \pickupZoneGateId -> do
-    let chosenVariants = DL.nub $ Kernel.Prelude.map (\e -> show e.vehicleServiceTier) estimates
-    fork "specialZoneDriverDemandPipeline" $
-      SpecialZoneDriverDemand.runDemandCheckForVariants
-        searchReq.merchantOperatingCityId
-        merchant.id
-        pickupZoneGateId
-        chosenVariants
+  -- NOTE: Special zone demand pipeline has been moved to Init handler (Domain.Action.Beckn.Init)
+  -- so that it fires for both estimate-based (Select → Init) and quote-based (direct Init)
+  -- flows. Special zone OTP rides skip Select entirely, so demand was never incrementing.
   Metrics.finishGenericLatencyMetrics Metrics.SELECT_TO_SEND_REQUEST searchReq.transactionId
   where
     mbGetPayoutFlag isMultipleOrNoDeviceIdExist = maybe Nothing (\val -> if val then Just DRD.MultipleDeviceIdExists else Nothing) isMultipleOrNoDeviceIdExist

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -252,22 +252,38 @@ checkAndNotifyDriverDemand merchantOpCityId merchantId gate variant = do
   mbDemandCount <- Redis.withCrossAppRedis $ Redis.get @Int (mkGateSearchDemandKey gateId variant)
   let demandCount = fromMaybe 0 mbDemandCount
       demandThresholdVal = fromMaybe 2 (DGI.demandThresholdFor gate variant)
-  when (demandCount >= demandThresholdVal) $ do
-    let minThreshold = fromMaybe 0 (DGI.minDriverThresholdFor gate variant)
-        -- If max isn't configured, fall back to min so we never overshoot the trigger threshold.
-        maxThreshold = fromMaybe minThreshold (DGI.maxDriverThresholdFor gate variant)
-    mbSupplyCount <- Redis.withCrossAppRedis $ Redis.get @Int (mkGateSearchSupplyKey gateId variant)
-    let supplyCount = fromMaybe 0 mbSupplyCount
-    when (supplyCount < minThreshold) $ do
-      let needed = max 0 (maxThreshold - supplyCount)
-      when (needed > 0) $ do
-        let cooldown = fromMaybe 900 gate.notificationCooldownInSec
-        -- Pull drivers from the LTS queue for this special location, ordered by queue position.
-        queueResp <- LTSFlow.getQueueDrivers specialLocationId variant
-        let sortedDrivers = sortOn (.queuePosition) queueResp.drivers
-            queueDriverIds = map (.driverId) sortedDrivers
-        eligible <- filterEligibleDrivers gate specialLocationId variant merchantId gateId queueDriverIds
-        void $ notifyDrivers merchantOpCityId merchantId gate specialLocationId variant cooldown (take needed eligible)
+  logDebug $
+    "checkAndNotifyDriverDemand gateId=" <> gateId <> " variant=" <> variant
+      <> " demand=" <> show demandCount <> " demandThreshold=" <> show demandThresholdVal
+  if demandCount < demandThresholdVal
+    then logDebug $ "Demand below threshold, skipping notification gateId=" <> gateId <> " variant=" <> variant
+    else do
+      let minThreshold = fromMaybe 0 (DGI.minDriverThresholdFor gate variant)
+          maxThreshold = fromMaybe minThreshold (DGI.maxDriverThresholdFor gate variant)
+      mbSupplyCount <- Redis.withCrossAppRedis $ Redis.get @Int (mkGateSearchSupplyKey gateId variant)
+      let supplyCount = fromMaybe 0 mbSupplyCount
+      logDebug $
+        "checkAndNotifyDriverDemand gateId=" <> gateId <> " variant=" <> variant
+          <> " supply=" <> show supplyCount <> " minThreshold=" <> show minThreshold
+          <> " maxThreshold=" <> show maxThreshold
+      if supplyCount >= minThreshold
+        then logDebug $ "Supply already at/above minThreshold, skipping gateId=" <> gateId <> " variant=" <> variant
+        else do
+          let needed = max 0 (maxThreshold - supplyCount)
+          when (needed > 0) $ do
+            let cooldown = fromMaybe 900 gate.notificationCooldownInSec
+            queueResp <- LTSFlow.getQueueDrivers specialLocationId variant
+            let sortedDrivers = sortOn (.queuePosition) queueResp.drivers
+                queueDriverIds = map (.driverId) sortedDrivers
+            logInfo $
+              "Notifying drivers gateId=" <> gateId <> " variant=" <> variant
+                <> " needed=" <> show needed <> " queueSize=" <> show (length queueDriverIds)
+                <> " cooldown=" <> show cooldown
+            eligible <- filterEligibleDrivers gate specialLocationId variant merchantId gateId queueDriverIds
+            logInfo $
+              "Eligible drivers after filter gateId=" <> gateId <> " variant=" <> variant
+                <> " eligible=" <> show (length eligible) <> " toNotify=" <> show (min needed (length eligible))
+            void $ notifyDrivers merchantOpCityId merchantId gate specialLocationId variant cooldown (take needed eligible)
 
 -- Force notify (dashboard trigger) — uses LTS queue order, skips demand/supply threshold checks
 forceNotifyDriverDemand ::


### PR DESCRIPTION
## Summary
- Move the special zone driver demand pipeline (`runDemandCheckForVariants`) from `Select.hs` to `Init.hs`
- Special zone OTP rides skip Select entirely (customer confirms a quote from `on_search` directly), so demand was never incrementing for these rides
- Init is called in both estimate-based (Select → Init) and quote-based (direct Init) flows, so this covers all paths
- Add debug logs in `Search.hs` (`getSpecialPickupZoneInfo`), `Init.hs` (pickupZoneGateId), and `SpecialZoneDriverDemand.hs` (demand/supply thresholds, eligible drivers) for production visibility

## Changes
| File | Change |
|------|--------|
| `Select.hs` | Remove demand pipeline + unused `DL` import |
| `Init.hs` | Add demand pipeline after booking creation (forked) + debug logs |
| `Search.hs` | Add debug log in `getSpecialPickupZoneInfo` (area, gate found, canQueueUp) |
| `SpecialZoneDriverDemand.hs` | Add debug/info logs at each decision point in `checkAndNotifyDriverDemand` |

## Test plan
- [ ] `cabal build all` passes
- [ ] Normal ride flow (estimate → Select → Init): demand still increments at Init
- [ ] Special zone OTP flow (quote → Init): demand now increments at Init
- [ ] Verify debug logs appear in Kibana for: getSpecialPickupZoneInfo, Init pickupZoneGateId, checkAndNotifyDriverDemand thresholds
- [ ] Dashboard queueStats shows correct demand/supply after both flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Special-zone driver demand checks now run during booking initialization, unifying behavior for both estimate- and quote-based flows.

* **Chores**
  * Improved logging around special pickup-zone detection, demand/supply thresholds, and notification decisions.
  * Simplified and clearer demand-threshold and supply-evaluation flow with more granular debug/info logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->