### PR TITLE
backend/fix: parity issues between rider-app and driver-app bus-drive…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/FRFSFleetOperator.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/FRFSFleetOperator.yaml
@@ -52,7 +52,8 @@ types:
 
   FleetOperatorTripActionReq:
     action: FleetOperatorTripAction
-    personId: Text
+    conductorToken: Maybe Text
+    driverToken: Maybe Text
     vehicleNumber: Maybe Text
     derive: "Show"
 
@@ -62,7 +63,8 @@ types:
     derive: "Show"
 
   FleetOperatorCurrentOperationReq:
-    personId: Text
+    conductorToken: Maybe Text
+    driverToken: Maybe Text
     vehicleNumber: Maybe Text
     derive: "Show"
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Person.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Person.yaml
@@ -24,7 +24,7 @@ Person:
       recordType: Type
       derive': ""
     Role:
-      enum: "DRIVER, ADMIN, FLEET_OWNER, FLEET_BUSINESS, OPERATOR, CONDUCTOR"
+      enum: "DRIVER, ADMIN, FLEET_OWNER, FLEET_BUSINESS, OPERATOR, BUS_CONDUCTOR, BUS_DRIVER"
       derive': "Show, Eq, Ord, Read, Generic, ToJSON, FromJSON, ToSchema,ToParamSchema"
 
     IdentifierType:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/FRFSFleetOperator.hs
@@ -51,7 +51,7 @@ data FRFSTripPassengerManifestResp = FRFSTripPassengerManifestResp {manifest :: 
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data FleetOperatorCurrentOperationReq = FleetOperatorCurrentOperationReq {personId :: Data.Text.Text, vehicleNumber :: Kernel.Prelude.Maybe Data.Text.Text}
+data FleetOperatorCurrentOperationReq = FleetOperatorCurrentOperationReq {conductorToken :: Kernel.Prelude.Maybe Data.Text.Text, driverToken :: Kernel.Prelude.Maybe Data.Text.Text, vehicleNumber :: Kernel.Prelude.Maybe Data.Text.Text}
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
@@ -68,7 +68,12 @@ data FleetOperatorCurrentOperationResp = FleetOperatorCurrentOperationResp
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data FleetOperatorTripActionReq = FleetOperatorTripActionReq {action :: Domain.Types.FleetOperatorTripAction.FleetOperatorTripAction, personId :: Data.Text.Text, vehicleNumber :: Kernel.Prelude.Maybe Data.Text.Text}
+data FleetOperatorTripActionReq = FleetOperatorTripActionReq
+  { action :: Domain.Types.FleetOperatorTripAction.FleetOperatorTripAction,
+    conductorToken :: Kernel.Prelude.Maybe Data.Text.Text,
+    driverToken :: Kernel.Prelude.Maybe Data.Text.Text,
+    vehicleNumber :: Kernel.Prelude.Maybe Data.Text.Text
+  }
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/Person.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/Person.hs
@@ -190,7 +190,15 @@ data Gender = MALE | FEMALE | OTHER | UNKNOWN | PREFER_NOT_TO_SAY | NON_BINARY d
 
 data IdentifierType = MOBILENUMBER | AADHAAR | EMAIL | GIMS_EMAIL_PASSWORD deriving (Show, Eq, Ord, Read, Generic, ToJSON, FromJSON, ToSchema, ToParamSchema)
 
-data Role = DRIVER | ADMIN | FLEET_OWNER | FLEET_BUSINESS | OPERATOR | CONDUCTOR deriving (Show, Eq, Ord, Read, Generic, ToJSON, FromJSON, ToSchema, ToParamSchema)
+data Role
+  = DRIVER
+  | ADMIN
+  | FLEET_OWNER
+  | FLEET_BUSINESS
+  | OPERATOR
+  | BUS_CONDUCTOR
+  | BUS_DRIVER
+  deriving (Show, Eq, Ord, Read, Generic, ToJSON, FromJSON, ToSchema, ToParamSchema)
 
 $(Kernel.Beam.Lib.UtilsTH.mkBeamInstancesForEnumAndList ''Role)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Communication.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Communication.hs
@@ -459,7 +459,8 @@ personRoleToCommRole DP.FLEET_OWNER = CommAPI.ROLE_FLEET_OWNER
 personRoleToCommRole DP.OPERATOR = CommAPI.ROLE_OPERATOR
 personRoleToCommRole DP.ADMIN = CommAPI.ROLE_ADMIN
 personRoleToCommRole DP.FLEET_BUSINESS = CommAPI.ROLE_FLEET_OWNER
-personRoleToCommRole DP.CONDUCTOR = CommAPI.ROLE_DRIVER
+personRoleToCommRole DP.BUS_CONDUCTOR = CommAPI.ROLE_DRIVER
+personRoleToCommRole DP.BUS_DRIVER = CommAPI.ROLE_DRIVER
 
 buildRecipientItem ::
   (EncFlow m r, EsqDBFlow m r, CacheFlow m r) =>

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -1306,7 +1306,7 @@ buildDriverEntityRes (person, driverInfo, driverStats, merchantOpCityId) merchan
         nomineeRelationship = driverInfo.nomineeRelationship,
         subscriptionCreditBalance = subsCreditBalance,
         role = person.role,
-        operatorBadgeToken = if person.role == SP.CONDUCTOR then person.operatorBadgeToken else Nothing,
+        operatorBadgeToken = if person.role `elem` [SP.BUS_CONDUCTOR, SP.BUS_DRIVER] then person.operatorBadgeToken else Nothing,
         ..
       }
   where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
