### PR TITLE
backend/fix: special zone queue bugs

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/SpecialZoneQueue.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/SpecialZoneQueue.yaml
@@ -35,6 +35,16 @@ apis:
       response:
         type: APISuccess
 
+  - GET:
+      endpoint: /driverQueuePosition
+      auth: ApiAuthV2
+      mandatoryQuery:
+        specialLocationId: Text
+        vehicleType: Text
+        driverId: Text
+      response:
+        type: DriverQueuePositionRes
+
 types:
   TriggerSpecialZoneQueueNotifyReq:
     - gateId: Text
@@ -80,3 +90,7 @@ types:
     - totalPendingDemand: Int
     - totalDriversCommittedToPickup: Int
     - totalAcceptedQueueRequests: Int
+
+  DriverQueuePositionRes:
+    - queuePosition: Maybe Int
+    - queueSize: Int

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/SpecialZoneQueue.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/SpecialZoneQueue.hs
@@ -14,6 +14,10 @@ import qualified Kernel.Types.HideSecrets
 import Servant
 import Servant.Client
 
+data DriverQueuePositionRes = DriverQueuePositionRes {queuePosition :: Kernel.Prelude.Maybe Kernel.Prelude.Int, queueSize :: Kernel.Prelude.Int}
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data ManualQueueAddReq = ManualQueueAddReq {specialLocationId :: Kernel.Prelude.Text, vehicleType :: Kernel.Prelude.Text, driverId :: Kernel.Prelude.Text, queuePosition :: Kernel.Prelude.Int}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -71,7 +75,7 @@ data VehicleQueueStats = VehicleQueueStats
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-type API = ("specialZoneQueue" :> (PostSpecialZoneQueueTriggerNotify :<|> GetSpecialZoneQueueQueueStats :<|> PostSpecialZoneQueueManualQueueAdd :<|> PostSpecialZoneQueueManualQueueRemove))
+type API = ("specialZoneQueue" :> (PostSpecialZoneQueueTriggerNotify :<|> GetSpecialZoneQueueQueueStats :<|> PostSpecialZoneQueueManualQueueAdd :<|> PostSpecialZoneQueueManualQueueRemove :<|> GetSpecialZoneQueueDriverQueuePosition))
 
 type PostSpecialZoneQueueTriggerNotify = ("triggerNotify" :> ReqBody ('[JSON]) TriggerSpecialZoneQueueNotifyReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
@@ -81,23 +85,34 @@ type PostSpecialZoneQueueManualQueueAdd = ("manualQueueAdd" :> ReqBody ('[JSON])
 
 type PostSpecialZoneQueueManualQueueRemove = ("manualQueueRemove" :> ReqBody ('[JSON]) ManualQueueRemoveReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
+type GetSpecialZoneQueueDriverQueuePosition =
+  ( "driverQueuePosition" :> MandatoryQueryParam "driverId" Kernel.Prelude.Text
+      :> MandatoryQueryParam
+           "specialLocationId"
+           Kernel.Prelude.Text
+      :> MandatoryQueryParam "vehicleType" Kernel.Prelude.Text
+      :> Get ('[JSON]) DriverQueuePositionRes
+  )
+
 data SpecialZoneQueueAPIs = SpecialZoneQueueAPIs
   { postSpecialZoneQueueTriggerNotify :: (TriggerSpecialZoneQueueNotifyReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
     getSpecialZoneQueueQueueStats :: (Kernel.Prelude.Text -> EulerHS.Types.EulerClient SpecialZoneQueueStatsRes),
     postSpecialZoneQueueManualQueueAdd :: (ManualQueueAddReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postSpecialZoneQueueManualQueueRemove :: (ManualQueueRemoveReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess)
+    postSpecialZoneQueueManualQueueRemove :: (ManualQueueRemoveReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    getSpecialZoneQueueDriverQueuePosition :: (Kernel.Prelude.Text -> Kernel.Prelude.Text -> Kernel.Prelude.Text -> EulerHS.Types.EulerClient DriverQueuePositionRes)
   }
 
 mkSpecialZoneQueueAPIs :: (Client EulerHS.Types.EulerClient API -> SpecialZoneQueueAPIs)
 mkSpecialZoneQueueAPIs specialZoneQueueClient = (SpecialZoneQueueAPIs {..})
   where
-    postSpecialZoneQueueTriggerNotify :<|> getSpecialZoneQueueQueueStats :<|> postSpecialZoneQueueManualQueueAdd :<|> postSpecialZoneQueueManualQueueRemove = specialZoneQueueClient
+    postSpecialZoneQueueTriggerNotify :<|> getSpecialZoneQueueQueueStats :<|> postSpecialZoneQueueManualQueueAdd :<|> postSpecialZoneQueueManualQueueRemove :<|> getSpecialZoneQueueDriverQueuePosition = specialZoneQueueClient
 
 data SpecialZoneQueueUserActionType
   = POST_SPECIAL_ZONE_QUEUE_TRIGGER_NOTIFY
   | GET_SPECIAL_ZONE_QUEUE_QUEUE_STATS
   | POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_ADD
   | POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_REMOVE
+  | GET_SPECIAL_ZONE_QUEUE_DRIVER_QUEUE_POSITION
   deriving stock (Show, Read, Generic, Eq, Ord)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/dashboard/provider-dashboard/src-read-only/API/Action/ProviderPlatform/Management/SpecialZoneQueue.hs
+++ b/Backend/app/dashboard/provider-dashboard/src-read-only/API/Action/ProviderPlatform/Management/SpecialZoneQueue.hs
@@ -22,10 +22,10 @@ import Servant
 import Storage.Beam.CommonInstances ()
 import Tools.Auth.Api
 
-type API = ("specialZoneQueue" :> (PostSpecialZoneQueueTriggerNotify :<|> GetSpecialZoneQueueQueueStats :<|> PostSpecialZoneQueueManualQueueAdd :<|> PostSpecialZoneQueueManualQueueRemove))
+type API = ("specialZoneQueue" :> (PostSpecialZoneQueueTriggerNotify :<|> GetSpecialZoneQueueQueueStats :<|> PostSpecialZoneQueueManualQueueAdd :<|> PostSpecialZoneQueueManualQueueRemove :<|> GetSpecialZoneQueueDriverQueuePosition))
 
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API)
-handler merchantId city = postSpecialZoneQueueTriggerNotify merchantId city :<|> getSpecialZoneQueueQueueStats merchantId city :<|> postSpecialZoneQueueManualQueueAdd merchantId city :<|> postSpecialZoneQueueManualQueueRemove merchantId city
+handler merchantId city = postSpecialZoneQueueTriggerNotify merchantId city :<|> getSpecialZoneQueueQueueStats merchantId city :<|> postSpecialZoneQueueManualQueueAdd merchantId city :<|> postSpecialZoneQueueManualQueueRemove merchantId city :<|> getSpecialZoneQueueDriverQueuePosition merchantId city
 
 type PostSpecialZoneQueueTriggerNotify =
   ( ApiAuth
@@ -59,6 +59,14 @@ type PostSpecialZoneQueueManualQueueRemove =
       :> API.Types.ProviderPlatform.Management.SpecialZoneQueue.PostSpecialZoneQueueManualQueueRemove
   )
 
+type GetSpecialZoneQueueDriverQueuePosition =
+  ( ApiAuth
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_MANAGEMENT) / ('API.Types.ProviderPlatform.Management.SPECIAL_ZONE_QUEUE) / ('API.Types.ProviderPlatform.Management.SpecialZoneQueue.GET_SPECIAL_ZONE_QUEUE_DRIVER_QUEUE_POSITION))
+      :> API.Types.ProviderPlatform.Management.SpecialZoneQueue.GetSpecialZoneQueueDriverQueuePosition
+  )
+
 postSpecialZoneQueueTriggerNotify :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.TriggerSpecialZoneQueueNotifyReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postSpecialZoneQueueTriggerNotify merchantShortId opCity apiTokenInfo req = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.Management.SpecialZoneQueue.postSpecialZoneQueueTriggerNotify merchantShortId opCity apiTokenInfo req
 
@@ -70,3 +78,6 @@ postSpecialZoneQueueManualQueueAdd merchantShortId opCity apiTokenInfo req = wit
 
 postSpecialZoneQueueManualQueueRemove :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.ManualQueueRemoveReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postSpecialZoneQueueManualQueueRemove merchantShortId opCity apiTokenInfo req = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.Management.SpecialZoneQueue.postSpecialZoneQueueManualQueueRemove merchantShortId opCity apiTokenInfo req
+
+getSpecialZoneQueueDriverQueuePosition :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Prelude.Text -> Kernel.Prelude.Text -> Kernel.Prelude.Text -> Environment.FlowHandler API.Types.ProviderPlatform.Management.SpecialZoneQueue.DriverQueuePositionRes)
+getSpecialZoneQueueDriverQueuePosition merchantShortId opCity apiTokenInfo driverId specialLocationId vehicleType = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.Management.SpecialZoneQueue.getSpecialZoneQueueDriverQueuePosition merchantShortId opCity apiTokenInfo driverId specialLocationId vehicleType

--- a/Backend/app/dashboard/provider-dashboard/src/Domain/Action/ProviderPlatform/Management/SpecialZoneQueue.hs
+++ b/Backend/app/dashboard/provider-dashboard/src/Domain/Action/ProviderPlatform/Management/SpecialZoneQueue.hs
@@ -5,6 +5,7 @@ module Domain.Action.ProviderPlatform.Management.SpecialZoneQueue
     getSpecialZoneQueueQueueStats,
     postSpecialZoneQueueManualQueueAdd,
     postSpecialZoneQueueManualQueueRemove,
+    getSpecialZoneQueueDriverQueuePosition,
   )
 where
 
@@ -46,3 +47,8 @@ postSpecialZoneQueueManualQueueRemove merchantShortId opCity apiTokenInfo req = 
   checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
   transaction <- SharedLogic.Transaction.buildTransaction (Domain.Types.Transaction.castEndpoint apiTokenInfo.userActionType) (Kernel.Prelude.Just DRIVER_OFFER_BPP_MANAGEMENT) (Kernel.Prelude.Just apiTokenInfo) Kernel.Prelude.Nothing Kernel.Prelude.Nothing (Kernel.Prelude.Just req)
   SharedLogic.Transaction.withTransactionStoring transaction $ (do API.Client.ProviderPlatform.Management.callManagementAPI checkedMerchantId opCity (.specialZoneQueueDSL.postSpecialZoneQueueManualQueueRemove) req)
+
+getSpecialZoneQueueDriverQueuePosition :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Prelude.Text -> Kernel.Prelude.Text -> Kernel.Prelude.Text -> Environment.Flow API.Types.ProviderPlatform.Management.SpecialZoneQueue.DriverQueuePositionRes)
+getSpecialZoneQueueDriverQueuePosition merchantShortId opCity apiTokenInfo driverId specialLocationId vehicleType = do
+  checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  API.Client.ProviderPlatform.Management.callManagementAPI checkedMerchantId opCity (.specialZoneQueueDSL.getSpecialZoneQueueDriverQueuePosition) driverId specialLocationId vehicleType

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -21,7 +21,7 @@ import Servant
 import Tools.Auth
 
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API.Types.ProviderPlatform.Management.SpecialZoneQueue.API)
-handler merchantId city = postSpecialZoneQueueTriggerNotify merchantId city :<|> getSpecialZoneQueueQueueStats merchantId city :<|> postSpecialZoneQueueManualQueueAdd merchantId city :<|> postSpecialZoneQueueManualQueueRemove merchantId city
+handler merchantId city = postSpecialZoneQueueTriggerNotify merchantId city :<|> getSpecialZoneQueueQueueStats merchantId city :<|> postSpecialZoneQueueManualQueueAdd merchantId city :<|> postSpecialZoneQueueManualQueueRemove merchantId city :<|> getSpecialZoneQueueDriverQueuePosition merchantId city
 
 postSpecialZoneQueueTriggerNotify :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.TriggerSpecialZoneQueueNotifyReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postSpecialZoneQueueTriggerNotify a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Management.SpecialZoneQueue.postSpecialZoneQueueTriggerNotify a3 a2 a1
@@ -34,3 +34,6 @@ postSpecialZoneQueueManualQueueAdd a3 a2 a1 = withDashboardFlowHandlerAPI $ Doma
 
 postSpecialZoneQueueManualQueueRemove :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> API.Types.ProviderPlatform.Management.SpecialZoneQueue.ManualQueueRemoveReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postSpecialZoneQueueManualQueueRemove a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Management.SpecialZoneQueue.postSpecialZoneQueueManualQueueRemove a3 a2 a1
+
+getSpecialZoneQueueDriverQueuePosition :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Prelude.Text -> Kernel.Prelude.Text -> Kernel.Prelude.Text -> Environment.FlowHandler API.Types.ProviderPlatform.Management.SpecialZoneQueue.DriverQueuePositionRes)
+getSpecialZoneQueueDriverQueuePosition a5 a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Management.SpecialZoneQueue.getSpecialZoneQueueDriverQueuePosition a5 a4 a3 a2 a1

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
@@ -3092,6 +3092,7 @@ postMerchantSpecialLocationGatesUpsert _merchantShortId _city specialLocationId 
             maxRideSkipsBeforeQueueRemoval = mbGate >>= (.maxRideSkipsBeforeQueueRemoval),
             pickupZoneArrivalTimeoutInSec = mbGate >>= (.pickupZoneArrivalTimeoutInSec),
             pickupRequestResponseTimeoutInSec = mbGate >>= (.pickupRequestResponseTimeoutInSec),
+            demandTtlInSec = mbGate >>= (.demandTtlInSec),
             ..
           }
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -5,6 +5,7 @@ module Domain.Action.Dashboard.Management.SpecialZoneQueue
     getSpecialZoneQueueQueueStats,
     postSpecialZoneQueueManualQueueAdd,
     postSpecialZoneQueueManualQueueRemove,
+    getSpecialZoneQueueDriverQueuePosition,
   )
 where
 
