### PR TITLE
backend/feat: Expose driver wallet balance to BPP dashboard

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/AppManagement/API/DriverWallet.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/AppManagement/API/DriverWallet.yaml
@@ -1,5 +1,6 @@
 imports:
   Driver: Domain.Types.Person
+  WalletBalanceResponse: API.Types.UI.DriverWallet
   WalletSummaryResponse: API.Types.UI.DriverWallet
   TopUpRequest: API.Types.UI.DriverWallet
   PayoutHistoryResponse: API.Types.UI.DriverWallet
@@ -17,6 +18,13 @@ importPackageOverrides:
 module: DriverWallet
 
 apis:
+  - GET:
+      endpoint: /wallet/{driverId}/balance
+      auth: ApiAuthV2
+      params:
+        driverId: Id Driver
+      response:
+        type: WalletBalanceResponse
   - GET:
       endpoint: /wallet/{driverId}/transactions
       auth: ApiAuthV2
@@ -68,5 +76,6 @@ apis:
 
 types:
   AirportCashRechargeRequest:
-    amount: HighPrecMoney
-    referenceId: Text
+    - amount: HighPrecMoney
+    - referenceId: Text
+    - derive: "'HideSecrets"

--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/AppManagement/API/DriverWallet.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/AppManagement/API/DriverWallet.yaml
@@ -1,6 +1,5 @@
 imports:
   Driver: Domain.Types.Person
-  WalletBalanceResponse: API.Types.UI.DriverWallet
   WalletSummaryResponse: API.Types.UI.DriverWallet
   TopUpRequest: API.Types.UI.DriverWallet
   PayoutHistoryResponse: API.Types.UI.DriverWallet

--- a/Backend/app/dashboard/provider-dashboard/src-read-only/API/Action/ProviderPlatform/AppManagement/DriverWallet.hs
+++ b/Backend/app/dashboard/provider-dashboard/src-read-only/API/Action/ProviderPlatform/AppManagement/DriverWallet.hs
@@ -26,52 +26,63 @@ import Servant
 import Storage.Beam.CommonInstances ()
 import Tools.Auth.Api
 
