### PR TITLE
feat: unpack and return isActiveTrip alongside each schedule, current…

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/RouteServiceability.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/RouteServiceability.hs
@@ -52,6 +52,21 @@ buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromS
       vehicleNos
   let seatLayoutMappingByVehicleNo = Map.fromList (zip vehicleNos seatLayoutMappings)
       shouldRunSeatHoldReaper = any ((== Just DVSLM.AUTO_ASSIGNED) . (>>= (.seatSelectionType))) seatLayoutMappings
+      -- Map of vehicleNo -> active tripId, derived from the schedule details' active trip
+      -- (same logic as the single-vehicle path), so live vehicles can carry their currentTripId.
+      activeTripIdByVehicleNo =
+        Map.fromList $
+          catMaybes $
+            map
+              ( \detail ->
+                  if detail.is_active_trip == Just True
+                    then do
+                      waybill <- detail.waybill_no
+                      tNum <- detail.trip_number
+                      return (detail.vehicle_no, JMU.makeTripIdFromWaybillNoAndTripNo waybill tNum)
+                    else Nothing
+              )
+              busScheduleDetails
 
   when shouldRunSeatHoldReaper $ do
     mRiderConfig <- getConfig (RiderDimensions {merchantOperatingCityId = integratedBPPConfig.merchantOperatingCityId.getId})
@@ -72,7 +87,7 @@ buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromS
       getBusScheduleInfo busScheduleDetails integratedBPPConfig routeInfo.routeId fromStopCode toStopCode frfsTierMap seatLayoutMappingByVehicleNo
   liveVehiclesFork <-
     awaitableFork "getLiveVehicles" $
-      getLiveVehicles routeInfo.buses integratedBPPConfig frfsTierMap mbSourceStopLatLong maxLiveVehicles seatLayoutMappingByVehicleNo
+      getLiveVehicles routeInfo.buses integratedBPPConfig frfsTierMap mbSourceStopLatLong maxLiveVehicles seatLayoutMappingByVehicleNo activeTripIdByVehicleNo
   schedules <-
     L.await Nothing schedulesFork >>= \case
       Left err -> throwError $ InternalError $ "getBusScheduleInfo fork failed: " <> show err
@@ -164,7 +179,7 @@ buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromS
                             serviceTierName = (.shortName) <$> frfsServiceTier,
                             vehicleNumber = detail.vehicle_no,
                             tripId = combinedTripId,
-                            isActiveTrip = Nothing,
+                            isActiveTrip = detail.is_active_trip,
                             serviceSubTypes = mbServiceSubTypes,
                             vehicleTagNumber = mbVehicleTagNumber,
                             availableSeats = availableSeatsCount,
@@ -176,7 +191,7 @@ buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromS
           )
           busScheduleDetails'
 
-    getLiveVehicles busesData integratedBPPConfig' frfsTierMap' mbSourceLatLong maxLiveCount seatLayoutMappingByVehicleNo' = do
+    getLiveVehicles busesData integratedBPPConfig' frfsTierMap' mbSourceLatLong maxLiveCount seatLayoutMappingByVehicleNo' activeTripIdByVehicleNo' = do
       allVehicles <-
         catMaybes
           <$> mapM
@@ -211,7 +226,7 @@ buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromS
                           locationUTCTimestamp = posixSecondsToUTCTime $ fromIntegral bus.busData.timestamp,
                           serviceTierType = serviceTier,
                           serviceTierName = (.shortName) <$> frfsServiceTier,
-                          currentTripId = Nothing,
+                          currentTripId = Map.lookup bus.vehicleNumber activeTripIdByVehicleNo',
                           serviceSubTypes = mbServiceSubTypes,
                           vehicleTagNumber = mbVehicleTagNumber,
                           seatSelectionType = seatSelType


### PR DESCRIPTION
…TripId with all liveVehicles

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accuracy of vehicle trip identification by properly deriving and utilizing active trip information from schedule details for live vehicles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->