### PR TITLE
ci: cache push after docker build

### DIFF
--- a/.github/workflows/nix-main-pull.yaml
+++ b/.github/workflows/nix-main-pull.yaml
@@ -68,21 +68,6 @@ jobs:
             printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')" "$line"
           done | tee build-log.txt
 
-      - name: Push to Cache (Local mode)        
-        continue-on-error: true
-        env:
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          PATHS=$(jq -r '.[].outPaths[]' ./result)
-          echo "Paths to push: $(echo "$PATHS" | wc -l)"
-
-          # Try attic, fall back to cachix on any failure
-          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
-            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
-            echo "✅ Pushed to attic" || \
-            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
-
       - name: Upload build log
         continue-on-error: true
         uses: actions/upload-artifact@v4
@@ -94,12 +79,28 @@ jobs:
       - name: Build Docker image (no push)
         if: matrix.system == 'x86_64-linux' || matrix.system == 'aarch64-linux'
         env:
-          DOCKER_TAG_PREFIX: "master-"          
+          DOCKER_TAG_PREFIX: "master-"
         run: |
-          NIX_LOCAL_BUILD="1" nix build .#packages.${{ matrix.system }}.dockerImage --impure
+          NIX_LOCAL_BUILD="1" nix build .#packages.${{ matrix.system }}.dockerImage --impure --out-link ./docker-result
 
           BASE_IMAGE="$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageName --impure):$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageTag --impure)"
           echo "Docker image built: ${BASE_IMAGE} (not pushed)"
+
+      - name: Push to Cache (Local mode)
+        continue-on-error: true
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          PATHS=$(jq -r '.[].outPaths[]' ./result)
+          echo "Paths to push: $(echo "$PATHS" | wc -l)"
+          echo "$PATHS" | xargs -r du -sch 2>/dev/null
+
+          # Try attic, fall back to cachix on any failure
+          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
+            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
+            echo "✅ Pushed to attic" || \
+            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
 
   analyze-build-times:
     name: Analyze Build Times

--- a/.github/workflows/nix-main-push.yaml
+++ b/.github/workflows/nix-main-push.yaml
@@ -49,21 +49,6 @@ jobs:
             printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')" "$line"
           done | tee master-build-log.txt
 
-      - name: Push to Cache (Local mode)        
-        continue-on-error: true
-        env:
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          PATHS=$(jq -r '.[].outPaths[]' ./result)
-          echo "Paths to push: $(echo "$PATHS" | wc -l)"
-
-          # Try attic, fall back to cachix on any failure
-          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
-            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
-            echo "✅ Pushed to attic" || \
-            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
-
       - name: Upload master build log
         continue-on-error: true
         uses: actions/upload-artifact@v4
@@ -76,18 +61,34 @@ jobs:
         id: docker
         if: matrix.system == 'x86_64-linux' || matrix.system == 'aarch64-linux'
         env:
-          DOCKER_REGISTRY: ghcr.io          
-          DOCKER_TAG_PREFIX: "master-"          
+          DOCKER_REGISTRY: ghcr.io
+          DOCKER_TAG_PREFIX: "master-"
         run: |
-          NIX_LOCAL_BUILD="1" nix build .#packages.${{ matrix.system }}.dockerImage --impure
+          NIX_LOCAL_BUILD="1" nix build .#packages.${{ matrix.system }}.dockerImage --impure --out-link ./docker-result
 
           BASE_IMAGE="$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageName --impure):$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageTag --impure)"
           echo "base_image=${BASE_IMAGE}" >> $GITHUB_OUTPUT
 
-          gunzip -c ./result > image.tar || cp ./result image.tar
+          gunzip -c ./docker-result > image.tar || cp ./docker-result image.tar
           echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ${DOCKER_REGISTRY} -u "${{ github.actor }}" --password-stdin
           crane push image.tar "${DOCKER_REGISTRY}/${BASE_IMAGE}"
           crane auth logout ${DOCKER_REGISTRY}