-type API = ("driverWallet" :> (GetDriverWalletWalletTransactions :<|> PostDriverWalletWalletPayout :<|> PostDriverWalletWalletTopup :<|> PostDriverWalletWalletAirportCashRecharge :<|> GetDriverWalletWalletPayoutHistory))
+type API = ("driverWallet" :> (GetDriverWalletWalletBalance :<|> GetDriverWalletWalletTransactions :<|> PostDriverWalletWalletPayout :<|> PostDriverWalletWalletTopup :<|> PostDriverWalletWalletAirportCashRecharge :<|> GetDriverWalletWalletPayoutHistory))
 
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API)
-handler merchantId city = getDriverWalletWalletTransactions merchantId city :<|> postDriverWalletWalletPayout merchantId city :<|> postDriverWalletWalletTopup merchantId city :<|> postDriverWalletWalletAirportCashRecharge merchantId city :<|> getDriverWalletWalletPayoutHistory merchantId city
+handler merchantId city = getDriverWalletWalletBalance merchantId city :<|> getDriverWalletWalletTransactions merchantId city :<|> postDriverWalletWalletPayout merchantId city :<|> postDriverWalletWalletTopup merchantId city :<|> postDriverWalletWalletAirportCashRecharge merchantId city :<|> getDriverWalletWalletPayoutHistory merchantId city
+
+type GetDriverWalletWalletBalance =
+  ( ApiAuth
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_APP_MANAGEMENT) / ('API.Types.Dashboard.AppManagement.DRIVER_WALLET) / ('API.Types.Dashboard.AppManagement.DriverWallet.GET_DRIVER_WALLET_WALLET_BALANCE))
+      :> API.Types.Dashboard.AppManagement.DriverWallet.GetDriverWalletWalletBalance
+  )
 
 type GetDriverWalletWalletTransactions =
   ( ApiAuth
-      'DRIVER_OFFER_BPP_MANAGEMENT
-      'DSL
-      ('PROVIDER_APP_MANAGEMENT / 'API.Types.Dashboard.AppManagement.DRIVER_WALLET / 'API.Types.Dashboard.AppManagement.DriverWallet.GET_DRIVER_WALLET_WALLET_TRANSACTIONS)
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_APP_MANAGEMENT) / ('API.Types.Dashboard.AppManagement.DRIVER_WALLET) / ('API.Types.Dashboard.AppManagement.DriverWallet.GET_DRIVER_WALLET_WALLET_TRANSACTIONS))
       :> API.Types.Dashboard.AppManagement.DriverWallet.GetDriverWalletWalletTransactions
   )
 
 type PostDriverWalletWalletPayout =
   ( ApiAuth
-      'DRIVER_OFFER_BPP_MANAGEMENT
-      'DSL
-      ('PROVIDER_APP_MANAGEMENT / 'API.Types.Dashboard.AppManagement.DRIVER_WALLET / 'API.Types.Dashboard.AppManagement.DriverWallet.POST_DRIVER_WALLET_WALLET_PAYOUT)
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_APP_MANAGEMENT) / ('API.Types.Dashboard.AppManagement.DRIVER_WALLET) / ('API.Types.Dashboard.AppManagement.DriverWallet.POST_DRIVER_WALLET_WALLET_PAYOUT))
       :> API.Types.Dashboard.AppManagement.DriverWallet.PostDriverWalletWalletPayout
   )
 
 type PostDriverWalletWalletTopup =
   ( ApiAuth
-      'DRIVER_OFFER_BPP_MANAGEMENT
-      'DSL
-      ('PROVIDER_APP_MANAGEMENT / 'API.Types.Dashboard.AppManagement.DRIVER_WALLET / 'API.Types.Dashboard.AppManagement.DriverWallet.POST_DRIVER_WALLET_WALLET_TOPUP)
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_APP_MANAGEMENT) / ('API.Types.Dashboard.AppManagement.DRIVER_WALLET) / ('API.Types.Dashboard.AppManagement.DriverWallet.POST_DRIVER_WALLET_WALLET_TOPUP))
       :> API.Types.Dashboard.AppManagement.DriverWallet.PostDriverWalletWalletTopup
   )
 
 type PostDriverWalletWalletAirportCashRecharge =
   ( ApiAuth
-      'DRIVER_OFFER_BPP_MANAGEMENT
-      'DSL
-      ('PROVIDER_APP_MANAGEMENT / 'API.Types.Dashboard.AppManagement.DRIVER_WALLET / 'API.Types.Dashboard.AppManagement.DriverWallet.POST_DRIVER_WALLET_WALLET_AIRPORT_CASH_RECHARGE)
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_APP_MANAGEMENT) / ('API.Types.Dashboard.AppManagement.DRIVER_WALLET) / ('API.Types.Dashboard.AppManagement.DriverWallet.POST_DRIVER_WALLET_WALLET_AIRPORT_CASH_RECHARGE))
       :> API.Types.Dashboard.AppManagement.DriverWallet.PostDriverWalletWalletAirportCashRecharge
   )
 
 type GetDriverWalletWalletPayoutHistory =
   ( ApiAuth
-      'DRIVER_OFFER_BPP_MANAGEMENT
-      'DSL
-      ('PROVIDER_APP_MANAGEMENT / 'API.Types.Dashboard.AppManagement.DRIVER_WALLET / 'API.Types.Dashboard.AppManagement.DriverWallet.GET_DRIVER_WALLET_WALLET_PAYOUT_HISTORY)
+      ('DRIVER_OFFER_BPP_MANAGEMENT)
+      ('DSL)
+      (('PROVIDER_APP_MANAGEMENT) / ('API.Types.Dashboard.AppManagement.DRIVER_WALLET) / ('API.Types.Dashboard.AppManagement.DriverWallet.GET_DRIVER_WALLET_WALLET_PAYOUT_HISTORY))
       :> API.Types.Dashboard.AppManagement.DriverWallet.GetDriverWalletWalletPayoutHistory
   )
 
-getDriverWalletWalletTransactions :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Environment.FlowHandler API.Types.UI.DriverWallet.WalletSummaryResponse)
+getDriverWalletWalletBalance :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Environment.FlowHandler API.Types.UI.DriverWallet.WalletBalanceResponse)
+getDriverWalletWalletBalance merchantShortId opCity apiTokenInfo driverId = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.AppManagement.DriverWallet.getDriverWalletWalletBalance merchantShortId opCity apiTokenInfo driverId
+
+getDriverWalletWalletTransactions :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Environment.FlowHandler API.Types.UI.DriverWallet.WalletSummaryResponse)
 getDriverWalletWalletTransactions merchantShortId opCity apiTokenInfo driverId fromDate toDate = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.AppManagement.DriverWallet.getDriverWalletWalletTransactions merchantShortId opCity apiTokenInfo driverId fromDate toDate
 
 postDriverWalletWalletPayout :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
@@ -83,5 +94,5 @@ postDriverWalletWalletTopup merchantShortId opCity apiTokenInfo driverId req = w
 postDriverWalletWalletAirportCashRecharge :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> API.Types.Dashboard.AppManagement.DriverWallet.AirportCashRechargeRequest -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postDriverWalletWalletAirportCashRecharge merchantShortId opCity apiTokenInfo driverId req = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.AppManagement.DriverWallet.postDriverWalletWalletAirportCashRecharge merchantShortId opCity apiTokenInfo driverId req
 
-getDriverWalletWalletPayoutHistory :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe [Lib.Payment.Domain.Types.PayoutRequest.PayoutRequestStatus] -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Environment.FlowHandler API.Types.UI.DriverWallet.PayoutHistoryResponse)
+getDriverWalletWalletPayoutHistory :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe ([Lib.Payment.Domain.Types.PayoutRequest.PayoutRequestStatus]) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Environment.FlowHandler API.Types.UI.DriverWallet.PayoutHistoryResponse)
 getDriverWalletWalletPayoutHistory merchantShortId opCity apiTokenInfo driverId from to status limit offset = withFlowHandlerAPI' $ Domain.Action.ProviderPlatform.AppManagement.DriverWallet.getDriverWalletWalletPayoutHistory merchantShortId opCity apiTokenInfo driverId from to status limit offset

