### PR TITLE
backend/feat: enrich special-zone queue poll response with fare/demand metrics

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/SpecialZoneQueue.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/SpecialZoneQueue.yaml
@@ -1,6 +1,7 @@
 imports:
   Id: Kernel.Types.Id
   APISuccess: Kernel.Types.APISuccess
+  HighPrecMoney: Kernel.Types.Common
   SpecialZoneQueueRequest: Domain.Types.SpecialZoneQueueRequest
   SpecialZoneQueueRequestResponse: Domain.Types.SpecialZoneQueueRequest
   SpecialZoneQueueRequestStatus: Domain.Types.SpecialZoneQueueRequest
@@ -17,6 +18,9 @@ types:
     vehicleType: Text
     validTill: UTCTime
     status: SpecialZoneQueueRequestStatus
+    perKmFare: Maybe HighPrecMoney
+    isDemandHigh: Bool
+    demandCount: Int
 
   SpecialZoneQueueRequestListRes:
     requests: "[SpecialZoneQueueRequestRes]"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/SpecialZoneQueue.hs
@@ -6,6 +6,7 @@ import Data.OpenApi (ToSchema)
 import qualified Domain.Types.SpecialZoneQueueRequest
 import EulerHS.Prelude hiding (id)
 import qualified Kernel.Prelude
+import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
 import Servant
 import Tools.Auth
