### PR TITLE
rider-app/feat: add cancellationCharge/cancellationTax to RidePaymentLedgerInfo and fix cash cancellation void

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
@@ -566,6 +566,8 @@ rideAssignedReqHandler req = do
                       cashbackPayoutAmount = bookingPayoutAmount,
                       platformFee = applicationFeeAmount,
                       rideVatAbsorbedOnDiscount = 0,
+                      cancellationCharge = 0,
+                      cancellationTax = 0,
                       financeCtx = ledgerCtx
                     }
                   mbLedgerInfo
@@ -612,6 +614,8 @@ rideAssignedReqHandler req = do
                       cashbackPayoutAmount = bookingPayoutAmount,
                       platformFee = applicationFeeAmount,
                       rideVatAbsorbedOnDiscount = 0,
+                      cancellationCharge = 0,
+                      cancellationTax = 0,
                       financeCtx = ledgerCtx
                     }
                   mbLedgerInfo
@@ -994,6 +998,8 @@ rideCompletedReqHandler ValidatedRideCompletedReq {..} = do
                   offerDiscountAmount = rideDiscountAmount,
                   cashbackPayoutAmount = ridePayoutAmount,
                   rideVatAbsorbedOnDiscount = 0,
+                  cancellationCharge = 0,
+                  cancellationTax = 0,
                   financeCtx = cashLedgerCtx
                 }
               mbCashLedgerInfo
@@ -1008,6 +1014,8 @@ rideCompletedReqHandler ValidatedRideCompletedReq {..} = do
           cashLedgerInfo.offerDiscountAmount
           cashLedgerInfo.cashbackPayoutAmount
           cashLedgerInfo.rideVatAbsorbedOnDiscount
+          0 -- cancellationCharge (not applicable at ride-end)
+          0 -- cancellationTax
       unless (null upsertRes.coreEntryIds) $ do
         settleResult <- RidePaymentFinance.settleRidePaymentLedger cashLedgerCtx upsertRes.coreEntryIds RidePaymentFinance.settledReasonRidePayment
         case settleResult of
@@ -1039,6 +1047,8 @@ rideCompletedReqHandler ValidatedRideCompletedReq {..} = do
                   offerDiscountAmount = rideDiscountAmount,
                   cashbackPayoutAmount = ridePayoutAmount,
                   rideVatAbsorbedOnDiscount = 0,
+                  cancellationCharge = 0,
+                  cancellationTax = 0,
                   financeCtx = ledgerCtx
                 }
               mbLedgerInfo
@@ -1409,8 +1419,8 @@ cancellationTransaction booking mbRide cancellationSource cancellationFee cancel
                 logDebug $ "[CancellationSettlement] Creating cancellation payment intent amount=" <> show fee.amount <> " currency=" <> show fee.currency
                 let cancellationLedgerInfo =
                       SPayment.RidePaymentLedgerInfo
-                        { rideFare = cancellationBase,
-                          gstAmount = cancellationGST,
+                        { rideFare = 0,
+                          gstAmount = 0,
                           tollFare = 0,
                           tollVatAmount = 0,
                           parkingCharge = 0,
@@ -1419,6 +1429,8 @@ cancellationTransaction booking mbRide cancellationSource cancellationFee cancel
                           offerDiscountAmount = 0,
                           cashbackPayoutAmount = 0,
                           rideVatAbsorbedOnDiscount = 0,
+                          cancellationCharge = cancellationBase,
+                          cancellationTax = cancellationGST,
                           financeCtx = ledgerCtx
                         }
                 eitherMbIntent <-
@@ -1450,7 +1462,14 @@ cancellationTransaction booking mbRide cancellationSource cancellationFee cancel
                             logError $ "[CancellationSettlement] Charge failed for PI: " <> cancellationPaymentIntentResp.paymentIntentId
                             markDueOnFailure
               _ -> do
-                -- Cash/UPI: create pending entries then mark as DUE for later collection
+                -- Cash/UPI: void any unsettled ride-fare entries before creating cancellation entries
+                pendingEntries <- RidePaymentFinance.findUnsettledRidePaymentEntries ride.id.getId
+                unless (null pendingEntries) $ do
+                  let entryIds = map (.id) pendingEntries
+                  RidePaymentFinance.voidRidePaymentLedger entryIds
+                  logInfo $ "Voided " <> show (length entryIds) <> " pending ledger entries for cancelled ride: " <> ride.id.getId
+                RidePaymentFinance.voidRideInvoice ride.id.getId
+                -- Create pending cancellation entries then mark as DUE for later collection
                 cashLedgerResp <- RidePaymentFinance.createPendingCancellationFeeLedger ledgerCtx cancellationBase cancellationGST
                 case cashLedgerResp of
                   Right (_mbInvoiceId, pendingEntryIds) ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/RidePayment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/RidePayment.hs
@@ -343,6 +343,8 @@ postPaymentAddTip (mbPersonId, merchantId) rideId tipRequest = do
                     offerDiscountAmount = rideDiscountAmount,
                     cashbackPayoutAmount = ridePayoutAmount,
                     rideVatAbsorbedOnDiscount = 0,
+                    cancellationCharge = 0,
+                    cancellationTax = 0,
                     financeCtx = tipLedgerCtx
                   }
                 mbTipLedgerInfo
