### PR TITLE
backend/enhc: Add ride breakup in cancellation dues API

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/RiderPlatform/Management/API/Customer.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/RiderPlatform/Management/API/Customer.yaml
@@ -1,6 +1,7 @@
 imports:
   Customer: Dashboard.Common
   Summary: Dashboard.Common
+  Ride: Dashboard.Common
   HighPrecMoney: Kernel.Types.Common
   PriceAPIEntity: Kernel.Types.Common
   PersonRes: Dashboard.Common
@@ -160,6 +161,13 @@ types:
     - noOfTimesCancellationDuesPaid: Int
     - waivedOffAmount: HighPrecMoney
     - noOfTimesWaiveOffUsed: Int
+    - duesBreakup: Maybe [CancellationDueBreakup]
+  CancellationDueBreakup:
+    - rideId: Id Ride
+    - dueAmount: PriceAPIEntity
+    - dueStatus: CancellationDuesPaymentStatus
+  CancellationDuesPaymentStatus:
+    - enum: "PENDING, PAID, WAIVED"
   UpdateSafetyCenterBlockingReq:
     - incrementCount: Maybe Bool
     - resetCount: Maybe Bool

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/RiderPlatform/Management/Endpoints/Customer.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/RiderPlatform/Management/Endpoints/Customer.hs
@@ -20,14 +20,26 @@ import qualified Kernel.Types.Id
 import Servant
 import Servant.Client
 
+data CancellationDueBreakup = CancellationDueBreakup {rideId :: Kernel.Types.Id.Id Dashboard.Common.Ride, dueAmount :: Kernel.Types.Common.PriceAPIEntity, dueStatus :: CancellationDuesPaymentStatus}
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data CancellationDuesDetailsRes = CancellationDuesDetailsRes
   { cancellationDues :: Kernel.Types.Common.PriceAPIEntity,
     cancellationDuesPaid :: Kernel.Types.Common.HighPrecMoney,
     noOfTimesCancellationDuesPaid :: Kernel.Prelude.Int,
     waivedOffAmount :: Kernel.Types.Common.HighPrecMoney,
-    noOfTimesWaiveOffUsed :: Kernel.Prelude.Int
+    noOfTimesWaiveOffUsed :: Kernel.Prelude.Int,
+    duesBreakup :: Kernel.Prelude.Maybe [CancellationDueBreakup]
   }
   deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+data CancellationDuesPaymentStatus
+  = PENDING
+  | PAID
+  | WAIVED
+  deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data CustomerCancellationDuesSyncReq = CustomerCancellationDuesSyncReq

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/CustomerCancellationDues.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/CustomerCancellationDues.hs
@@ -20,6 +20,7 @@ type API =
     :> Capture "merchantCity" Context.City
     :> "getCancellationDuesDetails"
     :> Header "token" Text
+    :> QueryParam "includeBreakup" Bool
     :> ReqBody '[JSON] Domain.CancellationDuesReq
     :> Get '[JSON] Domain.CancellationDuesDetailsRes
     :<|> Capture "merchantId" (Id Merchant)
@@ -34,8 +35,8 @@ handler =
   getCancellationDuesDetails
     :<|> customerCancellationDuesSync
 
-getCancellationDuesDetails :: Id Merchant -> Context.City -> Maybe Text -> Domain.CancellationDuesReq -> FlowHandler Domain.CancellationDuesDetailsRes
-getCancellationDuesDetails merchantId merchantCity apiKey = withFlowHandlerAPI . Domain.getCancellationDuesDetails merchantId merchantCity apiKey
+getCancellationDuesDetails :: Id Merchant -> Context.City -> Maybe Text -> Maybe Bool -> Domain.CancellationDuesReq -> FlowHandler Domain.CancellationDuesDetailsRes
+getCancellationDuesDetails merchantId merchantCity apiKey mbIncludeBreakup = withFlowHandlerAPI . Domain.getCancellationDuesDetails merchantId merchantCity apiKey mbIncludeBreakup
 
 customerCancellationDuesSync :: Id Merchant -> Context.City -> Maybe Text -> Domain.CustomerCancellationDuesSyncReq -> FlowHandler APISuccess
 customerCancellationDuesSync merchantId merchantCity apiKey = withFlowHandlerAPI . Domain.customerCancellationDuesSync merchantId merchantCity apiKey

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/CustomerCancellationDues.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/CustomerCancellationDues.hs
@@ -19,6 +19,7 @@ import qualified Domain.Types.CancellationCharges as DCC
 import qualified Domain.Types.CancellationDuesDetails as DCDD
 import qualified Domain.Types.DailyStats as DDS
 import Domain.Types.Merchant (Merchant)