+
+      - name: Push to Cache (Local mode)
+        continue-on-error: true
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          PATHS=$(jq -r '.[].outPaths[]' ./result)
+          echo "Paths to push: $(echo "$PATHS" | wc -l)"
+          echo "$PATHS" | xargs -r du -sch 2>/dev/null
+
+          # Try attic, fall back to cachix on any failure
+          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
+            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
+            echo "✅ Pushed to attic" || \
+            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
   
   analyze-master-build-times:
     name: Analyze Master Build Times
@@ -156,21 +157,6 @@ jobs:
             printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')" "$line"
           done | tee prod-build-log.txt
 
-      - name: Push to Cache
-        continue-on-error: true
-        env:
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          PATHS=$(jq -r '.[].outPaths[]' ./result)
-          echo "Paths to push: $(echo "$PATHS" | wc -l)"
-
-          # Try attic, fall back to cachix on any failure
-          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
-            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
-            echo "✅ Pushed to attic" || \
-            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
-
       - name: Upload build log
         continue-on-error: true
         uses: actions/upload-artifact@v4
@@ -186,15 +172,31 @@ jobs:
           DOCKER_REGISTRY: ghcr.io
           DOCKER_TAG_PREFIX: "prod-"
         run: |
-          nix build .#packages.${{ matrix.system }}.dockerImage
+          nix build .#packages.${{ matrix.system }}.dockerImage --out-link ./docker-result
 
           BASE_IMAGE="$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageName):$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageTag)"
           echo "base_image=${BASE_IMAGE}" >> $GITHUB_OUTPUT
 
-          gunzip -c ./result > image.tar || cp ./result image.tar
+          gunzip -c ./docker-result > image.tar || cp ./docker-result image.tar
           echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ${DOCKER_REGISTRY} -u "${{ github.actor }}" --password-stdin
           crane push image.tar "${DOCKER_REGISTRY}/${BASE_IMAGE}"
           crane auth logout ${DOCKER_REGISTRY}
+
+      - name: Push to Cache
+        continue-on-error: true
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          PATHS=$(jq -r '.[].outPaths[]' ./result)
+          echo "Paths to push: $(echo "$PATHS" | wc -l)"
+          echo "$PATHS" | xargs -r du -sch 2>/dev/null
+
+          # Try attic, fall back to cachix on any failure
+          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
+            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
+            echo "✅ Pushed to attic" || \
+            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
 
   analyze-prod-build-times:
     name: Analyze Prod Build Times

--- a/.github/workflows/nix-prod-hot-fix-pull.yaml
+++ b/.github/workflows/nix-prod-hot-fix-pull.yaml
@@ -108,22 +108,6 @@ jobs:
             printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')" "$line"
           done | tee build-log.txt
 
-      - name: Push to Cache
-        if: steps.check-conditions.outputs.should_build == 'true'
-        continue-on-error: true
-        env:
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          PATHS=$(jq -r '.[].outPaths[]' ./result)
-          echo "Paths to push: $(echo "$PATHS" | wc -l)"
-
-          # Try attic, fall back to cachix on any failure
-          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
-            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
-            echo "✅ Pushed to attic" || \
-            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
-
       - name: Upload build log
         if: steps.check-conditions.outputs.should_build == 'true'
         continue-on-error: true
@@ -139,16 +123,33 @@ jobs:
         env:
           DOCKER_REGISTRY: ghcr.io
         run: |
-          nix build .#packages.${{ matrix.system }}.dockerImage
-    
+          nix build .#packages.${{ matrix.system }}.dockerImage --out-link ./docker-result
+
           BASE_IMAGE="$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageName):$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageTag)"
           echo "base_image=${BASE_IMAGE}" >> $GITHUB_OUTPUT
 
-          gunzip -c ./result > image.tar || cp ./result image.tar
+          gunzip -c ./docker-result > image.tar || cp ./docker-result image.tar
           echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ${DOCKER_REGISTRY} -u "${{ github.actor }}" --password-stdin
           # crane push image.tar "${DOCKER_REGISTRY}/${BASE_IMAGE}-${{ matrix.arch }}" use this for multi arch builds, not needed for now
           crane push image.tar "${DOCKER_REGISTRY}/${BASE_IMAGE}"
           crane auth logout ${DOCKER_REGISTRY}