--- a/Backend/app/dashboard/provider-dashboard/src/Domain/Action/ProviderPlatform/AppManagement/DriverWallet.hs
+++ b/Backend/app/dashboard/provider-dashboard/src/Domain/Action/ProviderPlatform/AppManagement/DriverWallet.hs
@@ -1,7 +1,8 @@
 {-# OPTIONS_GHC -Wwarn=unused-imports #-}
 
 module Domain.Action.ProviderPlatform.AppManagement.DriverWallet
-  ( getDriverWalletWalletTransactions,
+  ( getDriverWalletWalletBalance,
+    getDriverWalletWalletTransactions,
     postDriverWalletWalletPayout,
     postDriverWalletWalletTopup,
     postDriverWalletWalletAirportCashRecharge,
@@ -28,6 +29,11 @@ import qualified SharedLogic.Transaction
 import Storage.Beam.CommonInstances ()
 import Tools.Auth.Api
 import Tools.Auth.Merchant
+
+getDriverWalletWalletBalance :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Environment.Flow API.Types.UI.DriverWallet.WalletBalanceResponse)
+getDriverWalletWalletBalance merchantShortId opCity apiTokenInfo driverId = do
+  checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  API.Client.ProviderPlatform.AppManagement.callAppManagementAPI checkedMerchantId opCity (.driverWalletDSL.getDriverWalletWalletBalance) driverId
 
 getDriverWalletWalletTransactions :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Environment.Flow API.Types.UI.DriverWallet.WalletSummaryResponse)
 getDriverWalletWalletTransactions merchantShortId opCity apiTokenInfo driverId fromDate toDate = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/Dashboard/AppManagement/DriverWallet.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/Dashboard/AppManagement/DriverWallet.hs
@@ -25,9 +25,12 @@ import Servant
 import Tools.Auth
 
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API.Types.Dashboard.AppManagement.DriverWallet.API)
-handler merchantId city = getDriverWalletWalletTransactions merchantId city :<|> postDriverWalletWalletPayout merchantId city :<|> postDriverWalletWalletTopup merchantId city :<|> postDriverWalletWalletAirportCashRecharge merchantId city :<|> getDriverWalletWalletPayoutHistory merchantId city
+handler merchantId city = getDriverWalletWalletBalance merchantId city :<|> getDriverWalletWalletTransactions merchantId city :<|> postDriverWalletWalletPayout merchantId city :<|> postDriverWalletWalletTopup merchantId city :<|> postDriverWalletWalletAirportCashRecharge merchantId city :<|> getDriverWalletWalletPayoutHistory merchantId city
 
