### PR TITLE
backend/fix: build errors from canSwitchToAirport refactor

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
@@ -2830,7 +2830,7 @@ postDriverFleetLinkRCWithDriver merchantShortId opCity fleetOwnerId mbRequestorI
   unless (merchant.id == merchantId && merchantOpCityId == driver.merchantOperatingCityId) $ throwError (PersonDoesNotExist driver.id.getId)
   driverInfo <- QDriverInfo.findById driver.id >>= fromMaybeM (DriverNotFound driver.id.getId)
   unless driverInfo.enabled $ throwError DriverAccountDisabled
-  when driverInfo.blocked $ throwError (DriverAccountBlocked (BlockErrorPayload driverInfo.blockExpiryTime driverInfo.blockedReason))
+  when driverInfo.blocked $ throwError (DriverAccountBlocked (BlockErrorPayload driverInfo.blockExpiryTime driverInfo.blockReasonFlag))
   unless driverInfo.verified $ throwError (InvalidRequest "Driver documents are not verified")
   rc <- RCQuery.findLastVehicleRCWrapper req.vehicleRegistrationNumber >>= fromMaybeM (RCNotFound req.vehicleRegistrationNumber)
   when (isNothing rc.fleetOwnerId || (isJust rc.fleetOwnerId && rc.fleetOwnerId /= Just fleetOwnerId)) $ throwError VehicleNotPartOfFleet

--- a/Backend/hunit-tests/src/AddVehicleUnitTests.hs
+++ b/Backend/hunit-tests/src/AddVehicleUnitTests.hs
@@ -117,14 +117,18 @@ createTestVehicleRequest =
       Common.airConditioned = Just True,
       Common.driverName = Just "John Doe",
       Common.imageId = Just (Kernel.Types.Id.Id "image-123"),
+      Common.imageId2 = Nothing,
       Common.vehicleCategory = Nothing,
       Common.oxygen = Just False,
       Common.ventilator = Just False,
+      Common.enableForAirport = Nothing,
       Common.dateOfRegistration = Just (UTCTime (fromGregorian 2023 1 1) 0),
       Common.mYManufacturing = Just (fromGregorian 2023 1 1),
       Common.vehicleModelYear = Just 2023,
       Common.vehicleTags = Just ["Premium", "AC"],
-      Common.fuelType = Just "Petrol"
+      Common.fuelType = Just "Petrol",
+      Common.skipFleetChecks = Nothing,
+      Common.udinNumber = Nothing
     }
 
 -- | Generate a test vehicle request with custom parameters
@@ -141,14 +145,18 @@ createCustomVehicleRequest regNo vehicleClass capacity colour energyType model m
       Common.airConditioned = airConditioned,
       Common.driverName = driverName,
       Common.imageId = Just (Kernel.Types.Id.Id "image-123"),
+      Common.imageId2 = Nothing,
       Common.vehicleCategory = Nothing,
       Common.oxygen = oxygen,
       Common.ventilator = Just False,
+      Common.enableForAirport = Nothing,
       Common.dateOfRegistration = Just (UTCTime (fromGregorian 2023 1 1) 0),
       Common.mYManufacturing = Just (fromGregorian 2023 1 1),
       Common.vehicleModelYear = Just 2023,
       Common.vehicleTags = Just ["Premium", "AC"],
-      Common.fuelType = Just "Petrol"
+      Common.fuelType = Just "Petrol",
+      Common.skipFleetChecks = Nothing,
+      Common.udinNumber = Nothing
     }
 
 -- | Generate standard test API token info


### PR DESCRIPTION
## Summary

- **`Fleet/Driver.hs:2833`** — `postDriverFleetLinkRCWithDriver` was passing `driverInfo.blockedReason` (`Maybe Text`) as the second argument to `BlockErrorPayload`, but `BlockErrorPayload.blockReason` expects `Maybe BlockReasonFlag`. Fixed by using `driverInfo.blockReasonFlag`, consistent with every other call site (`DriverLicense.hs`, `AadhaarVerification.hs`, `Ride.hs`).
- **`hunit-tests/AddVehicleUnitTests.hs`** — The `canSwitchToAirport` refactor added four new `Maybe` fields to `AddVehicleReq` (`imageId2`, `enableForAirport`, `skipFleetChecks`, `udinNumber`). The two record-construction sites in the unit tests weren't updated, triggering `-Wmissing-fields` which is a hard error under `-Werror`. Added all four as `Nothing`.

## Test plan

- [ ] `cabal build dynamic-offer-driver-app` passes (no type error at `Fleet/Driver.hs:2833`)
- [ ] `cabal build hunit-tests` passes (no missing-fields warning)
- [ ] Existing behaviour of `postDriverFleetLinkRCWithDriver` is unchanged — blocked drivers still get `DriverAccountBlocked` with the correct flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed driver account blocking validation to use correct error information source.

* **Tests**
  * Updated vehicle request test helpers to align with updated request structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->