### PR TITLE
backend/feat: send net fare (gross - commission) in driver search request API entity

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SearchRequestForDriver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SearchRequestForDriver.hs
@@ -130,6 +130,8 @@ makeSearchRequestForDriverAPIEntity nearbyReq searchRequest searchTry bapMetadat
       isAutoPlus = requestedVehicleServiceTier == DVST.AUTO_PLUS
       cCharges = roundToIntegral <$> congestionCharges
       pCharges = roundToIntegral <$> priorityCharges
+      rawBaseFare = fromMaybe searchTry.baseFare nearbyReq.baseFare
+      netBaseFare = rawBaseFare - fromMaybe 0 nearbyReq.commissionCharges
    in SearchRequestForDriverAPIEntity
         { searchRequestId = nearbyReq.searchTryId,
           searchTryId = nearbyReq.searchTryId,
@@ -143,8 +145,8 @@ makeSearchRequestForDriverAPIEntity nearbyReq searchRequest searchTry bapMetadat
           distanceToPickup = nearbyReq.actualDistanceToPickup,
           distanceToPickupWithUnit = convertMetersToDistance nearbyReq.distanceUnit nearbyReq.actualDistanceToPickup,
           durationToPickup = nearbyReq.durationToPickup,
-          baseFare = roundToIntegral $ fromMaybe searchTry.baseFare nearbyReq.baseFare, -- short term, later remove searchTry.baseFare
-          baseFareWithCurrency = PriceAPIEntity (roundAmountByCurrency' nearbyReq.currency (fromMaybe searchTry.baseFare nearbyReq.baseFare)) nearbyReq.currency,
+          baseFare = roundToIntegral netBaseFare, -- net fare = gross fare - commission
+          baseFareWithCurrency = PriceAPIEntity (roundAmountByCurrency' nearbyReq.currency netBaseFare) nearbyReq.currency,
           customerExtraFee = roundToIntegral <$> searchTry.customerExtraFee,
           customerExtraFeeWithCurrency = flip PriceAPIEntity searchTry.currency <$> searchTry.customerExtraFee,
           fromLocation = convertDomainType searchRequest.fromLocation,


### PR DESCRIPTION
## Summary

- In `makeSearchRequestForDriverAPIEntity`, the `baseFare` and `baseFareWithCurrency` fields now reflect the **net fare** (gross fare minus commission) instead of the gross fare.
- Commission is still returned separately in the existing `commissionCharges` field, so clients have both values available.
- No changes to data storage or commission calculation logic — this is purely a presentation change in the API entity builder.

## Changes

**File:** `Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/SearchRequestForDriver.hs`

- Added `rawBaseFare` binding to capture the gross fare (`fromMaybe searchTry.baseFare nearbyReq.baseFare`)
- Added `netBaseFare` binding: `rawBaseFare - fromMaybe 0 nearbyReq.commissionCharges`
- Updated `baseFare` and `baseFareWithCurrency` to use `netBaseFare`

## Test plan

- [ ] Verify that for a ride with commission configured, the `baseFare` returned in the driver search request equals gross fare minus commission
- [ ] Verify that `commissionCharges` in the response still holds the commission amount
- [ ] Verify that for rides with no commission (`commissionCharges = Nothing`), `baseFare` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated base fare calculation for driver search requests to properly account for commission charges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->