### PR TITLE
backend/fix: resolve MediaFile records in live issue chat API

### DIFF
--- a/Backend/lib/shared-services/src/IssueManagement/Common/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Common/UI/Issue.hs
@@ -301,6 +301,9 @@ data ChatMessageItem = ChatMessageItem
     chatContentType :: DCM.ChatContentType,
     text :: Text,
     mediaFileIds :: [Id MediaFile],
+    -- Resolved MediaFile records aligned with mediaFileIds (server fills these
+    -- so clients don't have to translate the UUID to an S3 key themselves).
+    mediaFiles :: [MediaFile_],
     deliveredAt :: Maybe UTCTime,
     readAt :: Maybe UTCTime,
     createdAt :: UTCTime

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/Dashboard/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/Dashboard/Issue.hs
@@ -45,6 +45,7 @@ import qualified IssueManagement.Storage.Queries.Issue.IssueMessage as QIM
 import qualified IssueManagement.Storage.Queries.Issue.IssueOption as QIO
 import qualified IssueManagement.Storage.Queries.Issue.IssueReport as QIR
 import qualified IssueManagement.Storage.Queries.Issue.IssueTranslation as QIT
+import qualified IssueManagement.Storage.Queries.MediaFile as QMF
 import IssueManagement.Tools.Error
 import qualified Kernel.Beam.Functions as B
 import Kernel.External.Encryption (decrypt, getDbHash)
@@ -2025,7 +2026,10 @@ sendDashboardChatMessage merchantShortId opCity issueReportId issueHandle req = 
     case result of
       Right _ -> pure ()
       Left err -> logError $ "sendDashboardChatMessage: sendChatNotification failed " <> show err
-  pure $ UIR.toChatMessageItem chatMsg
+  -- Resolve any MediaFile UUIDs to URLs before responding so the dashboard can
+  -- render attachments without a follow-up call.
+  mfs <- if null mediaIds then pure [] else QMF.findAllIn mediaIds
+  pure $ UIR.toChatMessageItem mfs chatMsg
 
 listDashboardChatMessages ::
   ( Esq.EsqDBReplicaFlow m r,
@@ -2042,7 +2046,11 @@ listDashboardChatMessages merchantShortId opCity issueReportId issueHandle mbSin
   issueReport <- QIR.findById issueReportId >>= fromMaybeM (IssueReportDoesNotExist issueReportId.getId)
   _merchantOpCity <- checkMerchantCityAccess merchantShortId opCity issueReport Nothing issueHandle
   messages <- B.runInReplica $ QCM.findChatMessagesAfter issueReportId mbSince mbLimit
-  pure $ map UIR.toChatMessageItem messages
+  -- Batch-resolve all referenced MediaFile records in one query so the
+  -- dashboard receives ready-to-render URLs alongside the raw UUIDs.
+  let allMediaIds = concatMap (.mediaFileIds) messages
+  allMfs <- if null allMediaIds then pure [] else B.runInReplica $ QMF.findAllIn allMediaIds
+  pure $ map (UIR.toChatMessageItem allMfs) messages
 
 markDashboardChatRead ::
   ( Esq.EsqDBReplicaFlow m r,

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
@@ -1172,7 +1172,10 @@ createChatMessage personId issueReportId identifier req = do
             merchantId = issueReport.merchantId
           }
   QCM.create chatMsg
-  pure (toChatMessageItem chatMsg)
+  -- Resolve attached MediaFile records so the client receives both the raw
+  -- UUIDs (for back-compat) and the rendered URLs in a single round trip.
+  mfs <- if null mediaIds then pure [] else QMF.findAllIn mediaIds
+  pure (toChatMessageItem mfs chatMsg)
 
 -- | Fetches chat messages on an issue ordered by createdAt ascending.
 -- Optionally filters to messages strictly newer than @since@. Used by both
@@ -1191,7 +1194,11 @@ listChatMessages personId issueReportId mbSince mbLimit = do
   unless (issueReport.personId == personId) $
     throwError (InvalidRequest "This issue does not belong to the caller.")
   messages <- QCM.findChatMessagesAfter issueReportId mbSince mbLimit
-  pure $ map toChatMessageItem messages
+  -- Batch-fetch every referenced MediaFile in one query, then attach the
+  -- relevant subset to each message in toChatMessageItem (avoids N+1).
+  let allMediaIds = concatMap (.mediaFileIds) messages
+  allMfs <- if null allMediaIds then pure [] else QMF.findAllIn allMediaIds
+  pure $ map (toChatMessageItem allMfs) messages
 
 -- | Rider marks operator messages as read up to a given timestamp.
 markChatRead ::
@@ -1233,18 +1240,24 @@ getChatState personId issueReportId = do
         [] -> Nothing
   pure $ Common.ChatStateRes {unread, latestMessageAt = latestAt}
 
-toChatMessageItem :: DCM.ChatMessage -> Common.ChatMessageItem
-toChatMessageItem c =
-  Common.ChatMessageItem
-    { messageId = c.id.getId,
-      senderType = c.senderType,
-      chatContentType = c.chatContentType,
-      text = c.message,
-      mediaFileIds = c.mediaFileIds,
-      deliveredAt = Nothing,
-      readAt = c.readAt,
-      createdAt = c.createdAt
-    }
+-- | Converts a stored ChatMessage to its API representation, attaching the
+-- pre-resolved MediaFile records for any mediaFileIds the message references.
+-- Callers must supply the relevant MediaFile rows (typically batch-fetched);
+-- this function filters to the ones whose id matches the message.
+toChatMessageItem :: [D.MediaFile] -> DCM.ChatMessage -> Common.ChatMessageItem
+toChatMessageItem allMediaFiles c =
+  let relevantMfs = filter (\mf -> mf.id `elem` c.mediaFileIds) allMediaFiles
+   in Common.ChatMessageItem
+        { messageId = c.id.getId,
+          senderType = c.senderType,
+          chatContentType = c.chatContentType,
+          text = c.message,
+          mediaFileIds = c.mediaFileIds,
+          mediaFiles = mkMediaFiles relevantMfs,
+          deliveredAt = Nothing,
+          readAt = c.readAt,
+          createdAt = c.createdAt
+        }
 
 mkIssueOption :: (D.IssueOption, Maybe D.IssueTranslation) -> Text
 mkIssueOption (issueOption, issueOptionTranslation) =


### PR DESCRIPTION
## Summary
- The live issue-chat endpoints (`/chat/messages`, `POST /chat/message` on both rider-app and dashboard) returned `mediaFileIds: [Id MediaFile]` for `CHAT_MEDIA` messages.
- Clients constructed `/issueV2/media?filePath=<UUID>` from that, but `fetchMedia` / `issueFetchMedia` do raw `S3.get filePath` — feeding it a UUID makes the AWS CLI exit 255 and the request becomes **HTTP 500** for every live-chat image. Verified on prod and master with the same failing UUID.
- This mirrors what `recreateIssueChats` already does for chatbot-history media (`mediaFile.url` baked into `chats[].content`). We do the same for live messages now: batch-resolve the `MediaFile` rows and attach `mediaFiles :: [MediaFile_]` to each `ChatMessageItem` alongside the existing `mediaFileIds`.
- Additive on the contract — `mediaFileIds` stays populated for back-compat with any existing consumer.

## Evidence the bug exists
- Prod ANNA_APP failing request: `?filePath=3e4f423f-1b7b-4b89-ad93-a9f370bb603b` → 500 INTERNAL_ERROR
- Backend logs: `aws s3api get-object --bucket image-bucket-beckn --key 3e4f423f-...` (exit 255)
- Master (integ) same request → identical 500 (same `fetchMedia` code on both deployments)
- History-media still works on both envs because its `filePath` is the real S3 key (`productionissue-media/driver-.../...jpg`)

## Changes
- `Common/UI/Issue.hs`: add `mediaFiles :: [MediaFile_]` to `ChatMessageItem` (additive).
- `Domain/Action/UI/Issue.hs`:
  - `toChatMessageItem` now takes `[MediaFile]` and filters per-message.
  - `createChatMessage` and `listChatMessages` batch-fetch via `QMF.findAllIn` once per request.
- `Domain/Action/Dashboard/Issue.hs`:
  - `sendDashboardChatMessage` and `listDashboardChatMessages` do the same batch-resolve (`B.runInReplica` for the read path).

## Test plan
- [ ] `cabal build all` clean
- [ ] Send a chat message with media via rider app → response includes both `mediaFileIds` and `mediaFiles[].url` pointing to the resolved S3 path
- [ ] Dashboard `GET /chat/messages` for an issue with prior CHAT_MEDIA → each media message has populated `mediaFiles[]`
- [ ] Existing chatbot-history image rendering unchanged
- [ ] Confirm no N+1 — single `QMF.findAllIn` per list call regardless of message count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Media files attached to chat messages are now pre-resolved and returned with complete URLs and metadata, eliminating the need for clients to translate file identifiers separately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->