@@ -8,10 +8,10 @@ where
 
 import API.Types.UI.FRFSFleetOperator
 import BecknV2.FRFS.Enums (VehicleCategory (..))
-import Domain.Types.FleetOperatorTripAction (FleetOperatorTripAction (..))
 import qualified Data.HashMap.Strict as HashMap
 import Data.Text (unpack)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Domain.Types.FleetOperatorTripAction (FleetOperatorTripAction (..))
 import Domain.Types.IntegratedBPPConfig (PlatformType (..))
 import qualified Domain.Types.IntegratedBPPConfig as DIBC
 import qualified Domain.Types.Merchant
@@ -23,17 +23,14 @@ import Kernel.Prelude (listToMaybe)
 import qualified Kernel.Storage.Hedis as Hedis
 import qualified Kernel.Types.Beckn.Context
 import Kernel.Types.Common (Seconds (..))
-import Kernel.Types.Error (PersonError (PersonNotFound))
 import Kernel.Types.Id (Id (..), getId)
 import Kernel.Types.TimeBound (TimeBound (..))
 import Kernel.Utils.Common (fromMaybeM, getCurrentTime, logError, logInfo, throwError)
 import qualified Lib.GtfsDataServer.Flow as NandiFlow
 import Lib.GtfsDataServer.Types
 import SharedLogic.CallBAPInternal (getFrfsTripManifest)
-import SharedLogic.IntegratedBPPConfig (findIntegratedBPPConfig, getGimsBaseUrl)
-import Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import SharedLogic.IntegratedBPPConfig (findFirstIbppConfigByCityAndVehicle, findIntegratedBPPConfig, getGimsBaseUrl)
 import Storage.CachedQueries.OTPRest.OTPRest as OTPRest
-import qualified Storage.Queries.Person as QPerson
 import Tools.Error (GenericError (InvalidRequest))
 
 getV2FrfsRoute ::
@@ -155,13 +152,12 @@ getV2FrfsTripRouteManifest ::
     Text ->
     Flow FRFSTripPassengerManifestResp
   )
-getV2FrfsTripRouteManifest (_, _merchantId, merchantOpCityId) tripId routeId = do
+getV2FrfsTripRouteManifest (_, _merchantId, _merchantOpCityId) tripId routeId = do
   logInfo $ "FRFSFleetOperator: Getting trip manifest for tripId: " <> tripId <> ", routeId: " <> routeId
   bapInternal <- asks (.appBackendBapInternal)
-  merchantOpCity <- CQMOC.findById merchantOpCityId >>= fromMaybeM (InvalidRequest $ "MerchantOperatingCity not found: " <> merchantOpCityId.getId)
   let riderAppUrl = bapInternal.url
       riderAppApiKey = bapInternal.apiKey
