### PR TITLE
feat: add FRFSInternal API for trip route manifest retrieval

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
@@ -31,6 +31,7 @@ import qualified Lib.GtfsDataServer.Flow as NandiFlow
 import Lib.GtfsDataServer.Types
 import SharedLogic.CallBAPInternal (getFrfsTripManifest)
 import SharedLogic.IntegratedBPPConfig (findIntegratedBPPConfig, getGimsBaseUrl)
+import Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import Storage.CachedQueries.OTPRest.OTPRest as OTPRest
 import qualified Storage.Queries.Person as QPerson
 import Tools.Error (GenericError (InvalidRequest))
@@ -154,12 +155,13 @@ getV2FrfsTripRouteManifest ::
     Text ->
     Flow FRFSTripPassengerManifestResp
   )
-getV2FrfsTripRouteManifest (_, _merchantId, _merchantOpCityId) tripId routeId = do
+getV2FrfsTripRouteManifest (_, _merchantId, merchantOpCityId) tripId routeId = do
   logInfo $ "FRFSFleetOperator: Getting trip manifest for tripId: " <> tripId <> ", routeId: " <> routeId
   bapInternal <- asks (.appBackendBapInternal)
+  merchantOpCity <- CQMOC.findById merchantOpCityId >>= fromMaybeM (InvalidRequest $ "MerchantOperatingCity not found: " <> merchantOpCityId.getId)
   let riderAppUrl = bapInternal.url
       riderAppApiKey = bapInternal.apiKey
-  getFrfsTripManifest riderAppApiKey riderAppUrl tripId routeId
+  getFrfsTripManifest riderAppApiKey riderAppUrl tripId routeId merchantOpCity.city
 
 -- | Perform trip action (start, end, reset, rollback)
 postFrfsFleetOperatorTripAction ::

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAPInternal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAPInternal.hs
@@ -23,6 +23,7 @@ import qualified Domain.SharedLogic.RideDiscount as RD
 import Domain.Types.Ride as DRide
 import EulerHS.Types (EulerClient, client)
 import Kernel.External.Slack.Types
+import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Prelude
 import Kernel.Types.APISuccess
 import Kernel.Types.Id (Id)
@@ -393,7 +394,7 @@ getOfferDiscount apiKey internalUrl bppBookingId req = do
 
 -- GET /v2/frfs/trip/{tripId}/route/{routeId}/manifest - Get passenger manifest
 type FrfsTripManifestAPI =
-  "v2"
+  "internal"
     :> "frfs"
     :> "trip"
     :> Capture "tripId" Text
@@ -401,9 +402,10 @@ type FrfsTripManifestAPI =
     :> Capture "routeId" Text
     :> "manifest"
     :> Header "token" Text
+    :> QueryParam "city" Context.City
     :> Get '[JSON] FRFSFleetOperatorAPI.FRFSTripPassengerManifestResp
 
-frfsTripManifestClient :: Text -> Text -> Maybe Text -> EulerClient FRFSFleetOperatorAPI.FRFSTripPassengerManifestResp
+frfsTripManifestClient :: Text -> Text -> Maybe Text -> Maybe Context.City -> EulerClient FRFSFleetOperatorAPI.FRFSTripPassengerManifestResp
 frfsTripManifestClient = client (Proxy @FrfsTripManifestAPI)
 
 frfsTripManifestAPI :: Proxy FrfsTripManifestAPI
@@ -419,8 +421,9 @@ getFrfsTripManifest ::
   BaseUrl ->
   Text ->
   Text ->
+  Context.City ->
   m FRFSFleetOperatorAPI.FRFSTripPassengerManifestResp
-getFrfsTripManifest apiKey internalUrl tripId routeId = do
+getFrfsTripManifest apiKey internalUrl tripId routeId city = do
   logInfo $ "CallBAPInternal: Getting FRFS trip manifest for tripId: " <> tripId <> ", routeId: " <> routeId
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
-  EC.callApiUnwrappingApiError (identity @Error) Nothing (Just "BAP_INTERNAL_API_ERROR") (Just internalEndPointHashMap) internalUrl (frfsTripManifestClient tripId routeId (Just apiKey)) "GetFrfsTripManifest" frfsTripManifestAPI
+  EC.callApiUnwrappingApiError (identity @Error) Nothing (Just "BAP_INTERNAL_API_ERROR") (Just internalEndPointHashMap) internalUrl (frfsTripManifestClient tripId routeId (Just apiKey) (Just city)) "GetFrfsTripManifest" frfsTripManifestAPI

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -276,6 +276,7 @@ library
       Domain.Action.UI.FeedbackForm
       Domain.Action.UI.FinanceInvoice
       Domain.Action.UI.FollowRide
+      Domain.Action.UI.FRFSInternal
       Domain.Action.UI.FRFSTicketService
       Domain.Action.UI.Frontend
       Domain.Action.UI.GetDailyMetrics
@@ -845,6 +846,7 @@ library
       API.Action.UI.FavouriteDriver
       API.Action.UI.FinanceInvoice
       API.Action.UI.FollowRide
