### PR TITLE
backend/feat: add dashboard APIs for special zone queue management

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/SpecialZoneQueue.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/SpecialZoneQueue.yaml
@@ -19,11 +19,41 @@ apis:
       response:
         type: SpecialZoneQueueStatsRes
 
+  - POST:
+      endpoint: /manualQueueAdd
+      auth: ApiAuthV2
+      request:
+        type: ManualQueueAddReq
+      response:
+        type: APISuccess
+
+  - POST:
+      endpoint: /manualQueueRemove
+      auth: ApiAuthV2
+      request:
+        type: ManualQueueRemoveReq
+      response:
+        type: APISuccess
+
 types:
   TriggerSpecialZoneQueueNotifyReq:
     - gateId: Text
     - vehicleType: Text
     - driversToNotify: Int
+    - forceNotifyDriverIds: Maybe [Text]
+    - derive: "'HideSecrets"
+
+  ManualQueueAddReq:
+    - specialLocationId: Text
+    - vehicleType: Text
+    - driverId: Text
+    - queuePosition: Int
+    - derive: "'HideSecrets"
+
+  ManualQueueRemoveReq:
+    - specialLocationId: Text
+    - vehicleType: Text
+    - driverId: Text
     - derive: "'HideSecrets"
 
   VehicleQueueStats:

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/SpecialZoneQueue.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/SpecialZoneQueue.hs
@@ -14,6 +14,20 @@ import qualified Kernel.Types.HideSecrets
 import Servant
 import Servant.Client
 