-  getFrfsTripManifest riderAppApiKey riderAppUrl tripId routeId merchantOpCity.city
+  getFrfsTripManifest riderAppApiKey riderAppUrl tripId routeId
 
 -- | Perform trip action (start, end, reset, rollback)
 postFrfsFleetOperatorTripAction ::
@@ -172,47 +168,32 @@ postFrfsFleetOperatorTripAction ::
     FleetOperatorTripActionReq ->
     Flow FleetOperatorTripActionResp
   )
-postFrfsFleetOperatorTripAction (mbCallerId, _merchantId, merchantOpCityId) req = do
-  let FleetOperatorTripActionReq {action = act, personId = pid} = req
-  callerId <- mbCallerId & fromMaybeM (InvalidRequest "Unauthorized")
-  unless (getId callerId == pid) $
-    throwError $ InvalidRequest "Unauthorized: personId mismatch"
-
-  person <- QPerson.findById callerId >>= fromMaybeM (PersonNotFound pid)
-  condToken <- person.operatorBadgeToken & fromMaybeM (InvalidRequest $ "No operatorBadgeToken for person: " <> pid)
-
+postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
+  let FleetOperatorTripActionReq {action = act} = req
   integratedBPPConfig <-
-    findIntegratedBPPConfig
-      Nothing
+    findFirstIbppConfigByCityAndVehicle
       merchantOpCityId
       (show BUS)
-      MULTIMODAL
-
   baseUrl <- getGimsBaseUrl integratedBPPConfig
-
-  let anchor =
+  let gtfsId = DIBC.feedKey integratedBPPConfig
+      anchor =
         GimsOperationAnchor
-          { conductor_token = Just condToken,
-            driver_token = Nothing,
-            vehicle_number = Nothing
+          { conductor_token = req.conductorToken,
+            driver_token = req.driverToken,
+            vehicle_number = req.vehicleNumber
           }
-
-  gimsOps <- NandiFlow.gimsCurrentOperation baseUrl (DIBC.feedKey integratedBPPConfig) anchor
+  gimsOps <- NandiFlow.gimsCurrentOperation baseUrl gtfsId anchor
   let GimsCurrentOperationResp {waybill_no = wbNo, number_of_trips = numTrips} = gimsOps
-
-  let configId = getId integratedBPPConfig.id
-      redisKey = configId <> ":" <> condToken <> ":" <> wbNo <> ":tripnumber"
+      configId = getId integratedBPPConfig.id
+      redisKey = configId <> ":" <> wbNo <> ":tripnumber"
   now <- getCurrentTime
   let epochNow = round (utcTimeToPOSIXSeconds now * 1000) :: Int64
-
   logInfo $ "FRFSFleetOperator: Trip action - " <> show act
-  result <- case act of
-    TripStart -> handleTripStart baseUrl (DIBC.feedKey integratedBPPConfig) anchor numTrips redisKey epochNow
-    TripEnd -> handleTripEnd baseUrl (DIBC.feedKey integratedBPPConfig) anchor redisKey numTrips
-    TripReset -> handleTripReset baseUrl (DIBC.feedKey integratedBPPConfig) anchor redisKey numTrips
-    TripRollback -> handleTripRollback baseUrl (DIBC.feedKey integratedBPPConfig) anchor redisKey epochNow numTrips
-
-  return result
+  case act of
+    TripStart -> handleTripStart baseUrl gtfsId anchor numTrips redisKey epochNow
+    TripEnd -> handleTripEnd baseUrl gtfsId anchor redisKey numTrips
+    TripReset -> handleTripReset baseUrl gtfsId anchor redisKey numTrips
+    TripRollback -> handleTripRollback baseUrl gtfsId anchor redisKey epochNow numTrips
   where
     handleTripStart baseUrl gtfsId anchor numTrips redisKey epochNow = do
       let lockKey = redisKey <> ":lock"
@@ -350,65 +331,43 @@ postFrfsFleetOperatorCurrentOperation ::
     FleetOperatorCurrentOperationReq ->
     Flow FleetOperatorCurrentOperationResp
   )
