### PR TITLE
backend/fix: DailyPassStatusUpdate reliability — reviver self-healing + chain delay

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/DailyPassStatusUpdate.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/DailyPassStatusUpdate.hs
@@ -59,7 +59,7 @@ dailyPassStatusUpdate Job {id, jobInfo} = withLogTag ("JobId-" <> id.getId) $ do
   when autoSchedule $
     if expiredCount + activatedCount < batchSize
       then scheduleTomorrow merchantId' merchantOpCityId timeDiffFromUtc istTime
-      else createJobIn @_ @'DailyPassStatusUpdate (Just merchantId') (Just merchantOpCityId) 0 jobData
+      else createJobIn @_ @'DailyPassStatusUpdate (Just merchantId') (Just merchantOpCityId) 60 jobData
 
   pure Complete
 

--- a/Backend/lib/producer/src/Producer/Flow.hs
+++ b/Backend/lib/producer/src/Producer/Flow.hs
@@ -83,7 +83,13 @@ runReviver producerType = do
   let secondsTillNow = T.diffTimeToPicoseconds todaysDiffTime `div` 1000000000000
       minutesTillNow = secondsTillNow `div` 60
       shouldRunReviver = minutesTillNow `mod` (fromIntegral reviverInterval.getMinutes) == 0
-  when shouldRunReviver $ Hedis.whenWithLockRedis reviverLockKey 300 (runReviver' producerType)
+  when shouldRunReviver $ do
+    someErr <-
+      withTryCatch "runReviver:cycleFailure" $
+        Hedis.whenWithLockRedis reviverLockKey 300 (runReviver' producerType)
+    case someErr of
+      Left err -> logError $ "Reviver iteration failed, will retry next cycle: " <> show err
+      Right _ -> pure ()
   threadDelayMilliSec 60000
 
 mkRunningJobKey :: Text -> Text


### PR DESCRIPTION
Two small fixes to make DailyPassStatusUpdate (and the rider scheduler reviver generally) actually work in prod.

## Fix 1 — Reviver self-healing via `withTryCatch`

`Backend/lib/producer/src/Producer/Flow.hs:79-87`

`runReviver` runs on the main thread of `loopGracefully` with no exception handler. Any transient inside `runReviver'` (Postgres `FatalError` from connection drop, `InternalError` from parse failure, Hedis blip) propagates up, the main thread dies, but the 3 forked producer threads keep the pod alive — so reviver dies silently with no pod restart, no alert.

**Prod evidence** (`atlas_app.scheduler_job`):

| Day | Revived count |
|---|---|
| Apr 27 – May 15 (18 days) | **0** |
| 2026-04-26 | 1,940 |
| 2026-04-25 | 6,619 |
| 2026-04-24 | 4,385 |

Driver-side `atlas_driver_offer_bpp.scheduler_job` ran 57k revivals same period — same shared code, but driver pods recycle more often (HPA / evictions) and reset the dead reviver thread. Rider pods stay up 22h+ with zero restarts.

The single observed crash in current rider-producer pod logs is `PostgresFatalError` with empty fields at `DB/Queries.hs:145` (`getPendingStuckJobs`) on 2026-05-13 15:38 UTC — classic Aurora `-ro` replica connection drop.

**Fix**: wrap `runReviver'` in `withTryCatch` mirroring `runProducer` (lines 58-77 in the same file). Transient error logs at ERROR, lock releases via existing `finally`, outer `loop` retries 60s later. Applies to both rider and driver producers (shared file). No new imports.

## Fix 2 — Within-day chain delay `0` → `60`

`Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/DailyPassStatusUpdate.hs:62`

Handler's within-day chain was `createJobIn ... 0 jobData` — creating the next chain row with `scheduledAt = now` exactly. Producer's `runProducer` reads ZSET range `[startTime, endTime]` where `startTime` is its monotonically-advancing cursor. If the handler writes a chain row at instant T but the producer's most recent tick already advanced its cursor past T (handler took real time to complete the bulk UPDATE before calling `createJobIn`), the chain row's score falls below `startTime` and the next producer cycle's `zRangeByScoreByCount` misses it. Row stranded in ZSET, chain dies.

Same race the reviver suffers — `scheduledAt = now` loses against monotonic cursor advancement.

**Observed**: each manual dashboard trigger processes one ~1000-row batch then stops chaining. Within-day cascade has never been observed in prod data, only `scheduleTomorrow` paths.

**Fix**: change `0` → `60` (seconds). Chain row lands safely 1 minute above any plausible producer cursor position. For a 22k-row Chennai backlog: 22 batches × 60s = ~22-minute drain, comfortably within the cron's daily window. Gentler on Aurora replica than back-to-back bulk writes; each minute = expected 1k expirations makes anomalies easy to spot in metrics.

The sibling `scheduleTomorrow` path (line 143) is unaffected — its delay is computed to reach next 01:00 IST.

## Why these go together

- Fix 1 alone: reviver wakes, rescues orphan PG rows from past dashboard triggers. But daily cron's within-day chain still doesn't cascade.
- Fix 2 alone: chain cascades correctly. But any transient PG/Hedis blip permanently kills the reviver again → next backlog accumulates silently.
- Both: cron drains the daily cohort via cascading within-day chain, reviver self-heals from transients, orphan rows from any path get recovered.

## Test plan

- [ ] CI build passes (local build blocked by unrelated `dynamic-offer-driver-app` GHC panic)
- [ ] After deploy, `Revived` count in `atlas_app.scheduler_job` starts growing within minutes (Fix 1)
- [ ] After tomorrow's 19:30 UTC cron tick, watch within-day cascade fire ~22 batches over ~22 minutes — Chennai `TO_BE_EXPIRED` bucket drops from ~21k → near 0 in one tick (Fix 2)
- [ ] Watch for `"Reviver iteration failed, will retry next cycle"` log lines on the next Aurora blip — proves the catch is wired (Fix 1)

## Followups (separate PRs, not in scope)

- Widen the 24h reviver lookback (`Producer/Flow.hs:198-199`) so the long-stranded backlog (~1,000 rows in `CheckRefundStatus` etc.) becomes reachable
- Make chain delay configurable from `RiderConfig.passStatusUpdateChainDelaySeconds` if 60s ever needs tuning per-MOC
- Change `fromTType''` in `DB/Queries.hs:41-44` to `pure Nothing` instead of throwing — single corrupt row shouldn't crash an entire 300-row batch (shared-lib change, needs broader review)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for producer operations during execution.
  * Adjusted scheduling behavior for daily pass status updates to prevent excessive immediate rescheduling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14795)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->