@@ -151,3 +152,18 @@ getSpecialZoneQueueQueueStats merchantShortId opCity gateId = do
         || s.driversCommittedToPickup > 0
         || s.acceptedQueueRequests > 0
         || hasVariantConfig gate s.vehicleType
+
+getSpecialZoneQueueDriverQueuePosition :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Text -> Text -> Text -> Environment.Flow SZQT.DriverQueuePositionRes)
+getSpecialZoneQueueDriverQueuePosition merchantShortId opCity driverIdText specialLocationId vehicleType = do
+  _merchant <- findMerchantByShortId merchantShortId
+  _merchantOpCity <- CQMOC.findByMerchantIdAndCity _merchant.id opCity >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantShortId: " <> merchantShortId.getShortId <> " ,city: " <> show opCity)
+  let driverId = Kernel.Types.Id.Id driverIdText :: Kernel.Types.Id.Id DP.Person
+  posResp <- LTSFlow.getQueueDriverPosition specialLocationId vehicleType driverId
+  let mbPos = case posResp.queuePositionRange of
+        Just (lo, _hi) -> Just lo
+        Nothing -> Nothing
+  pure
+    SZQT.DriverQueuePositionRes
+      { queuePosition = mbPos,
+        queueSize = posResp.queueSize
+      }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -1753,7 +1753,7 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
       -- can't add latency to the driver-respond hot path.
       fork "specialZoneQueueSkipOnDriverReject" $ do
         searchReq <- QSR.findById searchTry.requestId >>= fromMaybeM (SearchRequestNotFound searchTry.requestId.getId)
