### PR TITLE
beckn-spec/fix: fix VAT back-calculation in applyRideDiscount (inclusive ratio scaling)

### DIFF
--- a/Backend/lib/beckn-spec/src/Domain/SharedLogic/RideDiscount.hs
+++ b/Backend/lib/beckn-spec/src/Domain/SharedLogic/RideDiscount.hs
@@ -16,12 +16,10 @@
 --   is zero and the cancellation pair carries the full amount.
 --
 --   The customer offer discount applies only to the discount-applicable ride
---   pair. We recompute VAT by applying the original tax multiplier
---     m = (taxExcl + tax) / taxExcl
---   to the post-discount taxable base (= taxExcl * ratio), which is
---   mathematically identical to ratio-scaling each component — the
---   multiplier phrasing is used here because it reads as "recompute VAT
---   over the post-discount fare" at the call site.
+--   pair. We back-calculate VAT from the post-discount tax-inclusive amount by
+--   scaling each component (taxExcl, tax) by ratio = basePostDiscount / base.
+--   This correctly handles the tax-inclusive base: solving x + rate*x = basePostDiscount
+--   gives x = basePostDiscount / (1 + rate), which is equivalent to taxExcl * ratio.
 --
 --   Non-discountable ride and toll are carried through untouched.
 module Domain.SharedLogic.RideDiscount
@@ -112,12 +110,15 @@ clampDiscount b raw = max 0 (min raw (discountApplicableBase b))
 --   recompute ride VAT over the post-discount inclusive amount.
 --
 --   Algorithm:
---     base        = discountApplicableRideFareTaxExclusive + discountApplicableRideFareTax
+--     base             = discountApplicableRideFareTaxExclusive + discountApplicableRideFareTax
 --     basePostDiscount = base − clampedDiscount
---     multiplier  = preTax / preExcl      -- pre-discount tax-on-base multiplier
---     postTax     = basePostDiscount × multiplier
---     postExcl    = basePostDiscount − postTax
---     absorbedVat = preTax − postTax      -- VAT lost to the discount (platform covers)
+--     ratio            = basePostDiscount / base
+--     postExcl         = taxExclPreDiscount × ratio   -- back-calculate from tax-inclusive total
+--     postTax          = taxPreDiscount × ratio
+--     absorbedVat      = preTax − postTax             -- VAT lost to the discount (platform covers)
+--
+--   Both components scale by the same ratio because basePostDiscount is tax-inclusive.
+--   Equivalently: postExcl = basePostDiscount / (1 + taxRate), postTax = basePostDiscount − postExcl.
 --
 --   Invariant: postExcl + postTax = basePostDiscount = base − clampedDiscount.
 --   absorbedVat is a separate platform expense, not part of the fare partition.
@@ -139,9 +140,8 @@ applyRideDiscount b rawDiscount
     taxPreDiscount = b.discountApplicableRideFareTax
     basePostDiscount = base - clamped
     ratio = toRational basePostDiscount / toRational base
