### PR TITLE
backend/fix: Use merchant name in invoice emails

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/InvoiceGeneration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/InvoiceGeneration.hs
@@ -255,8 +255,8 @@ generateAndEmailInvoice invoiceId person bookingAPIEntities merchantId email = d
     throwError $ InternalError "Invoice file generation failed - file not found"
 
   -- Send email with PDF attachment
-  let subject = "Your Namma Yatri Invoice - " <> invoiceId.getId
-      bodyText = buildInvoiceEmailBody invoiceId.getId
+  let subject = "Your " <> merchant.name <> " Invoice - " <> invoiceId.getId
+      bodyText = buildInvoiceEmailBody invoiceId.getId merchant.name
       fileName = "invoice_" <> invoiceId.getId <> ".pdf"
 
   emailServiceConfig <- asks (.emailServiceConfig)
@@ -266,19 +266,19 @@ generateAndEmailInvoice invoiceId person bookingAPIEntities merchantId email = d
   logInfo $ "Invoice PDF generated and emailed successfully for invoiceId: " <> invoiceId.getId
 
 -- | Build plain text email body for invoice
-buildInvoiceEmailBody :: Text -> Text
-buildInvoiceEmailBody invoiceId =
+buildInvoiceEmailBody :: Text -> Text -> Text
+buildInvoiceEmailBody invoiceId appName =
   T.unlines
     [ "Dear Customer,",
       "",
-      "Please find attached your Namma Yatri invoice (" <> invoiceId <> ") for the requested period.",
+      "Please find attached your " <> appName <> " invoice (" <> invoiceId <> ") for the requested period.",
       "",
       "The invoice contains details of all your rides during the selected date range.",
       "",
       "If you have any questions or concerns, please contact our support team.",
       "",
-      "Thank you for choosing Namma Yatri!",
+      "Thank you for choosing " <> appName <> "!",
       "",
       "Best regards,",
-      "Namma Yatri Team"
+      appName <> " Team"
     ]


### PR DESCRIPTION
## Summary
- Replaced hardcoded "Namma Yatri" with `merchant.name` in the invoice email subject, body, and sign-off
- No new lookups needed — `merchant` was already fetched in `generateAndEmailInvoice`
- Ensures correct branding for all merchants (e.g. Yatri Sathi, Booth Taxi)

## Test plan
- [ ] Trigger invoice generation for a non-Namma Yatri merchant and verify the email subject/body uses that merchant's name
- [ ] Trigger invoice generation for Namma Yatri merchant and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice emails now display merchant-specific branding with the merchant's name in both the subject line and email body instead of generic application wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->