-        SpecialZoneDriverDemand.handleQueueSkipIfApplicable searchReq.pickupZoneGateId (show searchTry.vehicleServiceTier) driverId merchantId
+        SpecialZoneDriverDemand.handleQueueSkipIfApplicable searchReq.pickupZoneGateId (show searchTry.vehicleServiceTier) driverId merchantId (searchTry.id.getId <> ":" <> driverId.getId)
       unlockRedisQuoteKeys
     Pulled -> do
       when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False False False True

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
@@ -94,7 +94,13 @@ getSpecialZoneQueueRequest (mbPersonId, _merchantId, _merchantOpCityId) = do
     collectValidActive now (req : rest) =
       if req.validTill < now
         then do
-          QSZQR.updateResponse (Just Domain.Types.SpecialZoneQueueRequest.Ignored) Domain.Types.SpecialZoneQueueRequest.Expired req.id
+          let lockKey = "SpecialZoneQueueRespond:Lock:" <> req.id.getId
+          Redis.whenWithLockRedis lockKey 10 $ do
+            -- Re-read to ensure the respond handler hasn't already processed this
+            mbLatest <- QSZQR.findByPrimaryKey req.id
+            whenJust mbLatest $ \latest ->
+              when (latest.status == Domain.Types.SpecialZoneQueueRequest.Active) $
+                QSZQR.updateResponse (Just Domain.Types.SpecialZoneQueueRequest.Ignored) Domain.Types.SpecialZoneQueueRequest.Expired req.id
           collectValidActive now rest
         else do
           rest' <- collectValidActive now rest