-    multiplier = if taxExclPreDiscount > 0 then toRational taxPreDiscount / toRational taxExclPreDiscount else 0
-    postTax = fromRational (toRational basePostDiscount * multiplier)
-    postExcl = basePostDiscount - postTax
+    postTax = fromRational (toRational taxPreDiscount * ratio)
+    postExcl = fromRational (toRational taxExclPreDiscount * ratio)
     noOpResult =
       RideDiscountResult
         { postDiscountApplicableTaxExclusive = taxExclPreDiscount,


### PR DESCRIPTION
## Problem

`applyRideDiscount` in `Domain.SharedLogic.RideDiscount` incorrectly computed `postTax` after applying a discount.

The old code used:

```haskell
multiplier = tax / taxExcl            -- e.g. 13.50 / 100.00 = 0.135
postTax    = basePostDiscount × multiplier
postExcl   = basePostDiscount − postTax
```

`multiplier` is the VAT rate relative to the **tax-exclusive** amount. But `basePostDiscount` is the **tax-inclusive** post-discount total. Multiplying a tax-inclusive amount by an exclusive-based rate overstates tax and — critically — makes `absorbedVat = taxPreDiscount − postTax` go **negative**, which is impossible (the platform would appear to _gain_ VAT from a discount).

---

## Root Cause (with numbers)

**Setup:** ride fare = **€100.00 excl. VAT**, VAT = **13.5%** → **€13.50**, inclusive base = **€113.50**. Customer discount = **€10**.

```
basePostDiscount = 113.50 − 10.00 = 103.50 €   ← tax-INCLUSIVE
```

### Old (wrong)

```
multiplier = 13.50 / 100.00 = 0.135   ← rate on exclusive base

postTax  = 103.50 × 0.135 = 13.97 €  ← wrong: exclusive rate applied to inclusive amount
postExcl = 103.50 − 13.97 = 89.53 €

absorbedVat = 13.50 − 13.97 = −0.47 €  ❌  (negative — impossible)
```

The tax after discount (€13.97) exceeds the pre-discount tax (€13.50). Nonsensical.

### New (correct)

`basePostDiscount` is tax-inclusive, so both components (`taxExcl` and `tax`) must scale by the same ratio:

```
ratio    = 103.50 / 113.50 = 207/227

postTax  = 13.50 × 207/227 ≈ 12.31 €
postExcl = 100.00 × 207/227 ≈ 91.19 €

Check:        91.19 + 12.31 = 103.50 ✓
absorbedVat:  13.50 − 12.31 =   1.19 €  ✓  (platform absorbs this portion of VAT)
```

---

## Additional scenarios (13.5% VAT, discount up to €10)

### Small discount — €2 on €113.50 fare

```
basePostDiscount = 111.50 €,  ratio = 111.50/113.50 ≈ 0.9824

postTax  = 13.50 × 0.9824 ≈ 13.26 €
postExcl = 100.00 × 0.9824 ≈ 98.24 €
Check:       98.24 + 13.26 = 111.50 ✓
absorbedVat: 13.50 − 13.26 =   0.24 €  ✓
```

### Discount equals full base — €10 ride, €10 discount

```
taxExcl = 8.81 €,  tax = 1.19 €,  base = 10.00 €
discount = 10.00 € (clamped = 10.00)
ratio = 0

postTax  = 1.19 × 0 = 0 €
postExcl = 8.81 × 0 = 0 €
absorbedVat = 1.19 €  ✓  (platform absorbs full pre-discount VAT)
```

### Discount exceeds base (clamped) — €10 discount on €8 fare

```
taxExcl = 7.05 €,  tax = 0.95 €,  base = 8.00 €
rawDiscount = 10.00 €  →  clamped = 8.00 €
basePostDiscount = 0 €,  ratio = 0

postTax  = 0 €,  postExcl = 0 €
absorbedVat = 0.95 €  ✓
```

---

## The Fix

```haskell
-- Before
multiplier = if taxExclPreDiscount > 0
               then toRational taxPreDiscount / toRational taxExclPreDiscount
               else 0
postTax    = fromRational (toRational basePostDiscount * multiplier)
postExcl   = basePostDiscount - postTax

-- After
postTax  = fromRational (toRational taxPreDiscount * ratio)
postExcl = fromRational (toRational taxExclPreDiscount * ratio)
```

Both `taxExcl` and `tax` are components of the same inclusive `base`, so after the discount reduces the inclusive total by `ratio = basePostDiscount / base`, both scale by that same factor. The `multiplier` variable is removed entirely.

Equivalently, this is back-calculating from the inclusive total:
```
postExcl = basePostDiscount / (1 + taxRate)   where taxRate = tax / taxExcl
postTax  = basePostDiscount − postExcl
```

Both forms are algebraically identical; the ratio form is simpler and avoids a separate variable.

## Files Changed

- `Backend/lib/beckn-spec/src/Domain/SharedLogic/RideDiscount.hs`

## Test plan

- [ ] `applyRideDiscount` with VAT=13.5%, base=€113.50, discount=€10 → `postTax≈€12.31`, `absorbedVat≈€1.19` (positive)
- [ ] Full-discount case (discount = base) → `postTax=0`, `postExcl=0`, `absorbedVat=preTax`
- [ ] No-op case (discount=0 or base=0) → pre-discount values unchanged, `absorbedVat=0`
- [ ] `cabal build beckn-spec` passes with `-Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Refined ride discount and tax calculation logic for improved accuracy in discount application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->