### PR TITLE
fix: restore Expired-row recycle to stop drainer 23505 on device-switch

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
@@ -87,13 +87,7 @@ findPendingPassByPersonIdAndPassTypeId personId merchantId passTypeId =
     [ Se.Is Beam.personId $ Se.Eq (getId personId),
       Se.Is Beam.merchantId $ Se.Eq (getId merchantId),
       Se.Is Beam.passTypeId $ Se.Eq (getId passTypeId),
-      Se.Is Beam.status $
-        Se.In
-          [ DPurchasedPass.Pending,
-            DPurchasedPass.Active,
-            DPurchasedPass.PreBooked,
-            DPurchasedPass.PhotoPending
-          ]
+      Se.Is Beam.status $ Se.Not $ Se.In [DPurchasedPass.Active, DPurchasedPass.PreBooked]
     ]
 
 updatePurchaseData ::


### PR DESCRIPTION
## Summary
- Revert `findPendingPassByPersonIdAndPassTypeId` to `Se.Not $ Se.In [Active, PreBooked]` — restores the implicit Expired/Refund/Failed-row recycle in the buy flow.
- Stops new orphan rows from being created at pass purchase, which were tripping `purchased_pass_unique_person_pass_device` (`23505`) in the drainer on subsequent device-switch attempts.

## Why
Commit 446b65d063 (2026-05-16) narrowed the query from `Se.Not $ Se.In [Active, PreBooked]` to an explicit `Se.In [Pending, Active, PreBooked, PhotoPending]` list. That dropped `Expired/Failed/Refund*` from the recycle path. After deploy, any user buying a new gold-unlimited pass on a device different from their previous (now-Expired) pass left an orphan row claiming the old device. When the user later tapped "switch device" back to that old device, the drainer's flush of the UPDATE hit the unique index and got stuck in a `Force Sync` retry loop.

**18 victims confirmed in prod as of 2026-05-18, rate ~1/few hours.** Their orphan Expired rows are being cleaned up via a separate SQL mutation.

The `notElem [Active, PreBooked]` guard at `Pass.hs:213` already protects live passes from accidental clobber, so the broader `Not In` filter is the single source of truth and is future-proof against new status additions.

Paired with the hot-push PR #14825 targeting `prodHotPush-BAP`.

## Test plan
- [ ] `cabal build rider-app` passes
- [ ] In staging: buy a pass, expire it, buy a new pass on a different device → verify only one `purchased_pass` row per (person, pass_type) (recycled, not duplicated)
- [ ] Drainer stops emitting new `23505` errors on `purchased_pass_unique_person_pass_device` after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal database query optimization with no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->