+data ManualQueueAddReq = ManualQueueAddReq {specialLocationId :: Kernel.Prelude.Text, vehicleType :: Kernel.Prelude.Text, driverId :: Kernel.Prelude.Text, queuePosition :: Kernel.Prelude.Int}
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+instance Kernel.Types.HideSecrets.HideSecrets ManualQueueAddReq where
+  hideSecrets = Kernel.Prelude.identity
+
+data ManualQueueRemoveReq = ManualQueueRemoveReq {specialLocationId :: Kernel.Prelude.Text, vehicleType :: Kernel.Prelude.Text, driverId :: Kernel.Prelude.Text}
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+instance Kernel.Types.HideSecrets.HideSecrets ManualQueueRemoveReq where
+  hideSecrets = Kernel.Prelude.identity
+
 data SpecialZoneQueueStatsRes = SpecialZoneQueueStatsRes
   { gateId :: Kernel.Prelude.Text,
     gateName :: Kernel.Prelude.Text,
@@ -30,7 +44,12 @@ data SpecialZoneQueueStatsRes = SpecialZoneQueueStatsRes
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data TriggerSpecialZoneQueueNotifyReq = TriggerSpecialZoneQueueNotifyReq {gateId :: Kernel.Prelude.Text, vehicleType :: Kernel.Prelude.Text, driversToNotify :: Kernel.Prelude.Int}
+data TriggerSpecialZoneQueueNotifyReq = TriggerSpecialZoneQueueNotifyReq
+  { gateId :: Kernel.Prelude.Text,
+    vehicleType :: Kernel.Prelude.Text,
+    driversToNotify :: Kernel.Prelude.Int,
+    forceNotifyDriverIds :: Kernel.Prelude.Maybe [Kernel.Prelude.Text]
+  }
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
@@ -52,25 +71,33 @@ data VehicleQueueStats = VehicleQueueStats
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-type API = ("specialZoneQueue" :> (PostSpecialZoneQueueTriggerNotify :<|> GetSpecialZoneQueueQueueStats))
+type API = ("specialZoneQueue" :> (PostSpecialZoneQueueTriggerNotify :<|> GetSpecialZoneQueueQueueStats :<|> PostSpecialZoneQueueManualQueueAdd :<|> PostSpecialZoneQueueManualQueueRemove))
 
 type PostSpecialZoneQueueTriggerNotify = ("triggerNotify" :> ReqBody ('[JSON]) TriggerSpecialZoneQueueNotifyReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
 type GetSpecialZoneQueueQueueStats = ("queueStats" :> Capture "gateId" Kernel.Prelude.Text :> Get ('[JSON]) SpecialZoneQueueStatsRes)
 
+type PostSpecialZoneQueueManualQueueAdd = ("manualQueueAdd" :> ReqBody ('[JSON]) ManualQueueAddReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+
+type PostSpecialZoneQueueManualQueueRemove = ("manualQueueRemove" :> ReqBody ('[JSON]) ManualQueueRemoveReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+
 data SpecialZoneQueueAPIs = SpecialZoneQueueAPIs
   { postSpecialZoneQueueTriggerNotify :: (TriggerSpecialZoneQueueNotifyReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    getSpecialZoneQueueQueueStats :: (Kernel.Prelude.Text -> EulerHS.Types.EulerClient SpecialZoneQueueStatsRes)
+    getSpecialZoneQueueQueueStats :: (Kernel.Prelude.Text -> EulerHS.Types.EulerClient SpecialZoneQueueStatsRes),
+    postSpecialZoneQueueManualQueueAdd :: (ManualQueueAddReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    postSpecialZoneQueueManualQueueRemove :: (ManualQueueRemoveReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess)
   }
 
 mkSpecialZoneQueueAPIs :: (Client EulerHS.Types.EulerClient API -> SpecialZoneQueueAPIs)
 mkSpecialZoneQueueAPIs specialZoneQueueClient = (SpecialZoneQueueAPIs {..})
   where
-    postSpecialZoneQueueTriggerNotify :<|> getSpecialZoneQueueQueueStats = specialZoneQueueClient
+    postSpecialZoneQueueTriggerNotify :<|> getSpecialZoneQueueQueueStats :<|> postSpecialZoneQueueManualQueueAdd :<|> postSpecialZoneQueueManualQueueRemove = specialZoneQueueClient
 
 data SpecialZoneQueueUserActionType
   = POST_SPECIAL_ZONE_QUEUE_TRIGGER_NOTIFY
   | GET_SPECIAL_ZONE_QUEUE_QUEUE_STATS
+  | POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_ADD
+  | POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_REMOVE
   deriving stock (Show, Read, Generic, Eq, Ord)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/dashboard/provider-dashboard/src-read-only/API/Action/ProviderPlatform/Management/SpecialZoneQueue.hs
+++ b/Backend/app/dashboard/provider-dashboard/src-read-only/API/Action/ProviderPlatform/Management/SpecialZoneQueue.hs
@@ -22,10 +22,10 @@ import Servant
 import Storage.Beam.CommonInstances ()
 import Tools.Auth.Api
 
-type API = ("specialZoneQueue" :> (PostSpecialZoneQueueTriggerNotify :<|> GetSpecialZoneQueueQueueStats))
+type API = ("specialZoneQueue" :> (PostSpecialZoneQueueTriggerNotify :<|> GetSpecialZoneQueueQueueStats :<|> PostSpecialZoneQueueManualQueueAdd :<|> PostSpecialZoneQueueManualQueueRemove))
 
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API)
-handler merchantId city = postSpecialZoneQueueTriggerNotify merchantId city :<|> getSpecialZoneQueueQueueStats merchantId city
+handler merchantId city = postSpecialZoneQueueTriggerNotify merchantId city :<|> getSpecialZoneQueueQueueStats merchantId city :<|> postSpecialZoneQueueManualQueueAdd merchantId city :<|> postSpecialZoneQueueManualQueueRemove merchantId city
 
 type PostSpecialZoneQueueTriggerNotify =
   ( ApiAuth
@@ -43,8 +43,30 @@ type GetSpecialZoneQueueQueueStats =
       :> API.Types.ProviderPlatform.Management.SpecialZoneQueue.GetSpecialZoneQueueQueueStats
   )
 
+type PostSpecialZoneQueueManualQueueAdd =
+  ( ApiAuth
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_MANAGEMENT) / ('API.Types.ProviderPlatform.Management.SPECIAL_ZONE_QUEUE) / ('API.Types.ProviderPlatform.Management.SpecialZoneQueue.POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_ADD))
+      :> API.Types.ProviderPlatform.Management.SpecialZoneQueue.PostSpecialZoneQueueManualQueueAdd
+  )
+
+type PostSpecialZoneQueueManualQueueRemove =
+  ( ApiAuth
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_MANAGEMENT) / ('API.Types.ProviderPlatform.Management.SPECIAL_ZONE_QUEUE) / ('API.Types.ProviderPlatform.Management.SpecialZoneQueue.POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_REMOVE))
+      :> API.Types.ProviderPlatform.Management.SpecialZoneQueue.PostSpecialZoneQueueManualQueueRemove
+  )
+
 postSpecialZoneQueueTriggerNotify :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.TriggerSpecialZoneQueueNotifyReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postSpecialZoneQueueTriggerNotify merchantShortId opCity apiTokenInfo req = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.Management.SpecialZoneQueue.postSpecialZoneQueueTriggerNotify merchantShortId opCity apiTokenInfo req
 
 getSpecialZoneQueueQueueStats :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Prelude.Text -> Environment.FlowHandler API.Types.ProviderPlatform.Management.SpecialZoneQueue.SpecialZoneQueueStatsRes)
 getSpecialZoneQueueQueueStats merchantShortId opCity apiTokenInfo gateId = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.Management.SpecialZoneQueue.getSpecialZoneQueueQueueStats merchantShortId opCity apiTokenInfo gateId
+
+postSpecialZoneQueueManualQueueAdd :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.ManualQueueAddReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
+postSpecialZoneQueueManualQueueAdd merchantShortId opCity apiTokenInfo req = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.Management.SpecialZoneQueue.postSpecialZoneQueueManualQueueAdd merchantShortId opCity apiTokenInfo req
+
+postSpecialZoneQueueManualQueueRemove :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.ManualQueueRemoveReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
+postSpecialZoneQueueManualQueueRemove merchantShortId opCity apiTokenInfo req = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.Management.SpecialZoneQueue.postSpecialZoneQueueManualQueueRemove merchantShortId opCity apiTokenInfo req

--- a/Backend/app/dashboard/provider-dashboard/src/Domain/Action/ProviderPlatform/Management/SpecialZoneQueue.hs
+++ b/Backend/app/dashboard/provider-dashboard/src/Domain/Action/ProviderPlatform/Management/SpecialZoneQueue.hs
@@ -3,6 +3,8 @@
 module Domain.Action.ProviderPlatform.Management.SpecialZoneQueue
   ( postSpecialZoneQueueTriggerNotify,
     getSpecialZoneQueueQueueStats,
+    postSpecialZoneQueueManualQueueAdd,
+    postSpecialZoneQueueManualQueueRemove,
   )
 where
 
@@ -32,3 +34,15 @@ getSpecialZoneQueueQueueStats :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.
 getSpecialZoneQueueQueueStats merchantShortId opCity apiTokenInfo gateId = do
   checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
   API.Client.ProviderPlatform.Management.callManagementAPI checkedMerchantId opCity (.specialZoneQueueDSL.getSpecialZoneQueueQueueStats) gateId
+
+postSpecialZoneQueueManualQueueAdd :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.ManualQueueAddReq -> Environment.Flow Kernel.Types.APISuccess.APISuccess)
+postSpecialZoneQueueManualQueueAdd merchantShortId opCity apiTokenInfo req = do
+  checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  transaction <- SharedLogic.Transaction.buildTransaction (Domain.Types.Transaction.castEndpoint apiTokenInfo.userActionType) (Kernel.Prelude.Just DRIVER_OFFER_BPP_MANAGEMENT) (Kernel.Prelude.Just apiTokenInfo) Kernel.Prelude.Nothing Kernel.Prelude.Nothing (Kernel.Prelude.Just req)
+  SharedLogic.Transaction.withTransactionStoring transaction $ (do API.Client.ProviderPlatform.Management.callManagementAPI checkedMerchantId opCity (.specialZoneQueueDSL.postSpecialZoneQueueManualQueueAdd) req)
+
+postSpecialZoneQueueManualQueueRemove :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.ManualQueueRemoveReq -> Environment.Flow Kernel.Types.APISuccess.APISuccess)
+postSpecialZoneQueueManualQueueRemove merchantShortId opCity apiTokenInfo req = do
+  checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  transaction <- SharedLogic.Transaction.buildTransaction (Domain.Types.Transaction.castEndpoint apiTokenInfo.userActionType) (Kernel.Prelude.Just DRIVER_OFFER_BPP_MANAGEMENT) (Kernel.Prelude.Just apiTokenInfo) Kernel.Prelude.Nothing Kernel.Prelude.Nothing (Kernel.Prelude.Just req)
+  SharedLogic.Transaction.withTransactionStoring transaction $ (do API.Client.ProviderPlatform.Management.callManagementAPI checkedMerchantId opCity (.specialZoneQueueDSL.postSpecialZoneQueueManualQueueRemove) req)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -486,6 +486,7 @@ library
       SharedLogic.External.LocationTrackingService.API.DriverLocation
       SharedLogic.External.LocationTrackingService.API.DriversLocation
       SharedLogic.External.LocationTrackingService.API.EndRide
+      SharedLogic.External.LocationTrackingService.API.ManualQueueAdd
       SharedLogic.External.LocationTrackingService.API.ManualQueueRemove
       SharedLogic.External.LocationTrackingService.API.NearBy
       SharedLogic.External.LocationTrackingService.API.RideDetails

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -21,10 +21,16 @@ import Servant
 import Tools.Auth
 
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API.Types.ProviderPlatform.Management.SpecialZoneQueue.API)
-handler merchantId city = postSpecialZoneQueueTriggerNotify merchantId city :<|> getSpecialZoneQueueQueueStats merchantId city
+handler merchantId city = postSpecialZoneQueueTriggerNotify merchantId city :<|> getSpecialZoneQueueQueueStats merchantId city :<|> postSpecialZoneQueueManualQueueAdd merchantId city :<|> postSpecialZoneQueueManualQueueRemove merchantId city
 
 postSpecialZoneQueueTriggerNotify :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.TriggerSpecialZoneQueueNotifyReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postSpecialZoneQueueTriggerNotify a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Management.SpecialZoneQueue.postSpecialZoneQueueTriggerNotify a3 a2 a1
 
 getSpecialZoneQueueQueueStats :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Prelude.Text -> Environment.FlowHandler API.Types.ProviderPlatform.Management.SpecialZoneQueue.SpecialZoneQueueStatsRes)
 getSpecialZoneQueueQueueStats a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Management.SpecialZoneQueue.getSpecialZoneQueueQueueStats a3 a2 a1
+
+postSpecialZoneQueueManualQueueAdd :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.ManualQueueAddReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
+postSpecialZoneQueueManualQueueAdd a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Management.SpecialZoneQueue.postSpecialZoneQueueManualQueueAdd a3 a2 a1
+
+postSpecialZoneQueueManualQueueRemove :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.ManualQueueRemoveReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
+postSpecialZoneQueueManualQueueRemove a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Management.SpecialZoneQueue.postSpecialZoneQueueManualQueueRemove a3 a2 a1

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -3,6 +3,8 @@
 module Domain.Action.Dashboard.Management.SpecialZoneQueue
   ( postSpecialZoneQueueTriggerNotify,
     getSpecialZoneQueueQueueStats,
+    postSpecialZoneQueueManualQueueAdd,
+    postSpecialZoneQueueManualQueueRemove,
   )
 where
 
@@ -11,7 +13,7 @@ import Data.List (nub)
 import qualified Data.Map.Strict as Map
 import Data.Time (addUTCTime)
 import qualified Domain.Types.Merchant
-import qualified Domain.Types.SpecialZoneQueueRequest as DSZQR
+import qualified Domain.Types.Person as DP
 import qualified Environment
 import EulerHS.Prelude hiding (id)
 import Kernel.External.Maps.Types (LatLong (..))
@@ -36,8 +38,29 @@ postSpecialZoneQueueTriggerNotify merchantShortId opCity req = do
   merchant <- findMerchantByShortId merchantShortId
   merchantOpCity <- CQMOC.findByMerchantIdAndCity merchant.id opCity >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantShortId: " <> merchantShortId.getShortId <> " ,city: " <> show opCity)
   gate <- Esq.runInReplica (QGI.findById (Kernel.Types.Id.Id req.gateId)) >>= fromMaybeM (InvalidRequest $ "Gate not found: " <> req.gateId)
-  notifiedCount <- SpecialZoneDriverDemand.forceNotifyDriverDemand merchantOpCity.id merchant.id gate req.vehicleType req.driversToNotify
-  logInfo $ "Dashboard trigger: notified " <> show notifiedCount <> " drivers for gate " <> req.gateId
+  let mbPriorityIds = fmap (map Kernel.Types.Id.Id) req.forceNotifyDriverIds
+  totalNotified <- SpecialZoneDriverDemand.forceNotifyDriverDemand merchantOpCity.id merchant.id gate req.vehicleType req.driversToNotify mbPriorityIds
+  logInfo $ "Dashboard trigger: notified " <> show totalNotified <> " drivers for gate " <> req.gateId
+  pure Kernel.Types.APISuccess.Success
+
+postSpecialZoneQueueManualQueueAdd :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> SZQT.ManualQueueAddReq -> Environment.Flow Kernel.Types.APISuccess.APISuccess)
+postSpecialZoneQueueManualQueueAdd merchantShortId opCity req = do
+  merchant <- findMerchantByShortId merchantShortId
+  _merchantOpCity <- CQMOC.findByMerchantIdAndCity merchant.id opCity >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantShortId: " <> merchantShortId.getShortId <> " ,city: " <> show opCity)
+  let driverId = Kernel.Types.Id.Id req.driverId :: Kernel.Types.Id.Id DP.Person
+  -- Remove first (if already in queue), then add at desired position
+  void $ LTSFlow.manualQueueRemove req.specialLocationId req.vehicleType merchant.id driverId
+  void $ LTSFlow.manualQueueAdd req.specialLocationId req.vehicleType merchant.id driverId req.queuePosition
+  logInfo $ "Dashboard: added driver " <> req.driverId <> " to queue at position " <> show req.queuePosition <> " for " <> req.specialLocationId <> "/" <> req.vehicleType
+  pure Kernel.Types.APISuccess.Success
+
+postSpecialZoneQueueManualQueueRemove :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> SZQT.ManualQueueRemoveReq -> Environment.Flow Kernel.Types.APISuccess.APISuccess)
+postSpecialZoneQueueManualQueueRemove merchantShortId opCity req = do
+  merchant <- findMerchantByShortId merchantShortId
+  _merchantOpCity <- CQMOC.findByMerchantIdAndCity merchant.id opCity >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantShortId: " <> merchantShortId.getShortId <> " ,city: " <> show opCity)
+  let driverId = Kernel.Types.Id.Id req.driverId :: Kernel.Types.Id.Id DP.Person
+  void $ LTSFlow.manualQueueRemove req.specialLocationId req.vehicleType merchant.id driverId
+  logInfo $ "Dashboard: removed driver " <> req.driverId <> " from queue for " <> req.specialLocationId <> "/" <> req.vehicleType
   pure Kernel.Types.APISuccess.Success
 
 getSpecialZoneQueueQueueStats :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Text -> Environment.Flow SZQT.SpecialZoneQueueStatsRes)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/API/ManualQueueAdd.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/API/ManualQueueAdd.hs