+
+      - name: Push to Cache
+        if: steps.check-conditions.outputs.should_build == 'true'
+        continue-on-error: true
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          PATHS=$(jq -r '.[].outPaths[]' ./result)
+          echo "Paths to push: $(echo "$PATHS" | wc -l)"
+          echo "$PATHS" | xargs -r du -sch 2>/dev/null
+
+          # Try attic, fall back to cachix on any failure
+          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
+            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
+            echo "✅ Pushed to attic" || \
+            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
 
   analyze-build-times:
     name: Analyze Build Times

--- a/.github/workflows/nix-prod-hot-fix-push.yaml
+++ b/.github/workflows/nix-prod-hot-fix-push.yaml
@@ -95,22 +95,6 @@ jobs:
             printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')" "$line"
           done | tee build-log.txt
 
-      - name: Push to Cache
-        if: steps.check-conditions.outputs.should_build == 'true'
-        continue-on-error: true
-        env:
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: |
-          PATHS=$(jq -r '.[].outPaths[]' ./result)
-          echo "Paths to push: $(echo "$PATHS" | wc -l)"
-
-          # Try attic, fall back to cachix on any failure
-          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
-            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
-            echo "✅ Pushed to attic" || \
-            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
-
       - name: Upload build log
         if: steps.check-conditions.outputs.should_build == 'true'
         continue-on-error: true
@@ -126,16 +110,33 @@ jobs:
         env:
           DOCKER_REGISTRY: ghcr.io
         run: |
-          nix build .#packages.${{ matrix.system }}.dockerImage
-    
+          nix build .#packages.${{ matrix.system }}.dockerImage --out-link ./docker-result
+
           BASE_IMAGE="$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageName):$(nix eval --raw .#packages.${{ matrix.system }}.dockerImage.imageTag)"
           echo "base_image=${BASE_IMAGE}" >> $GITHUB_OUTPUT
 
-          gunzip -c ./result > image.tar || cp ./result image.tar
+          gunzip -c ./docker-result > image.tar || cp ./docker-result image.tar
           echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ${DOCKER_REGISTRY} -u "${{ github.actor }}" --password-stdin
           # crane push image.tar "${DOCKER_REGISTRY}/${BASE_IMAGE}-${{ matrix.arch }}" use this for multi arch builds, not needed for now
           crane push image.tar "${DOCKER_REGISTRY}/${BASE_IMAGE}"
           crane auth logout ${DOCKER_REGISTRY}
+
+      - name: Push to Cache
+        if: steps.check-conditions.outputs.should_build == 'true'
+        continue-on-error: true
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          PATHS=$(jq -r '.[].outPaths[]' ./result)
+          echo "Paths to push: $(echo "$PATHS" | wc -l)"
+          echo "$PATHS" | xargs -r du -sch 2>/dev/null
+
+          # Try attic, fall back to cachix on any failure
+          attic login cache-nixos-asia https://cache.nixos.asia "$ATTIC_TOKEN" && \
+            echo "$PATHS" | attic push cache-nixos-asia:oss --stdin && \
+            echo "✅ Pushed to attic" || \
+            { echo "⚠️ Attic failed, falling back to cachix..."; echo "$PATHS" | cachix push nammayatri; }
     
   analyze-build-times:
     name: Analyze Build Times


### PR DESCRIPTION
## Type of Change

- [x] Enhancement

## Description

Cherry-pick of #14891 onto `prodHotPush-Common`.

Fixes the order of CI steps so that cache is pushed **after** the Docker build completes, and fixes result overwrite during the Docker build step.

### Changes

- `.github/workflows/nix-main-pull.yaml`
- `.github/workflows/nix-main-push.yaml`
- `.github/workflows/nix-prod-hot-fix-pull.yaml`
- `.github/workflows/nix-prod-hot-fix-push.yaml`

## Motivation and Context

Same as #14891 — ensures cache is populated correctly after builds and prevents result overwrites in the Docker build step.

## Checklist

- [x] I reviewed submitted code

🤖 Generated with [Claude Code](https://claude.com/claude-code)