### PR TITLE
Backend/fix: added multi cloud redis lock on getOrCreatePaymentCustomer

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/DriverRegistration.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/DriverRegistration.hs
@@ -1608,6 +1608,8 @@ rejectAndUpdateCommonDocument req _mOpCityId = do
   let updatedDocument = document {DCommonDoc.verificationStatus = INVALID, DCommonDoc.rejectReason = Just req.reason}
 
   QCommonDriverOnboardingDocuments.updateByPrimaryKey updatedDocument
+  whenJust document.documentImageId $ \imgIdText ->
+    QImage.updateVerificationStatusAndFailureReason INVALID (ImageNotValid req.reason) (Id imgIdText)
 
 approveAndUpdateUdyamDocument :: Common.UDYAMApproveDetails -> Id DM.Merchant -> Id DMOC.MerchantOperatingCity -> Flow ()
 approveAndUpdateUdyamDocument req _mId _mOpCityId = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
@@ -1287,7 +1287,7 @@ getProcessedDriverDocuments driverId entityImagesInfo docType useHVSdkForDL = do
     DVC.TAXDetails -> commonDocStatus DVC.TAXDetails
     DVC.FinnishIDResidencePermit -> commonDocStatus DVC.FinnishIDResidencePermit
     DVC.TaxiDriverPermit -> commonDocStatus DVC.TaxiDriverPermit
-    _ -> return (Nothing, Nothing, Nothing, Nothing, mbS3Path, mbImageId)
+    _ -> commonDocStatus docType
 
 callGetDLGetStatus :: Id DP.Person -> Id DMOC.MerchantOperatingCity -> Flow ()
 callGetDLGetStatus driverId merchantOpCityId = do
@@ -1351,7 +1351,12 @@ getProcessedVehicleDocuments entityImagesInfo docType vehicleRC mbRcImagesInfo =
         mbPlan <- snd <$> DAPlan.getSubcriptionStatusWithPlan Plan.YATRI_SUBSCRIPTION person.id -- fix later on basis of vehicle category
         return (Just $ boolToStatus (isJust mbPlan), Nothing, Nothing, Nothing, Nothing, Nothing)
       IQuery.VehicleRCEntity _rc -> return (Nothing, Nothing, Nothing, Nothing, Nothing, Nothing)
-    _ -> return (Nothing, Nothing, Nothing, Nothing, mbS3Path, mbImageId)
+    _ -> do
+      let mbLatestImage = case mbRcImagesInfo of
+            Just rcImagesInfo -> listToMaybe (IQuery.filterRecentByPersonRCAndImageType rcImagesInfo docType)
+            Nothing -> Nothing
+          mbStatus = mbLatestImage >>= (.verificationStatus) <&> mapStatus
+      return (mbStatus, Nothing, Nothing, Nothing, mbS3Path, mbImageId)
   where
     boolToStatus :: Bool -> ResponseStatus
     boolToStatus = \case

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/RidePayment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/RidePayment.hs
@@ -118,8 +118,9 @@ getOrCreatePaymentCustomer person = do
   logInfo $ "getOrCreatePaymentCustomer: " <> person.id.getId <> " " <> show person.paymentMode
   let paymentMode = fromMaybe DMPM.LIVE person.paymentMode
       lockKey = "PaymentCustomer:Create:" <> person.id.getId <> ":" <> show paymentMode
-  Redis.withLockRedisAndReturnValue lockKey 60 $ do
+  Redis.withWaitAndLockMasterCloudCrossAppRedis lockKey 60 100 $ do
     -- Re-check inside the lock: another concurrent request may have already created it
+    logDebug $ "getOrCreatePaymentCustomer Lock Aquired On" <> lockKey
     mbCustomer <- QPaymentCustomer.findByPersonIdAndPaymentMode (Just person.id) (Just paymentMode)
     case mbCustomer of
       Just customer -> return customer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved payment-customer creation reliability by enhancing locking and adding diagnostic logging to better handle concurrent operations.
* **Bug Fixes**
  * Keep document image verification state in sync when a common document is rejected.
  * Provide more accurate fallback resolution for driver/vehicle document statuses by deriving status from common-document or most recent RC image data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14706)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->