### PR TITLE
rider-app/fix: resolve real Pass id in purchased pass list response

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -576,9 +576,10 @@ buildPassAPIEntityFromPurchasedPass ::
   (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>
   Maybe Lang.Language ->
   Id.Id DP.Person ->
+  Id.Id DPass.Pass ->
   DPurchasedPass.PurchasedPass ->
   m PassAPI.PassAPIEntity
-buildPassAPIEntityFromPurchasedPass mbLanguage _personId purchasedPass = do
+buildPassAPIEntityFromPurchasedPass mbLanguage _personId passId purchasedPass = do
   -- Reconstruct Pass.Benefit from flattened benefitType and benefitValue
   let benefit = case (purchasedPass.benefitType, purchasedPass.benefitValue) of
         (Nothing, _) -> Nothing
@@ -588,7 +589,6 @@ buildPassAPIEntityFromPurchasedPass mbLanguage _personId purchasedPass = do
         _ -> Nothing
 
   let language = fromMaybe Lang.ENGLISH mbLanguage
-  let passId = Id.cast purchasedPass.id :: Id.Id DPass.Pass
   let moid = purchasedPass.merchantOperatingCityId
   nameTranslation <- QT.findByMerchantOpCityIdMessageKeyLanguageWithInMemcache moid (mkPassMessageKey passId "name") language
   benefitTranslation <- QT.findByMerchantOpCityIdMessageKeyLanguageWithInMemcache moid (mkPassMessageKey passId "benefitDescription") language
@@ -604,7 +604,7 @@ buildPassAPIEntityFromPurchasedPass mbLanguage _personId purchasedPass = do
         Nothing -> purchasedPass.passAmount
   return $
     PassAPI.PassAPIEntity
-      { id = Id.cast purchasedPass.id,
+      { id = passId,
         amount = originalAmount, -- Doing this so that UI it shows the original amount instead of the discounted amount.
         originalAmount = originalAmount,
         savings = Nothing,
@@ -664,7 +664,16 @@ buildPurchasedPassAPIEntity mbLanguage person mbDeviceId today purchasedPass = d
         Just maxTrips -> Just $ max 0 (maxTrips - fromMaybe 0 purchasedPass.usedTripCount)
         Nothing -> Nothing
 
-  passAPIEntity <- buildPassAPIEntityFromPurchasedPass mbLanguage person.id purchasedPass
+  passes <- CQPass.findAllByPassTypeIdAndEnabled purchasedPass.passTypeId True
+  let findByCode ps = find (\p -> p.code == purchasedPass.passCode) ps
+  sourcePassId <- case findByCode passes of
+    Just p -> pure p.id
+    Nothing -> do
+      disabledPasses <- CQPass.findAllByPassTypeIdAndEnabled purchasedPass.passTypeId False
+      case findByCode disabledPasses of
+        Just p -> pure p.id
+        Nothing -> throwError $ PassNotFound $ "passTypeId=" <> purchasedPass.passTypeId.getId <> " code=" <> purchasedPass.passCode
+  passAPIEntity <- buildPassAPIEntityFromPurchasedPass mbLanguage person.id sourcePassId purchasedPass
   let passDetailsEntity =
         PassAPI.PassDetailsAPIEntity
           { category = buildPassCategoryAPIEntity passCategory,
@@ -674,7 +683,6 @@ buildPurchasedPassAPIEntity mbLanguage person mbDeviceId today purchasedPass = d
 
   let daysToExpire = fromIntegral $ DT.diffDays purchasedPass.endDate today
 
-  passes <- CQPass.findAllByPassTypeIdAndEnabled purchasedPass.passTypeId True
   let maxSwitchCount = case listToMaybe passes >>= (.passConfig) of
         Just pc -> pc.maxSwitchCount
         Nothing -> 1


### PR DESCRIPTION
## Summary
- `PassAPIEntity.id` inside `PurchasedPassAPIEntity.passEntity.passDetails` was set to `Id.cast purchasedPass.id`, so the same `PurchasedPass` instance id appeared at both the outer (`PurchasedPassAPIEntity.id`) and nested (`passEntity.passDetails.id`) level. The nested field claimed to be `Id Pass` but pointed to a non-existent `pass` row.
- Same cast was used as the translation key (`mkPassMessageKey passId ...`) — translations on the `pass` template never resolved for purchased passes, so localized name/benefit/description always fell back to the purchase-time snapshot fields.

## Fix
- `buildPurchasedPassAPIEntity` resolves the source `Pass` id once by reusing the existing cached `CQPass.findAllByPassTypeIdAndEnabled purchasedPass.passTypeId True` lookup (already required for `maxSwitchCount`) and matching on `passCode`.
- Disabled-passes lookup is used as a fallback so users with templates that were disabled after purchase aren't locked out of their list endpoint.
- `throwError PassNotFound` only if the template row is genuinely missing from both enabled and disabled.
- `buildPassAPIEntityFromPurchasedPass` now takes a non-`Maybe Id Pass` — the `Id.cast` workaround is removed and `passId` flows into both the API entity and the translation keys.

No new queries in the happy path. One extra cached lookup only when the template has been disabled.

## Test plan
- [ ] `cabal build rider-app` passes inside nix shell
- [ ] `GET /multimodal/pass/list` no longer returns the outer `PurchasedPass` id duplicated as `passEntity.passDetails.id`; the nested id resolves to a real row in the `pass` table
- [ ] Localized (non-English) name/benefit/description start resolving via the translation entries keyed on the real `Pass` id — verify any existing translations behave as intended
- [ ] User holding an Active pass whose template was disabled still sees that pass in `/list` (disabled-fallback path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pass code matching logic to ensure accurate pass identification and retrieval.

* **Performance**
  * Optimized pass data retrieval to reduce processing time and improve app responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->