### PR TITLE
backend/feat: introduce AirportReachargeService payment type for wallet topup

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
@@ -243,13 +243,18 @@ getStatus (personId, merchantId, merchantOperatingCityId) paymentOrderId = do
     else do
       -- Check if this is a STCL membership payment order
       let isStclOrder = order.paymentServiceType == Just DOrder.STCL || order.entityName == Just DPayment.DRIVER_STCL
+      let isWalletTopupOrder = order.entityName == Just DPayment.DRIVER_WALLET_TOPUP
       serviceConfig <-
         CQSC.findSubscriptionConfigsByMerchantOpCityIdAndServiceName merchantOperatingCityId Nothing serviceName
           >>= fromMaybeM (NoSubscriptionConfigForService merchantOperatingCityId.getId $ show serviceName)
       driver <- B.runInReplica $ QP.findById (cast order.personId) >>= fromMaybeM (PersonDoesNotExist order.personId.getId)
-      -- Use MembershipPaymentService for STCL orders, otherwise use the service config's payment service name
-      let defaultPaymentServiceName = if isStclOrder then DMSC.MembershipPaymentService Payment.Juspay else serviceConfig.paymentServiceName
-      paymentServiceName <- Payment.decidePaymentService defaultPaymentServiceName driver.clientSdkVersion driver.merchantOperatingCityId
+      -- Wallet topup uses AirportReachargeService (separate Juspay account); STCL uses MembershipPaymentService; otherwise use the service config's payment service name
+      paymentServiceName <-
+        if isWalletTopupOrder
+          then pure $ DMSC.AirportReachargeService Payment.Juspay
+          else do
+            let defaultPaymentServiceName = if isStclOrder then DMSC.MembershipPaymentService Payment.Juspay else serviceConfig.paymentServiceName
+            Payment.decidePaymentService defaultPaymentServiceName driver.clientSdkVersion driver.merchantOperatingCityId
       paymentStatus <- DPayment.orderStatusService commonMerchantOperatingCityId commonPersonId paymentOrderId (orderStatusCall paymentServiceName (Just order.personId.getId))
       case paymentStatus of
         DPayment.MandatePaymentStatus {..} -> do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
@@ -88,6 +88,7 @@ data ServiceName
   | PartnerSdkService PartnerSdkProvider
   | SettlementService Settlement.SettlementService
   | GSTEInvoiceService GSTEInvoice.GSTEInvoiceService
+  | AirportReachargeService Payment.PaymentService
   deriving stock (Eq, Ord, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
@@ -121,6 +122,7 @@ instance Show ServiceName where
   show (PartnerSdkService s) = "PartnerSdk_" <> show s
   show (SettlementService s) = "Settlement_" <> show s
   show (GSTEInvoiceService s) = "GSTEInvoice_" <> show s
+  show (AirportReachargeService s) = "AirportReacharge_" <> show s
 
 instance Read ServiceName where
   readsPrec d' =
@@ -235,6 +237,10 @@ instance Read ServiceName where
                  | r1 <- stripPrefix "GSTEInvoice_" r,
                    (v1, r2) <- readsPrec (app_prec + 1) r1
                ]
+            ++ [ (AirportReachargeService v1, r2)
+                 | r1 <- stripPrefix "AirportReacharge_" r,
+                   (v1, r2) <- readsPrec (app_prec + 1) r1
+               ]
       )
     where
       app_prec = 10
@@ -268,6 +274,7 @@ data ServiceConfigD (s :: UsageSafety)
   | PartnerSdkServiceConfig !PartnerSdk.PartnerSdkConfig
   | SettlementServiceConfig !Settlement.SettlementServiceConfig
   | GSTEInvoiceServiceConfig !GSTEInvoice.GSTEInvoiceConfig
+  | AirportReachargeServiceConfig !PaymentServiceConfig
   deriving (Generic, Eq, Show)
 
 type ServiceConfig = ServiceConfigD 'Safe

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs
@@ -458,11 +458,7 @@ createWalletTopupOrder (driverId, merchantId, mocId) amount mbExistingOrderId = 
   merchantServiceUsageConfig <-
     CQMSUC.findByMerchantOpCityId mocId
       >>= fromMaybeM (MerchantServiceUsageConfigNotFound mocId.getId)
-  paymentServiceName <-
-    TPayment.decidePaymentService
-      (DMSC.PaymentService merchantServiceUsageConfig.createBankAccount)
-      driver.clientSdkVersion
-      mocId
+  let paymentServiceName = DMSC.AirportReachargeService merchantServiceUsageConfig.createBankAccount
   (orderId, orderShortId) <- handleExistingOrder mbExistingOrderId
   let createOrderReq =
         Payment.CreateOrderReq

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
@@ -130,6 +130,10 @@ getConfigJSON = \case
   Domain.SettlementServiceConfig settlementCfg -> toJSON settlementCfg
   Domain.GSTEInvoiceServiceConfig eInvCfg -> case eInvCfg of
     GSTEInvoice.CharteredInfoEInvoiceConfig cfg -> toJSON cfg
+  Domain.AirportReachargeServiceConfig paymentCfg -> case paymentCfg of
+    Payment.JuspayConfig cfg -> toJSON cfg
+    Payment.StripeConfig cfg -> toJSON cfg
+    Payment.PaytmEDCConfig cfg -> toJSON cfg
 
 getServiceName :: Domain.ServiceConfig -> Domain.ServiceName
 getServiceName = \case