-getDriverWalletWalletTransactions :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Environment.FlowHandler API.Types.UI.DriverWallet.WalletSummaryResponse)
+getDriverWalletWalletBalance :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Environment.FlowHandler API.Types.UI.DriverWallet.WalletBalanceResponse)
+getDriverWalletWalletBalance a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.AppManagement.DriverWallet.getDriverWalletWalletBalance a3 a2 a1
+
+getDriverWalletWalletTransactions :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Environment.FlowHandler API.Types.UI.DriverWallet.WalletSummaryResponse)
 getDriverWalletWalletTransactions a5 a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.AppManagement.DriverWallet.getDriverWalletWalletTransactions a5 a4 a3 a2 a1
 
 postDriverWalletWalletPayout :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
@@ -39,5 +42,5 @@ postDriverWalletWalletTopup a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.A
 postDriverWalletWalletAirportCashRecharge :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> API.Types.Dashboard.AppManagement.DriverWallet.AirportCashRechargeRequest -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 postDriverWalletWalletAirportCashRecharge a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.AppManagement.DriverWallet.postDriverWalletWalletAirportCashRecharge a4 a3 a2 a1
 
-getDriverWalletWalletPayoutHistory :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe [Lib.Payment.Domain.Types.PayoutRequest.PayoutRequestStatus] -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Environment.FlowHandler API.Types.UI.DriverWallet.PayoutHistoryResponse)
+getDriverWalletWalletPayoutHistory :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe ([Lib.Payment.Domain.Types.PayoutRequest.PayoutRequestStatus]) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Environment.FlowHandler API.Types.UI.DriverWallet.PayoutHistoryResponse)
 getDriverWalletWalletPayoutHistory a8 a7 a6 a5 a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.AppManagement.DriverWallet.getDriverWalletWalletPayoutHistory a8 a7 a6 a5 a4 a3 a2 a1

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/Dashboard/AppManagement/Endpoints/DriverWallet.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/Dashboard/AppManagement/Endpoints/DriverWallet.hs
@@ -23,12 +23,13 @@ import Servant.Client
 data AirportCashRechargeRequest = AirportCashRechargeRequest {amount :: Kernel.Types.Common.HighPrecMoney, referenceId :: Kernel.Prelude.Text}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
-  deriving (Show)
 
 instance Kernel.Types.HideSecrets.HideSecrets AirportCashRechargeRequest where
   hideSecrets = Kernel.Prelude.identity
 