+import qualified Domain.Types.Ride as DRide
 import EulerHS.Prelude hiding (id)
 import Kernel.External.Encryption (DbHash, getDbHash, unDbHash)
 import Kernel.Prelude
@@ -55,7 +56,15 @@ data CancellationDuesDetailsRes = CancellationDuesDetailsRes
     cancellationDuesPaid :: HighPrecMoney,
     noOfTimesCancellationDuesPaid :: Int,
     waivedOffAmount :: HighPrecMoney,
-    noOfTimesWaiveOffUsed :: Int
+    noOfTimesWaiveOffUsed :: Int,
+    duesBreakup :: Maybe [CancellationDueBreakup]
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+data CancellationDueBreakup = CancellationDueBreakup
+  { rideId :: Id DRide.Ride,
+    dueAmount :: PriceAPIEntity,
+    dueStatus :: DCDD.CancellationDuesPaymentStatus
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
 
@@ -77,21 +86,37 @@ getCancellationDuesDetails ::
   Id Merchant ->
   Context.City ->
   Maybe Text ->
+  Maybe Bool ->
   CancellationDuesReq ->
   m CancellationDuesDetailsRes
-getCancellationDuesDetails merchantId _merchantCity apiKey CancellationDuesReq {..} = do
+getCancellationDuesDetails merchantId _merchantCity apiKey mbIncludeBreakup CancellationDuesReq {..} = do
   merchant <- QM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
   unless (Just merchant.internalApiKey == apiKey) $
     throwError $ AuthBlocked "Invalid BPP internal api key"
   riderDetails <- QRD.findByMobileNumberHashAndMerchant customerMobileNumberHash merchant.id >>= fromMaybeM (RiderDetailsDoNotExist "Mobile Number Hash" (showDbHashHex customerMobileNumberHash))
+  mbDuesBreakup <-
+    if mbIncludeBreakup == Just True
+      then do
+        pendingDues <- QCDD.findAllPendingByRiderId riderDetails.id
+        let sorted = sortOn (Down . (.createdAt)) pendingDues
+        pure $ Just $ fmap mkBreakup sorted
+      else pure Nothing
   return $
     CancellationDuesDetailsRes
       { cancellationDues = PriceAPIEntity riderDetails.cancellationDues riderDetails.currency,
         cancellationDuesPaid = riderDetails.cancellationDuesPaid,
         noOfTimesCancellationDuesPaid = riderDetails.noOfTimesCanellationDuesPaid,
         waivedOffAmount = riderDetails.waivedOffAmount,
-        noOfTimesWaiveOffUsed = riderDetails.noOfTimesWaiveOffUsed
+        noOfTimesWaiveOffUsed = riderDetails.noOfTimesWaiveOffUsed,
+        duesBreakup = mbDuesBreakup
       }
+  where
+    mkBreakup row =
+      CancellationDueBreakup
+        { rideId = row.rideId,
+          dueAmount = PriceAPIEntity row.cancellationAmount row.currency,
+          dueStatus = row.paymentStatus
+        }
 
 customerCancellationDuesSync ::
   ( MonadFlow m,

--- a/Backend/app/rider-platform/rider-app/Main/src/API/UI/Cancel.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/UI/Cancel.hs
@@ -93,7 +93,7 @@ getCancellationDuesDetails ::
   FlowHandler DCancel.CancellationDuesDetailsRes
 getCancellationDuesDetails (personId, merchantId) =
   withFlowHandlerAPIPersonId personId . withPersonIdLogTag personId $ do
-    DCancel.getCancellationDuesDetails (personId, merchantId)
+    DCancel.getCancellationDuesDetails (personId, merchantId) False
 
 cancel ::
   Id SRB.Booking ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Customer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Customer.hs
@@ -28,6 +28,7 @@ module Domain.Action.Dashboard.Customer
 where
 
 import qualified "dashboard-helper-api" API.Types.RiderPlatform.Management.Customer as Common
+import qualified "dashboard-helper-api" API.Types.RiderPlatform.Management.Customer as CommonC
 import qualified Dashboard.Common as Common
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -207,15 +208,26 @@ getCustomerCancellationDuesDetails ::
   Flow Common.CancellationDuesDetailsRes
 getCustomerCancellationDuesDetails merchantShortId _ personId = do
   merchant <- QM.findByShortId merchantShortId >>= fromMaybeM (MerchantDoesNotExist merchantShortId.getShortId)
-  res <- DCancel.getCancellationDuesDetails (cast personId, merchant.id)
+  res <- DCancel.getCancellationDuesDetails (cast personId, merchant.id) True
   return $
     Common.CancellationDuesDetailsRes
       { cancellationDues = res.cancellationDues,
         cancellationDuesPaid = res.cancellationDuesPaid,
         noOfTimesCancellationDuesPaid = res.noOfTimesCancellationDuesPaid,
         waivedOffAmount = res.waivedOffAmount,
-        noOfTimesWaiveOffUsed = res.noOfTimesWaiveOffUsed
+        noOfTimesWaiveOffUsed = res.noOfTimesWaiveOffUsed,
+        duesBreakup = fmap (map mkCommonBreakup) res.duesBreakup
       }
+  where
+    mkCommonBreakup b =
+      Common.CancellationDueBreakup
+        { rideId = cast b.rideId,
+          dueAmount = b.dueAmount,
+          dueStatus = toCommonStatus b.dueStatus
+        }
+    toCommonStatus CallBPPInternal.PENDING = CommonC.PENDING
+    toCommonStatus CallBPPInternal.PAID = CommonC.PAID
+    toCommonStatus CallBPPInternal.WAIVED = CommonC.WAIVED
 
 postCustomerUpdateSafetyCenterBlocking ::
   ShortId DM.Merchant ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Cancel.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Cancel.hs
@@ -19,6 +19,7 @@ module Domain.Action.UI.Cancel
     CancelRes (..),
     CancelSearch (..),
     CancellationDuesDetailsRes (..),
+    CancellationDueBreakup (..),
     CancellationReasonInput (..),
     computeCancellationReasons,
     mkDomainCancelSearch,
@@ -73,6 +74,7 @@ import qualified Storage.Queries.BookingCancellationReason as QBCR
 import qualified Storage.Queries.DriverOffer as QDOffer
 import qualified Storage.Queries.Estimate as QEstimate
 import qualified Storage.Queries.Person as QP
+import qualified Storage.Queries.Ride as QRide
 import Tools.Error
 import qualified Tools.Maps as Maps
 
@@ -116,7 +118,17 @@ data CancellationDuesDetailsRes = CancellationDuesDetailsRes
     cancellationDuesPaid :: HighPrecMoney,
     noOfTimesCancellationDuesPaid :: Int,
     waivedOffAmount :: HighPrecMoney,
-    noOfTimesWaiveOffUsed :: Int
+    noOfTimesWaiveOffUsed :: Int,
+    duesBreakup :: Maybe [CancellationDueBreakup]
+  }
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
+-- rideId here is the BAP rideId — translated from the BPP wire response
+-- so the dashboard waive-off endpoint (which expects a BAP rideId) accepts it.
+data CancellationDueBreakup = CancellationDueBreakup
+  { rideId :: Id Ride.Ride,
+    dueAmount :: PriceAPIEntity,
+    dueStatus :: CallBPPInternal.CancellationDuesPaymentStatus
   }
   deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
 
@@ -311,8 +323,8 @@ driverDistanceToPickup booking merchantOperatingCityId tripStartPos tripEndPos =
         }
   return distRes.distance
 
