### PR TITLE
backend/fix: remove merchantId from manualQueueAdd LTS API path

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -51,7 +51,7 @@ postSpecialZoneQueueManualQueueAdd merchantShortId opCity req = do
   let driverId = Kernel.Types.Id.Id req.driverId :: Kernel.Types.Id.Id DP.Person
   -- Remove first (if already in queue), then add at desired position
   void $ LTSFlow.manualQueueRemove req.specialLocationId req.vehicleType merchant.id driverId
-  void $ LTSFlow.manualQueueAdd req.specialLocationId req.vehicleType merchant.id driverId req.queuePosition
+  void $ LTSFlow.manualQueueAdd req.specialLocationId req.vehicleType driverId req.queuePosition
   logInfo $ "Dashboard: added driver " <> req.driverId <> " to queue at position " <> show req.queuePosition <> " for " <> req.specialLocationId <> "/" <> req.vehicleType
   pure Kernel.Types.APISuccess.Success
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/API/ManualQueueAdd.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/API/ManualQueueAdd.hs
@@ -14,7 +14,6 @@
 
 module SharedLogic.External.LocationTrackingService.API.ManualQueueAdd where
 
-import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.Person as DP
 import qualified EulerHS.Types as ET
 import Kernel.Prelude
@@ -29,7 +28,6 @@ type ManualQueueAddAPI =
     :> "queue"
     :> Capture "vehicleType" Text
     :> "drivers"
-    :> Capture "merchantId" (Id DM.Merchant)
     :> Capture "driverId" (Id DP.Person)
     :> "position"
     :> Capture "position" Int
@@ -38,5 +36,5 @@ type ManualQueueAddAPI =
 manualQueueAddAPI :: Proxy ManualQueueAddAPI
 manualQueueAddAPI = Proxy
 
-manualQueueAdd :: Text -> Text -> Id DM.Merchant -> Id DP.Person -> Int -> ET.EulerClient APISuccess
+manualQueueAdd :: Text -> Text -> Id DP.Person -> Int -> ET.EulerClient APISuccess
 manualQueueAdd = ET.client manualQueueAddAPI

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/Flow.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/Flow.hs
@@ -203,13 +203,13 @@ manualQueueRemove specialLocationId vehicleType merchantId driverId = do
   logDebug $ "lts manual queue remove: " <> show manualQueueRemoveResp
   return manualQueueRemoveResp
 
-manualQueueAdd :: (CoreMetrics m, MonadFlow m, HasLocationService m r, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => Text -> Text -> Id DM.Merchant -> Id DP.Person -> Int -> m APISuccess
-manualQueueAdd specialLocationId vehicleType merchantId driverId position = do
+manualQueueAdd :: (CoreMetrics m, MonadFlow m, HasLocationService m r, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => Text -> Text -> Id DP.Person -> Int -> m APISuccess
+manualQueueAdd specialLocationId vehicleType driverId position = do
   ltsCfg <- asks (.ltsCfg)
   let url = ltsCfg.url
   manualQueueAddResp <-
     withShortRetry $
-      callAPI url (ManualQueueAddAPI.manualQueueAdd specialLocationId vehicleType merchantId driverId position) "manualQueueAdd" ManualQueueAddAPI.manualQueueAddAPI
+      callAPI url (ManualQueueAddAPI.manualQueueAdd specialLocationId vehicleType driverId position) "manualQueueAdd" ManualQueueAddAPI.manualQueueAddAPI
         >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_MANUAL_QUEUE_ADD_API") url)
   logDebug $ "lts manual queue add: " <> show manualQueueAddResp
   return manualQueueAddResp


### PR DESCRIPTION
## Summary
- Removed `merchantId` Capture from `ManualQueueAddAPI` Servant type — LTS expects `/internal/special-locations/{slId}/queue/{vt}/drivers/{driverId}/position/{pos}` but we were generating `/drivers/{merchantId}/{driverId}/position/{pos}`
- Updated `Flow.manualQueueAdd` and dashboard handler to match the new signature

## Test plan
- [ ] Verify manualQueueAdd curl hits correct LTS path without merchantId
- [ ] Verify manualQueueRemove still works (unchanged, keeps merchantId as LTS expects)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined special zone queue management functionality by removing the merchant identifier parameter requirement from the manual queue addition process across the entire service layer infrastructure. This change reduces overall API complexity while fully preserving all queue positioning capabilities, vehicle type handling, and driver assignment operations in the location tracking system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->