### PR TITLE
backend/fix: skip cancellation charges for cash rides; consolidate void ledger logic

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -466,6 +466,12 @@ customerCancellationChargesCalculation booking ride riderDetails cancellationTyp
       driverWaitingTime = if isJust ride.driverArrivalTime then Just (round $ diffUTCTime now (fromJust ride.driverArrivalTime)) else Nothing
   mbSearchRequest <- QSR.findByTransactionIdAndMerchantId booking.transactionId booking.providerId
   let userSdkVersionText = Version.versionToText <$> (mbSearchRequest >>= (.userSdkVersion))
+  mbPaymentMethod <- forM booking.paymentMethodId $ \pmId ->
+    CQMPM.findByIdAndMerchantOpCityId pmId booking.merchantOperatingCityId
+      >>= fromMaybeM (MerchantPaymentMethodNotFound pmId.getId)
+  let isCashPayment = case mbPaymentMethod of
+        Nothing -> True
+        Just pm -> pm.paymentInstrument == DMPM.Cash
   let logicInput =
         UserCancellationDues.UserCancellationDuesData
           { cancelledBy = cancellationType,
@@ -486,7 +492,8 @@ customerCancellationChargesCalculation booking ride riderDetails cancellationTyp
             serviceTier = booking.vehicleServiceTier,
             tripCategory = booking.tripCategory,
             cancellationReasonSelected = reasonCode,
-            userSdkVersion = userSdkVersionText
+            userSdkVersion = userSdkVersionText,
+            isCashPayment = isCashPayment
           }
   if transporterConfig.canAddCancellationFee
     then do
@@ -545,7 +552,9 @@ getCancellationCharges booking ride cancellationType reasonCode = do
           case charges' of
             Just charges -> do
               let totalFee = charges + fromMaybe 0 tax'
