### PR TITLE
backend/fix(hotpush): DailyPassStatusUpdate reliability — reviver self-healing + chain delay

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/DailyPassStatusUpdate.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/DailyPassStatusUpdate.hs
@@ -59,7 +59,7 @@ dailyPassStatusUpdate Job {id, jobInfo} = withLogTag ("JobId-" <> id.getId) $ do
   when autoSchedule $
     if expiredCount + activatedCount < batchSize
       then scheduleTomorrow merchantId' merchantOpCityId timeDiffFromUtc istTime
-      else createJobIn @_ @'DailyPassStatusUpdate (Just merchantId') (Just merchantOpCityId) 0 jobData
+      else createJobIn @_ @'DailyPassStatusUpdate (Just merchantId') (Just merchantOpCityId) 60 jobData
 
   pure Complete
 

--- a/Backend/lib/producer/src/Producer/Flow.hs
+++ b/Backend/lib/producer/src/Producer/Flow.hs
@@ -83,7 +83,13 @@ runReviver producerType = do
   let secondsTillNow = T.diffTimeToPicoseconds todaysDiffTime `div` 1000000000000
       minutesTillNow = secondsTillNow `div` 60
       shouldRunReviver = minutesTillNow `mod` (fromIntegral reviverInterval.getMinutes) == 0
-  when shouldRunReviver $ Hedis.whenWithLockRedis reviverLockKey 300 (runReviver' producerType)
+  when shouldRunReviver $ do
+    someErr <-
+      withTryCatch "runReviver:cycleFailure" $
+        Hedis.whenWithLockRedis reviverLockKey 300 (runReviver' producerType)
+    case someErr of
+      Left err -> logError $ "Reviver iteration failed, will retry next cycle: " <> show err
+      Right _ -> pure ()
   threadDelayMilliSec 60000
 
 mkRunningJobKey :: Text -> Text


### PR DESCRIPTION
Hotpush port of [PR-14795](https://github.com/nammayatri/nammayatri/pull/14795). Single commit, same diff (8+/2- across 2 files). Cherry-picked from main's squashed commit `e604845855` → applied cleanly on `origin/prodHotPush-BAP` tip (auto-merge resolved one unrelated divergence in `Producer/Flow.hs:200` between hotpush and main).

## Why hotpush

Rider scheduler reviver has been dead for 18+ days in prod. Chennai pass-status cron's within-day chain never cascades, leaving ~21k overdue Active passes stale. Both fixes are tiny and operationally critical — too risky to wait for the next regular release cadence.

## What's in this PR

### Fix 1 — Reviver self-healing via withTryCatch

`Backend/lib/producer/src/Producer/Flow.hs:79-87` — wraps `runReviver'` in `withTryCatch` mirroring the existing `runProducer` pattern (lines 58-77). Transient PG/Hedis errors no longer kill the main thread of `loopGracefully`; outer loop retries 60s later. No new imports. Applies to both rider and driver producers (shared file).

### Fix 2 — Within-day chain delay 0 → 60

`Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/DailyPassStatusUpdate.hs:62` — was `createJobIn ... 0 jobData`, becomes `createJobIn ... 60 jobData`. The 0 delay races the producer's monotonically-advancing ZSET cursor; chain row's scheduledAt=now falls below startTime of the next producer tick → stranded. With 60s delay the chain row lands safely above any plausible cursor position.

## See main PR for full context

[PR-14795](https://github.com/nammayatri/nammayatri/pull/14795) has the complete diagnosis: 18-day timeline, prod evidence (rider 0 Revived vs driver 57k same period), observed crash trigger, why these two fixes go together, deploy verification steps.

## Test plan

- [ ] CI build passes on hotpush branch
- [ ] After deploy: rider-producer Revived count starts growing within minutes
- [ ] After tomorrow 19:30 UTC cron tick: within-day cascade fires ~22 batches over ~22 min; Chennai TO_BE_EXPIRED bucket drops near 0
- [ ] On next Aurora -ro blip: see `Reviver iteration failed, will retry next cycle` log line (proves catch is wired)

## Deploys needed post-merge

- `beckn-rider-job-producer-service-production` (Fix 1)
- `beckn-rider-app-scheduler-production` (Fix 2)

Main rider-app and other binaries don't need to ship — `DailyPassStatusUpdate.hs` is only invoked from the scheduler binary's handler registry (`Scheduler/src/App.hs:132`).