@@ -123,40 +129,38 @@ postSpecialZoneQueueRequestRespond ::
   )
 postSpecialZoneQueueRequestRespond (mbPersonId, _merchantId, _merchantOpCityId) requestId req = do
   personId <- mbPersonId & fromMaybeM (PersonNotFound "No person id")
-  request <- QSZQR.findByPrimaryKey requestId >>= fromMaybeM (InvalidRequest "Request not found")
-  unless (request.driverId == personId) $ throwError (InvalidRequest "Request does not belong to this driver")
-  unless (request.status == Domain.Types.SpecialZoneQueueRequest.Active) $ throwError (InvalidRequest "Request is no longer active")
-  now <- getCurrentTime
-  let actualResponse =
-        if request.validTill < now
-          then Domain.Types.SpecialZoneQueueRequest.Ignored
-          else req.response
-  case actualResponse of
-    Domain.Types.SpecialZoneQueueRequest.Accept -> do
-      mbGate <- Esq.runInReplica $ QGI.findById (Kernel.Types.Id.Id request.gateId)
-      let timeoutSec = maybe 1200 (fromMaybe 1200 . (.pickupZoneArrivalTimeoutInSec)) mbGate
-          arrivalDeadline = addUTCTime (fromIntegral timeoutSec) now
-      -- Persist the arrival deadline so the GET handler can lazily detect a
-      -- missed-arrival NoShow without waiting for the scheduled job.
-      QSZQR.updateToAcceptedWithArrivalDeadline requestId arrivalDeadline
-      -- Supply increment: driver has committed to this gate for this variant.
-      fork "specialZoneSupplyIncrementOnAccept" $
-        SpecialZoneDriverDemand.runSupplyIncrementForRequest requestId.getId request.gateId request.vehicleType
-      createJobIn @_ @'CheckPickupZoneArrival
-        (Just request.merchantId)
-        (Just request.merchantOperatingCityId)
-        (secondsToNominalDiffTime $ Seconds timeoutSec)
-        CheckPickupZoneArrivalJobData
-          { requestId = requestId.getId,
-            driverId = personId,
-            gateId = request.gateId,
-            specialLocationId = request.specialLocationId,
-            vehicleType = request.vehicleType,
-            merchantId = request.merchantId,
-            merchantOperatingCityId = request.merchantOperatingCityId
-          }
-    _ ->
-      QSZQR.updateResponse (Just actualResponse) Domain.Types.SpecialZoneQueueRequest.Expired requestId
+  -- Re-read inside a Redis lock to prevent race between the GET handler's
+  -- lazy-expire (which sets Ignored/Expired) and this respond call.
+  let lockKey = "SpecialZoneQueueRespond:Lock:" <> requestId.getId
+  Redis.whenWithLockRedis lockKey 10 $ do
+    request <- QSZQR.findByPrimaryKey requestId >>= fromMaybeM (InvalidRequest "Request not found")
+    unless (request.driverId == personId) $ throwError (InvalidRequest "Request does not belong to this driver")
+    unless (request.status == Domain.Types.SpecialZoneQueueRequest.Active) $ throwError (InvalidRequest "Request is no longer active")
+    now <- getCurrentTime
+    when (request.validTill < now) $ throwError (InvalidRequest "Request has expired")
+    case req.response of
+      Domain.Types.SpecialZoneQueueRequest.Accept -> do
+        mbGate <- Esq.runInReplica $ QGI.findById (Kernel.Types.Id.Id request.gateId)
+        let timeoutSec = maybe 1200 (fromMaybe 1200 . (.pickupZoneArrivalTimeoutInSec)) mbGate
+            arrivalDeadline = addUTCTime (fromIntegral timeoutSec) now
+        QSZQR.updateToAcceptedWithArrivalDeadline requestId arrivalDeadline
+        fork "specialZoneSupplyIncrementOnAccept" $
+          SpecialZoneDriverDemand.runSupplyIncrementForRequest requestId.getId request.gateId request.vehicleType
+        createJobIn @_ @'CheckPickupZoneArrival
+          (Just request.merchantId)
+          (Just request.merchantOperatingCityId)
+          (secondsToNominalDiffTime $ Seconds timeoutSec)
+          CheckPickupZoneArrivalJobData
+            { requestId = requestId.getId,
+              driverId = personId,
+              gateId = request.gateId,
+              specialLocationId = request.specialLocationId,
+              vehicleType = request.vehicleType,
+              merchantId = request.merchantId,
+              merchantOperatingCityId = request.merchantOperatingCityId
+            }
+      _ ->
+        QSZQR.updateResponse (Just req.response) Domain.Types.SpecialZoneQueueRequest.Expired requestId
   pure Kernel.Types.APISuccess.Success
 
 postSpecialZoneQueueRequestCancel ::

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
@@ -165,7 +165,7 @@ sendSearchRequestToDrivers isAllocatorBatch tripQuoteDetails oldSearchReq search
       activeSRFDs <- QSRD.findAllActiveBySTId searchTry.id Active
       let timedOutQueueDrivers = filter (\srfd -> isNothing srfd.response && srfd.pickupZone) activeSRFDs
       forM_ timedOutQueueDrivers $ \srfd ->
