### PR TITLE
Backend/BugFix - Handle Edge case in VehicleListStats

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
@@ -4449,7 +4449,13 @@ getDriverFleetVehicleListStats merchantShortId opCity fleetOwnerId mbRequestorId
       case mbRc of
         Just rc -> case rc.fleetOwnerId of
           Just rcFleetOwnerId -> validateOperatorToFleetAssoc requestorId rcFleetOwnerId
-          Nothing -> throwError (InvalidRequest "Vehicle is not associated with any fleet")
+          Nothing -> do
+            activeAssociationsOfRC <- DRCAE.findAllActiveAssociationByRCId rc.id
+            let rcAssociatedDriverIds = map (.driverId) activeAssociationsOfRC
+            isAnyDriverLinkedToOperator <- fmap or $ forM rcAssociatedDriverIds $ \driverId ->
+              isJust <$> (B.runInReplica $ QDOAExtra.findByDriverIdAndOperatorId driverId (Id requestorId) True)
+            unless isAnyDriverLinkedToOperator $
+              throwError (InvalidRequest "Vehicle's driver is not associated with this operator")
         Nothing -> throwError (InvalidRequest "Vehicle not found")
   merchant <- findMerchantByShortId merchantShortId
   merchantOpCityId <- CQMOC.getMerchantOpCityId Nothing merchant (Just opCity)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to fleet vehicle statistics when a vehicle lacks a direct fleet owner: the system now examines active driver associations and grants access if at least one driver is associated with the requesting operator; otherwise the request is rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14787)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->