-getCancellationDuesDetails :: (Id Person.Person, Id Merchant.Merchant) -> Flow CancellationDuesDetailsRes
-getCancellationDuesDetails (personId, merchantId) = do
+getCancellationDuesDetails :: (Id Person.Person, Id Merchant.Merchant) -> Bool -> Flow CancellationDuesDetailsRes
+getCancellationDuesDetails (personId, merchantId) includeBreakup = do
   person <- QP.findById personId >>= fromMaybeM (PersonNotFound personId.getId) >>= decrypt
   merchant <- CQM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
   mobileNumber <- person.mobileNumber & fromMaybeM (PersonMobileNumberIsNULL person.id.getId)
@@ -324,14 +336,35 @@ getCancellationDuesDetails (personId, merchantId) = do
       merchant.driverOfferMerchantId
       mobileHash
       person.currentCity
+      includeBreakup
+  translatedBreakup <- traverse (fmap catMaybes . traverse translateBreakup) res.duesBreakup
   return $
     CancellationDuesDetailsRes
       { cancellationDues = res.cancellationDues,
         cancellationDuesPaid = res.cancellationDuesPaid,
         noOfTimesCancellationDuesPaid = res.noOfTimesCancellationDuesPaid,
         waivedOffAmount = res.waivedOffAmount,
-        noOfTimesWaiveOffUsed = res.noOfTimesWaiveOffUsed
+        noOfTimesWaiveOffUsed = res.noOfTimesWaiveOffUsed,
+        duesBreakup = translatedBreakup
       }
