### PR TITLE
fix: invoice domain

### DIFF
--- a/Backend/lib/yudhishthira/src/Lib/Yudhishthira/Types.hs
+++ b/Backend/lib/yudhishthira/src/Lib/Yudhishthira/Types.hs
@@ -275,7 +275,7 @@ newtype YudhishthiraDecideResp = YudhishthiraDecideResp
 data InvoiceTemplateScope
   = InvoiceTypeGeneric
   | InvoiceTypeSpecific InvoiceType
-  deriving (Eq, Ord, Generic, ToJSON, FromJSON, ToSchema)
+  deriving (Eq, Ord, Generic, ToSchema)
 
 -- Hand-rolled (dashed) so the string is whitespace-free for DB column + Redis key use.
 instance Show InvoiceTemplateScope where
@@ -290,6 +290,17 @@ instance Read InvoiceTemplateScope where
         Just it -> [(InvoiceTypeSpecific it, "")]
         Nothing -> []
     _ -> []
+
+-- Hand-rolled to encode as a flat string via Show/Read. Generic Aeson would
+-- otherwise emit a tagged object (since this type has a mixed nullary +
+-- parametric structure) which doesn't match how the other LogicDomain parameter types serialize.
+instance ToJSON InvoiceTemplateScope where
+  toJSON = String . T.pack . show
+
+instance FromJSON InvoiceTemplateScope where
+  parseJSON = withText "InvoiceTemplateScope" $ \t ->
+    maybe (fail $ "Failed to parse InvoiceTemplateScope: " <> T.unpack t) pure
+      $ readMaybe (T.unpack t)
 
 data LogicDomain
   = POOLING


### PR DESCRIPTION
  Before:
  {"tag":"INVOICE_TEMPLATE","contents":{"tag":"InvoiceTypeGeneric"}}
  {"tag":"INVOICE_TEMPLATE","contents":{"tag":"InvoiceTypeSpecific","contents":"Ride"}}
  contents = an object
  
  After: 
  {"tag":"INVOICE_TEMPLATE","contents":"InvoiceTypeGeneric"}
  {"tag":"INVOICE_TEMPLATE","contents":"InvoiceTypeSpecific-Ride"}
  contents = a flat string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON serialization and deserialization of invoice template scope data with string-based encoding and explicit error handling on parse failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->