@@ -15,8 +16,11 @@ data SpecialZoneQueueRequestListRes = SpecialZoneQueueRequestListRes {currentSki
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data SpecialZoneQueueRequestRes = SpecialZoneQueueRequestRes
-  { gateId :: Kernel.Prelude.Text,
+  { demandCount :: Kernel.Prelude.Int,
+    gateId :: Kernel.Prelude.Text,
     gateName :: Kernel.Prelude.Text,
+    isDemandHigh :: Kernel.Prelude.Bool,
+    perKmFare :: Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecMoney,
     requestId :: Kernel.Types.Id.Id Domain.Types.SpecialZoneQueueRequest.SpecialZoneQueueRequest,
     specialLocationId :: Kernel.Prelude.Text,
     specialLocationName :: Kernel.Prelude.Text,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SpecialZoneQueue.hs
@@ -9,10 +9,12 @@ where
 
 import qualified API.Types.UI.SpecialZoneQueue
 import Data.List (partition)
+import qualified Data.Text as T
 import Data.Time (addUTCTime)
 import qualified Domain.Types.Merchant
 import qualified Domain.Types.MerchantOperatingCity
 import qualified Domain.Types.Person
+import qualified Domain.Types.ServiceTierType as DVST
 import qualified Domain.Types.SpecialZoneQueueRequest
 import qualified Environment
 import EulerHS.Prelude hiding (id)
@@ -30,7 +32,7 @@ import Lib.Scheduler.JobStorageType.SchedulerType (createJobIn)
 import SharedLogic.Allocator (AllocatorJobType (..), CheckPickupZoneArrivalJobData (..))
 import qualified SharedLogic.Allocator.Jobs.SpecialZoneQueue.CheckPickupZoneArrival as ArrivalCheck
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTSFlow
-import SharedLogic.SpecialZoneDriverDemand (mkQueueSkipCountKey, mkSpecialZoneQueueRequestLockKey)
+import SharedLogic.SpecialZoneDriverDemand (mkGateSearchDemandKey, mkQueueSkipCountKey, mkSpecialZoneQueueRequestLockKey)
 import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import Storage.Beam.SchedulerJob ()
 import qualified Storage.Queries.SpecialZoneQueueRequest as QSZQR
@@ -43,7 +45,7 @@ getSpecialZoneQueueRequest ::
     ) ->
     Environment.Flow API.Types.UI.SpecialZoneQueue.SpecialZoneQueueRequestListRes
   )
-getSpecialZoneQueueRequest (mbPersonId, _merchantId, _merchantOpCityId) = do
+getSpecialZoneQueueRequest (mbPersonId, merchantId, merchantOpCityId) = do
   personId <- mbPersonId & fromMaybeM (PersonNotFound "No person id")
   now <- getCurrentTime
   -- Fetch both Active and Accepted requests in one query, then split
@@ -70,8 +72,8 @@ getSpecialZoneQueueRequest (mbPersonId, _merchantId, _merchantOpCityId) = do
         req.vehicleType
         req.merchantId
         req.merchantOperatingCityId
-  let acceptedRes = map mkRes freshAccepted
-      responseRequests = validActiveRequests ++ acceptedRes
+  acceptedRes <- mapM enrichRes freshAccepted
+  let responseRequests = validActiveRequests ++ acceptedRes
   -- Get skip count from driver's current location's special location
   mbDriverLoc <- LTSFlow.driversLocation [personId]
   mbSpecialLoc <- case mbDriverLoc of
@@ -113,19 +115,44 @@ getSpecialZoneQueueRequest (mbPersonId, _merchantId, _merchantOpCityId) = do
           collectValidActive now rest
         else do
           rest' <- collectValidActive now rest
-          pure (mkRes req : rest')
+          enriched <- enrichRes req
+          pure (enriched : rest')
 
-    mkRes req =
-      API.Types.UI.SpecialZoneQueue.SpecialZoneQueueRequestRes
-        { requestId = req.id,
-          gateId = req.gateId,
-          gateName = req.gateName,
-          specialLocationId = req.specialLocationId,
-          specialLocationName = req.specialLocationName,
-          vehicleType = req.vehicleType,
-          validTill = req.validTill,
-          status = req.status
-        }
+    -- | Build the response row for a request, enriching it with the same three
+    --   metrics surfaced over the trigger-notify FCM (perKmFare, isDemandHigh,
+    --   demandCount). Recompute on each poll; 'getAirportPerKmFare' is cached
+    --   for one day per (specialLocation, variant) and 'demandCount' is one
+    --   Redis read. 'isDemandHigh' has no caller-supplied value at poll time
+    --   — defaulting to True mirrors 'fromMaybe True mbIsDemandHigh' in
+    --   'notifyDrivers'.
+    enrichRes req = do
+      mbGate <- QGI.findById (Kernel.Types.Id.Id req.gateId)
+      let mbServiceTier = Kernel.Prelude.readMaybe (T.unpack req.vehicleType) :: Maybe DVST.ServiceTierType
+      mbPerKmFare <- case (mbGate, mbServiceTier) of
+        (Just gate, Just serviceTier) ->
+          SpecialZoneDriverDemand.getAirportPerKmFare
+            merchantId
+            merchantOpCityId
+            (Kernel.Types.Id.Id req.specialLocationId)
+            gate.point
+            req.gateId
+            serviceTier
+        _ -> pure Nothing
+      mbDemandCount <- Redis.withCrossAppRedis $ Redis.get @Int (mkGateSearchDemandKey req.gateId req.vehicleType)
+      pure $
+        API.Types.UI.SpecialZoneQueue.SpecialZoneQueueRequestRes
+          { requestId = req.id,
+            gateId = req.gateId,
+            gateName = req.gateName,
+            specialLocationId = req.specialLocationId,
+            specialLocationName = req.specialLocationName,
+            vehicleType = req.vehicleType,
+            validTill = req.validTill,
+            status = req.status,
+            perKmFare = mbPerKmFare,
+            isDemandHigh = True,
+            demandCount = fromMaybe 0 mbDemandCount
+          }
 
 postSpecialZoneQueueRequestRespond ::
   ( ( Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -36,6 +36,7 @@ module SharedLogic.SpecialZoneDriverDemand
     cancelPickupZoneRequestsForDriver,
     filterByGateProximity,
     clearAirportPerKmFareCacheForPolicy,
+    getAirportPerKmFare,
   )
 where
 


### PR DESCRIPTION
## Summary

The trigger-notify FCM (sent when a pickup-zone request is created) already carries three contextual fields — `perKmFare`, `isDemandHigh`, `demandCount`. The polling endpoint `GET /specialZoneQueue/request` (which the driver app calls to render the queue screen between FCM ticks) wasn't returning them, so the UI lost the context once the FCM was acknowledged.

This PR adds the same three fields to every row of the polling response and computes them on each poll.

## What changed

- **Spec** (`spec/API/SpecialZoneQueue.yaml`) — three new fields on `SpecialZoneQueueRequestRes`:
  ```yaml
  perKmFare: Maybe HighPrecMoney
  isDemandHigh: Bool
  demandCount: Int
  ```
- **Handler** (`Domain/Action/UI/SpecialZoneQueue.hs`):
  - `merchantId` / `merchantOpCityId` no longer underscored (now used for fare lookup).
  - New local `enrichRes` builds the response row per request, calling:
    - `SpecialZoneDriverDemand.getAirportPerKmFare` (cached one day per `(specialLocation, variant)`, so hot-path cost is one Redis GET).
    - `Redis.get @Int (mkGateSearchDemandKey gateId vehicleType)` for the demand counter.
  - `isDemandHigh` defaults to `True` — mirrors `fromMaybe True mbIsDemandHigh` inside `notifyDrivers`; there's no caller-supplied value at poll time.
- **Export** — `SpecialZoneDriverDemand` now exports `getAirportPerKmFare` so the poll handler can reach it.

## Design choice

Recompute-on-poll, not snapshot-on-row. Trade-offs:

| | Recompute (this PR) | Snapshot |
|---|---|---|
| Schema change | None | Three new columns + migration |
| Cost per poll | 1 Redis GET (cache hit) + 1 Redis GET (demand) per request | Zero |
| Drift if fare policy / demand changes mid-window | Reflected | Frozen at notify time |

Polling responses are meant to reflect current state, and the cached `getAirportPerKmFare` makes recompute negligible (sub-ms hot path), so this avoids the schema change.

Per-request cost: one cache-hit Redis GET (fare) + one Redis GET (demand) + one DB read for the gate row (already cached upstream). For a driver with 0–2 active queue requests typical, that's at most ~6 fast Redis ops per poll.

## Test plan

- [ ] Manual: `GET /specialZoneQueue/request` returns the three new fields on each row.
- [ ] `perKmFare` value matches the corresponding FCM payload for a driver who just received one.
- [ ] When fare policy is updated mid-window, next poll reflects the new fare (cache invalidation via `clearAirportPerKmFareCacheForPolicy` already runs on policy update).
- [ ] `demandCount` increments visibly when a new search hits the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Special zone queue requests now display demand metrics and per-km fare pricing, providing drivers with real-time pricing and demand level information for special zone opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->