+  where
+    -- Maps a BPP-side breakup row to a BAP-side one by looking up the BAP
+    -- ride keyed by bppRideId. Rows with no BAP match are dropped (the
+    -- aggregate cancellationDues still reflects them).
+    translateBreakup b = do
+      mbRide <- QRide.findByBPPRideId b.rideId
+      case mbRide of
+        Nothing -> do
+          logWarning $ "getCancellationDuesDetails: no BAP ride for BPP rideId " <> b.rideId.getId
+          pure Nothing
+        Just ride ->
+          pure $
+            Just
+              CancellationDueBreakup
+                { rideId = ride.id,
+                  dueAmount = b.dueAmount,
+                  dueStatus = b.dueStatus
+                }
 
 makeCustomerBlockingKey :: Text -> Text
 makeCustomerBlockingKey bid = "CCRBlock:" <> bid

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPPInternal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPPInternal.hs
@@ -24,6 +24,7 @@ import Domain.Types.Common
 import qualified Domain.Types.FeedbackForm as DFF
 import Domain.Types.Merchant
 import qualified Domain.Types.RefereeLink as LibTypes
+import qualified Domain.Types.Ride as DRide
 import EulerHS.Types (EulerClient, client)
 import IssueManagement.Common (IssueReportType)
 import Kernel.External.Encryption (DbHash)
@@ -185,9 +186,23 @@ data CancellationDuesDetailsRes = CancellationDuesDetailsRes
     cancellationDuesPaid :: HighPrecMoney,
     noOfTimesCancellationDuesPaid :: Int,
     waivedOffAmount :: HighPrecMoney,
-    noOfTimesWaiveOffUsed :: Int
+    noOfTimesWaiveOffUsed :: Int,
+    duesBreakup :: Maybe [CancellationDueBreakup]
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+-- rideId here is the BPP-side rideId — the only id stored in the BPP
+-- cancellation_dues_details table. Consumers on the BAP must translate to
+-- Id DRide.Ride before exposing it externally.
+data CancellationDueBreakup = CancellationDueBreakup
+  { rideId :: Id DRide.BPPRide,
+    dueAmount :: PriceAPIEntity,
+    dueStatus :: CancellationDuesPaymentStatus
+  }
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
+data CancellationDuesPaymentStatus = PENDING | PAID | WAIVED
+  deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema)
 
 type GetCancellationDuesDetailsAPI =
   "internal"
@@ -195,10 +210,11 @@ type GetCancellationDuesDetailsAPI =
     :> Capture "merchantCity" Context.City
     :> "getCancellationDuesDetails"
     :> Header "token" Text
+    :> QueryParam "includeBreakup" Bool
     :> ReqBody '[JSON] CancellationDuesReq
     :> Get '[JSON] CancellationDuesDetailsRes
 
-getCancellationDuesDetailsClient :: Text -> Context.City -> Maybe Text -> CancellationDuesReq -> EulerClient CancellationDuesDetailsRes
+getCancellationDuesDetailsClient :: Text -> Context.City -> Maybe Text -> Maybe Bool -> CancellationDuesReq -> EulerClient CancellationDuesDetailsRes
 getCancellationDuesDetailsClient = client getCancellationDuesDetailsApi
 
 getCancellationDuesDetailsApi :: Proxy GetCancellationDuesDetailsAPI
@@ -215,10 +231,11 @@ getCancellationDuesDetails ::
   Text ->
   DbHash ->
   Context.City ->
+  Bool ->
   m CancellationDuesDetailsRes