@@ -365,6 +367,8 @@ postPaymentAddTip (mbPersonId, merchantId) rideId tipRequest = do
                         offerDiscountAmount = rideDiscountAmount,
                         cashbackPayoutAmount = ridePayoutAmount,
                         rideVatAbsorbedOnDiscount = 0,
+                        cancellationCharge = 0,
+                        cancellationTax = 0,
                         financeCtx = ledgerCtx
                       }
                     mbLedgerInfo
@@ -794,6 +798,8 @@ postPaymentClearDues (mbPersonId, merchantId) req = do
             debtDiscountAmount
             0 -- debt settlement doesn't have cashback
             0 -- rideVatAbsorbedOnDiscount (debt settlement: no absorbed VAT split)
+            0 -- cancellationCharge (not applicable for debt settlement)
+            0 -- cancellationTax
             debtLedgerCtx
 
     paymentIntentResp <-

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Finance/RidePayment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Finance/RidePayment.hs
@@ -459,8 +459,13 @@ upsertCoreRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platfo
                 <> show newTotal
                 <> ") for ride: "
                 <> rideId
-            (newIds, mbInv) <- doCreate
-            pure UpsertCoreLedgerResult {coreEntryIds = newIds, invoiceId = mbInv, didCreate = True, didVoidStale = True}
+            if newTotal > 0
+              then do
+                (newIds, mbInv) <- doCreate
+                pure UpsertCoreLedgerResult {coreEntryIds = newIds, invoiceId = mbInv, didCreate = True, didVoidStale = True}
+              else do
+                logInfo $ "Core ride payment total is zero, skipping create after void for ride: " <> rideId
+                pure UpsertCoreLedgerResult {coreEntryIds = [], invoiceId = Nothing, didCreate = False, didVoidStale = True}
           else do
             logInfo $ "Core ride payment ledger already up to date for ride: " <> rideId
             pure

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Finance/RidePayment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Finance/RidePayment.hs
@@ -401,8 +401,10 @@ upsertCoreRidePaymentLedger ::
   HighPrecMoney -> -- offerDiscountAmount
   HighPrecMoney -> -- cashbackPayoutAmount
   HighPrecMoney -> -- rideVatAbsorbedOnDiscount
+  HighPrecMoney -> -- cancellationCharge (0 for normal ride)
+  HighPrecMoney -> -- cancellationTax (0 for normal ride)
   m UpsertCoreLedgerResult
-upsertCoreRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platformFee offerDiscountAmount cashbackPayoutAmount rideVatAbsorbedOnDiscount = do
+upsertCoreRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platformFee offerDiscountAmount cashbackPayoutAmount rideVatAbsorbedOnDiscount cancellationCharge cancellationTax = do
   let rideId = ctx.referenceId
   existingEntries <- findRidePaymentEntries rideId
   let coreEntries = filter (\e -> e.referenceType `elem` coreRidePaymentRefTypes) existingEntries
@@ -433,35 +435,50 @@ upsertCoreRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platfo
           Left err -> do
             logError $ "Failed to create core ride payment ledger for " <> rideId <> ": " <> show err
             pure ([], Nothing)