-        SpecialZoneDriverDemand.handleQueueSkipIfApplicable searchReq.pickupZoneGateId (show searchTry.vehicleServiceTier) srfd.driverId searchReq.providerId
+        SpecialZoneDriverDemand.handleQueueSkipIfApplicable searchReq.pickupZoneGateId (show searchTry.vehicleServiceTier) srfd.driverId searchReq.providerId (searchTry.id.getId <> ":" <> srfd.driverId.getId)
   whenM (anyM (\driverId -> CQDGR.getDriverGoHomeRequestInfo driverId searchReq.merchantOperatingCityId (Just goHomeConfig) <&> isNothing . (.status)) prevBatchDrivers) $ QSRD.setInactiveBySTId searchTry.id -- inactive previous request by drivers so that they can make new offers.
   _ <- QSRD.createMany searchRequestsForDrivers
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialLocationUpsert.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialLocationUpsert.hs
@@ -288,7 +288,8 @@ makeSpecialLocation locationGeomFiles gateGeomFiles merchantOpCity idx row = do
             notificationCooldownInSec = readMaybeCSVField idx (fromMaybe "" row.gateInfoNotificationCooldownInSec) "Gate Info (notification_cooldown_in_sec)",
             maxRideSkipsBeforeQueueRemoval = readMaybeCSVField idx (fromMaybe "" row.gateInfoMaxRideSkipsBeforeQueueRemoval) "Gate Info (max_ride_skips_before_queue_removal)",
             pickupZoneArrivalTimeoutInSec = readMaybeCSVField idx (fromMaybe "" row.gateInfoPickupZoneArrivalTimeoutInSec) "Gate Info (pickup_zone_arrival_timeout_in_sec)",
-            pickupRequestResponseTimeoutInSec = readMaybeCSVField idx (fromMaybe "" row.gateInfoPickupRequestResponseTimeoutInSec) "Gate Info (pickup_request_response_timeout_in_sec)"
+            pickupRequestResponseTimeoutInSec = readMaybeCSVField idx (fromMaybe "" row.gateInfoPickupRequestResponseTimeoutInSec) "Gate Info (pickup_request_response_timeout_in_sec)",
+            demandTtlInSec = Nothing
           }
   return (city, locationName, (specialLocation, gateInfo), pickupPriority, dropPriority, mbSpecialLocationId)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -77,11 +77,12 @@ incrementGateSearchDemand ::
   ) =>
   Text -> -- gateId
   Text -> -- vehicleVariant