@@ -1,0 +1,42 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module SharedLogic.External.LocationTrackingService.API.ManualQueueAdd where
+
+import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.Person as DP
+import qualified EulerHS.Types as ET
+import Kernel.Prelude
+import Kernel.Types.APISuccess (APISuccess)
+import Kernel.Types.Id
+import Servant
+
+type ManualQueueAddAPI =
+  "internal"
+    :> "special-locations"
+    :> Capture "specialLocationId" Text
+    :> "queue"
+    :> Capture "vehicleType" Text
+    :> "drivers"
+    :> Capture "merchantId" (Id DM.Merchant)
+    :> Capture "driverId" (Id DP.Person)
+    :> "position"
+    :> Capture "position" Int
+    :> Post '[JSON] APISuccess
+
+manualQueueAddAPI :: Proxy ManualQueueAddAPI
+manualQueueAddAPI = Proxy
+
+manualQueueAdd :: Text -> Text -> Id DM.Merchant -> Id DP.Person -> Int -> ET.EulerClient APISuccess
+manualQueueAdd = ET.client manualQueueAddAPI

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/Flow.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/Flow.hs
@@ -32,6 +32,7 @@ import qualified SharedLogic.External.LocationTrackingService.API.DriverBlockTil
 import qualified SharedLogic.External.LocationTrackingService.API.DriverLocation as DriverLocationAPI
 import qualified SharedLogic.External.LocationTrackingService.API.DriversLocation as DriversLocationAPI
 import qualified SharedLogic.External.LocationTrackingService.API.EndRide as EndRideAPI