@@ -209,6 +213,7 @@ getServiceName = \case
   Domain.SettlementServiceConfig settlementCfg -> Domain.SettlementService settlementCfg.settlementService
   Domain.GSTEInvoiceServiceConfig eInvCfg -> case eInvCfg of
     GSTEInvoice.CharteredInfoEInvoiceConfig _ -> Domain.GSTEInvoiceService GSTEInvoice.CharteredInfo
+  Domain.AirportReachargeServiceConfig paymentCfg -> Domain.AirportReachargeService $ getPaymentServiceConfigJson paymentCfg
 
 getPaymentServiceConfigJson :: Payment.PaymentServiceConfig -> Payment.PaymentService
 getPaymentServiceConfigJson = \case
@@ -300,6 +305,7 @@ mkServiceConfig configJSON serviceName = either (\err -> throwError $ InternalEr
               <> ")"
       Left err -> Left err
   Domain.GSTEInvoiceService GSTEInvoice.CharteredInfo -> Domain.GSTEInvoiceServiceConfig . GSTEInvoice.CharteredInfoEInvoiceConfig <$> eitherValue configJSON
+  Domain.AirportReachargeService paymentServiceName -> Domain.AirportReachargeServiceConfig <$> mkPaymentServiceConfig configJSON paymentServiceName
 
 eitherValue :: FromJSON a => A.Value -> Either Text a
 eitherValue value = case A.fromJSON value of

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Payment.hs
@@ -80,6 +80,7 @@ runWithServiceConfigAndName func merchantId merchantOperatingCity serviceName mR
     DMSC.RentalPaymentServiceConfig vsc -> return (func vsc getRoutingId, getPclient vsc)
     DMSC.CautioPaymentServiceConfig vsc -> return (func vsc getRoutingId, getPclient vsc)
     DMSC.MembershipPaymentServiceConfig vsc -> return (func vsc getRoutingId, getPclient vsc)
+    DMSC.AirportReachargeServiceConfig vsc -> return (func vsc getRoutingId, getPclient vsc)
     _ -> throwError $ InternalError "Unknown Service Config"
   where
     getPclient vsc = do


### PR DESCRIPTION
## Summary

- Adds a new `AirportReachargeService` ServiceName/ServiceConfig variant in driver-app so wallet-related Juspay traffic can be routed through a dedicated Juspay account, separate from the shared `PaymentService`.
- Switches `createWalletTopupOrder` and the `DRIVER_WALLET_TOPUP` webhook lookup in `getStatus` to use the new service.

## Why

Driver wallet topup currently runs through the same Juspay merchant credentials as the rest of the platform (`Payment_Juspay`). We need a separate Juspay account for wallet/airport-related flows; introducing a dedicated `ServiceName` keeps configs cleanly partitioned in `merchant_service_config` and lets ops point each entity at the right Juspay merchant without repurposing the existing `PaymentService` row.

`decidePaymentService` is intentionally bypassed in `createWalletTopupOrder` because it force-overrides to `PaymentService Payment.AAJuspay` for newer SDKs — that would defeat the routing change, and AA mandate routing is not relevant for a one-off wallet topup.

## Files

- `Domain/Types/Extra/MerchantServiceConfig.hs` — new `ServiceName` + `ServiceConfigD` constructors with matching `Show`/`Read` clauses (`AirportReacharge_<svc>`).
- `Storage/Queries/Transformers/MerchantServiceConfig.hs` — handle the new variant in `getConfigJSON`, `getServiceName`, and `mkServiceConfig`.
- `Tools/Payment.hs` — `runWithServiceConfigAndName` dispatches `AirportReachargeServiceConfig`.
- `SharedLogic/Payment.hs` — `createWalletTopupOrder` uses `AirportReachargeService` directly.
- `Domain/Action/UI/Payment.hs` — `getStatus` routes `DRIVER_WALLET_TOPUP` orders to `AirportReachargeService` so webhook status reads the same Juspay account.

## Out of scope (follow-up needed)

1. **DB seed**: `merchant_service_config` rows must be inserted per merchant op city with `service_name = AirportReacharge_Juspay` (and the new account's Juspay creds in `config_json`). Without it, `createWalletTopupOrder` will throw `MerchantServiceConfigNotFound` for `AirportReacharge_Juspay`.
2. **Dashboard airport cash recharge**: `recordAirportCashRecharge` (the booth-cash flow behind `postDriverWalletWalletAirportCashRecharge`) is a pure ledger transfer and does not call any payment service today, so there is nothing to switch there in code. If we want booth entries also tracked in this Juspay account, that's a separate change to introduce an order-create call in that flow.

## Test plan

- [ ] Build: `cabal build dynamic-offer-driver-app` (verified locally)
- [ ] Seed `AirportReacharge_Juspay` config in a non-prod env and trigger a wallet topup; confirm Juspay order is created against the new merchant.
- [ ] Trigger Juspay webhook for a `DRIVER_WALLET_TOPUP` order; confirm `getStatus` looks up `AirportReacharge_Juspay` config and credits the wallet via `processWalletTopupWebhook`.
- [ ] Confirm existing flows (subscription, rental, membership, cautio payment) continue to use their existing `*PaymentService` configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Airport Recharge Service payment option to support wallet top-up transactions.

* **Improvements**
  * Enhanced payment processing logic to differentiate between wallet top-up and subscription orders, routing each to the appropriate payment service for improved accuracy and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14726)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->