+  Int -> -- TTL in seconds
   m ()
-incrementGateSearchDemand gateId variant = Redis.withCrossAppRedis $ do
+incrementGateSearchDemand gateId variant ttlInSec = Redis.withCrossAppRedis $ do
   let key = mkGateSearchDemandKey gateId variant
   void $ Redis.incr key
-  Redis.expire key 300 -- 5 min sliding window
+  Redis.expire key ttlInSec
 
 -- | Decrement the gate demand counter (clamp at 0). Called when demand is fulfilled or retracted.
 decrementGateSearchDemand ::
@@ -224,7 +225,8 @@ runDemandCheckForVariants merchantOpCityId merchantId pickupZoneGateId variants 
   case mbGate of
     Nothing -> logWarning $ "runDemandCheckForVariants: gate not found id=" <> pickupZoneGateId
     Just gate -> forM_ variants $ \variant -> do
-      incrementGateSearchDemand pickupZoneGateId variant
+      let demandTtl = fromMaybe 300 gate.demandTtlInSec
+      incrementGateSearchDemand pickupZoneGateId variant demandTtl
       checkAndNotifyDriverDemand merchantOpCityId merchantId gate variant
 
 -- | Per-variant demand check. Triggered from Select once an estimate is chosen.
@@ -323,8 +325,9 @@ forceNotifyDriverDemand merchantOpCityId merchantId gate vehicleType needed mbPr
       gateId = gate.id.getId
       cooldown = fromMaybe 900 gate.notificationCooldownInSec
       priorityDriverIds = fromMaybe [] mbPriorityDriverIds
-  -- Notify priority drivers first
-  priorityCount <- notifyDrivers merchantOpCityId merchantId gate specialLocationId vehicleType cooldown priorityDriverIds
+  -- Filter priority drivers through eligibility checks (cooldown, skip count, accepted state)
+  eligiblePriority <- filterEligibleDrivers gate specialLocationId vehicleType merchantId gateId priorityDriverIds
+  priorityCount <- notifyDrivers merchantOpCityId merchantId gate specialLocationId vehicleType cooldown eligiblePriority
   let remaining = max 0 (needed - priorityCount)
   -- Fill remaining from LTS queue
   queueCount <-
@@ -332,7 +335,7 @@ forceNotifyDriverDemand merchantOpCityId merchantId gate vehicleType needed mbPr
       then do
         queueResp <- LTSFlow.getQueueDrivers specialLocationId vehicleType
         let sortedDrivers = sortOn (.queuePosition) queueResp.drivers
-            -- Exclude priority drivers already notified
+            -- Exclude priority drivers already processed
             queueDriverIds = filter (`notElem` priorityDriverIds) $ map (.driverId) sortedDrivers
         eligible <- filterEligibleDrivers gate specialLocationId vehicleType merchantId gateId queueDriverIds
         notifyDrivers merchantOpCityId merchantId gate specialLocationId vehicleType cooldown (take remaining eligible)
@@ -522,18 +525,15 @@ cancelPickupZoneRequestsForDriver ::
   Id DP.Person ->
   m ()
 cancelPickupZoneRequestsForDriver driverId = do
-  -- Same rationale as completePickupZoneRequestsForDriver: look up last Accept
-  -- response regardless of current status so post-arrival Expired rows still
-  -- get their supply retracted.
   mbReq <- QSZQR.findLastAcceptedByDriverId driverId
-  forM_ mbReq $ \req ->
-    -- If the request is already Completed, the pickup-zone commitment was
-    -- already fulfilled (ride confirmed); don't overwrite that history with
-    -- Cancelled/Expired just because the ride was later cancelled.
-    unless (req.status == DSZQR.Completed) $ do
-      QSZQR.updateResponse (Just DSZQR.Cancelled) DSZQR.Expired req.id
-      runSupplyDecrementForRequest req.id.getId req.gateId req.vehicleType
-      logInfo $ "Cancelled pickup zone request " <> req.id.getId <> " after ride cancel by driver " <> driverId.getId
+  forM_ mbReq $ \req -> do
+    let idempotencyKey = "PickupZoneCancel:Done:" <> req.id.getId
+    wasSet <- Redis.withCrossAppRedis $ Redis.setNxExpire idempotencyKey 86400 ("1" :: Text)
+    when wasSet $
+      unless (req.status == DSZQR.Completed) $ do
+        QSZQR.updateResponse (Just DSZQR.Cancelled) DSZQR.Expired req.id
+        runSupplyDecrementForRequest req.id.getId req.gateId req.vehicleType
+        logInfo $ "Cancelled pickup zone request " <> req.id.getId <> " after ride cancel by driver " <> driverId.getId
 
 -- Queue skip handling
 