-  if null coreEntries
-    then do
-      (newIds, mbInv) <- doCreate
-      logInfo $ "Created PENDING core ride payment ledger entries for ride: " <> rideId
-      pure UpsertCoreLedgerResult {coreEntryIds = newIds, invoiceId = mbInv, didCreate = True, didVoidStale = False}
-    else
-      if not (null pendingCoreEntries) && newTotal /= oldTotal
-        then do
-          let staleIds = map (.id) pendingCoreEntries
-          voidRidePaymentLedger staleIds
-          voidRideInvoice rideId
-          logInfo $
-            "Voided " <> show (length staleIds) <> " stale PENDING core entries (old="
-              <> show oldTotal
-              <> " new="
-              <> show newTotal
-              <> ") for ride: "
-              <> rideId
-          (newIds, mbInv) <- doCreate
-          pure UpsertCoreLedgerResult {coreEntryIds = newIds, invoiceId = mbInv, didCreate = True, didVoidStale = True}
-        else do
-          logInfo $ "Core ride payment ledger already up to date for ride: " <> rideId
-          pure
-            UpsertCoreLedgerResult
-              { coreEntryIds = map (.id) pendingCoreEntries,
-                invoiceId = Nothing,
-                didCreate = False,
-                didVoidStale = False
-              }
+  coreResult <-
+    if null coreEntries
+      then do
+        if newTotal > 0
+          then do
+            (newIds, mbInv) <- doCreate
+            logInfo $ "Created PENDING core ride payment ledger entries for ride: " <> rideId
+            pure UpsertCoreLedgerResult {coreEntryIds = newIds, invoiceId = mbInv, didCreate = True, didVoidStale = False}
+          else do
+            logInfo $ "Core ride payment total is zero, skipping create for ride: " <> rideId
+            pure UpsertCoreLedgerResult {coreEntryIds = [], invoiceId = Nothing, didCreate = False, didVoidStale = False}
+      else
+        if not (null pendingCoreEntries) && newTotal /= oldTotal
+          then do
+            let staleIds = map (.id) pendingCoreEntries
+            voidRidePaymentLedger staleIds
+            voidRideInvoice rideId
+            logInfo $
+              "Voided " <> show (length staleIds) <> " stale PENDING core entries (old="
+                <> show oldTotal
+                <> " new="
+                <> show newTotal
+                <> ") for ride: "
+                <> rideId
+            (newIds, mbInv) <- doCreate
+            pure UpsertCoreLedgerResult {coreEntryIds = newIds, invoiceId = mbInv, didCreate = True, didVoidStale = True}
+          else do
+            logInfo $ "Core ride payment ledger already up to date for ride: " <> rideId
+            pure
+              UpsertCoreLedgerResult
+                { coreEntryIds = map (.id) pendingCoreEntries,
+                  invoiceId = Nothing,
+                  didCreate = False,
+                  didVoidStale = False
+                }
+  -- Upsert cancellation fee entries when cancellationCharge is non-zero.
+  -- Idempotent: if entries were already created (e.g. by createPendingCancellationFeeLedger
+  -- before this call) the existing-entries check skips re-creation.
+  when (cancellationCharge > 0) $ do
+    let cancelEntries = filter (\e -> e.referenceType `elem` [ridePaymentRefCancellationFee, ridePaymentRefCancellationGST]) existingEntries
+    when (null cancelEntries) $ do
+      void $ createPendingCancellationFeeLedger ctx cancellationCharge cancellationTax
+      logInfo $ "Created PENDING cancellation fee ledger entries for ride: " <> rideId
+  pure coreResult
 
 -- ---------------------------------------------------------------------------
 -- 1b. Create SETTLED ledger entries for fully discounted rides (amount = 0)

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Payment.hs
@@ -648,6 +648,8 @@ data RidePaymentLedgerInfo = RidePaymentLedgerInfo
     --   BuyerExpense → BuyerAsset; paid across to BPP via buyer-external
     --   where it is credited to the driver as part of BaseRide.
     rideVatAbsorbedOnDiscount :: HighPrecMoney,
+    cancellationCharge :: HighPrecMoney, -- cancellation fee without tax (0 for normal ride)
+    cancellationTax :: HighPrecMoney, -- GST/VAT on cancellation fee (0 for normal ride)
     financeCtx :: FinanceCtx
   }
   deriving (Show, Generic)
@@ -669,9 +671,11 @@ mkRidePaymentLedgerInfo ::
   HighPrecMoney -> -- offerDiscountAmount
   HighPrecMoney -> -- cashbackPayoutAmount
   HighPrecMoney -> -- rideVatAbsorbedOnDiscount
+  HighPrecMoney -> -- cancellationCharge (0 for normal ride)
+  HighPrecMoney -> -- cancellationTax (0 for normal ride)
   FinanceCtx ->
   RidePaymentLedgerInfo
-mkRidePaymentLedgerInfo rideFare gstAmount tollFare tollVatAmount parkingCharge parkingChargeVat platformFee offerDiscountAmount cashbackPayoutAmount rideVatAbsorbedOnDiscount financeCtx =
+mkRidePaymentLedgerInfo rideFare gstAmount tollFare tollVatAmount parkingCharge parkingChargeVat platformFee offerDiscountAmount cashbackPayoutAmount rideVatAbsorbedOnDiscount cancellationCharge cancellationTax financeCtx =
   RidePaymentLedgerInfo
     { rideFare,
       gstAmount,
@@ -683,6 +687,8 @@ mkRidePaymentLedgerInfo rideFare gstAmount tollFare tollVatAmount parkingCharge 
       offerDiscountAmount,
       cashbackPayoutAmount,
       rideVatAbsorbedOnDiscount,
+      cancellationCharge,
+      cancellationTax,
       financeCtx
     }
 
