### PR TITLE
backend/fix/stale-read-replication-lag-clear-dues

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -2515,23 +2515,23 @@ clearDriverDues (personId, _merchantId, opCityId) serviceName clearSelectedReq m
   (dueDriverFees', mKey) <- do
     case clearSelectedReq of
       Just req -> do
-        dfees <- QDF.findAllByStatusAndDriverIdWithServiceName personId [DDF.PAYMENT_OVERDUE] (Just $ req.driverFeeIds) serviceName
+        dfees <- runInMasterDbAndRedis $ QDF.findAllByStatusAndDriverIdWithServiceName personId [DDF.PAYMENT_OVERDUE] (Just $ req.driverFeeIds) serviceName
         let len = length dfees
         let paymentIdLength = length req.driverFeeIds
         unless (len == paymentIdLength) $
           throwError $ InvalidRequest "Status of some id is not PAYMENT_OVERDUE."
         return (dfees, subscriptionConfig.partialDueClearanceMessageKey)
       Nothing -> do
-        dfees <- QDF.findAllByStatusAndDriverIdWithServiceName personId [DDF.PAYMENT_OVERDUE] Nothing serviceName
+        dfees <- runInMasterDbAndRedis $ QDF.findAllByStatusAndDriverIdWithServiceName personId [DDF.PAYMENT_OVERDUE] Nothing serviceName
         return (dfees, Nothing)
 
   --------- to crub up cases related to double debit ----------
-  successfulInvoices <- mapM (\fee -> runInReplica (QINV.findInvoiceByFeeIdAndStatus fee.id Domain.SUCCESS)) dueDriverFees'
+  successfulInvoices <- mapM (\fee -> runInMasterDbAndRedis (QINV.findInvoiceByFeeIdAndStatus fee.id Domain.SUCCESS)) dueDriverFees'
   let allPaidFeeNotMarkedCleared = nub $ map INV.driverFeeId (concat successfulInvoices)
   forM_ allPaidFeeNotMarkedCleared $ \feeId -> QDF.updateStatus DDF.CLEARED feeId now
   let dueDriverFees = filter (\fee -> not $ fee.id `elem` allPaidFeeNotMarkedCleared) dueDriverFees'
   ----------------------------------------------------------
-  invoices <- mapM (\fee -> runInReplica (QINV.findActiveManualInvoiceByFeeId fee.id Domain.MANUAL_INVOICE Domain.ACTIVE_INVOICE)) dueDriverFees
+  invoices <- mapM (\fee -> runInMasterDbAndRedis (QINV.findActiveManualInvoiceByFeeId fee.id Domain.MANUAL_INVOICE Domain.ACTIVE_INVOICE)) dueDriverFees
   let paymentService = subscriptionConfig.paymentServiceName
       sortedInvoices = mergeSortAndRemoveDuplicate invoices
       splitEnabled = subscriptionConfig.isVendorSplitEnabled == Just True
@@ -2567,7 +2567,7 @@ clearDriverDues (personId, _merchantId, opCityId) serviceName clearSelectedReq m
       return (vendorFees, finalInvoices)
 
     validateExistingInvoice invoice driverFees = do
-      invoices <- runInReplica $ QINV.findAllByInvoiceId invoice.id
+      invoices <- runInMasterDbAndRedis $ QINV.findAllByInvoiceId invoice.id
       let driverFeeIds = driverFees <&> getId . (.id)
       let currentDueDriverFee = (invoices <&> getId . (.driverFeeId)) `intersect` driverFeeIds
       if isJust clearSelectedReq


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
## Fix: Prevent Stale Reads in `clearDriverDues` Caused by Replica Lag

### Problem
All read queries in `clearDriverDues` were hitting the replica DB. Due to replication lag, recently committed writes on master were not immediately visible, creating race conditions in payment processing.

#### Impact

**Double billing risk**
- Payment webhook marks invoice as `SUCCESS` on master.
- Replica has not synced yet.
- `clearDriverDues` misses the successful payment check and creates a new payment order for an already-paid fee.

**Duplicate payment order creation**
- Concurrent `clearDriverDues` requests both read from replica.
- Each misses the other's newly created `ACTIVE_INVOICE` written on master.
- Multiple payment orders can be created for the same due.

---

### Fix
Moved all read queries in `clearDriverDues` to `runInMasterDbAndRedis`, ensuring:

- Reads are served from **master DB**
- Redis KV cache continues to be populated
- Forward-compatible with future KV migration

**Total queries moved:** 5

---

### Production Query Verification
All affected queries were verified on production and are index-backed.

| Query | Table | Index Used | Execution Time |
|------|-------|------------|----------------|
| `findAllByStatusAndDriverIdWithServiceName` | `driver_fee` | `idx_driver_fee_driver_id` | 0.16 ms |
| `findAllByStatusAndDriverIdWithServiceName` (with fee IDs) | `driver_fee` | `driver_fee_pkey` | 0.06 ms |
| `findInvoiceByFeeIdAndStatus` (`SUCCESS` guard) | `invoice` | `idx_invoice_driver_fee_id` | 0.04 ms |
| `findActiveManualInvoiceByFeeId` | `invoice` | `idx_invoice_driver_fee_id` | 0.05 ms |
| `findAllByDriverFeeId` | `vendor_fee` | `idx_driver_fee` | 0.05 ms |

---

### Performance Impact
All queries are sub-millisecond, so moving these reads to master adds negligible DB load while eliminating stale-read race conditions.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver fee and invoice clearing process to ensure real-time data consistency and accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14788)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->