@@ -551,16 +551,22 @@ handleQueueSkipIfApplicable ::
   Text -> -- vehicleType for LTS queue
   Id DP.Person ->
   Id DM.Merchant ->
+  Text -> -- searchTryId for idempotency
   m ()
-handleQueueSkipIfApplicable Nothing _ _ _ = pure ()
-handleQueueSkipIfApplicable (Just gateId) vehicleType driverId merchantId = do
-  mbGateInfo <- Esq.runInReplica $ QGI.findById (Id gateId)
-  case mbGateInfo >>= (.maxRideSkipsBeforeQueueRemoval) of
-    Nothing -> pure ()
-    Just threshold -> do
-      let slId = maybe "" (.getId) ((.specialLocationId) <$> mbGateInfo)
-      newCount <- incrementQueueSkipCount slId driverId 86400 -- 24hr TTL
-      when (newCount >= threshold) $ do
-        void $ LTSFlow.manualQueueRemove slId vehicleType merchantId driverId
-        resetQueueSkipCount slId driverId
-        logInfo $ "Driver " <> driverId.getId <> " removed from queue at " <> slId <> " after " <> show newCount <> " skips"
+handleQueueSkipIfApplicable Nothing _ _ _ _ = pure ()
+handleQueueSkipIfApplicable (Just gateId) vehicleType driverId merchantId searchTryId = do
+  -- Idempotency: each searchTry should only increment skip count once, even if
+  -- both the allocator timeout and driver reject paths fire.
+  let idempotencyKey = "QueueSkip:Done:" <> searchTryId
+  wasSet <- Redis.withCrossAppRedis $ Redis.setNxExpire idempotencyKey 86400 ("1" :: Text)
+  when wasSet $ do
+    mbGateInfo <- Esq.runInReplica $ QGI.findById (Id gateId)
+    case mbGateInfo >>= (.maxRideSkipsBeforeQueueRemoval) of
+      Nothing -> pure ()
+      Just threshold -> do
+        let slId = maybe "" (.getId) ((.specialLocationId) <$> mbGateInfo)
+        newCount <- incrementQueueSkipCount slId driverId 86400 -- 24hr TTL
+        when (newCount >= threshold) $ do
+          void $ LTSFlow.manualQueueRemove slId vehicleType merchantId driverId
+          resetQueueSkipCount slId driverId
+          logInfo $ "Driver " <> driverId.getId <> " removed from queue at " <> slId <> " after " <> show newCount <> " skips"

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Merchant.hs
@@ -452,6 +452,7 @@ postMerchantSpecialLocationGatesUpsert _merchantShortId _city specialLocationId 
             maxRideSkipsBeforeQueueRemoval = mbGate >>= (.maxRideSkipsBeforeQueueRemoval),
             pickupZoneArrivalTimeoutInSec = mbGate >>= (.pickupZoneArrivalTimeoutInSec),
             pickupRequestResponseTimeoutInSec = mbGate >>= (.pickupRequestResponseTimeoutInSec),
+            demandTtlInSec = mbGate >>= (.demandTtlInSec),
             ..
           }
 
@@ -1604,7 +1605,8 @@ postMerchantConfigSpecialLocationUpsert merchantShortId opCity req = do
                 notificationCooldownInSec = Nothing,
                 maxRideSkipsBeforeQueueRemoval = Nothing,
                 pickupZoneArrivalTimeoutInSec = Nothing,
-                pickupRequestResponseTimeoutInSec = Nothing
+                pickupRequestResponseTimeoutInSec = Nothing,
+                demandTtlInSec = Nothing
               }
       return (city, locationName, (specialLocation, gateInfo), mbSpecialLocationId)
 

--- a/Backend/dev/migrations-read-only/provider-dashboard/Local_API_Management_SpecialZoneQueue.sql
+++ b/Backend/dev/migrations-read-only/provider-dashboard/Local_API_Management_SpecialZoneQueue.sql
@@ -21,3 +21,9 @@ INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_acc
 
 -- {"api":"PostSpecialZoneQueueManualQueueRemove","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bpp_dashboard"}
 INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bpp_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'PROVIDER_MANAGEMENT/SPECIAL_ZONE_QUEUE/POST_SPECIAL_ZONE_QUEUE_MANUAL_QUEUE_REMOVE' ) ON CONFLICT DO NOTHING;
+
+
+------- SQL updates -------
+
+-- {"api":"GetSpecialZoneQueueDriverQueuePosition","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bpp_dashboard"}
+INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bpp_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'PROVIDER_MANAGEMENT/SPECIAL_ZONE_QUEUE/GET_SPECIAL_ZONE_QUEUE_DRIVER_QUEUE_POSITION' ) ON CONFLICT DO NOTHING;

