### PR TITLE
Backend/fix/quote_sorting_for_otp_rides

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Quote.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Quote.hs
@@ -203,13 +203,15 @@ getQuotes searchRequestId mbAllowMultiple = do
 
     let vehicleServiceTierOrderConfig = maybe [] (.userServiceTierOrderConfig) riderConfig
         defaultServiceTierOrderConfig = maybe [] (.defaultServiceTierOrderConfig) riderConfig
-        estimates = estimatesSorting estimates' (mostFrequentVehicleCategoryConfig mostFrequentVehicleCategory vehicleServiceTierOrderConfig) defaultServiceTierOrderConfig
+        mbUserConfig = mostFrequentVehicleCategoryConfig mostFrequentVehicleCategory vehicleServiceTierOrderConfig
+        estimates = estimatesSorting estimates' mbUserConfig defaultServiceTierOrderConfig
+        sortedQuotes = quotesSorting offers mbUserConfig defaultServiceTierOrderConfig
     return $
       GetQuotesRes
         { fromLocation = DL.makeLocationAPIEntity searchRequest.fromLocation,
           toLocation = DL.makeLocationAPIEntity <$> searchRequest.toLocation,
           stops = DL.makeLocationAPIEntity <$> searchRequest.stops,
-          quotes = offers,
+          quotes = sortedQuotes,
           estimates,
           paymentMethods = [],
           allJourneysLoaded = fromMaybe False searchRequest.allJourneysLoaded,
@@ -470,6 +472,18 @@ estimatesSorting :: [UEstimate.EstimateAPIEntity] -> Maybe VehicleServiceTierOrd
 estimatesSorting list Nothing order = sortBy (comparing (\estimate -> vehicleOrderIndex order estimate.serviceTierType)) list
 estimatesSorting list (Just config) _ =
   sortBy (comparing (\estimate -> vehicleOrderIndex config.orderArray estimate.serviceTierType)) list
+
+quotesSorting :: [OfferRes] -> Maybe VehicleServiceTierOrderConfig -> [DVST.ServiceTierType] -> [OfferRes]
+quotesSorting list mbConfig defaultOrder =
+  let order = maybe defaultOrder (.orderArray) mbConfig
+   in sortBy (comparing (offerVehicleOrderIndex order)) list
+  where
+    offerVehicleOrderIndex order = \case
+      OnDemandCab q -> vehicleOrderIndex order q.vehicleVariant
+      OnRentalCab q -> vehicleOrderIndex order q.vehicleVariant
+      OnMeterRide q -> vehicleOrderIndex order q.vehicleVariant
+      Metro _ -> maxBound
+      PublicTransport _ -> maxBound
 
 vehicleOrderIndex :: [DVST.ServiceTierType] -> DVST.ServiceTierType -> Int
 vehicleOrderIndex order v =


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personalized sorting of transportation quotes and estimates based on the rider's most frequent vehicle category to surface more relevant options.
* **Bug Fixes**
  * Metro and public-transport options are forced to appear last, improving clarity when comparing cab, rental, and meter-ride choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->