### PR TITLE
backend/fix: use vehicle variant for demand keys and guard with isQueueEnabled

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
@@ -167,10 +167,11 @@ handler merchantId req validatedReq = do
       <> " searchRequestId="
       <> searchRequest.id.getId
   whenJust searchRequest.pickupZoneGateId $ \pickupZoneGateId -> do
+    let vehicleVariant = Veh.castServiceTierToVariant booking.vehicleServiceTier
     logInfo $
       "Firing special zone demand pipeline from Init for gateId=" <> pickupZoneGateId
         <> " variant="
-        <> show booking.vehicleServiceTier
+        <> show vehicleVariant
         <> " searchRequestId="
         <> searchRequest.id.getId
     fork "specialZoneDriverDemandPipeline" $
@@ -178,7 +179,7 @@ handler merchantId req validatedReq = do
         searchRequest.merchantOperatingCityId
         merchantId
         pickupZoneGateId
-        [show booking.vehicleServiceTier]
+        [show vehicleVariant]
   fork "Updating Demand Hotspots on booking" $ do
     let lat = searchRequest.fromLocation.lat
         lon = searchRequest.fromLocation.lon

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -228,10 +228,16 @@ runDemandCheckForVariants merchantOpCityId merchantId pickupZoneGateId variants 
   mbGate <- Esq.runInReplica $ QGI.findById (Id pickupZoneGateId)
   case mbGate of
     Nothing -> logWarning $ "runDemandCheckForVariants: gate not found id=" <> pickupZoneGateId
-    Just gate -> forM_ variants $ \variant -> do
-      let demandTtl = fromMaybe 300 gate.demandTtlInSec
-      incrementGateSearchDemand pickupZoneGateId variant demandTtl
-      checkAndNotifyDriverDemand merchantOpCityId merchantId gate variant
+    Just gate -> do
+      mbSpecialLocation <- Esq.runInReplica $ QSL.findById gate.specialLocationId
+      let isQueueEnabled = fromMaybe False (mbSpecialLocation >>= (.isQueueEnabled))
+      unless isQueueEnabled $
+        logDebug $ "runDemandCheckForVariants: queue not enabled for specialLocation=" <> gate.specialLocationId.getId <> ", skipping"
+      when isQueueEnabled $
+        forM_ variants $ \variant -> do
+          let demandTtl = fromMaybe 300 gate.demandTtlInSec
+          incrementGateSearchDemand pickupZoneGateId variant demandTtl
+          checkAndNotifyDriverDemand merchantOpCityId merchantId gate variant
 
 -- | Per-variant demand check. Triggered from Select once an estimate is chosen.
 --   Compares per-variant demand against the gate's demand threshold; when it's hit and


### PR DESCRIPTION
## Summary
- **Demand key mismatch fix**: `Init.hs` was passing `show booking.vehicleServiceTier` (e.g. `COMFY`) as the demand key variant, but supply side uses the driver's vehicle variant (e.g. `SEDAN`). Demand and supply Redis keys never matched. Fixed by using `castServiceTierToVariant` to map service tier to vehicle variant before passing to demand pipeline.
- **isQueueEnabled guard**: `runDemandCheckForVariants` now checks `isQueueEnabled` on the gate's special location before creating demand/supply Redis keys. Prevents unnecessary Redis keys for special locations where queue is not enabled.

## Test plan
- [ ] Book a COMFY ride at a queue-enabled special location → verify demand Redis key uses `SEDAN` (not `COMFY`)
- [ ] Book at a special location with `isQueueEnabled = false` → verify no demand Redis keys are created
- [ ] Book at a special location with `isQueueEnabled = true` → verify demand pipeline fires normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle variant selection for special zone driver demand processing.
  * Added queue enablement check for special zone driver notifications—driver demand processing now conditionally executes based on queue status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->