### PR TITLE
fix: pass device-switch duplicate constraint (hotpush)

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -1017,8 +1017,8 @@ postMultimodalPassSwitchDeviceId (mbCallerPersonId, merchantId) req = do
 
   forM_ allActivePurchasedPasses $ \purchasedPass -> do
     when (purchasedPass.deviceId /= deviceId) $ do
-      -- Check if there are other passes with the same passTypeId that already have this deviceId
-      duplicatePasses <- QPurchasedPass.findAllByPersonIdAndPassTypeIdAndStatus personId merchantId purchasedPass.passTypeId [DPurchasedPass.Active, DPurchasedPass.PreBooked]
+      -- Check if there are other passes with the same passTypeId that already have this deviceId.
+      duplicatePasses <- QPurchasedPass.findAllByPersonIdAndPassTypeIdAndStatus personId merchantId purchasedPass.passTypeId [DPurchasedPass.Active, DPurchasedPass.PreBooked, DPurchasedPass.Pending, DPurchasedPass.PhotoPending]
       let otherDevicePasses = filter (\p -> p.id /= purchasedPass.id && p.deviceId == deviceId) duplicatePasses
 
       case otherDevicePasses of

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
@@ -86,13 +86,13 @@ findPendingPassByPersonIdAndPassTypeId personId merchantId passTypeId =
     [ Se.Is Beam.personId $ Se.Eq (getId personId),
       Se.Is Beam.merchantId $ Se.Eq (getId merchantId),
       Se.Is Beam.passTypeId $ Se.Eq (getId passTypeId),
-      Se.Or
-        [ Se.Is Beam.status $ Se.Not $ Se.In [DPurchasedPass.Active, DPurchasedPass.PreBooked],
-          Se.Or
-            [ Se.Is Beam.deviceSwitchCount $ Se.LessThanOrEq (Just 1),
-              Se.Is Beam.deviceSwitchCount $ Se.Eq Nothing
-            ]
-        ]
+      Se.Is Beam.status $
+        Se.In
+          [ DPurchasedPass.Pending,
+            DPurchasedPass.Active,
+            DPurchasedPass.PreBooked,
+            DPurchasedPass.PhotoPending
+          ]
     ]
 
 updatePurchaseData ::


### PR DESCRIPTION
## Summary
- Hotpush cherry-pick of #14818
- Fixes `purchased_pass_unique_person_pass_device` constraint violations in the drainer caused by parallel pass rows when a user buys a renewal on a different device than their existing Active pass
- Two-layer fix in one commit:
  - **L1 — `PurchasedPassExtra.hs`**: `findPendingPassByPersonIdAndPassTypeId` now matches by status set `[Pending, Active, PreBooked, PhotoPending]` instead of the stale `deviceSwitchCount <= 1` heuristic (which was inconsistent with the prod `maxSwitchCount = 5` config and made high-switch-count Active passes invisible to renewal-reuse discovery → parallel pass row created)
  - **L2 — `Pass.hs`**: `postMultimodalPassSwitchDeviceId` duplicate filter now includes `Pending` and `PhotoPending`, so the existing merge branch handles in-flight purchases instead of blindly issuing a conflicting UPDATE that fails in the drainer with `sqlState=23505`

## Reproducer (already in prod)
Person `e962aca7-83d9-4e32-b95a-c77cc9574e08`, `gold-unlimited-pass-type`, target device `7871d2b939c4ad9a` — drainer pod `beckn-app-drainer-production` retrying same failing UPDATE every ~16 min since 2026-05-16 15:57 UTC.

## Test plan
- [ ] `, cabal build rider-app` passes
- [ ] Deploy to staging; confirm `[QUERY UPDATE FAILED] purchased_pass_unique_person_pass_device` ERROR count drops to zero
- [ ] Verify the reproducer person can switch device cleanly post-deploy (manual one-off)
- [ ] Monitor `getMultimodalPassListUtil` 5xx rate stays flat (no regression from broader status-set match)