+import qualified SharedLogic.External.LocationTrackingService.API.ManualQueueAdd as ManualQueueAddAPI
 import qualified SharedLogic.External.LocationTrackingService.API.ManualQueueRemove as ManualQueueRemoveAPI
 import qualified SharedLogic.External.LocationTrackingService.API.NearBy as NearByAPI
 import qualified SharedLogic.External.LocationTrackingService.API.RideDetails as RideDetailsAPI
@@ -201,6 +202,17 @@ manualQueueRemove specialLocationId vehicleType merchantId driverId = do
         >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_MANUAL_QUEUE_REMOVE_API") url)
   logDebug $ "lts manual queue remove: " <> show manualQueueRemoveResp
   return manualQueueRemoveResp
+
+manualQueueAdd :: (CoreMetrics m, MonadFlow m, HasLocationService m r, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => Text -> Text -> Id DM.Merchant -> Id DP.Person -> Int -> m APISuccess
+manualQueueAdd specialLocationId vehicleType merchantId driverId position = do
+  ltsCfg <- asks (.ltsCfg)
+  let url = ltsCfg.url
+  manualQueueAddResp <-
+    withShortRetry $
+      callAPI url (ManualQueueAddAPI.manualQueueAdd specialLocationId vehicleType merchantId driverId position) "manualQueueAdd" ManualQueueAddAPI.manualQueueAddAPI
+        >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_MANUAL_QUEUE_ADD_API") url)
+  logDebug $ "lts manual queue add: " <> show manualQueueAddResp
+  return manualQueueAddResp
 
 getQueueDriverPosition :: (CoreMetrics m, MonadFlow m, HasFlowEnv m r '["ltsCfg" ::: LocationTrackingeServiceConfig], HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => Text -> Text -> Id DP.Person -> m QueueDriverPositionResp
 getQueueDriverPosition specialLocationId vehicleType driverId = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -285,7 +285,8 @@ checkAndNotifyDriverDemand merchantOpCityId merchantId gate variant = do
                 <> " eligible=" <> show (length eligible) <> " toNotify=" <> show (min needed (length eligible))
             void $ notifyDrivers merchantOpCityId merchantId gate specialLocationId variant cooldown (take needed eligible)
 
--- Force notify (dashboard trigger) — uses LTS queue order, skips demand/supply threshold checks
+-- Force notify (dashboard trigger) — notifies priority drivers first, then fills
+-- remaining slots from LTS queue order. Skips demand/supply threshold checks.
 forceNotifyDriverDemand ::
   ( Redis.HedisFlow m r,
     MonadFlow m,
@@ -301,18 +302,28 @@ forceNotifyDriverDemand ::
   DGI.GateInfo ->
   Text -> -- vehicleType
   Int -> -- number of drivers to notify
+  Maybe [Id DP.Person] -> -- optional priority driver IDs to notify first
   m Int -- returns count of drivers actually notified
-forceNotifyDriverDemand merchantOpCityId merchantId gate vehicleType needed = do
+forceNotifyDriverDemand merchantOpCityId merchantId gate vehicleType needed mbPriorityDriverIds = do
   let specialLocationId = gate.specialLocationId.getId
       gateId = gate.id.getId
       cooldown = fromMaybe 900 gate.notificationCooldownInSec
-  -- Get drivers from LTS queue sorted by queue position
-  queueResp <- LTSFlow.getQueueDrivers specialLocationId vehicleType
-  let sortedDrivers = sortOn (.queuePosition) queueResp.drivers
-      queueDriverIds = map (.driverId) sortedDrivers
-  eligible <- filterEligibleDrivers gate specialLocationId vehicleType merchantId gateId queueDriverIds
-  let toNotify = take needed eligible
-  notifyDrivers merchantOpCityId merchantId gate specialLocationId vehicleType cooldown toNotify
+      priorityDriverIds = fromMaybe [] mbPriorityDriverIds
+  -- Notify priority drivers first
+  priorityCount <- notifyDrivers merchantOpCityId merchantId gate specialLocationId vehicleType cooldown priorityDriverIds
+  let remaining = max 0 (needed - priorityCount)
+  -- Fill remaining from LTS queue
+  queueCount <-
+    if remaining > 0
+      then do
+        queueResp <- LTSFlow.getQueueDrivers specialLocationId vehicleType
+        let sortedDrivers = sortOn (.queuePosition) queueResp.drivers
+            -- Exclude priority drivers already notified
+            queueDriverIds = filter (`notElem` priorityDriverIds) $ map (.driverId) sortedDrivers
+        eligible <- filterEligibleDrivers gate specialLocationId vehicleType merchantId gateId queueDriverIds
+        notifyDrivers merchantOpCityId merchantId gate specialLocationId vehicleType cooldown (take remaining eligible)
+      else pure 0
+  pure (priorityCount + queueCount)
 
 -- Common notification logic: create SpecialZoneQueueRequest entries and send FCM
 notifyDrivers ::

--- a/Backend/dev/migrations-read-only/provider-dashboard/Local_API_Management_SpecialZoneQueue.sql
+++ b/Backend/dev/migrations-read-only/provider-dashboard/Local_API_Management_SpecialZoneQueue.sql
@@ -12,3 +12,12 @@ INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_acc
 
 -- {"api":"GetSpecialZoneQueueQueueStats","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bpp_dashboard"}
 INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bpp_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'PROVIDER_MANAGEMENT/SPECIAL_ZONE_QUEUE/GET_SPECIAL_ZONE_QUEUE_QUEUE_STATS' ) ON CONFLICT DO NOTHING;
+
+
+------- SQL updates -------
+
+-- {"api":"PostSpecialZoneQueueManualQueueAdd","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bpp_dashboard"}
+INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bpp_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'PROVIDER_MANAGEMENT/SPECIAL_ZONE_QUEUE/POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_ADD' ) ON CONFLICT DO NOTHING;
+
+-- {"api":"PostSpecialZoneQueueManualQueueRemove","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bpp_dashboard"}
+INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bpp_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'PROVIDER_MANAGEMENT/SPECIAL_ZONE_QUEUE/POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_REMOVE' ) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- Add `manualQueueAdd` and `manualQueueRemove` dashboard APIs for manual queue position management
- Add `forceNotifyDriverIds` field to `triggerNotify` request — priority drivers get notified first, remaining slots filled from LTS queue
- Add `ManualQueueAdd` LTS API endpoint for inserting drivers at specific queue positions
- Merge priority driver notification logic directly into `forceNotifyDriverDemand`

## Test plan
- [ ] Verify `POST /specialZoneQueue/manualQueueAdd` adds driver to LTS queue at specified position
- [ ] Verify `POST /specialZoneQueue/manualQueueRemove` removes driver from LTS queue
- [ ] Verify `POST /specialZoneQueue/triggerNotify` with `forceNotifyDriverIds` notifies those drivers first
- [ ] Verify `triggerNotify` without `forceNotifyDriverIds` works as before (queue-order only)
- [ ] Verify `GET /specialZoneQueue/queueStats/{gateId}` still returns correct stats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two new authenticated endpoints to manually add or remove drivers from special-zone queues.
  * New internal flow to call location-tracking for manual queue adjustments.

* **Enhancements**
  * Queue stats now include pending demand, drivers committed to pickup, and accepted queue requests.
  * Trigger notifications can target specific driver lists; forced notifications now prioritize those IDs before filling from the queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->