-getCancellationDuesDetails apiKey internalUrl merchantId mobileHash merchantCity = do
+getCancellationDuesDetails apiKey internalUrl merchantId mobileHash merchantCity includeBreakup = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
-  EC.callApiUnwrappingApiError (identity @Error) Nothing (Just "BPP_INTERNAL_API_ERROR") (Just internalEndPointHashMap) internalUrl (getCancellationDuesDetailsClient merchantId merchantCity (Just apiKey) (CancellationDuesReq mobileHash)) "GetCancellationDuesDetails" getCancellationDuesDetailsApi
+  EC.callApiUnwrappingApiError (identity @Error) Nothing (Just "BPP_INTERNAL_API_ERROR") (Just internalEndPointHashMap) internalUrl (getCancellationDuesDetailsClient merchantId merchantCity (Just apiKey) (Just includeBreakup) (CancellationDuesReq mobileHash)) "GetCancellationDuesDetails" getCancellationDuesDetailsApi
 
 data GetFavouriteDriverInfoReq = GetFavouriteDriverInfoReq
   { customerMobileNumber :: Text,


### PR DESCRIPTION
## Summary

Extends `GET /customer/{customerId}/getCancellationDuesDetails` (rider-platform dashboard) with an optional per-ride `duesBreakup` array, populated only when the call originates from the dashboard. The customer-facing mobile UI (`GET /rideBooking/cancellationDues`), which hits the same BPP-internal endpoint, is unaffected.

- New optional response field `duesBreakup: Maybe [{rideId, dueAmount, dueStatus}]` listing **PENDING** rows from the BPP `cancellation_dues_details` table for the rider.
- Threaded as a new `includeBreakup` query param on the BPP-internal `getCancellationDuesDetails` endpoint: dashboard handler sets `true`, UI handler omits → BPP returns `Nothing`.
- Reuses the existing `findAllPendingByRiderId` query — no new storage layer or migrations.

## Wire flow

```
Dashboard -> rider-dashboard -> rider-app (Domain.Action.Dashboard.Customer)
  -> DCancel.getCancellationDuesDetails (..., includeBreakup = True)
  -> CallBPPInternal: GET /internal/{m}/{city}/getCancellationDuesDetails?includeBreakup=true
  -> BPP: findAllPendingByRiderId -> duesBreakup = Just [...]

Customer UI -> rider-app API.UI.Cancel (includeBreakup = False)
  -> same BPP endpoint without the flag -> duesBreakup = Nothing
```

## Files of interest

- `Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/CustomerCancellationDues.hs` — response type + PENDING breakup logic.
- `Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/CustomerCancellationDues.hs` — new `QueryParam "includeBreakup" Bool`.
- `Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPPInternal.hs` — BAP-side mirror types + client wrapper.
- `Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Cancel.hs` — `getCancellationDuesDetails` gains `Bool` arg.
- `Backend/app/rider-platform/rider-app/Main/src/API/UI/Cancel.hs` — UI handler passes `False`.
- `Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Customer.hs` — dashboard handler passes `True` and maps the breakup to dashboard types.
- `Backend/app/dashboard/CommonAPIs/spec/RiderPlatform/Management/API/Customer.yaml` — adds `duesBreakup` field, `CancellationDueBreakup` record, `CancellationDuesPaymentStatus` enum (regenerated dashboard types follow).

A few small unrelated touch-ups landed in the same commit (SendSMS/IssueManagement/Passetto.Lib/dhall-configs minor edits). They are limited to import/name plumbing and do not change cancellation-dues behavior.

## Test plan

- [ ] `cabal build all` is green (CI).
- [ ] Dashboard: `GET /customer/{customerId}/getCancellationDuesDetails` for a rider with at least one PENDING `cancellation_dues_details` row returns `duesBreakup` populated; each entry has `rideId` / `dueAmount` / `dueStatus = PENDING`; the sum of `dueAmount.amount` matches the existing aggregate `cancellationDues.amount`.
- [ ] Customer UI: `GET /rideBooking/cancellationDues` for the same rider returns `duesBreakup` as `null`; the other fields are unchanged from before.
- [ ] Rider with zero pending dues: dashboard call returns `duesBreakup: []`.
- [ ] Rider with only PAID/WAIVED rows: dashboard call still returns `duesBreakup: []` (PENDING-only filter).
- [ ] Rider with no `RiderDetails` row: existing `RiderDetailsDoNotExist` error path is unchanged.
- [ ] BPP internal-key check still rejects calls with a missing/wrong `token` header, regardless of the new query param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancellation dues API supports an optional per-ride breakdown.
  * Clients can request granular cancellation dues via an include-breakup flag.
  * Responses now include an optional duesBreakup list with per-ride IDs, amounts, and payment statuses.
  * Added tracking for number of times a waiver was used.
  * Dues payment status expanded to: PENDING, PAID, WAIVED.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14805)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->