--- a/Backend/dev/migrations/dynamic-offer-driver-app/0805-add-demand-ttl-in-sec-to-gate-info.sql
+++ b/Backend/dev/migrations/dynamic-offer-driver-app/0805-add-demand-ttl-in-sec-to-gate-info.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_driver_offer_bpp.gate_info ADD COLUMN demand_ttl_in_sec integer;

--- a/Backend/dev/migrations/rider-app/1526-add-demand-ttl-in-sec-to-gate-info.sql
+++ b/Backend/dev/migrations/rider-app/1526-add-demand-ttl-in-sec-to-gate-info.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_app.gate_info ADD COLUMN demand_ttl_in_sec integer;

--- a/Backend/lib/special-zone/src/Lib/Tabular/GateInfo.hs
+++ b/Backend/lib/special-zone/src/Lib/Tabular/GateInfo.hs
@@ -61,6 +61,7 @@ mkPersist
       maxRideSkipsBeforeQueueRemoval Int Maybe
       pickupZoneArrivalTimeoutInSec Int Maybe
       pickupRequestResponseTimeoutInSec Int Maybe
+      demandTtlInSec Int Maybe
       Primary id
       deriving Generic
     |]

--- a/Backend/lib/special-zone/src/Lib/Tabular/GateInfoGeom.hs
+++ b/Backend/lib/special-zone/src/Lib/Tabular/GateInfoGeom.hs
@@ -59,6 +59,7 @@ mkPersist
       maxRideSkipsBeforeQueueRemoval Int Maybe
       pickupZoneArrivalTimeoutInSec Int Maybe
       pickupRequestResponseTimeoutInSec Int Maybe
+      demandTtlInSec Int Maybe
       Primary id
       deriving Generic
     |]

--- a/Backend/lib/special-zone/src/Lib/Types/GateInfo.hs
+++ b/Backend/lib/special-zone/src/Lib/Types/GateInfo.hs
@@ -43,7 +43,8 @@ data GateInfoFull = GateInfoFull
     notificationCooldownInSec :: Maybe Int,
     maxRideSkipsBeforeQueueRemoval :: Maybe Int,
     pickupZoneArrivalTimeoutInSec :: Maybe Int,
-    pickupRequestResponseTimeoutInSec :: Maybe Int
+    pickupRequestResponseTimeoutInSec :: Maybe Int,
+    demandTtlInSec :: Maybe Int
   }
   deriving (Generic, Show, Eq, FromJSON, ToJSON, ToSchema)
 
@@ -79,7 +80,8 @@ data GateInfo = GateInfo
     notificationCooldownInSec :: Maybe Int,
     maxRideSkipsBeforeQueueRemoval :: Maybe Int,
     pickupZoneArrivalTimeoutInSec :: Maybe Int,
-    pickupRequestResponseTimeoutInSec :: Maybe Int
+    pickupRequestResponseTimeoutInSec :: Maybe Int,
+    demandTtlInSec :: Maybe Int
   }
   deriving (Generic, Show, Eq, FromJSON, ToJSON, ToSchema)
 


### PR DESCRIPTION
## Summary
- **Bug 1**: Force-notify priority drivers now go through `filterEligibleDrivers` (skip/cooldown/accepted checks) instead of being notified blindly
- **Bug 2**: Demand counter TTL is configurable via `gate_info.demand_ttl_in_sec` instead of hardcoded 300s; migration adds column to both driver-app and rider-app schemas
- **Bug 3**: `postSpecialZoneQueueRequestRespond` uses Redis lock (`whenWithLockRedis`) to prevent race between GET handler's lazy-expire and POST respond; `collectValidActive` re-reads before expiring
- **Bug 4**: Skip count increment and cancel supply decrement use Redis SETNX idempotency keys to prevent double-counting
- **Bug 5**: New dashboard API `GET /driverQueuePosition?driverId=&specialLocationId=&vehicleType=` to look up a driver's queue position by driverId via LTS `getQueueDriverPosition`

## Migrations
- `0805-add-demand-ttl-in-sec-to-gate-info.sql` (driver-app)
- `1526-add-demand-ttl-in-sec-to-gate-info.sql` (rider-app)
- Access matrix entry for `GET_SPECIAL_ZONE_QUEUE_DRIVER_QUEUE_POSITION`

## Test plan
- [ ] Verify force-notify with priority drivers respects skip count and cooldown
- [ ] Set `demand_ttl_in_sec` on a gate and verify demand counter expires at configured TTL
- [ ] Rapid accept/reject on a request — verify no double supply count via Redis lock
- [ ] Cancel a ride twice in quick succession — verify single supply decrement via idempotency key
- [ ] Call dashboard `driverQueuePosition` API with a queued driver — verify correct position returned
- [ ] Call dashboard `driverQueuePosition` API with a non-queued driver — verify null position returned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoint to query driver queue position in special zones with queue size information.
  * Added configurable demand time-to-live setting for gate management.

* **Bug Fixes**
  * Improved queue state consistency with concurrency protection and idempotency safeguards.
  * Enhanced expiration handling for queue requests to prevent race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->