### PR TITLE
backend/fix: Use merchant name in invoice emails

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/InvoiceGeneration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/InvoiceGeneration.hs
@@ -255,8 +255,8 @@ generateAndEmailInvoice invoiceId person bookingAPIEntities merchantId email = d
     throwError $ InternalError "Invoice file generation failed - file not found"
 
   -- Send email with PDF attachment
-  let subject = "Your Namma Yatri Invoice - " <> invoiceId.getId
-      bodyText = buildInvoiceEmailBody invoiceId.getId
+  let subject = "Your " <> merchant.name <> " Invoice - " <> invoiceId.getId
+      bodyText = buildInvoiceEmailBody invoiceId.getId merchant.name
       fileName = "invoice_" <> invoiceId.getId <> ".pdf"
 
   emailServiceConfig <- asks (.emailServiceConfig)
@@ -266,19 +266,19 @@ generateAndEmailInvoice invoiceId person bookingAPIEntities merchantId email = d
   logInfo $ "Invoice PDF generated and emailed successfully for invoiceId: " <> invoiceId.getId
 
 -- | Build plain text email body for invoice
-buildInvoiceEmailBody :: Text -> Text
-buildInvoiceEmailBody invoiceId =
+buildInvoiceEmailBody :: Text -> Text -> Text
+buildInvoiceEmailBody invoiceId appName =
   T.unlines
     [ "Dear Customer,",
       "",
-      "Please find attached your Namma Yatri invoice (" <> invoiceId <> ") for the requested period.",
+      "Please find attached your " <> appName <> " invoice (" <> invoiceId <> ") for the requested period.",
       "",
       "The invoice contains details of all your rides during the selected date range.",
       "",
       "If you have any questions or concerns, please contact our support team.",
       "",
-      "Thank you for choosing Namma Yatri!",
+      "Thank you for choosing " <> appName <> "!",
       "",
       "Best regards,",
-      "Namma Yatri Team"
+      appName <> " Team"
     ]


### PR DESCRIPTION
## Summary
- Cherry-pick of da9865372b from main PR #14547
- Replaced hardcoded "Namma Yatri" with `merchant.name` in the invoice email subject, body, and sign-off
- Ensures correct branding for all merchants (e.g. Yatri Sathi, Booth Taxi)

## Test plan
- [ ] Trigger invoice generation for a non-Namma Yatri merchant and verify the email subject/body uses that merchant's name
- [ ] Trigger invoice generation for Namma Yatri merchant and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)