### PR TITLE
backend/hotpush: FRFS on_confirm diagnostic logs

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/Forwarding.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/Forwarding.hs
@@ -78,6 +78,7 @@ withRedirect ::
   Flow (Maybe Spec.AckResponse)
 withRedirect mbMerchantId mbBapUriText act = do
   redirectMap <- asks (.bapHostRedirectMap)
+  logError $ "FRFS forwarding check: bap_uri=" <> show mbBapUriText <> " merchantId=" <> show (getId <$> mbMerchantId) <> " redirectMap=" <> show redirectMap
   case mbBapUriText >>= parseBaseUrl of
     Nothing -> pure Nothing
     Just bapUri ->
@@ -98,7 +99,7 @@ signed authResult =
   withHeaders [("Authorization", decodeUtf8 $ HttpSig.encode authResult.signature)]
 
 logForward :: Text -> BaseUrl -> Flow ()
-logForward tag url = logInfo $ "Forwarding FRFS " <> tag <> " to " <> showBaseUrl url
+logForward tag url = logError $ "Forwarding FRFS " <> tag <> " to " <> showBaseUrl url
 
 forwardOnSearch :: BaseUrl -> SignatureAuthResult -> ByteString -> Flow Spec.AckResponse
 forwardOnSearch baseUrl authResult reqBS = do

--- a/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnConfirm.hs
@@ -65,7 +65,7 @@ processOnConfirm req = do
   routeStopMappingToStation <- OTPRest.getRouteStopMappingByStopCode ticketBooking.toStationCode integratedBppConfig
   let fromStationProviderCode = fromMaybe ticketBooking.fromStationCode (listToMaybe routeStopMappingFromStation <&> (.providerCode))
       toStationProviderCode = fromMaybe ticketBooking.toStationCode (listToMaybe routeStopMappingToStation <&> (.providerCode))
-  logDebug $ "Received OnConfirm request" <> encodeToText req
+  logError $ "Received OnConfirm request" <> encodeToText req
   withTransactionIdLogTag' transaction_id $ do
     dOnConfirmReq <- ACL.buildOnConfirmReq fromStationProviderCode toStationProviderCode req
     case dOnConfirmReq of


### PR DESCRIPTION
## Summary
- Promotes `Received OnConfirm request` log to `logError` so the decoded request body is visible without depending on `system_configs.log_levels`.
- Adds a `logError` at the top of `Forwarding.withRedirect` printing the incoming `bap_uri`, `merchantId`, and the loaded `bapHostRedirectMap` — fires on every BAP-side BECKN callback (on_search/on_init/on_confirm/on_update/on_status/on_cancel).
- Bumps the existing `Forwarding FRFS <tag> to <url>` log from `logInfo` to `logError`.

## Why
Debugging why `bapHostRedirectMap` (api.c2.moving.tech → /pilot/app) isn't taking effect for `on_confirm`. Setting DEBUG via `log_levels` produced no logs, suggesting the request either never reaches the pod or the forwarding decision short-circuits silently — these logs make both observable at error level.

## Test plan
- [ ] Build passes in CI
- [ ] After deploy, confirm `FRFS forwarding check: bap_uri=...` appears for incoming on_confirm in Kibana
- [ ] Verify `redirectMap=` payload matches the dhall config
- [ ] Revert these severity bumps once diagnosis is complete