### PR TITLE
ci: fix LOCAL_BINARIES_PATH $HOME not expanding in Docker build step

### DIFF
--- a/.github/workflows/cabal-main-push.yaml
+++ b/.github/workflows/cabal-main-push.yaml
@@ -103,8 +103,8 @@ jobs:
         env:
           DOCKER_REGISTRY: ghcr.io
           DOCKER_TAG_PREFIX: "cabal-master-"
-          LOCAL_BINARIES_PATH: $HOME/ny-staging/${{ github.run_id }}
         run: |
+          export LOCAL_BINARIES_PATH=$HOME/ny-staging/${{ github.run_id }}
           nix build .#packages.${{ matrix.system }}.dockerImage --impure
 
           BASE_IMAGE="$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageName --impure):$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageTag --impure)"
@@ -240,8 +240,8 @@ jobs:
         env:
           DOCKER_REGISTRY: ghcr.io
           DOCKER_TAG_PREFIX: "cabal-prod-"
-          LOCAL_BINARIES_PATH: $HOME/ny-staging/${{ github.run_id }}
         run: |
+          export LOCAL_BINARIES_PATH=$HOME/ny-staging/${{ github.run_id }}
           nix build .#packages.${{ matrix.system }}.dockerImage --impure
 
           BASE_IMAGE="$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageName --impure):$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageTag --impure)"


### PR DESCRIPTION
## Summary

- GitHub Actions `env:` block does not shell-expand variables, so `LOCAL_BINARIES_PATH: $HOME/ny-staging/...` was passing the literal string `$HOME` to the Nix evaluation
- Nix then tried to access path `/$HOME/ny-staging/<run_id>` which doesn't exist, causing the "Build And Push Docker image" step to fail
- Fix: moved `LOCAL_BINARIES_PATH` from the `env:` block into the `run:` script as `export LOCAL_BINARIES_PATH=$HOME/...` where the shell properly expands it before Nix reads it

Fixes: https://github.com/nammayatri/nammayatri/actions/runs/26307598243/job/77448185131

## Test plan
- [ ] Verify the next push to `main` triggers a successful Docker image build for both master and prod jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize environment variable management in Docker build processes.

---

**Note:** This release contains no user-facing changes; the updates are internal infrastructure improvements only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->