### PR TITLE
backend/fix: deterministic pass-category ordering on renew sheet

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/PassCategory.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/PassCategory.yaml
@@ -9,6 +9,7 @@ PassCategory:
     id: Id PassCategory
     name: Text
     description: Text
+    order: Maybe Int
     merchantId: Id Merchant
     merchantOperatingCityId: Id MerchantOperatingCity
 

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/PassCategory.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/PassCategory.hs
@@ -16,6 +16,7 @@ data PassCategory = PassCategory
     merchantId :: Kernel.Types.Id.Id Domain.Types.Merchant.Merchant,
     merchantOperatingCityId :: Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity,
     name :: Kernel.Prelude.Text,
+    order :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
     createdAt :: Kernel.Prelude.UTCTime,
     updatedAt :: Kernel.Prelude.UTCTime
   }

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/PassCategory.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/PassCategory.hs
@@ -16,6 +16,7 @@ data PassCategoryT f = PassCategoryT
     merchantId :: B.C f Kernel.Prelude.Text,
     merchantOperatingCityId :: B.C f Kernel.Prelude.Text,
     name :: B.C f Kernel.Prelude.Text,
+    order :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int),
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     updatedAt :: B.C f Kernel.Prelude.UTCTime
   }

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/PassCategory.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/PassCategory.hs
@@ -22,6 +22,7 @@ instance FromTType' Beam.PassCategory Domain.Types.PassCategory.PassCategory whe
             merchantId = Kernel.Types.Id.Id merchantId,
             merchantOperatingCityId = Kernel.Types.Id.Id merchantOperatingCityId,
             name = name,
+            order = order,
             createdAt = createdAt,
             updatedAt = updatedAt
           }
@@ -34,6 +35,7 @@ instance ToTType' Beam.PassCategory Domain.Types.PassCategory.PassCategory where
         Beam.merchantId = Kernel.Types.Id.getId merchantId,
         Beam.merchantOperatingCityId = Kernel.Types.Id.getId merchantOperatingCityId,
         Beam.name = name,
+        Beam.order = order,
         Beam.createdAt = createdAt,
         Beam.updatedAt = updatedAt
       }

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/PassCategory.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/PassCategory.hs
@@ -32,6 +32,7 @@ updateByPrimaryKey (Domain.Types.PassCategory.PassCategory {..}) = do
       Se.Set Beam.merchantId (Kernel.Types.Id.getId merchantId),
       Se.Set Beam.merchantOperatingCityId (Kernel.Types.Id.getId merchantOperatingCityId),
       Se.Set Beam.name name,
+      Se.Set Beam.order order,
       Se.Set Beam.updatedAt _now
     ]
     [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]]

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PassCategoryExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PassCategoryExtra.hs
@@ -3,6 +3,7 @@
 
 module Storage.Queries.PassCategoryExtra where
 
+import qualified Data.List as DL
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.PassCategory as DPassCategory
 import Kernel.Beam.Functions
@@ -21,10 +22,17 @@ findById ::
   m (Maybe DPassCategory.PassCategory)
 findById passCategoryId = findOneWithKV [Se.Is Beam.id $ Se.Eq (getId passCategoryId)]
 
+sortPassCategoriesByOrder :: [DPassCategory.PassCategory] -> [DPassCategory.PassCategory]
+sortPassCategoriesByOrder =
+  DL.sortOn $ \pc ->
+    case pc.order of
+      Just n -> Left n
+      Nothing -> Right ()
+
 findAllByMerchantOperatingCityId ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
   Id DMOC.MerchantOperatingCity ->
   m [DPassCategory.PassCategory]
 findAllByMerchantOperatingCityId merchantOperatingCityId = do
-  findAllWithKV
-    [Se.Is Beam.merchantOperatingCityId $ Se.Eq (getId merchantOperatingCityId)]
+  categories <- findAllWithKV [Se.Is Beam.merchantOperatingCityId $ Se.Eq (getId merchantOperatingCityId)]
+  pure $ sortPassCategoriesByOrder categories

--- a/Backend/dev/migrations-read-only/rider-app/pass_category.sql
+++ b/Backend/dev/migrations-read-only/rider-app/pass_category.sql
@@ -8,3 +8,9 @@ ALTER TABLE atlas_app.pass_category ADD COLUMN name text NOT NULL;
 ALTER TABLE atlas_app.pass_category ADD COLUMN created_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
 ALTER TABLE atlas_app.pass_category ADD COLUMN updated_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
 ALTER TABLE atlas_app.pass_category ADD PRIMARY KEY ( id);
+
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.pass_category ADD COLUMN "order" integer ;


### PR DESCRIPTION
## Summary

- `findAllByMerchantOperatingCityId` for `PassCategory` had no `ORDER BY` → non-deterministic category order across pods/cache populations.
- Combined with frontend `BusPass/Flow.tsx:32-33` reading only `data?.[0]?.passes`, Chennai customers intermittently saw the wrong renew options when the Ulla category sorted ahead of the unlimited-pass one.
- Adds `order: Maybe Int` to the spec (mirrors `Pass.order` / `PassType.order`; `Maybe` because NammaDSL gates net-new NOT NULL columns) and switches the query to `findAllWithOptionsKV ... (Se.Asc Beam.order) Nothing Nothing`. Byte-for-byte the same shape as `PassTypeExtra.hs:24-33`.

## Scope

**Backend hardening only.** The load-bearing fix is on the frontend — `BusPass/Flow.tsx` needs to `flatMap` across all categories instead of reading only `data[0]`. Sister file `consumer/src-v2/screens/Passes/Flow.tsx:23` already does this correctly. Filed separately on the ny-react-native side.

## Post-deploy operational steps

Existing rows ship with `order = NULL`. Until backfilled, both Chennai categories tie → ordering is still non-deterministic for the transient window.

**Preferred**: set `order` via the dashboard's PassCategory editor (writes through `updateWithKV`, no manual cache flush needed).

**Manual fallback**:

```sql
UPDATE atlas_app.pass_category SET "order" = 1 WHERE id = 'unlimited-pass-cat-1';
UPDATE atlas_app.pass_category SET "order" = 2 WHERE id = 'unlimited-ulla-pass';
```

Then flush AWS Redis (cluster-mode) prefixes — raw SQL alone gets overwritten by KV reconciliation:
- `pass_category:*`
- `CachedQueries:PassCategory:MerchantOperatingCityId-*`

## Test plan

- [ ] CI green under \`-Werror\`.
- [ ] Deploy to master env, confirm `getMultimodalPassAvailablePasses` for Chennai mocId returns categories in stable order across repeated calls and across pods.
- [ ] Set `order` values per the operational steps above on a non-prod cluster, confirm category order matches `order` ascending.
- [ ] Verify `getAllAvailablePass` and dashboard `/transactions` are unaffected (separate code paths but same KV layer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "order" field to pass categories.
  * Listings of pass categories now sort by this order (empty values shown after set values).
  * Create/update operations persist the order value.
  * A database migration was added to add the nullable order column and related table updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->