### PR TITLE
Vehicle passed with correct values for DriverVehicleQuality

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/DriverVehicleQuality.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/DriverVehicleQuality.hs
@@ -122,7 +122,12 @@ postDriverVehicleQualityUpdateVehicleRating merchantShortId opCity req = do
   mbVehicle <- QVehicle.findByRegistrationNo req.registrationNo
   whenJust mbVehicle $ \vehicle -> do
     QVehicle.updateVehicleRatingAndRemark (Just req.rating) (Just req.remark) vehicle.driverId
-    tierResults <- fetchVehicleTierForDriverWithUsageRestriction True Nothing Nothing Nothing Nothing vehicle.driverId _merchantOpCity.id
+
+    -- Create updated vehicle object with new rating for tier calculation
+    let updatedVehicle = vehicle {DVeh.vehicleRating = Just req.rating, DVeh.vehicleRatingRemark = Just req.remark}
+
+    -- Recalculate service tiers with updated vehicle
+    tierResults <- fetchVehicleTierForDriverWithUsageRestriction True Nothing (Just updatedVehicle) Nothing Nothing vehicle.driverId _merchantOpCity.id
     let newTiers = (.serviceTierType) . fst <$> filter (not . snd) tierResults
     QVehicle.updateSelectedServiceTiers newTiers vehicle.driverId
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
DriverVehicleQuality API was not setting selected service tiers correctly, becaue vehicle was being passed as nothing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where vehicle service tiers were not being recalculated with the latest vehicle rating and remarks. Service tiers are now accurately updated when driver vehicle ratings are modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->