### PR TITLE
fix: ride vat backward compatiblity

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareCalculator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareCalculator.hs
@@ -106,6 +106,14 @@ mkFareParamsBreakups mkPrice mkBreakupItem fareParams = do
       mbFixedGovtRateCaption = show Enums.FIXED_GOVERNMENT_RATE
       mbFixedGovtRateItem = mkBreakupItem mbFixedGovtRateCaption . mkPrice <$> fareParams.govtCharges
 
+      -- Backward compat: emit RIDE_VAT for VAT-type rides (isVatTaxType=True)
+      -- govtCharges holds the merged VAT value (set by FareCalculatorV2)
+      mbRideVatCaption = show Enums.RIDE_VAT
+      mbRideVatItem =
+        if fromMaybe False fareParams.isVatTaxType
+          then mkBreakupItem mbRideVatCaption . mkPrice <$> fareParams.govtCharges
+          else Nothing
+
       customerCancellationDuesCaption = show Enums.CANCELLATION_CHARGES
       mbCustomerCancellationDues = mkBreakupItem customerCancellationDuesCaption . mkPrice <$> fareParams.customerCancellationDues
 
@@ -168,6 +176,7 @@ mkFareParamsBreakups mkPrice mkBreakupItem fareParams = do
       mbBusinessDiscountItem,
       mbPersonalDiscountItem,
       mbFixedGovtRateItem,
+      mbRideVatItem,
       mbPetChargesItem,
       mbDriverAllowanceItem,
       mbAirportConvenienceFeeItem,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced fare transparency with VAT support: when applicable, a dedicated VAT line item is shown in the fare breakdown alongside other components. It is calculated from relevant government charges and only appears when VAT applies, giving clearer visibility into tax-inclusive fare details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->