### PR TITLE
fix: Pass Constraint

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -214,9 +214,8 @@ purchasePassWithPayment isDashboard person pass merchantId personId mbStartDay m
         case mbPending of
           Just pendingPass -> do
             -- don't update device id if existing different device id pass is active or prebooked
-            when (pendingPass.status `notElem` [DPurchasedPass.Active, DPurchasedPass.PreBooked]) $ do
-              QPurchasedPass.updateDeviceIdById deviceId 0 pendingPass.id
-              logInfo $ "Reusing existing purchased pass " <> pendingPass.id.getId <> " and updated deviceId to " <> deviceId
+            QPurchasedPass.updateDeviceIdById deviceId 0 pendingPass.id
+            logInfo $ "Reusing existing purchased pass " <> pendingPass.id.getId <> " and updated deviceId to " <> deviceId
             return $ Just pendingPass
           Nothing -> return Nothing
 
@@ -928,7 +927,17 @@ getMultimodalPassListUtil isDashboard (mbCallerPersonId, merchantId) mbDeviceIdP
 
     return updatedPass
 
-  let allActivePurchasedPasses = updatedPassEntities
+  let allActivePurchasedPasses =
+        HM.elems $
+          foldr
+            (\el acc -> do
+                case HM.lookup el.passType acc of
+                  Just pass ->
+                    case mbDeviceId of
+                      Just deviceId | el.deviceId == deviceId -> HM.insert el.passType el acc
+                      Nothing -> acc
+                  Nothing -> HM.insert el.passType el acc
+            ) HM.empty updatedPassEntities
 
   -- Always show all passes regardless of device. The deviceMismatch flag in
   -- PurchasedPassAPIEntity will inform the UI which passes need device switching.

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -931,12 +931,12 @@ getMultimodalPassListUtil isDashboard (mbCallerPersonId, merchantId) mbDeviceIdP
         HM.elems $
           foldr
             ( \el acc ->
-                case HM.lookup el.passType acc of
+                case HM.lookup el.passTypeId acc of
                   Just _ ->
                     case mbDeviceId of
-                      Just deviceId | el.deviceId == deviceId -> HM.insert el.passType el acc
+                      Just deviceId | el.deviceId == deviceId -> HM.insert el.passTypeId el acc
                       _ -> acc
-                  Nothing -> HM.insert el.passType el acc
+                  Nothing -> HM.insert el.passTypeId el acc
             )
             HM.empty
             updatedPassEntities

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -930,14 +930,16 @@ getMultimodalPassListUtil isDashboard (mbCallerPersonId, merchantId) mbDeviceIdP
   let allActivePurchasedPasses =
         HM.elems $
           foldr
-            (\el acc ->
+            ( \el acc ->
                 case HM.lookup el.passType acc of
                   Just _ ->
                     case mbDeviceId of
                       Just deviceId | el.deviceId == deviceId -> HM.insert el.passType el acc
                       _ -> acc
                   Nothing -> HM.insert el.passType el acc
-            ) HM.empty updatedPassEntities
+            )
+            HM.empty
+            updatedPassEntities
 
   -- Always show all passes regardless of device. The deviceMismatch flag in
   -- PurchasedPassAPIEntity will inform the UI which passes need device switching.

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -930,12 +930,12 @@ getMultimodalPassListUtil isDashboard (mbCallerPersonId, merchantId) mbDeviceIdP
   let allActivePurchasedPasses =
         HM.elems $
           foldr
-            (\el acc -> do
+            (\el acc ->
                 case HM.lookup el.passType acc of
-                  Just pass ->
+                  Just _ ->
                     case mbDeviceId of
                       Just deviceId | el.deviceId == deviceId -> HM.insert el.passType el acc
-                      Nothing -> acc
+                      _ -> acc
                   Nothing -> HM.insert el.passType el acc
             ) HM.empty updatedPassEntities
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
@@ -87,7 +87,7 @@ findPendingPassByPersonIdAndPassTypeId personId merchantId passTypeId =
     [ Se.Is Beam.personId $ Se.Eq (getId personId),
       Se.Is Beam.merchantId $ Se.Eq (getId merchantId),
       Se.Is Beam.passTypeId $ Se.Eq (getId passTypeId),
-      Se.Is Beam.status $ Se.Is Beam.status $ Se.Not $ Se.In [DPurchasedPass.Active, DPurchasedPass.PreBooked]
+      Se.Is Beam.status $ Se.Not $ Se.In [DPurchasedPass.Active, DPurchasedPass.PreBooked]
     ]
 
 updatePurchaseData ::

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
@@ -87,13 +87,7 @@ findPendingPassByPersonIdAndPassTypeId personId merchantId passTypeId =
     [ Se.Is Beam.personId $ Se.Eq (getId personId),
       Se.Is Beam.merchantId $ Se.Eq (getId merchantId),
       Se.Is Beam.passTypeId $ Se.Eq (getId passTypeId),
-      Se.Is Beam.status $
-        Se.In
-          [ DPurchasedPass.Pending,
-            DPurchasedPass.Active,
-            DPurchasedPass.PreBooked,
-            DPurchasedPass.PhotoPending
-          ]
+      Se.Is Beam.status $ Se.Is Beam.status $ Se.Not $ Se.In [DPurchasedPass.Active, DPurchasedPass.PreBooked]
     ]
 
 updatePurchaseData ::


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures a reused pending pass has its device association updated when moved across devices.
  * Rebuilds pass lists to retain at most one purchased pass per pass type, applying device filtering when a device is specified.
  * Broadens pending-pass detection so a wider set of non-active statuses are considered eligible for reuse or activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->