### PR TITLE
backend/enh: fetching upiId from fleet_owner_information table for fl…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
@@ -2407,9 +2407,6 @@ getDriverFleetOwnerInfo requestorMerchantShortId requestorCity driverId = do
       let name = fleetOwner.firstName <> maybe "" (" " <>) fleetOwner.middleName <> maybe "" (" " <>) fleetOwner.lastName
       mobileNo' <- mapM decrypt fleetOwner.mobileNumber
 
-      -- Fetch DriverInformation for upiId
-      mbDriverInfo <- QDriverInfo.findById fleetOwnerPersonId
-
       -- Fetch GSTIN details for gstinApplicableFlag and gstImageId
       mbGstin <- QDGExtra.findGSTInByDriverId fleetOwnerPersonId
       let gstinApplicableFlag = mbGstin <&> \gstin -> gstin.verificationStatus == Documents.VALID
@@ -2432,8 +2429,8 @@ getDriverFleetOwnerInfo requestorMerchantShortId requestorCity driverId = do
       let walletId' = (\acc -> acc.id.getId) <$> mbWalletAccount
       let bankVerificationStatus' = mbBankAccount <&> (\ba -> if ba.detailsSubmitted then "VERIFIED" else "PENDING")
 
-      -- upiId from DriverInformation
-      let upiId' = mbDriverInfo >>= (.payoutVpa)
+      -- upiId from FleetOwnerInformation
+      let upiId' = payoutVpa
 
       -- Fetch linked drivers
       linkedDrivers <- FDV.findAllActiveByFleetOwnerId fleetOwnerPersonId.getId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/PayoutAccount.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/PayoutAccount.hs
@@ -19,7 +19,6 @@ import Kernel.Types.Id
 import Kernel.Utils.Common
 import SharedLogic.Merchant (findMerchantByShortId)
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
-import qualified Storage.Queries.FleetOwnerInformation as QFOI
 import qualified Storage.Queries.FleetOwnerInformationExtra as QFOIE
 import Tools.Error
 
@@ -72,13 +71,11 @@ postPayoutAccountStatus merchantShortId opCity requestorId req = do
     Common.BANK -> do
       bankRequestId <- req.bankRequestId & fromMaybeM (InvalidRequest "bankRequestId required for Bank status")
       bankInfoResp <- BankAccountVerification.getInfoBankAccount (personId, merchant.id, merchantOpCityId) bankRequestId
-      when (bankInfoResp.accountExists) $ do
-        mbFleetInfo <- QFOI.findByPrimaryKey personId
-        when (isNothing (mbFleetInfo >>= (.payoutVpa))) $
-          case (bankInfoResp.bankAccountNumber, bankInfoResp.ifscCode) of
-            (Just accNo, Just ifsc) ->
-              QFOIE.updatePayoutVpaAndStatus (Just (accNo <> "@" <> ifsc <> ".ifsc.npci")) (Just DFOI.MANUALLY_ADDED) personId
-            _ -> pure ()
+      when (bankInfoResp.accountExists) $
+        case (bankInfoResp.bankAccountNumber, bankInfoResp.ifscCode) of
+          (Just accNo, Just ifsc) ->
+            QFOIE.updatePayoutVpaAndStatus (Just (accNo <> "@" <> ifsc <> ".ifsc.npci")) (Just DFOI.MANUALLY_ADDED) personId
+          _ -> pure ()
       pure $
         Common.PayoutAccountStatusResp
           { accountType = Common.BANK,


### PR DESCRIPTION
…eet owners

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment contact resolution now always uses the fleet owner's payout VPA when present; legacy fallback to the driver is removed for fleet-owner cases.
  * Bank verification results now update payout VPA/status whenever a valid bank account and IFSC are provided, even if a payout VPA already existed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->