-              return (Just $ PriceAPIEntity {amount = totalFee, currency = booking.currency}, tax', mbVersion)
+              if totalFee == 0
+                then return (Nothing, Nothing, mbVersion)
+                else return (Just $ PriceAPIEntity {amount = totalFee, currency = booking.currency}, tax', mbVersion)
             Nothing -> return (Nothing, tax', mbVersion)
         else return (Nothing, Nothing, Nothing)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/UserCancellationDues.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/UserCancellationDues.hs
@@ -27,7 +27,8 @@ data UserCancellationDuesData = UserCancellationDuesData
     serviceTier :: DServiceTierType.ServiceTierType,
     tripCategory :: DTC.TripCategory,
     cancellationReasonSelected :: Maybe DCancellationReason.CancellationReasonCode,
-    userSdkVersion :: Maybe Text
+    userSdkVersion :: Maybe Text,
+    isCashPayment :: Bool
   }
   deriving (Generic, Show, FromJSON, ToJSON)
 
@@ -52,7 +53,8 @@ instance Default UserCancellationDuesData where
         serviceTier = DServiceTierType.TAXI,
         tripCategory = DTC.OneWay DTC.OneWayOnDemandDynamicOffer,
         cancellationReasonSelected = Nothing,
-        userSdkVersion = Nothing
+        userSdkVersion = Nothing,
+        isCashPayment = False
       }
 
 data UserCancellationDuesResult = UserCancellationDuesResult

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
@@ -1463,12 +1463,7 @@ cancellationTransaction booking mbRide cancellationSource cancellationFee cancel
                             markDueOnFailure
               _ -> do
                 -- Cash/UPI: void any unsettled ride-fare entries before creating cancellation entries
-                pendingEntries <- RidePaymentFinance.findUnsettledRidePaymentEntries ride.id.getId
-                unless (null pendingEntries) $ do
-                  let entryIds = map (.id) pendingEntries
-                  RidePaymentFinance.voidRidePaymentLedger entryIds
-                  logInfo $ "Voided " <> show (length entryIds) <> " pending ledger entries for cancelled ride: " <> ride.id.getId
-                RidePaymentFinance.voidRideInvoice ride.id.getId
+                void $ RidePaymentFinance.voidRidePaymentEntriesAndInvoice ride.id.getId
                 -- Create pending cancellation entries then mark as DUE for later collection
                 cashLedgerResp <- RidePaymentFinance.createPendingCancellationFeeLedger ledgerCtx cancellationBase cancellationGST
                 case cashLedgerResp of
@@ -1488,10 +1483,12 @@ cancellationTransaction booking mbRide cancellationSource cancellationFee cancel
         _ -> pure ()
     when (isNothing cancellationFee) $
       whenJust mbRide $ \ride -> do
-        when ride.onlinePayment $ do
-          logInfo $ "Cancel payment intent as no cancellation fees found: rideId: " <> ride.id.getId
-          void $ SPayment.cancelPaymentIntent booking.merchantId booking.merchantOperatingCityId booking.paymentMode ride.id
-  -- Ledger entries are voided inside cancelPaymentIntent
+        if ride.onlinePayment
+          then do
+            logInfo $ "Cancel payment intent as no cancellation fees found: rideId: " <> ride.id.getId
+            void $ SPayment.cancelPaymentIntent booking.merchantId booking.merchantOperatingCityId booking.paymentMode ride.id
+          else void $ RidePaymentFinance.voidRidePaymentEntriesAndInvoice ride.id.getId
+  -- Ledger entries are voided inside cancelPaymentIntent (online) or voidRidePaymentEntriesAndInvoice (cash)
 
   unless (cancellationSource == DBCR.ByUser) $
     QBCR.upsert bookingCancellationReason

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Finance/RidePayment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Finance/RidePayment.hs
@@ -113,6 +113,7 @@ module SharedLogic.Finance.RidePayment
     markCashbackEntriesAsDue,
     markCashbackEntriesAsPaidOut,
     voidRidePaymentLedger,
+    voidRidePaymentEntriesAndInvoice,
     createTipLedger,
     regenerateRideTipInvoice,
     createCancellationFeeLedger,
@@ -835,6 +836,19 @@ voidRideInvoice rideId = do
         Just inv -> do
           FInvoiceService.updateInvoiceStatus inv.id FInvoice.Cancelled
           logInfo $ "[voidRideInvoice] Cancelled Ride invoice " <> inv.id.getId <> " for rideId=" <> rideId
+
+-- | Void all unsettled ledger entries for a ride then cancel the ride invoice.
+--   Single call-site for any cancellation path (cash or online, with or without fee).
+voidRidePaymentEntriesAndInvoice ::
+  (BeamFlow.BeamFlow m r, MonadFlow m) =>
+  Text -> -- rideId
+  m ()
+voidRidePaymentEntriesAndInvoice rideId = do
+  pendingEntries <- findUnsettledRidePaymentEntries rideId
+  unless (null pendingEntries) $ do
+    voidRidePaymentLedger (map (.id) pendingEntries)
+    logInfo $ "Voided " <> show (length pendingEntries) <> " pending ledger entries for cancelled ride: " <> rideId
+  voidRideInvoice rideId
 
 -- | Mark the Ride invoice as Paid after successful payment capture.
 markRideInvoicePaid ::

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Payment.hs
@@ -904,14 +904,8 @@ cancelPaymentIntent merchantId merchantOpCityId paymentMode rideId = do
   -- Cancel at Stripe — tolerate failures (PI may already be cancelled/captured/expired)
   handle (\(e :: SomeException) -> logError $ "Cancel payment intent failed for ride " <> rideId.getId <> ": " <> show e) $
     DPayment.cancelPaymentIntentService commonMerchantOperatingCityId (cast @Ride.Ride @DPayment.Ride rideId) cancelPaymentIntentCall
-  -- Void unsettled ledger entries (PENDING or DUE) regardless of Stripe cancel result
-  pendingEntries <- RidePaymentFinance.findUnsettledRidePaymentEntries rideId.getId
-  unless (null pendingEntries) $ do
-    let entryIds = map (.id) pendingEntries
-    RidePaymentFinance.voidRidePaymentLedger entryIds
-    logInfo $ "Voided " <> show (length entryIds) <> " pending ledger entries for cancelled ride: " <> rideId.getId
-  -- Cancel the associated Ride invoice
-  RidePaymentFinance.voidRideInvoice rideId.getId
+  -- Void unsettled ledger entries and ride invoice regardless of Stripe cancel result
+  void $ RidePaymentFinance.voidRidePaymentEntriesAndInvoice rideId.getId
 
 chargePaymentIntent ::
   ( MonadFlow m,


### PR DESCRIPTION
## Summary

- **BPP**: Add `isCashPayment :: Bool` to `UserCancellationDuesData` so the `USER_CANCELLATION_DUES` Yudhishthira JSON-logic rule can short-circuit and return 0 for cash rides. Payment instrument is resolved in `customerCancellationChargesCalculation` (same DB lookup already done in `createCancellationLedgerEntries`). `getCancellationCharges` now filters `totalFee == 0 → Nothing` so a zero result never propagates as a spurious cancellation fee to BAP.
- **BAP**: Extract `voidRidePaymentEntriesAndInvoice :: Text -> m ()` helper into `RidePayment.hs`, consolidating the repeated `findUnsettledRidePaymentEntries` + `voidRidePaymentLedger` + `voidRideInvoice` pattern. Use it in the Cash/UPI arm of `cancellationTransaction`, in `cancelPaymentIntent`, and fix the `isNothing cancellationFee` path which previously skipped the void entirely for cash rides (only called `cancelPaymentIntent` when `ride.onlinePayment = True`).

## Files changed

| File | Change |
|---|---|
| `SharedLogic/UserCancellationDues.hs` | Add `isCashPayment :: Bool` field (default `False`) |
| `CancelRide/Internal.hs` | Resolve payment instrument in `customerCancellationChargesCalculation`; filter `totalFee == 0 → Nothing` in `getCancellationCharges` |
| `SharedLogic/Finance/RidePayment.hs` | Add + export `voidRidePaymentEntriesAndInvoice` |
| `Domain/Action/Beckn/Common.hs` | Use common helper in Cash/UPI arm; fix `isNothing cancellationFee` path for cash rides |
| `SharedLogic/Payment.hs` | Use common helper in `cancelPaymentIntent` |

## Test plan

- [ ] Cancel a cash ride (driver-cancel): confirm no cancellation-fee ledger entries are created
- [ ] Cancel a cash ride with `cancellationFee = Nothing`: confirm `voidRidePaymentEntriesAndInvoice` is called and any PENDING/DUE entries are voided + ride invoice is Cancelled
- [ ] Cancel an online (Card/UPI) ride: existing charge + ledger flow unchanged
- [ ] `cancelPaymentIntent` path: Stripe cancel + ledger void still works via the common helper
- [ ] `cabal build rider-app dynamic-offer-driver-app` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ride cancellation fee calculation to accurately detect cash payment methods and determine charge applicability.
  * Enhanced payment cleanup logic during ride cancellations to ensure ride payments and invoices are properly voided.
  * Fixed handling of zero cancellation fees to return no charge instead of a zero amount.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->