### PR TITLE
backend/fix: fix manualQueueAdd LTS API to send position in request body

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -51,7 +51,7 @@ postSpecialZoneQueueManualQueueAdd merchantShortId opCity req = do
   let driverId = Kernel.Types.Id.Id req.driverId :: Kernel.Types.Id.Id DP.Person
   -- Remove first (if already in queue), then add at desired position
   void $ LTSFlow.manualQueueRemove req.specialLocationId req.vehicleType merchant.id driverId
-  void $ LTSFlow.manualQueueAdd req.specialLocationId req.vehicleType driverId req.queuePosition
+  void $ LTSFlow.manualQueueAdd req.specialLocationId req.vehicleType merchant.id driverId req.queuePosition
   logInfo $ "Dashboard: added driver " <> req.driverId <> " to queue at position " <> show req.queuePosition <> " for " <> req.specialLocationId <> "/" <> req.vehicleType
   pure Kernel.Types.APISuccess.Success
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/API/ManualQueueAdd.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/API/ManualQueueAdd.hs
@@ -14,12 +14,18 @@
 
 module SharedLogic.External.LocationTrackingService.API.ManualQueueAdd where
 
+import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.Person as DP
 import qualified EulerHS.Types as ET
 import Kernel.Prelude
 import Kernel.Types.APISuccess (APISuccess)
 import Kernel.Types.Id
 import Servant
+
+data ManualQueueAddRequest = ManualQueueAddRequest
+  { queuePosition :: Int
+  }
+  deriving (Generic, ToJSON, FromJSON, Show)
 
 type ManualQueueAddAPI =
   "internal"
@@ -28,13 +34,13 @@ type ManualQueueAddAPI =
     :> "queue"
     :> Capture "vehicleType" Text
     :> "drivers"
+    :> Capture "merchantId" (Id DM.Merchant)
     :> Capture "driverId" (Id DP.Person)
-    :> "position"
-    :> Capture "position" Int
+    :> ReqBody '[JSON] ManualQueueAddRequest
     :> Post '[JSON] APISuccess
 
 manualQueueAddAPI :: Proxy ManualQueueAddAPI
 manualQueueAddAPI = Proxy
 
-manualQueueAdd :: Text -> Text -> Id DP.Person -> Int -> ET.EulerClient APISuccess
+manualQueueAdd :: Text -> Text -> Id DM.Merchant -> Id DP.Person -> ManualQueueAddRequest -> ET.EulerClient APISuccess
 manualQueueAdd = ET.client manualQueueAddAPI

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/Flow.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/External/LocationTrackingService/Flow.hs
@@ -203,13 +203,14 @@ manualQueueRemove specialLocationId vehicleType merchantId driverId = do
   logDebug $ "lts manual queue remove: " <> show manualQueueRemoveResp
   return manualQueueRemoveResp
 
-manualQueueAdd :: (CoreMetrics m, MonadFlow m, HasLocationService m r, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => Text -> Text -> Id DP.Person -> Int -> m APISuccess
-manualQueueAdd specialLocationId vehicleType driverId position = do
+manualQueueAdd :: (CoreMetrics m, MonadFlow m, HasLocationService m r, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => Text -> Text -> Id DM.Merchant -> Id DP.Person -> Int -> m APISuccess
+manualQueueAdd specialLocationId vehicleType merchantId driverId position = do
   ltsCfg <- asks (.ltsCfg)
   let url = ltsCfg.url
+  let req = ManualQueueAddAPI.ManualQueueAddRequest {queuePosition = position}
   manualQueueAddResp <-
     withShortRetry $
-      callAPI url (ManualQueueAddAPI.manualQueueAdd specialLocationId vehicleType driverId position) "manualQueueAdd" ManualQueueAddAPI.manualQueueAddAPI
+      callAPI url (ManualQueueAddAPI.manualQueueAdd specialLocationId vehicleType merchantId driverId req) "manualQueueAdd" ManualQueueAddAPI.manualQueueAddAPI
         >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_MANUAL_QUEUE_ADD_API") url)
   logDebug $ "lts manual queue add: " <> show manualQueueAddResp
   return manualQueueAddResp


### PR DESCRIPTION
## Summary
- Fixes the `manualQueueAdd` LTS API type to match the actual Rust endpoint
- `merchantId` and `driverId` stay in the path: `POST /internal/special-locations/{slId}/queue/{vt}/drivers/{merchantId}/{driverId}`
- `queuePosition` is sent in the JSON request body (`{"queuePosition": N}`) instead of as a path capture
- Reverts the incorrect merchantId removal from #14421

## Test plan
- [ ] Verify `manualQueueAdd` curl hits correct LTS path with merchantId in path and position in body
- [ ] Verify `manualQueueRemove` still works (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated manual-queue API: queue position is now provided in the request body (JSON) instead of the URL.
  * API now requires the merchant identifier as part of the request path before the driver identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->