-postFrfsFleetOperatorCurrentOperation (mbCallerId, _merchantId, merchantOpCityId) req = do
-  let FleetOperatorCurrentOperationReq {personId = pid} = req
+postFrfsFleetOperatorCurrentOperation (_, _merchantId, merchantOpCityId) req = do
   logInfo "FRFSFleetOperator: Current operation"
-  callerId <- mbCallerId & fromMaybeM (InvalidRequest "Unauthorized")
-  unless (getId callerId == pid) $
-    throwError $ InvalidRequest "Unauthorized: personId mismatch"
-
-  person <- QPerson.findById callerId >>= fromMaybeM (PersonNotFound pid)
-  condToken <- person.operatorBadgeToken & fromMaybeM (InvalidRequest $ "No operatorBadgeToken for person: " <> pid)
-
-  -- 1.Find BPP config for BUS/MULTIMODAL
   integratedBPPConfig <-
-    findIntegratedBPPConfig
-      Nothing
+    findFirstIbppConfigByCityAndVehicle
       merchantOpCityId
       (show BUS)
-      MULTIMODAL
-
-  -- 2.Get OTP REST base URL
   baseUrl <- getGimsBaseUrl integratedBPPConfig
-
-  let anchor =
+  let gtfsId = DIBC.feedKey integratedBPPConfig
+      anchor =
         GimsOperationAnchor
