### PR TITLE
backend/fix: use casted vehicle variant in all demand decrement call sites

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
@@ -132,7 +132,7 @@ handler merchant req validatedQuote = do
       -- Booking confirmed: decrement demand at this pickup gate AND complete any
       -- Accepted pickup-zone request for this driver (supply -1). Idempotent with StartRide.
       fork "specialZoneCompletePickupZoneOnConfirm" $
-        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driver.id uBooking2.id.getId uBooking2.pickupGateId (show uBooking2.vehicleServiceTier)
+        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driver.id uBooking2.id.getId uBooking2.pickupGateId (show $ DV.castServiceTierToVariant uBooking2.vehicleServiceTier)
       mkDConfirmResp (Just $ RideInfo {ride, driver, vehicle}) uBooking2 riderDetails
 
     handleRideOtpFlow isNewRider _ booking riderDetails = do
@@ -156,7 +156,7 @@ handler merchant req validatedQuote = do
       (ride, _, vehicle) <- initializeRide merchant driver uBooking dynamicReferralCode (Just req.enableFrequentLocationUpdates) Nothing (Just req.enableOtpLessRide) (mFleetOwnerId <&> (.fleetOwnerId) <&> Id)
       uBooking2 <- QRB.findById booking.id >>= fromMaybeM (BookingNotFound booking.id.getId)
       fork "specialZoneCompletePickupZoneOnMeterConfirm" $
-        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driver.id uBooking2.id.getId uBooking2.pickupGateId (show uBooking2.vehicleServiceTier)
+        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driver.id uBooking2.id.getId uBooking2.pickupGateId (show $ DV.castServiceTierToVariant uBooking2.vehicleServiceTier)
       mkDConfirmResp (Just $ RideInfo {ride, driver, vehicle}) uBooking2 riderDetails
 
     generateUniqueOTPCode merchantOperatingCityId cnt = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -82,6 +82,7 @@ import SharedLogic.GoogleTranslate (TranslateFlow)
 import SharedLogic.Ride (releaseLien, updateOnRideStatusWithAdvancedRideCheck)
 import SharedLogic.RuleBasedTierUpgrade
 import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
+import qualified Domain.Types.VehicleVariant as Veh
 import qualified SharedLogic.UserCancellationDues as UserCancellationDues
 import qualified Storage.Cac.TransporterConfig as CCT
 import qualified Storage.CachedQueries.Driver.GoHomeRequest as CQDGR
@@ -199,7 +200,7 @@ cancelRideImpl rideId rideEndedBy bookingCReason isForceReallocation doCancellat
             -- Only applies to pickup-gate bookings cancelled by the user (ByDriver cancels keep demand live).
             when (bookingCReason.source == SBCR.ByUser && isJust booking.pickupGateId) $
               fork "specialZoneDemandDecrementOnCancel" $
-                SpecialZoneDriverDemand.runDemandDecrementForBooking booking.id.getId booking.pickupGateId (show booking.vehicleServiceTier)
+                SpecialZoneDriverDemand.runDemandDecrementForBooking booking.id.getId booking.pickupGateId (show $ Veh.castServiceTierToVariant booking.vehicleServiceTier)
             -- Supply decrement: driver cancelled pre-start ride → retract the pickup-zone commitment.
             when (bookingCReason.source == SBCR.ByDriver) $
               fork "specialZoneSupplyDecrementOnDriverCancel" $

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
@@ -70,6 +70,7 @@ import qualified SharedLogic.IffcoTokioInsurance as IffcoInsurance
 import SharedLogic.Ride (calculateEstimatedEndTimeRange, getPayoutVpaForRide, isKaaliPeeliBooking)
 import qualified SharedLogic.ScheduledNotifications as SN
 import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
+import qualified Domain.Types.VehicleVariant as Veh
 import Storage.Beam.Payment ()
 import Storage.Cac.TransporterConfig as SCTC
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
@@ -225,7 +226,7 @@ startRide ServiceHandle {..} rideId req = withLogTag ("rideId-" <> rideId.getId)
       fork "notify customer for ride start" $ notifyBAPRideStarted booking updatedRide (Just point)
       fork "startRide - Notify driver" $ Notify.notifyOnRideStarted ride booking
       fork "startRide - Complete pickup zone request" $
-        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driverId booking.id.getId booking.pickupGateId (show booking.vehicleServiceTier)
+        SpecialZoneDriverDemand.completePickupZoneRequestsForDriver driverId booking.id.getId booking.pickupGateId (show $ Veh.castServiceTierToVariant booking.vehicleServiceTier)
       if isInterCityTrip booking.tripCategory || isRentalTrip booking.tripCategory
         then logTagInfo "IffcoTokio driver insurance skipped" ("tripCategory=" <> show booking.tripCategory <> ", rideId=" <> ride.id.getId)
         else fork "IffcoTokio driver insurance" $ IffcoInsurance.triggerIffcoTokioInsurance driverId booking.providerId ride.merchantOperatingCityId


### PR DESCRIPTION
## Summary
- Fixes demand decrement call sites in Confirm.hs, StartRide.hs, and CancelRide/Internal.hs to use `castServiceTierToVariant` instead of raw `vehicleServiceTier`
- The demand keys use vehicle variant (e.g. `SEDAN`) but decrements were passing service tier (e.g. `COMFY`), causing decrements to be no-ops since the keys never matched
- Follow-up to PR #14463 which fixed the increment side

## Test plan
- [ ] Verify demand Redis keys (`DriverDemand:Gate:<gateId>:<variant>`) are correctly decremented on booking confirm, ride start, and ride cancel
- [ ] Confirm decrement uses `SEDAN`/`SUV`/`HATCHBACK` (vehicle variant) instead of `COMFY`/`ECO`/`PREMIUM` (service tier)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal handling of service tier representation across multiple ride operation workflows to improve data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->