@@ -725,6 +731,8 @@ buildLedgerInfoFromBreakups breakups discount cashback appFee _tip ctx =
               r.clampedDiscount
               cashback
               r.rideVatAbsorbedOnDiscount
+              0 -- cancellationCharge (not applicable for normal ride)
+              0 -- cancellationTax
               ctx
       pure (Just info)
   where
@@ -859,7 +867,7 @@ makePaymentIntent merchantId merchantOpCityId paymentMode personId mbRideId mbEx
                 orderId = serviceResp.orderId
               }
       -- Create or update PENDING core ride ledger entries (RideFare, GST, PlatformFee) after successful payment creation.
-      -- Tip and cancellation entries are managed separately — not touched here.
+      -- Cancellation entries are handled via cancellationCharge/cancellationTax fields; tip entries are managed separately.
       whenJust mbLedgerInfo $ \ledgerInfo ->
         void $
           RidePaymentFinance.upsertCoreRidePaymentLedger
@@ -872,6 +880,8 @@ makePaymentIntent merchantId merchantOpCityId paymentMode personId mbRideId mbEx
             ledgerInfo.offerDiscountAmount
             ledgerInfo.cashbackPayoutAmount
             ledgerInfo.rideVatAbsorbedOnDiscount
+            ledgerInfo.cancellationCharge
+            ledgerInfo.cancellationTax
       pure (Just resp)
 
 cancelPaymentIntent ::

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/ExecutePaymentIntent.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/ExecutePaymentIntent.hs
@@ -130,6 +130,8 @@ executePaymentIntentJob Job {id, jobInfo} = withLogTag ("JobId-" <> id.getId) do
                         offerDiscountAmount = rideDiscountAmount,
                         cashbackPayoutAmount = ridePayoutAmount,
                         rideVatAbsorbedOnDiscount = 0,
+                        cancellationCharge = 0,
+                        cancellationTax = 0,
                         financeCtx = ledgerCtx
                       }
                     mbLedgerInfo


### PR DESCRIPTION
## Summary

- **New fields** — `cancellationCharge` and `cancellationTax` added to `RidePaymentLedgerInfo` and `mkRidePaymentLedgerInfo`. All normal ride call sites pass `0` for both.
- **Fix card-cancellation ledger bug** — `cancellationLedgerInfo` in `cancellationTransaction` now uses the dedicated fields instead of repurposing `rideFare`/`gstAmount`. This prevents spurious `RideFare`/`RideGST` entries being written alongside the correct `CancellationFee`/`CancellationGST` entries from `createPendingCancellationFeeLedger`.
- **Extend `upsertCoreRidePaymentLedger`** — accepts `cancellationCharge`/`cancellationTax`; when non-zero, idempotently creates `CancellationFee`/`CancellationGST` PENDING entries (skips if already present). Also guards core-entry creation behind `newTotal > 0` so a zero-amount core payload produces no entries.
- **Fix cash/UPI cancellation void** — before calling `createPendingCancellationFeeLedger` in the cash path, unsettled ledger entries are voided and the ride invoice is cancelled, mirroring what `cancelPaymentIntent` already does for online/card rides.

## Files changed

| File | Change |
|------|--------|
| `SharedLogic/Payment.hs` | Add fields to `RidePaymentLedgerInfo` / `mkRidePaymentLedgerInfo`; forward from `makePaymentIntent` |
| `SharedLogic/Finance/RidePayment.hs` | Extend `upsertCoreRidePaymentLedger` |
| `Domain/Action/Beckn/Common.hs` | Fix `cancellationLedgerInfo` construction; add cash void logic |
| `Domain/Action/UI/RidePayment.hs` | Update record literals with new fields |
| `SharedLogic/Scheduler/Jobs/ExecutePaymentIntent.hs` | Update record literal with new fields |

## Test plan

- [ ] Card cancellation: confirm no `RideFare`/`RideGST` entries appear after cancellation; `CancellationFee`/`CancellationGST` entries present and settle to PAID on charge success
- [ ] Cash cancellation: confirm pre-existing PENDING ride-fare entries are VOIDED before new `CancellationFee`/`CancellationGST` entries are created and marked DUE
- [ ] Normal ride-end (no regression): `RideFare`/`RideGST` entries created and settled as before (`cancellationCharge = 0` path is a no-op)
- [ ] `cabal build rider-app` — passes with `-Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking and processing of cancellation charges and taxes across payment flows.
  * Explicitly zeroes cancellation fields for non-cancellation flows (tips, completions, payment intents) to ensure consistent ledger amounts.
  * Better handling of cancellations: unsettled ride payments/invoices are voided when appropriate, and cancellation amounts are recorded correctly for card and cash/UPI paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->