-          { conductor_token = Just condToken,
-            driver_token = Nothing,
-            vehicle_number = Nothing
+          { conductor_token = req.conductorToken,
+            driver_token = req.driverToken,
+            vehicle_number = req.vehicleNumber
           }
-
-  -- 3.Get current operation (waybill)
-  gimsOps <- NandiFlow.gimsCurrentOperation baseUrl (DIBC.feedKey integratedBPPConfig) anchor
-  let GimsCurrentOperationResp {waybill_no = wbNo} = gimsOps
-
-  -- 4.Get trip number from Redis
+  gimsOps <- NandiFlow.gimsCurrentOperation baseUrl gtfsId anchor
   let configId = getId integratedBPPConfig.id
-      redisKey = configId <> ":" <> condToken <> ":" <> wbNo <> ":tripnumber"
+      redisKey = configId <> ":" <> gimsOps.waybill_no <> ":tripnumber"
   mbPrevTrip <- Hedis.get redisKey
   let prevTrip = fromMaybe 0 (mbPrevTrip :: Maybe Int)
-
-  -- 5.Get trip details
   tripResp <-
     NandiFlow.gimsCurrentTripDetails
       baseUrl
-      (DIBC.feedKey integratedBPPConfig)
+      gtfsId
       GimsCurrentTripDetailsReq
         { previous_trip_number = prevTrip,
-          conductor_token = Just condToken,
-          driver_token = Nothing,
-          vehicle_number = Nothing
+          conductor_token = req.conductorToken,
+          driver_token = req.driverToken,
+          vehicle_number = req.vehicleNumber
         }
-
-  -- 6.Transform to API response
   let GimsCurrentTripDetailsResp {waybill_no = wNo, vehicle_number = vNum, conductor_token = cToken, driver_token = dToken, history = hist, current = curr, upcoming = upc} = tripResp
   return $
     FleetOperatorCurrentOperationResp
       { waybillNo = wNo,
         vehicleNumber = vNum,
-        gtfsId = DIBC.feedKey integratedBPPConfig,
-        conductorToken = Just cToken,
-        driverToken = Just dToken,
+        gtfsId = gtfsId,
+        conductorToken = cToken,
+        driverToken = dToken,
         history = map transformTripInfo hist,
         current = transformTripInfo <$> curr,
         upcoming = map transformTripInfo upc

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Registration.hs
@@ -80,7 +80,7 @@ import Kernel.Utils.SlidingWindowLimiter
 import Kernel.Utils.Validation
 import Kernel.Utils.Version
 import qualified Lib.GtfsDataServer.Flow as NandiFlow
-import Lib.GtfsDataServer.Types (GimsEmployeeLoginReq (..))
+import Lib.GtfsDataServer.Types (GimsEmployeeLoginReq (..), GimsEmployeeRole (..))
 import Lib.SessionizerMetrics.Types.Event
 import qualified Lib.Yudhishthira.Tools.Utils as Yudhishthira
 import qualified Lib.Yudhishthira.Types as LYT
@@ -230,17 +230,27 @@ auth isDashboard req' mbBundleVersion mbClientVersion mbClientConfigVersion mbRe
       unless gimsResp.verified $ throwError $ InvalidRequest "GIMS verification failed"
       operatorBadgeToken <- gimsResp.token & fromMaybeM (InvalidRequest "GIMS did not return operator badge token")
       transporterConfig <- SCTC.findByMerchantOpCityId merchantOpCityId Nothing >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
+      let loginRole = case gimsResp.role of
+            Just GimsConductor -> SP.BUS_CONDUCTOR
+            _ -> SP.BUS_DRIVER
       person <-
-        QP.findByEmailAndMerchantIdAndRole (Just email) merchant.id SP.CONDUCTOR
+        QP.findByEmailAndMerchantIdAndRole (Just email) merchant.id loginRole
           >>= maybe
             ( do
-                basePerson <- makePerson req' transporterConfig mbBundleVersion mbClientVersion mbClientConfigVersion mbReactBundleVersion mbDevice Nothing mbCloudType merchant.id merchantOpCityId False (Just SP.CONDUCTOR)
-                let conductorPerson = basePerson {SP.identifier = Just operatorBadgeToken, SP.operatorBadgeToken = Just operatorBadgeToken}
+                basePerson <- makePerson req' transporterConfig mbBundleVersion mbClientVersion mbClientConfigVersion mbReactBundleVersion mbDevice Nothing mbCloudType merchant.id merchantOpCityId False (Just loginRole)
+                let conductorPerson = basePerson {SP.operatorBadgeToken = Just operatorBadgeToken}
                 void $ QP.create conductorPerson
                 createDriverDetails conductorPerson.id merchant.id merchantOpCityId transporterConfig
                 pure conductorPerson
             )
-            return
+            ( \existingPerson ->
+                if existingPerson.operatorBadgeToken == Just operatorBadgeToken
+                  then pure existingPerson
+                  else do
+                    let refreshedPerson = existingPerson {SP.operatorBadgeToken = Just operatorBadgeToken}
+                    QP.updateByPrimaryKey refreshedPerson
+                    pure refreshedPerson
+            )
       checkSlidingWindowLimit (authHitsCountKey person)
       let entityId = getId person.id
           useFakeOtpM = (show <$> useFakeSms smsCfg) <|> person.useFakeOtp

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAPInternal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAPInternal.hs
@@ -23,7 +23,6 @@ import qualified Domain.SharedLogic.RideDiscount as RD
 import Domain.Types.Ride as DRide
 import EulerHS.Types (EulerClient, client)
 import Kernel.External.Slack.Types
-import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Prelude
 import Kernel.Types.APISuccess
 import Kernel.Types.Id (Id)
@@ -402,10 +401,9 @@ type FrfsTripManifestAPI =
     :> Capture "routeId" Text
     :> "manifest"
     :> Header "token" Text
-    :> QueryParam "city" Context.City
     :> Get '[JSON] FRFSFleetOperatorAPI.FRFSTripPassengerManifestResp
 
-frfsTripManifestClient :: Text -> Text -> Maybe Text -> Maybe Context.City -> EulerClient FRFSFleetOperatorAPI.FRFSTripPassengerManifestResp
+frfsTripManifestClient :: Text -> Text -> Maybe Text -> EulerClient FRFSFleetOperatorAPI.FRFSTripPassengerManifestResp
 frfsTripManifestClient = client (Proxy @FrfsTripManifestAPI)
 
 frfsTripManifestAPI :: Proxy FrfsTripManifestAPI
@@ -421,9 +419,8 @@ getFrfsTripManifest ::
   BaseUrl ->
   Text ->
   Text ->
-  Context.City ->
   m FRFSFleetOperatorAPI.FRFSTripPassengerManifestResp
-getFrfsTripManifest apiKey internalUrl tripId routeId city = do
+getFrfsTripManifest apiKey internalUrl tripId routeId = do
   logInfo $ "CallBAPInternal: Getting FRFS trip manifest for tripId: " <> tripId <> ", routeId: " <> routeId
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
-  EC.callApiUnwrappingApiError (identity @Error) Nothing (Just "BAP_INTERNAL_API_ERROR") (Just internalEndPointHashMap) internalUrl (frfsTripManifestClient tripId routeId (Just apiKey) (Just city)) "GetFrfsTripManifest" frfsTripManifestAPI
+  EC.callApiUnwrappingApiError (identity @Error) Nothing (Just "BAP_INTERNAL_API_ERROR") (Just internalEndPointHashMap) internalUrl (frfsTripManifestClient tripId routeId (Just apiKey)) "GetFrfsTripManifest" frfsTripManifestAPI

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/FRFSInternal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/FRFSInternal.yaml
@@ -1,6 +1,5 @@
 imports:
   FRFSTripPassengerManifestResp: API.Types.UI.FRFSTicketService
-  City: Kernel.Types.Beckn.Context
 
 module: FRFSInternal
 
@@ -15,7 +14,5 @@ apis:
       params:
         tripId: Text
         routeId: Text
-      mandatoryQuery:
-        city: City
       response:
         type: "API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp"

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/FrfsTicket.yaml
@@ -367,8 +367,8 @@ types:
   FleetOperatorCurrentOperationResp:
     waybillNo: Text
     vehicleNumber: Text
-    conductorToken: Text
-    driverToken: Text
+    conductorToken: Maybe Text
+    driverToken: Maybe Text
     history: "[OperatorTripInfo]"
     current: Maybe OperatorTripInfo
     upcoming: "[OperatorTripInfo]"

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/FRFSInternal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/FRFSInternal.hs
@@ -12,18 +12,13 @@ import qualified Domain.Action.UI.FRFSInternal
 import qualified Environment
 import EulerHS.Prelude
 import qualified Kernel.Prelude
-import qualified Kernel.Types.Beckn.Context
 import Kernel.Utils.Common
 import Servant
 import Storage.Beam.SystemConfigs ()
 import Tools.Auth
 
 type API =
-  ( "frfs" :> "trip" :> Capture "tripId" Kernel.Prelude.Text :> "route" :> Capture "routeId" Kernel.Prelude.Text :> "manifest"
-      :> MandatoryQueryParam
-           "city"
-           Kernel.Types.Beckn.Context.City
-      :> Header "token" Kernel.Prelude.Text
+  ( "frfs" :> "trip" :> Capture "tripId" Kernel.Prelude.Text :> "route" :> Capture "routeId" Kernel.Prelude.Text :> "manifest" :> Header "token" Kernel.Prelude.Text
       :> Get
            '[JSON]
            API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp
@@ -32,5 +27,5 @@ type API =
 handler :: Environment.FlowServer API
 handler = getFrfsTripRouteManifest
 
-getFrfsTripRouteManifest :: (Kernel.Prelude.Text -> Kernel.Prelude.Text -> Kernel.Types.Beckn.Context.City -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Environment.FlowHandler API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp)
-getFrfsTripRouteManifest a4 a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.FRFSInternal.getFrfsTripRouteManifest a4 a3 a2 a1
+getFrfsTripRouteManifest :: (Kernel.Prelude.Text -> Kernel.Prelude.Text -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Environment.FlowHandler API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp)
+getFrfsTripRouteManifest a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.FRFSInternal.getFrfsTripRouteManifest a3 a2 a1

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/FRFSTicketService.hs
@@ -349,9 +349,9 @@ data FleetOperatorCurrentOperationReq = FleetOperatorCurrentOperationReq {conduc
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data FleetOperatorCurrentOperationResp = FleetOperatorCurrentOperationResp
-  { conductorToken :: Data.Text.Text,
+  { conductorToken :: Data.Maybe.Maybe Data.Text.Text,
     current :: Data.Maybe.Maybe OperatorTripInfo,
-    driverToken :: Data.Text.Text,
+    driverToken :: Data.Maybe.Maybe Data.Text.Text,
     history :: [OperatorTripInfo],
     upcoming :: [OperatorTripInfo],
     vehicleNumber :: Data.Text.Text,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSInternal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSInternal.hs
@@ -4,20 +4,16 @@ import qualified API.Types.UI.FRFSTicketService
 import qualified Domain.Action.UI.FRFSTicketService as FRFSTicketService
 import qualified Environment
 import EulerHS.Prelude hiding (id)
-import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Types.Error
 import Kernel.Utils.Common
-import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 
 getFrfsTripRouteManifest ::
   Text ->
   Text ->
-  Context.City ->
   Maybe Text ->
   Environment.Flow API.Types.UI.FRFSTicketService.FRFSTripPassengerManifestResp
-getFrfsTripRouteManifest tripId routeId city mbToken = do
+getFrfsTripRouteManifest tripId routeId mbToken = do
   internalAPIKey <- asks (.internalAPIKey)
   unless (Just internalAPIKey == mbToken) $
     throwError $ AuthBlocked "Invalid BPP internal api key"
-  merchantOpCity <- CQMOC.findByCity city >>= fromMaybeM (MerchantOperatingCityNotFound $ "city: " <> show city)
-  FRFSTicketService.buildTripRouteManifest merchantOpCity.id tripId routeId
+  FRFSTicketService.buildTripRouteManifest tripId routeId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -1398,24 +1398,34 @@ getFrfsTripRouteManifest ::
   Text ->
   Environment.Flow FRFSTripPassengerManifestResp
 getFrfsTripRouteManifest (mbPersonId, _merchantId) tripId routeId = do
-  personId <- mbPersonId & fromMaybeM (InvalidRequest "Person not found")
-  personCityInfo <- QP.findCityInfoById personId >>= fromMaybeM (PersonNotFound personId.getId)
-  buildTripRouteManifest personCityInfo.merchantOperatingCityId tripId routeId
+  _ <- mbPersonId & fromMaybeM (InvalidRequest "Person not found")
+  buildTripRouteManifest tripId routeId
 
 buildTripRouteManifest ::
-  Kernel.Types.Id.Id DMOC.MerchantOperatingCity ->
   Text ->
   Text ->
   Environment.Flow FRFSTripPassengerManifestResp
-buildTripRouteManifest cityId tripId routeId = do
-  integratedBPPConfig <- fromMaybeM (InvalidRequest "Integrated BPP config not found") . listToMaybe =<< SIBC.findAllIntegratedBPPConfig cityId Enums.BUS DIBC.MULTIMODAL
+buildTripRouteManifest tripId routeId = do
+  bookings <- JMU.measureLatency (QFRFSTicketBooking.findAllConfirmedByTripId tripId) "findAllByTripId"
+  case listToMaybe bookings of
+    Nothing ->
+      pure $ FRFSTripPassengerManifestResp {manifest = []}
+    Just firstBooking -> buildManifestForBookings firstBooking bookings tripId routeId
+
+buildManifestForBookings ::
+  DFRFSTicketBooking.FRFSTicketBooking ->
+  [DFRFSTicketBooking.FRFSTicketBooking] ->
+  Text ->
+  Text ->
+  Environment.Flow FRFSTripPassengerManifestResp
+buildManifestForBookings firstBooking bookings tripId routeId = do
+  integratedBPPConfig <- SIBC.findIntegratedBPPConfigById firstBooking.integratedBppConfigId
   let (waybillNo, tripNo) = JMU.getWaybillNoAndTripNoFromTripId tripId
   schedule <- JMU.measureLatency (OTPRest.getBusTripSchedule waybillNo tripNo routeId integratedBPPConfig) "getBusTripSchedule"
   scheduleDetail <-
     schedule & listToMaybe
       & fromMaybeM (InvalidRequest "Bus schedule not found")
   let stops = scheduleDetail.eta
-  bookings <- JMU.measureLatency (QFRFSTicketBooking.findAllConfirmedByTripId tripId) "findAllByTripId"
   let bookingIds = map (.id) bookings
   allTickets <- JMU.measureLatency (QFRFSTicket.findAllByTicketBookingIds bookingIds) "findAllByTicketBookingIds"
   let ticketMap = Map.fromListWith (++) $ map (\t -> (t.frfsTicketBookingId, [t])) allTickets

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Types.hs
@@ -1238,8 +1238,8 @@ data GimsTripInfo = GimsTripInfo
 data GimsCurrentTripDetailsResp = GimsCurrentTripDetailsResp
   { waybill_no :: Text,
     vehicle_number :: Text,
-    conductor_token :: Text,
-    driver_token :: Text,
+    conductor_token :: Maybe Text,
+    driver_token :: Maybe Text,
     history :: [GimsTripInfo],
     current :: Maybe GimsTripInfo,
     upcoming :: [GimsTripInfo]

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/person.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/person.sql
@@ -133,3 +133,7 @@ ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN cloud_type text ;
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.person ADD COLUMN operator_badge_token text ;
+
+
+------- SQL updates -------
+

--- a/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
+++ b/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
@@ -271,8 +271,8 @@ instance FromJSON GimsTripInfo where
 data GimsCurrentTripDetailsResp = GimsCurrentTripDetailsResp
   { waybill_no :: Text,
     vehicle_number :: Text,
-    conductor_token :: Text,
-    driver_token :: Text,
+    conductor_token :: Maybe Text,
+    driver_token :: Maybe Text,
     history :: [GimsTripInfo],
     current :: Maybe GimsTripInfo,
     upcoming :: [GimsTripInfo]
@@ -316,9 +316,26 @@ data GimsEmployeeLoginReq = GimsEmployeeLoginReq
 instance HideSecrets GimsEmployeeLoginReq where
   hideSecrets req = req {email_hash = "***", password_hash = "***"}
 
+-- | Roles GIMS recognises for an employee. Wire form is lowercase
+-- (\"driver\" / \"conductor\"); parser is case-insensitive. Unknown values
+-- fail the whole login response — keep this in sync with the Rust enum.
+data GimsEmployeeRole = GimsDriver | GimsConductor
+  deriving (Generic, Show, Eq)
+
+instance FromJSON GimsEmployeeRole where
+  parseJSON = withText "GimsEmployeeRole" $ \t -> case T.toLower t of
+    "driver" -> pure GimsDriver
+    "conductor" -> pure GimsConductor
+    other -> fail $ "Unknown GIMS employee role: " <> T.unpack other
+
+instance ToJSON GimsEmployeeRole where
+  toJSON GimsDriver = String "driver"
+  toJSON GimsConductor = String "conductor"
+
 -- | Response from the employee login endpoint (driver-app only).
 data GimsEmployeeLoginResp = GimsEmployeeLoginResp
   { verified :: Bool,
-    token :: Maybe Text
+    token :: Maybe Text,
+    role :: Maybe GimsEmployeeRole
   }
   deriving (Generic, FromJSON, ToJSON, Show)


### PR DESCRIPTION
 ## Summary

  Aligns driver-app's FRFS fleet operator endpoints (`tripAction`, `currentOperation`)
  with rider-app. Drops `personId` from requests and adds `conductorToken` /
  `driverToken` instead, matching rider-app's wire shape. Tokens now flow straight
  from request to GIMS — no more `operatorBadgeToken` DB lookup.

  Driver-app keeps `gtfsId` in the response, the distributed Redis lock on
  trip actions, and a `<configId>` prefix on the Redis trip-counter key for
  per-config isolation. Rider-app has none of these — kept as deliberate
  driver-side divergences (locking guards against concurrent `TripStart` racing
  the counter; `configId` keeps counters scoped per `IntegratedBPPConfig`).

  Redis key narrowed from `<configId>:<condToken>:<waybill>:tripnumber` to
  `<configId>:<waybill>:tripnumber` (drops the `condToken` segment now that
  the conductor token is no longer DB-derived). **Deploy note:** counters under
  the old four-segment key won't be read post-deploy and will reset to 0 on the
  next `TripStart`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented token-based authentication for fleet operator operations using conductor and driver tokens instead of person identifiers.
  * Added bus driver role type to support new driver classifications.
  * Enhanced GIMS employee login integration with role-based authentication support.

* **Refactor**
  * Streamlined FRFS trip manifest API endpoint by removing the mandatory city parameter requirement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->