-type API = ("driverWallet" :> (GetDriverWalletWalletTransactions :<|> PostDriverWalletWalletPayout :<|> PostDriverWalletWalletTopup :<|> PostDriverWalletWalletAirportCashRecharge :<|> GetDriverWalletWalletPayoutHistory))
+type API = ("driverWallet" :> (GetDriverWalletWalletBalance :<|> GetDriverWalletWalletTransactions :<|> PostDriverWalletWalletPayout :<|> PostDriverWalletWalletTopup :<|> PostDriverWalletWalletAirportCashRecharge :<|> GetDriverWalletWalletPayoutHistory))
+
+type GetDriverWalletWalletBalance = ("wallet" :> Capture "driverId" (Kernel.Types.Id.Id Domain.Types.Person.Driver) :> "balance" :> Get ('[JSON]) API.Types.UI.DriverWallet.WalletBalanceResponse)
 
 type GetDriverWalletWalletTransactions =
   ( "wallet" :> Capture "driverId" (Kernel.Types.Id.Id Domain.Types.Person.Driver) :> "transactions"
@@ -36,25 +37,25 @@ type GetDriverWalletWalletTransactions =
            "fromDate"
            Kernel.Prelude.UTCTime
       :> QueryParam "toDate" Kernel.Prelude.UTCTime
-      :> Get '[JSON] API.Types.UI.DriverWallet.WalletSummaryResponse
+      :> Get ('[JSON]) API.Types.UI.DriverWallet.WalletSummaryResponse
   )
 
-type PostDriverWalletWalletPayout = ("wallet" :> Capture "driverId" (Kernel.Types.Id.Id Domain.Types.Person.Driver) :> "payout" :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
+type PostDriverWalletWalletPayout = ("wallet" :> Capture "driverId" (Kernel.Types.Id.Id Domain.Types.Person.Driver) :> "payout" :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
 type PostDriverWalletWalletTopup =
   ( "wallet" :> Capture "driverId" (Kernel.Types.Id.Id Domain.Types.Person.Driver) :> "topup"
       :> ReqBody
-           '[JSON]
+           ('[JSON])
            API.Types.UI.DriverWallet.TopUpRequest
-      :> Post '[JSON] Domain.Action.UI.Plan.PlanSubscribeRes
+      :> Post ('[JSON]) Domain.Action.UI.Plan.PlanSubscribeRes
   )
 
 type PostDriverWalletWalletAirportCashRecharge =
   ( "wallet" :> Capture "driverId" (Kernel.Types.Id.Id Domain.Types.Person.Driver) :> "airportCashRecharge"
       :> ReqBody
-           '[JSON]
+           ('[JSON])
            AirportCashRechargeRequest
-      :> Post '[JSON] Kernel.Types.APISuccess.APISuccess
+      :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess
   )
 
 type GetDriverWalletWalletPayoutHistory =
@@ -73,25 +74,27 @@ type GetDriverWalletWalletPayoutHistory =
            "offset"
            Kernel.Prelude.Int
       :> Get
-           '[JSON]
+           ('[JSON])
            API.Types.UI.DriverWallet.PayoutHistoryResponse
   )
 
 data DriverWalletAPIs = DriverWalletAPIs
-  { getDriverWalletWalletTransactions :: Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> EulerHS.Types.EulerClient API.Types.UI.DriverWallet.WalletSummaryResponse,
-    postDriverWalletWalletPayout :: Kernel.Types.Id.Id Domain.Types.Person.Driver -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    postDriverWalletWalletTopup :: Kernel.Types.Id.Id Domain.Types.Person.Driver -> API.Types.UI.DriverWallet.TopUpRequest -> EulerHS.Types.EulerClient Domain.Action.UI.Plan.PlanSubscribeRes,
-    postDriverWalletWalletAirportCashRecharge :: Kernel.Types.Id.Id Domain.Types.Person.Driver -> AirportCashRechargeRequest -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    getDriverWalletWalletPayoutHistory :: Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe Kernel.Prelude.UTCTime -> Kernel.Prelude.Maybe [Lib.Payment.Domain.Types.PayoutRequest.PayoutRequestStatus] -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> EulerHS.Types.EulerClient API.Types.UI.DriverWallet.PayoutHistoryResponse
+  { getDriverWalletWalletBalance :: (Kernel.Types.Id.Id Domain.Types.Person.Driver -> EulerHS.Types.EulerClient API.Types.UI.DriverWallet.WalletBalanceResponse),
+    getDriverWalletWalletTransactions :: (Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> EulerHS.Types.EulerClient API.Types.UI.DriverWallet.WalletSummaryResponse),
+    postDriverWalletWalletPayout :: (Kernel.Types.Id.Id Domain.Types.Person.Driver -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    postDriverWalletWalletTopup :: (Kernel.Types.Id.Id Domain.Types.Person.Driver -> API.Types.UI.DriverWallet.TopUpRequest -> EulerHS.Types.EulerClient Domain.Action.UI.Plan.PlanSubscribeRes),
+    postDriverWalletWalletAirportCashRecharge :: (Kernel.Types.Id.Id Domain.Types.Person.Driver -> AirportCashRechargeRequest -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    getDriverWalletWalletPayoutHistory :: (Kernel.Types.Id.Id Domain.Types.Person.Driver -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe (Kernel.Prelude.UTCTime) -> Kernel.Prelude.Maybe ([Lib.Payment.Domain.Types.PayoutRequest.PayoutRequestStatus]) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> EulerHS.Types.EulerClient API.Types.UI.DriverWallet.PayoutHistoryResponse)
   }
 
 mkDriverWalletAPIs :: (Client EulerHS.Types.EulerClient API -> DriverWalletAPIs)
 mkDriverWalletAPIs driverWalletClient = (DriverWalletAPIs {..})
   where
-    getDriverWalletWalletTransactions :<|> postDriverWalletWalletPayout :<|> postDriverWalletWalletTopup :<|> postDriverWalletWalletAirportCashRecharge :<|> getDriverWalletWalletPayoutHistory = driverWalletClient
+    getDriverWalletWalletBalance :<|> getDriverWalletWalletTransactions :<|> postDriverWalletWalletPayout :<|> postDriverWalletWalletTopup :<|> postDriverWalletWalletAirportCashRecharge :<|> getDriverWalletWalletPayoutHistory = driverWalletClient
 
 data DriverWalletUserActionType
-  = GET_DRIVER_WALLET_WALLET_TRANSACTIONS
+  = GET_DRIVER_WALLET_WALLET_BALANCE
+  | GET_DRIVER_WALLET_WALLET_TRANSACTIONS
   | POST_DRIVER_WALLET_WALLET_PAYOUT
   | POST_DRIVER_WALLET_WALLET_TOPUP
   | POST_DRIVER_WALLET_WALLET_AIRPORT_CASH_RECHARGE
@@ -99,4 +102,4 @@ data DriverWalletUserActionType
   deriving stock (Show, Read, Generic, Eq, Ord)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-$(Data.Singletons.TH.genSingletons [''DriverWalletUserActionType])
+$(Data.Singletons.TH.genSingletons [(''DriverWalletUserActionType)])

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/AppManagement/DriverWallet.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/AppManagement/DriverWallet.hs
@@ -1,5 +1,6 @@
 module Domain.Action.Dashboard.AppManagement.DriverWallet
-  ( getDriverWalletWalletTransactions,
+  ( getDriverWalletWalletBalance,
+    getDriverWalletWalletTransactions,
     postDriverWalletWalletPayout,
     postDriverWalletWalletTopup,
     postDriverWalletWalletAirportCashRecharge,
@@ -21,6 +22,16 @@ import qualified Kernel.Types.Id
 import qualified Lib.Payment.Domain.Types.PayoutRequest as PR
 import SharedLogic.Merchant (findMerchantByShortId)
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+
+getDriverWalletWalletBalance ::
+  Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant ->
+  Kernel.Types.Beckn.Context.City ->
+  Kernel.Types.Id.Id DP.Person ->
+  Environment.Flow DriverWallet.WalletBalanceResponse
+getDriverWalletWalletBalance merchantShortId opCity driverId = do
+  merchant <- findMerchantByShortId merchantShortId
+  merchantOpCityId <- CQMOC.getMerchantOpCityId Kernel.Prelude.Nothing merchant (Kernel.Prelude.Just opCity)
+  DDriverWallet.getWalletBalance (Kernel.Prelude.Just driverId, merchant.id, merchantOpCityId)
 
 getDriverWalletWalletTransactions ::
   Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant ->

--- a/Backend/dev/migrations-read-only/provider-dashboard/Local_API_AppManagement_DriverWallet.sql
+++ b/Backend/dev/migrations-read-only/provider-dashboard/Local_API_AppManagement_DriverWallet.sql
@@ -15,3 +15,9 @@ INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_acc
 
 -- {"api":"PostDriverWalletWalletAirportCashRecharge","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bpp_dashboard"}
 INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bpp_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'PROVIDER_APP_MANAGEMENT/DRIVER_WALLET/POST_DRIVER_WALLET_WALLET_AIRPORT_CASH_RECHARGE' ) ON CONFLICT DO NOTHING;
+
+
+------- SQL updates -------
+
+-- {"api":"GetDriverWalletWalletBalance","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_bpp_dashboard"}
+INSERT INTO atlas_bpp_dashboard.access_matrix (id, role_id, api_entity, user_access_type, user_action_type) VALUES ( atlas_bpp_dashboard.uuid_generate_v4(), '37947162-3b5d-4ed6-bcac-08841be1534d', 'DSL', 'USER_FULL_ACCESS', 'PROVIDER_APP_MANAGEMENT/DRIVER_WALLET/GET_DRIVER_WALLET_WALLET_BALANCE' ) ON CONFLICT DO NOTHING;

--- a/flake.lock
+++ b/flake.lock
@@ -1838,11 +1838,11 @@
         "common": "common_2"
       },
       "locked": {
-        "lastModified": 1776878429,
-        "narHash": "sha256-ZWTKVztLpKZ2mg1NBvURMXe7t0c3H0zWbFIh+wCKCgo=",
+        "lastModified": 1777300069,
+        "narHash": "sha256-/AlFRoRnwAJSTAZPc2da9o9ix/dU3ZK/fvqyIwe8tTg=",
         "owner": "nammayatri",
         "repo": "namma-dsl",
-        "rev": "aff6a19bad754ac9535b25f300dd85cdd125bfc9",
+        "rev": "3bbc8fbd79d983ea0fc36d888f747c538ef7d6df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Adds `GET /wallet/{driverId}/balance` to the BPP dashboard, proxying to the existing `Domain.Action.UI.DriverWallet.getWalletBalance` UI handler used by the driver app.
- Dashboard handler runs `merchantCityAccessCheck` and forwards via the typed Servant client; BPP-side handler resolves merchant/operating-city IDs and delegates to the same UI action — no response remapping.
- Generator-emitted SQL migration row grants the new `GET_DRIVER_WALLET_WALLET_BALANCE` permission to the default local-dev role (production grants handled separately via dashboard role-management UI).

## Notes for reviewers
- **`flake.lock` is bumped** as a side effect of `, run-generator`'s version check. Required to keep regenerated `src-read-only/` output consistent with the locked tooling.
- The newer `namma-dsl` template no longer auto-emits `HideSecrets` for inline request types. Added explicit `- derive: "'HideSecrets"` on `AirportCashRechargeRequest` in the YAML to restore the instance (matches the convention used elsewhere, e.g. `PlanSubscribeReq`, `SendSmsReq`).
- Cosmetic paren-wrapping in `src-read-only/.../Endpoints/DriverWallet.hs` (e.g. `'[JSON]` → `('[JSON])`, `Maybe X` → `Maybe (X)`) is the new template's emission style — unavoidable now that we touched these files.
- All other unrelated drift produced by `, run-generator` (treefmt import reorders, template re-renders in unrelated modules) was excluded from this PR to keep the diff scoped.

## Test plan
- [ ] `cabal build all` passes
- [ ] Hit `GET /wallet/{driverId}/balance` from the dashboard with a valid token; response matches the driver app's `WalletBalanceResponse`
- [ ] Verify access-matrix INSERT applied to `atlas_bpp_dashboard.access_matrix` for `GET_DRIVER_WALLET_WALLET_BALANCE`
- [ ] Confirm existing wallet endpoints (`/transactions`, `/payout`, `/topup`, `/airportCashRecharge`, `/payoutHistory`) still function — no regression from the regenerated dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drivers can retrieve their current wallet balance via a new balance endpoint.

* **Chores**
  * Routing and access controls updated to expose the new balance endpoint.

* **API Changes**
  * Airport cash recharge request now uses list-based amount/referenceId and hides sensitive fields server-side.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->