### PR TITLE
backend/fix: distinguish Rental RideOtp from static offer in fulfillmentType

### DIFF
--- a/Backend/lib/beckn-spec/src/BecknV2/OnDemand/Utils/Common.hs
+++ b/Backend/lib/beckn-spec/src/BecknV2/OnDemand/Utils/Common.hs
@@ -179,6 +179,10 @@ tripCategoryToFulfillmentType = \case
   OneWay OneWayRideOtp -> show Enums.RIDE_OTP
   CrossCity OneWayRideOtp _ -> show Enums.RIDE_OTP
   RideShare RideOtp -> show Enums.RIDE_OTP
+  -- Rental RideOtp uses on-us encoding so the BAP's readMaybe @TripCategory
+  -- fast-path can distinguish it from Rental OnDemandStaticOffer; "RENTAL"
+  -- alone is lossy and decodes back to OnDemandStaticOffer.
+  r@(Rental RideOtp) -> show r
   Rental _ -> show Enums.RENTAL
   i@(InterCity OneWayRideOtp _) -> show i
   InterCity _ _ -> show Enums.INTER_CITY


### PR DESCRIPTION
## Summary

`tripCategoryToFulfillmentType` collapsed both `Rental` subtypes into the off-us `RENTAL` enum, and `fulfillmentTypeToTripCategory` then unconditionally decoded `RENTAL` back to `Rental OnDemandStaticOffer` on the BAP. Result: a BPP-side `Rental RideOtp` booking arrived at the BAP as `Rental OnDemandStaticOffer`, the rider UI ran the static-offer wait-for-driver flow, and the booking timed out and got cancelled — even though the BPP had generated a valid OTP and skipped the search batch entirely.

Mirror the existing `InterCity OneWayRideOtp` pattern: emit `show (Rental RideOtp)` (`"Rental_RideOtp"`) so the BAP's `readMaybe @TripCategory` fast-path round-trips it correctly. Static-offer rentals and third-party Beckn participants still see `RENTAL`.

## Reproduced with

- BPP booking `3d050a9d-4b4f-4148-870b-e63d4ea8d362` — `tripCategory = Rental_RideOtp`, OTP `5401` generated, `searchTryId` empty (no driver search batch). ✓
- BAP booking `c238ccc5-1cf5-4b06-9bec-cf2ae84dbf3c` — same fulfillmentId, but `tripCategory = {"contents":"OnDemandStaticOffer","tag":"Rental"}`. ✗
- Booking `NEW → CANCELLED` two minutes later because the BAP ran the wrong flow.

## Test plan

- [ ] Search rental from a special pickup zone (airport) with only the `Rental_RideOtp` FarePolicy enabled
- [ ] Confirm BAP booking row shows `tripCategory = Rental RideOtp` (was `Rental OnDemandStaticOffer`)
- [ ] Confirm `specialZoneOtp` is populated on BAP booking and surfaced via the rider booking API
- [ ] Driver enters OTP on driver app → ride starts immediately, no search batch fired
- [ ] Static-offer rental (separate FarePolicy) still works unchanged — BPP emits `RENTAL`, BAP decodes to `Rental OnDemandStaticOffer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fulfillment type mapping for rental trips that use OTP authentication so they are categorized and processed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->