+      API.Action.UI.FRFSInternal
       API.Action.UI.FRFSTicketService
       API.Action.UI.Insurance
       API.Action.UI.InsuranceInternal

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/FRFSInternal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/FRFSInternal.yaml
@@ -1,0 +1,21 @@
+imports:
+  FRFSTripPassengerManifestResp: API.Types.UI.FRFSTicketService
+  City: Kernel.Types.Beckn.Context
+
+module: FRFSInternal
+
+types: {}
+
+apis:
+  - GET:
+      endpoint: /frfs/trip/{tripId}/route/{routeId}/manifest
+      auth: NoAuth
+      headers:
+        token: Text
+      params:
+        tripId: Text
+        routeId: Text
+      mandatoryQuery:
+        city: City
+      response:
+        type: "API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp"

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/FRFSInternal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/FRFSInternal.hs
@@ -1,0 +1,36 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module API.Action.UI.FRFSInternal
+  ( API,
+    handler,
+  )
+where
+
+import qualified API.Types.UI.FRFSTicketService
+import qualified Domain.Action.UI.FRFSInternal
+import qualified Environment
+import EulerHS.Prelude
+import qualified Kernel.Prelude
+import qualified Kernel.Types.Beckn.Context
+import Kernel.Utils.Common
+import Servant
+import Storage.Beam.SystemConfigs ()
+import Tools.Auth
+
+type API =
+  ( "frfs" :> "trip" :> Capture "tripId" Kernel.Prelude.Text :> "route" :> Capture "routeId" Kernel.Prelude.Text :> "manifest"
+      :> MandatoryQueryParam
+           "city"
+           Kernel.Types.Beckn.Context.City
+      :> Header "token" Kernel.Prelude.Text
+      :> Get
+           '[JSON]
+           API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp
+  )
+
+handler :: Environment.FlowServer API
+handler = getFrfsTripRouteManifest
+
+getFrfsTripRouteManifest :: (Kernel.Prelude.Text -> Kernel.Prelude.Text -> Kernel.Types.Beckn.Context.City -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Environment.FlowHandler API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp)
+getFrfsTripRouteManifest a4 a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.FRFSInternal.getFrfsTripRouteManifest a4 a3 a2 a1

--- a/Backend/app/rider-platform/rider-app/Main/src/API/Internal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Internal.hs
@@ -5,6 +5,7 @@ module API.Internal
 where
 
 import qualified API.Action.UI.AlertWebhook as AlertWebhook
+import qualified API.Action.UI.FRFSInternal as FRFSInternal
 import qualified API.Action.UI.InsuranceInternal as InsuranceInternal
 import qualified API.Action.UI.MeterRideInternal as MeterRideInternal
 import qualified API.Internal.Auth as Auth
@@ -48,6 +49,7 @@ type API =
            :<|> OfferDiscount.API
            :<|> SendSMS.API
            :<|> InMemManagement.API
+           :<|> FRFSInternal.API
        )
 
 handler :: FlowServer API
@@ -71,3 +73,4 @@ handler =
     :<|> OfferDiscount.handler
     :<|> SendSMS.handler
     :<|> InMemManagement.handler
+    :<|> FRFSInternal.handler

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSInternal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSInternal.hs
@@ -1,0 +1,23 @@
+module Domain.Action.UI.FRFSInternal (getFrfsTripRouteManifest) where
+
+import qualified API.Types.UI.FRFSTicketService
+import qualified Domain.Action.UI.FRFSTicketService as FRFSTicketService
+import qualified Environment
+import EulerHS.Prelude hiding (id)
+import qualified Kernel.Types.Beckn.Context as Context
+import Kernel.Types.Error
+import Kernel.Utils.Common
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+
+getFrfsTripRouteManifest ::
+  Text ->
+  Text ->
+  Context.City ->
+  Maybe Text ->
+  Environment.Flow API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp
+getFrfsTripRouteManifest tripId routeId city mbToken = do
+  internalAPIKey <- asks (.internalAPIKey)
+  unless (Just internalAPIKey == mbToken) $
+    throwError $ AuthBlocked "Invalid BPP internal api key"
+  merchantOpCity <- CQMOC.findByCity city >>= fromMaybeM (MerchantOperatingCityNotFound $ "city: " <> show city)
+  FRFSTicketService.buildTripRouteManifest merchantOpCity.id tripId routeId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -1400,7 +1400,14 @@ getFrfsTripRouteManifest ::
 getFrfsTripRouteManifest (mbPersonId, _merchantId) tripId routeId = do
   personId <- mbPersonId & fromMaybeM (InvalidRequest "Person not found")
   personCityInfo <- QP.findCityInfoById personId >>= fromMaybeM (PersonNotFound personId.getId)
-  let cityId = personCityInfo.merchantOperatingCityId
+  buildTripRouteManifest personCityInfo.merchantOperatingCityId tripId routeId
+
+buildTripRouteManifest ::
+  Kernel.Types.Id.Id DMOC.MerchantOperatingCity ->
+  Text ->
+  Text ->
+  Environment.Flow FRFSTripPassengerManifestResp
+buildTripRouteManifest cityId tripId routeId = do
   integratedBPPConfig <- fromMaybeM (InvalidRequest "Integrated BPP config not found") . listToMaybe =<< SIBC.findAllIntegratedBPPConfig cityId Enums.BUS DIBC.MULTIMODAL
   let (waybillNo, tripNo) = JMU.getWaybillNoAndTripNoFromTripId tripId
   schedule <- JMU.measureLatency (OTPRest.getBusTripSchedule waybillNo tripNo routeId integratedBPPConfig) "getBusTripSchedule"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal manifest API to retrieve FRFS trip route manifests with a required city parameter and token-based validation.
  * Exposed a new internal handler so the rider app can serve the internal manifest route.

* **Refactor**
  * Moved manifest construction into a dedicated helper for clearer flow and reuse.
  * Manifest calls now respect and forward the requested merchant operating city.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->