### PR TITLE
backend/fix/round-off-fare-for-inr

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
@@ -43,7 +43,7 @@ import GHC.Generics (Generic)
 import Kernel.Beam.Functions (runInReplica)
 import Kernel.Prelude (roundToIntegral)
 import Kernel.Types.CacheFlow (CacheFlow)
-import Kernel.Types.Common (BaseUrl, Distance, EncFlow, EsqDBFlow, HighPrecMeters, HighPrecMoney, Meters, Money, Months, PriceAPIEntity (..), Seconds, convertHighPrecMetersToDistance, convertMetersToDistance)
+import Kernel.Types.Common (BaseUrl, Distance, EncFlow, EsqDBFlow, HighPrecMeters, HighPrecMoney, Meters, Money, Months, PriceAPIEntity (..), Seconds, convertHighPrecMetersToDistance, convertMetersToDistance, roundAmountByCurrency)
 import Kernel.Types.Confidence (Confidence)
 import Kernel.Types.Id
 import qualified Lib.Queries.GateInfo as QGI
@@ -233,11 +233,11 @@ mkDriverRideRes rideDetails driverNumber rideRating mbExophone (ride, booking) b
         vehicleVariant = fromMaybe DVeh.SEDAN rideDetails.vehicleVariant,
         vehicleModel = fromMaybe initial rideDetails.vehicleModel,
         computedFare = roundToIntegral <$> ride.fare,
-        computedFareWithCurrency = (\fare -> PriceAPIEntity (fromIntegral (round fare :: Integer)) ride.currency) <$> ride.fare,
+        computedFareWithCurrency = (\fare -> PriceAPIEntity (roundAmountByCurrency ride.currency fare) ride.currency) <$> ride.fare,
         estimatedDuration = booking.estimatedDuration,
         actualDuration = roundToIntegral <$> (diffUTCTime <$> ride.tripEndTime <*> ride.tripStartTime),
         estimatedBaseFare = roundToIntegral estimatedBaseFare,
-        estimatedBaseFareWithCurrency = PriceAPIEntity (fromIntegral (round estimatedBaseFare :: Integer)) ride.currency,
+        estimatedBaseFareWithCurrency = PriceAPIEntity (roundAmountByCurrency ride.currency estimatedBaseFare) ride.currency,
         estimatedDistance = booking.estimatedDistance,
         estimatedDistanceWithUnit = convertMetersToDistance booking.distanceUnit <$> booking.estimatedDistance,
         driverSelectedFare = roundToIntegral $ fromMaybe 0.0 fareParams.driverSelectedFare,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SearchRequestForDriver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SearchRequestForDriver.hs
@@ -143,7 +143,7 @@ makeSearchRequestForDriverAPIEntity nearbyReq searchRequest searchTry bapMetadat
           distanceToPickupWithUnit = convertMetersToDistance nearbyReq.distanceUnit nearbyReq.actualDistanceToPickup,
           durationToPickup = nearbyReq.durationToPickup,
           baseFare = roundToIntegral $ fromMaybe searchTry.baseFare nearbyReq.baseFare, -- short term, later remove searchTry.baseFare
-          baseFareWithCurrency = PriceAPIEntity (fromIntegral (round (fromMaybe searchTry.baseFare nearbyReq.baseFare) :: Integer)) nearbyReq.currency,
+          baseFareWithCurrency = PriceAPIEntity (roundAmountByCurrency nearbyReq.currency (fromMaybe searchTry.baseFare nearbyReq.baseFare)) nearbyReq.currency,
           customerExtraFee = roundToIntegral <$> searchTry.customerExtraFee,
           customerExtraFeeWithCurrency = flip PriceAPIEntity searchTry.currency <$> searchTry.customerExtraFee,
           fromLocation = convertDomainType searchRequest.fromLocation,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fare calculation accuracy by implementing currency-specific rounding for ride fares and estimated base fares. Fares are now rounded according to the rules of each currency rather than using generic rounding, ensuring more precise fare displays across different currencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->