### PR TITLE
rider/fix: activateToday returns Expired for backdated past ranges

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/PurchasedPass.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/PurchasedPass.yaml
@@ -137,6 +137,7 @@ PurchasedPassPayment:
     id: PrimaryKey
     orderId: SecondaryKey
     purchasedPassId: SecondaryKey
+    personId: "!SecondaryKey"
 
   queries:
     findOneByPaymentOrderId:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/PurchasedPassPayment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/PurchasedPassPayment.hs
@@ -44,6 +44,6 @@ instance B.Table PurchasedPassPaymentT where
 
 type PurchasedPassPayment = PurchasedPassPaymentT Identity
 
-$(enableKVPG ''PurchasedPassPaymentT ['id] [['orderId], ['purchasedPassId]])
+$(enableKVPG ''PurchasedPassPaymentT ['id] [['orderId], ['personId], ['purchasedPassId]])
 
 $(mkTableInstances ''PurchasedPassPaymentT "purchased_pass_payment")

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -1070,10 +1070,12 @@ postMultimodalPassActivateTodayUtil isDashboard (mbCallerPersonId, _merchantId) 
       unless (purchasedPass.status `elem` [DPurchasedPass.PreBooked, DPurchasedPass.Active]) $
         throwError (PassActivationNotReady purchasedPass.id.getId "Only active or pre-booked passes can be rescheduled")
   _ <- purchasedPass.maxValidDays & fromMaybeM (PassActivationNotReady purchasedPass.id.getId "Pass does not have a valid duration")
-  let (newStartDate, newStatus) = case normalizedMbStartDate of
-        Nothing -> (today, DPurchasedPass.Active)
-        Just date -> if date < today then (date, DPurchasedPass.Active) else (date, DPurchasedPass.PreBooked)
+  let newStartDate = fromMaybe today normalizedMbStartDate
       newEndDate = calculatePassEndDate newStartDate purchasedPass.maxValidDays
+      newStatus
+        | newEndDate < today = DPurchasedPass.Expired
+        | newStartDate <= today = DPurchasedPass.Active
+        | otherwise = DPurchasedPass.PreBooked
 
   mbTargetPayment <- case mbPurchasedPassPaymentId of
     Just paymentId -> do


### PR DESCRIPTION
## Summary
- `postMultimodalPassActivateTodayUtil` (dashboard "Change Start Date") now correctly returns `Expired` when the new date range ends in the past
- Previously it only mapped to `Active` or `PreBooked`, so backdating past the pass duration left `status = Active` while `endDate < today`
- On the next list call, reconciliation at `Pass.hs:758-765` would flip the pass back to `Expired` via a status-only write, leaving `purchased_pass` and `purchased_pass_payment` with inconsistent dates/status

## Behaviour matrix

| newStartDate | newEndDate | Before | After |
|---|---|---|---|
| ≤ today | ≥ today | Active | Active |
| > today | > today | PreBooked | PreBooked |
| < today | **< today** | **Active** (bug) | **Expired** |

## Test plan
- [ ] On dashboard, backdate a pass so `startDate + maxValidDays < today`: verify both parent pass and primary payment row land in `Expired`, not `Active`
- [ ] Backdate a pass where the range still overlaps today: verify still `Active`
- [ ] Forward-date to a future day: verify still `PreBooked`
- [ ] Re-run existing pass activation/reschedule flows on mobile (`isDashboard = False`) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pass status now correctly marks expired passes based on end-date/duration as well as start date, fixing incorrect active/prebooked states.
* **Chores**
  * Improved backend pass/payment lookup to include person-based indexing for more reliable retrieval of purchased pass and payment records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->