### PR TITLE
backend/feat: enable KV secondary keys for rider & driver tables

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/CallStatus.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/CallStatus.yaml
@@ -31,6 +31,7 @@ CallStatus:
   constraints:
     id: PrimaryKey
     callId: "!SecondaryKey" # forcing to be a secondary key
+    entityId: "!SecondaryKey" # forcing; WARNING default 'UNKNOWN' -> unset rows collapse into one large SET
 
   queries:
     findById:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverOnboarding.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverOnboarding.yaml
@@ -1510,10 +1510,10 @@ MorthVerification:
       documentNumberEncrypted: Text
       documentNumberHash: DbHash
   fromTType:
-    documentNumber: EncryptedHashed <$> (Encrypted <$> documentNumberEncrypted) <*> documentNumberHash|E
+    documentNumber: EncryptedHashed (Encrypted documentNumberEncrypted) documentNumberHash|E
   toTType:
-    documentNumberEncrypted: (documentNumber <&> unEncrypted . (.encrypted))|E
-    documentNumberHash: (documentNumber <&> (.hash))|E
+    documentNumberEncrypted: (unEncrypted . (.encrypted) $ documentNumber)|E
+    documentNumberHash: ((.hash) documentNumber)|E
   queries:
     findById:
       kvFunction: findOneWithKV

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverOnboarding.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverOnboarding.yaml
@@ -452,6 +452,7 @@ Image:
     id: PrimaryKey
     personId: SecondaryKey
     rcId: SecondaryKey
+    workflowTransactionId: SecondaryKey
   queries:
     findById:
       kvFunction: findOneWithKV
@@ -977,6 +978,7 @@ DriverPanCard:
     id: PrimaryKey
     driverId: SecondaryKey
     panCardNumberHash: "!SecondaryKey" # forcing to be a secondary key
+    documentImageId1: SecondaryKey
   queries:
     findById:
       kvFunction: findOneWithKV

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverOnboarding.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverOnboarding.yaml
@@ -1117,7 +1117,8 @@ DriverUdyam :
   constraints:
     id: PrimaryKey
     driverId: SecondaryKey
-    # udyamNumberHash: "!SecondaryKey" # forcing to be a secondary key
+    udyamNumberHash: "!SecondaryKey" # forcing to be a secondary key
+
   queries:
     findById:
       kvFunction: findOneWithKV

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverOnboarding.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverOnboarding.yaml
@@ -320,6 +320,8 @@ VehicleRegistrationCertificate:
   constraints:
     id: PrimaryKey
     certificateNumberHash: "!SecondaryKey" # forcing to be a secondary key
+    documentImageId: SecondaryKey
+    fleetOwnerId: SecondaryKey # high fan-out (fleet -> many RCs), monitor SET size
   queries:
     findById:
       kvFunction: findOneWithKV
@@ -687,6 +689,7 @@ VehiclePermit:
   constraints:
     id: PrimaryKey
     rcId: SecondaryKey
+    documentImageId: SecondaryKey
   queries:
     findByRcIdAndDriverId:
       kvFunction: findAllWithKV
@@ -841,6 +844,7 @@ BusinessLicense:
   constraints:
     id: PrimaryKey
     documentImageId: SecondaryKey
+    driverId: SecondaryKey
   queries:
     findByPersonId:
       kvFunction: findAllWithKV
@@ -867,6 +871,7 @@ VehiclePUC:
   constraints:
     id: PrimaryKey
     rcId: SecondaryKey
+    documentImageId: SecondaryKey
   queries:
     findByRcIdAndDriverId:
       kvFunction: findAllWithKV
@@ -913,6 +918,7 @@ FleetRCAssociation:
   constraints:
     id: PrimaryKey
     rcId: "!SecondaryKey" # forcing to be a secondary key
+    fleetOwnerId: "!SecondaryKey" # forcing; high fan-out (fleet -> many RCs), monitor SET size
   queries:
     findById:
       kvFunction: findOneWithKV
@@ -1245,6 +1251,9 @@ AadhaarCard:
   derives: "Generic"
   constraints:
     driverId: PrimaryKey
+    aadhaarFrontImageId: SecondaryKey
+    aadhaarBackImageId: SecondaryKey
+    aadhaarNumberHash: "!SecondaryKey" # forcing; queried in AadhaarCardExtra.findByAadhaarNumberHash
 
   beamFields:
     aadhaarNumber:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FeedBack.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FeedBack.yaml
@@ -18,6 +18,8 @@ Feedback:
 
   constraints:
     id: PrimaryKey
+    rideId: "!SecondaryKey" # forcing; queried in FeedbackExtra.findFeedbackFromRatings (rideId IN)
+    driverId: "!SecondaryKey" # forcing; high fan-out (1 feedback/ride -> grows per driver), monitor SET size
 
   extraOperations:
     - EXTRA_QUERY_FILE

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FeedbackBadge.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FeedbackBadge.yaml
@@ -17,6 +17,7 @@ FeedbackBadge:
 
   constraints:
     id: PrimaryKey
+    driverId: SecondaryKey
 
   sqlType:
     badge: character varying (255)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FleetBadge.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FleetBadge.yaml
@@ -26,8 +26,6 @@ FleetBadge:
   constraints:
     id: PrimaryKey
     fleetOwnerId: SecondaryKey
-    badgeName: SecondaryKey
-    badgeType: SecondaryKey
 
   queries:
     findOneBadgeByNameAndBadgeTypeAndFleetOwnerId:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FleetBadgeAssociation.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FleetBadgeAssociation.yaml
@@ -25,7 +25,6 @@ FleetBadgeAssociation:
     badgeId: "!SecondaryKey"
     driverId: "!SecondaryKey"
     fleetOwnerId: "!SecondaryKey"
-    badgeType: "!SecondaryKey"
 
   default:
     badgeType: "'DRIVER'"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FleetBookingInformation.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FleetBookingInformation.yaml
@@ -91,6 +91,7 @@ FleetBookingAssignments:
   constraints:
     id: PrimaryKey
     mainAssignmentId: SecondaryKey
+    vehicleNo: "!SecondaryKey"
 
   queries:
     findAllByMainAssignmentId:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/LMS.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/LMS.yaml
@@ -391,6 +391,7 @@ LmsCertificate:
   constraints:
     id: PrimaryKey
     moduleCompletionId: SecondaryKey
+    driverId: SecondaryKey
 
   queries:
     getAllCertificate:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/ScheduledPayout.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/ScheduledPayout.yaml
@@ -30,6 +30,7 @@ ScheduledPayout:
   constraints:
     id: PrimaryKey
     rideId: SecondaryKey
+    payoutTransactionId: SecondaryKey
 
   queries:
     findById:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/ride.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/ride.yaml
@@ -301,6 +301,7 @@ Ride:
     bookingId: "!SecondaryKey" # forcing to be a secondary key
     driverId: "!SecondaryKey" # forcing to be a secondary key
     driverGoHomeRequestId: "!SecondaryKey" # forcing to be a secondary key
+    shortId: SecondaryKey
 
   queries:
     updateCancellationFeeIfCancelledField:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/AadhaarCard.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/AadhaarCard.hs
@@ -41,6 +41,6 @@ instance B.Table AadhaarCardT where
 
 type AadhaarCard = AadhaarCardT Identity
 
-$(enableKVPG ''AadhaarCardT ['driverId] [])
+$(enableKVPG ''AadhaarCardT ['driverId] [['aadhaarBackImageId], ['aadhaarFrontImageId], ['aadhaarNumberHash]])
 
 $(mkTableInstances ''AadhaarCardT "aadhaar_card")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/BusinessLicense.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/BusinessLicense.hs
@@ -13,17 +13,17 @@ import qualified Kernel.Types.Documents
 import Tools.Beam.UtilsTH
 
 data BusinessLicenseT f = BusinessLicenseT
-  { documentImageId :: (B.C f Kernel.Prelude.Text),
-    driverId :: (B.C f Kernel.Prelude.Text),
-    id :: (B.C f Kernel.Prelude.Text),
-    licenseExpiry :: (B.C f Kernel.Prelude.UTCTime),
-    licenseNumberEncrypted :: (B.C f Kernel.Prelude.Text),
-    licenseNumberHash :: (B.C f Kernel.External.Encryption.DbHash),
-    verificationStatus :: (B.C f Kernel.Types.Documents.VerificationStatus),
-    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime)
+  { documentImageId :: B.C f Kernel.Prelude.Text,
+    driverId :: B.C f Kernel.Prelude.Text,
+    id :: B.C f Kernel.Prelude.Text,
+    licenseExpiry :: B.C f Kernel.Prelude.UTCTime,
+    licenseNumberEncrypted :: B.C f Kernel.Prelude.Text,
+    licenseNumberHash :: B.C f Kernel.External.Encryption.DbHash,
+    verificationStatus :: B.C f Kernel.Types.Documents.VerificationStatus,
+    merchantId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime
   }
   deriving (Generic, B.Beamable)
 
@@ -33,6 +33,6 @@ instance B.Table BusinessLicenseT where
 
 type BusinessLicense = BusinessLicenseT Identity
 
-$(enableKVPG (''BusinessLicenseT) [('id)] [[('documentImageId)]])
+$(enableKVPG ''BusinessLicenseT ['id] [['documentImageId], ['driverId]])
 
-$(mkTableInstances (''BusinessLicenseT) "business_license")
+$(mkTableInstances ''BusinessLicenseT "business_license")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/CallStatus.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/CallStatus.hs
@@ -37,6 +37,6 @@ instance B.Table CallStatusT where
 
 type CallStatus = CallStatusT Identity
 
-$(enableKVPG ''CallStatusT ['id] [['callId]])
+$(enableKVPG ''CallStatusT ['id] [['callId], ['entityId]])
 
 $(mkTableInstances ''CallStatusT "call_status")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/DriverPanCard.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/DriverPanCard.hs
@@ -14,26 +14,26 @@ import qualified Kernel.Types.Documents
 import Tools.Beam.UtilsTH
 
 data DriverPanCardT f = DriverPanCardT
-  { consent :: (B.C f Kernel.Prelude.Bool),
-    consentTimestamp :: (B.C f Kernel.Prelude.UTCTime),
-    docType :: (B.C f (Kernel.Prelude.Maybe Domain.Types.DriverPanCard.PanType)),
-    documentImageId1 :: (B.C f Kernel.Prelude.Text),
-    documentImageId2 :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    driverDob :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
-    driverId :: (B.C f Kernel.Prelude.Text),
-    driverName :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    driverNameOnGovtDB :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    failedRules :: (B.C f [Kernel.Prelude.Text]),
-    id :: (B.C f Kernel.Prelude.Text),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    panAadhaarLinkage :: (B.C f (Kernel.Prelude.Maybe Domain.Types.DriverPanCard.PanAadhaarLinkage)),
-    panCardNumberEncrypted :: (B.C f Kernel.Prelude.Text),
-    panCardNumberHash :: (B.C f Kernel.External.Encryption.DbHash),
-    verificationStatus :: (B.C f Kernel.Types.Documents.VerificationStatus),
-    verifiedBy :: (B.C f (Kernel.Prelude.Maybe Domain.Types.DriverPanCard.VerifiedBy)),
-    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime)
+  { consent :: B.C f Kernel.Prelude.Bool,
+    consentTimestamp :: B.C f Kernel.Prelude.UTCTime,
+    docType :: B.C f (Kernel.Prelude.Maybe Domain.Types.DriverPanCard.PanType),
+    documentImageId1 :: B.C f Kernel.Prelude.Text,
+    documentImageId2 :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    driverDob :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime),
+    driverId :: B.C f Kernel.Prelude.Text,
+    driverName :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    driverNameOnGovtDB :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    failedRules :: B.C f [Kernel.Prelude.Text],
+    id :: B.C f Kernel.Prelude.Text,
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    panAadhaarLinkage :: B.C f (Kernel.Prelude.Maybe Domain.Types.DriverPanCard.PanAadhaarLinkage),
+    panCardNumberEncrypted :: B.C f Kernel.Prelude.Text,
+    panCardNumberHash :: B.C f Kernel.External.Encryption.DbHash,
+    verificationStatus :: B.C f Kernel.Types.Documents.VerificationStatus,
+    verifiedBy :: B.C f (Kernel.Prelude.Maybe Domain.Types.DriverPanCard.VerifiedBy),
+    merchantId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime
   }
   deriving (Generic, B.Beamable)
 
@@ -43,6 +43,6 @@ instance B.Table DriverPanCardT where
 
 type DriverPanCard = DriverPanCardT Identity
 
-$(enableKVPG (''DriverPanCardT) [('id)] [[('driverId)], [('panCardNumberHash)]])
+$(enableKVPG ''DriverPanCardT ['id] [['documentImageId1], ['driverId], ['panCardNumberHash]])
 
-$(mkTableInstances (''DriverPanCardT) "driver_pan_card")
+$(mkTableInstances ''DriverPanCardT "driver_pan_card")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/DriverUdyam.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/DriverUdyam.hs
@@ -36,6 +36,6 @@ instance B.Table DriverUdyamT where
 
 type DriverUdyam = DriverUdyamT Identity
 
-$(enableKVPG ''DriverUdyamT ['id] [['driverId]])
+$(enableKVPG ''DriverUdyamT ['id] [['driverId], ['udyamNumberHash]])
 
 $(mkTableInstances ''DriverUdyamT "driver_udyam")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Feedback.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Feedback.hs
@@ -29,6 +29,6 @@ instance B.Table FeedbackT where
 
 type Feedback = FeedbackT Identity
 
-$(enableKVPG ''FeedbackT ['id] [])
+$(enableKVPG ''FeedbackT ['id] [['driverId], ['rideId]])
 
 $(mkTableInstances ''FeedbackT "feedback")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FeedbackBadge.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FeedbackBadge.hs
@@ -29,6 +29,6 @@ instance B.Table FeedbackBadgeT where
 
 type FeedbackBadge = FeedbackBadgeT Identity
 
-$(enableKVPG ''FeedbackBadgeT ['id] [])
+$(enableKVPG ''FeedbackBadgeT ['id] [['driverId]])
 
 $(mkTableInstances ''FeedbackBadgeT "feedback_badge")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FleetBadge.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FleetBadge.hs
@@ -31,6 +31,6 @@ instance B.Table FleetBadgeT where
 
 type FleetBadge = FleetBadgeT Identity
 
-$(enableKVPG ''FleetBadgeT ['id] [['badgeName], ['badgeType], ['fleetOwnerId]])
+$(enableKVPG ''FleetBadgeT ['id] [['fleetOwnerId]])
 
 $(mkTableInstances ''FleetBadgeT "fleet_badge")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FleetBadgeAssociation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FleetBadgeAssociation.hs
@@ -31,6 +31,6 @@ instance B.Table FleetBadgeAssociationT where
 
 type FleetBadgeAssociation = FleetBadgeAssociationT Identity
 
-$(enableKVPG ''FleetBadgeAssociationT ['id] [['badgeId], ['badgeType], ['driverId], ['fleetOwnerId]])
+$(enableKVPG ''FleetBadgeAssociationT ['id] [['badgeId], ['driverId], ['fleetOwnerId]])
 
 $(mkTableInstances ''FleetBadgeAssociationT "fleet_badge_association")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FleetBookingAssignments.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FleetBookingAssignments.hs
@@ -40,6 +40,6 @@ instance B.Table FleetBookingAssignmentsT where
 
 type FleetBookingAssignments = FleetBookingAssignmentsT Identity
 
-$(enableKVPG ''FleetBookingAssignmentsT ['id] [['mainAssignmentId]])
+$(enableKVPG ''FleetBookingAssignmentsT ['id] [['mainAssignmentId], ['vehicleNo]])
 
 $(mkTableInstances ''FleetBookingAssignmentsT "fleet_booking_assignments")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FleetRCAssociation.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FleetRCAssociation.hs
@@ -11,15 +11,15 @@ import qualified Kernel.Prelude
 import Tools.Beam.UtilsTH
 
 data FleetRCAssociationT f = FleetRCAssociationT
-  { associatedOn :: (B.C f Kernel.Prelude.UTCTime),
-    associatedTill :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
-    fleetOwnerId :: (B.C f Kernel.Prelude.Text),
-    id :: (B.C f Kernel.Prelude.Text),
-    rcId :: (B.C f Kernel.Prelude.Text),
-    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime)
+  { associatedOn :: B.C f Kernel.Prelude.UTCTime,
+    associatedTill :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime),
+    fleetOwnerId :: B.C f Kernel.Prelude.Text,
+    id :: B.C f Kernel.Prelude.Text,
+    rcId :: B.C f Kernel.Prelude.Text,
+    merchantId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime
   }
   deriving (Generic, B.Beamable)
 
@@ -29,6 +29,6 @@ instance B.Table FleetRCAssociationT where
 
 type FleetRCAssociation = FleetRCAssociationT Identity
 
-$(enableKVPG (''FleetRCAssociationT) [('id)] [[('rcId)]])
+$(enableKVPG ''FleetRCAssociationT ['id] [['fleetOwnerId], ['rcId]])
 
-$(mkTableInstances (''FleetRCAssociationT) "fleet_rc_association")
+$(mkTableInstances ''FleetRCAssociationT "fleet_rc_association")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Image.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Image.hs
@@ -37,6 +37,6 @@ instance B.Table ImageT where
 
 type Image = ImageT Identity
 
-$(enableKVPG ''ImageT ['id] [['personId], ['rcId]])
+$(enableKVPG ''ImageT ['id] [['personId], ['rcId], ['workflowTransactionId]])
 
 $(mkTableInstances ''ImageT "image")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/LmsCertificate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/LmsCertificate.hs
@@ -26,6 +26,6 @@ instance B.Table LmsCertificateT where
 
 type LmsCertificate = LmsCertificateT Identity
 
-$(enableKVPG ''LmsCertificateT ['id] [['moduleCompletionId]])
+$(enableKVPG ''LmsCertificateT ['id] [['driverId], ['moduleCompletionId]])
 
 $(mkTableInstances ''LmsCertificateT "lms_certificate")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Ride.hs
@@ -132,6 +132,6 @@ instance B.Table RideT where
 
 type Ride = RideT Identity
 
-$(enableKVPG (''RideT) [('id)] [[('bookingId)], [('driverGoHomeRequestId)], [('driverId)]])
+$(enableKVPG ''RideT ['id] [['bookingId], ['driverGoHomeRequestId], ['driverId], ['shortId]])
 
 $(mkTableInstances (''RideT) "ride")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/ScheduledPayout.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/ScheduledPayout.hs
@@ -38,6 +38,6 @@ instance B.Table ScheduledPayoutT where
 
 type ScheduledPayout = ScheduledPayoutT Identity
 
-$(enableKVPG ''ScheduledPayoutT ['id] [['rideId]])
+$(enableKVPG ''ScheduledPayoutT ['id] [['payoutTransactionId], ['rideId]])
 
 $(mkTableInstances ''ScheduledPayoutT "scheduled_payout")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/VehiclePUC.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/VehiclePUC.hs
@@ -13,19 +13,19 @@ import qualified Kernel.Types.Documents
 import Tools.Beam.UtilsTH
 
 data VehiclePUCT f = VehiclePUCT
-  { documentImageId :: (B.C f Kernel.Prelude.Text),
-    driverId :: (B.C f Kernel.Prelude.Text),
-    id :: (B.C f Kernel.Prelude.Text),
-    pucExpiry :: (B.C f Kernel.Prelude.UTCTime),
-    pucNumberEncrypted :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    pucNumberHash :: (B.C f (Kernel.Prelude.Maybe Kernel.External.Encryption.DbHash)),
-    rcId :: (B.C f Kernel.Prelude.Text),
-    testDate :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
-    verificationStatus :: (B.C f Kernel.Types.Documents.VerificationStatus),
-    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime)
+  { documentImageId :: B.C f Kernel.Prelude.Text,
+    driverId :: B.C f Kernel.Prelude.Text,
+    id :: B.C f Kernel.Prelude.Text,
+    pucExpiry :: B.C f Kernel.Prelude.UTCTime,
+    pucNumberEncrypted :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    pucNumberHash :: B.C f (Kernel.Prelude.Maybe Kernel.External.Encryption.DbHash),
+    rcId :: B.C f Kernel.Prelude.Text,
+    testDate :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime),
+    verificationStatus :: B.C f Kernel.Types.Documents.VerificationStatus,
+    merchantId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime
   }
   deriving (Generic, B.Beamable)
 
@@ -35,6 +35,6 @@ instance B.Table VehiclePUCT where
 
 type VehiclePUC = VehiclePUCT Identity
 
-$(enableKVPG (''VehiclePUCT) [('id)] [[('rcId)]])
+$(enableKVPG ''VehiclePUCT ['id] [['documentImageId], ['rcId]])
 
-$(mkTableInstances (''VehiclePUCT) "vehicle_puc")
+$(mkTableInstances ''VehiclePUCT "vehicle_puc")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/VehiclePermit.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/VehiclePermit.hs
@@ -13,22 +13,22 @@ import qualified Kernel.Types.Documents
 import Tools.Beam.UtilsTH
 
 data VehiclePermitT f = VehiclePermitT
-  { documentImageId :: (B.C f Kernel.Prelude.Text),
-    driverId :: (B.C f Kernel.Prelude.Text),
-    id :: (B.C f Kernel.Prelude.Text),
-    issueDate :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
-    nameOfPermitHolder :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    permitExpiry :: (B.C f Kernel.Prelude.UTCTime),
-    permitNumberEncrypted :: (B.C f Kernel.Prelude.Text),
-    permitNumberHash :: (B.C f Kernel.External.Encryption.DbHash),
-    purposeOfJourney :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    rcId :: (B.C f Kernel.Prelude.Text),
-    regionCovered :: (B.C f Kernel.Prelude.Text),
-    verificationStatus :: (B.C f Kernel.Types.Documents.VerificationStatus),
-    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime)
+  { documentImageId :: B.C f Kernel.Prelude.Text,
+    driverId :: B.C f Kernel.Prelude.Text,
+    id :: B.C f Kernel.Prelude.Text,
+    issueDate :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime),
+    nameOfPermitHolder :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    permitExpiry :: B.C f Kernel.Prelude.UTCTime,
+    permitNumberEncrypted :: B.C f Kernel.Prelude.Text,
+    permitNumberHash :: B.C f Kernel.External.Encryption.DbHash,
+    purposeOfJourney :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    rcId :: B.C f Kernel.Prelude.Text,
+    regionCovered :: B.C f Kernel.Prelude.Text,
+    verificationStatus :: B.C f Kernel.Types.Documents.VerificationStatus,
+    merchantId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime
   }
   deriving (Generic, B.Beamable)
 
@@ -38,6 +38,6 @@ instance B.Table VehiclePermitT where
 
 type VehiclePermit = VehiclePermitT Identity
 
-$(enableKVPG (''VehiclePermitT) [('id)] [[('rcId)]])
+$(enableKVPG ''VehiclePermitT ['id] [['documentImageId], ['rcId]])
 
-$(mkTableInstances (''VehiclePermitT) "vehicle_permit")
+$(mkTableInstances ''VehiclePermitT "vehicle_permit")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/VehicleRegistrationCertificate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/VehicleRegistrationCertificate.hs
@@ -69,6 +69,6 @@ instance B.Table VehicleRegistrationCertificateT where
 
 type VehicleRegistrationCertificate = VehicleRegistrationCertificateT Identity
 
-$(enableKVPG ''VehicleRegistrationCertificateT ['id] [['certificateNumberHash]])
+$(enableKVPG ''VehicleRegistrationCertificateT ['id] [['certificateNumberHash], ['documentImageId], ['fleetOwnerId]])
 
 $(mkTableInstances ''VehicleRegistrationCertificateT "vehicle_registration_certificate")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/MorthVerification.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/MorthVerification.hs
@@ -78,8 +78,8 @@ updateByPrimaryKey (Domain.Types.MorthVerification.MorthVerification {..}) = do
   _now <- getCurrentTime
   updateWithKV
     [ Se.Set Beam.docType docType,
-      Se.Set Beam.documentNumberEncrypted (documentNumber & unEncrypted . encrypted),
-      Se.Set Beam.documentNumberHash (documentNumber & hash),
+      Se.Set Beam.documentNumberEncrypted (documentNumber <&> unEncrypted . (.encrypted)),
+      Se.Set Beam.documentNumberHash (documentNumber <&> (.hash)),
       Se.Set Beam.driverDateOfBirth driverDateOfBirth,
       Se.Set Beam.driverId (Kernel.Types.Id.getId driverId),
       Se.Set Beam.issueDateOnDoc issueDateOnDoc,
@@ -101,7 +101,7 @@ instance FromTType' Beam.MorthVerification Domain.Types.MorthVerification.MorthV
       Just
         Domain.Types.MorthVerification.MorthVerification
           { docType = docType,
-            documentNumber = EncryptedHashed (Encrypted documentNumberEncrypted) documentNumberHash,
+            documentNumber = EncryptedHashed <$> (Encrypted <$> documentNumberEncrypted) <*> documentNumberHash,
             driverDateOfBirth = driverDateOfBirth,
             driverId = Kernel.Types.Id.Id driverId,
             id = Kernel.Types.Id.Id id,
@@ -122,8 +122,8 @@ instance ToTType' Beam.MorthVerification Domain.Types.MorthVerification.MorthVer
   toTType' (Domain.Types.MorthVerification.MorthVerification {..}) = do
     Beam.MorthVerificationT
       { Beam.docType = docType,
-        Beam.documentNumberEncrypted = documentNumber & unEncrypted . encrypted,
-        Beam.documentNumberHash = documentNumber & hash,
+        Beam.documentNumberEncrypted = documentNumber <&> unEncrypted . (.encrypted),
+        Beam.documentNumberHash = documentNumber <&> (.hash),
         Beam.driverDateOfBirth = driverDateOfBirth,
         Beam.driverId = Kernel.Types.Id.getId driverId,
         Beam.id = Kernel.Types.Id.getId id,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/MorthVerification.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/MorthVerification.hs
@@ -78,8 +78,8 @@ updateByPrimaryKey (Domain.Types.MorthVerification.MorthVerification {..}) = do
   _now <- getCurrentTime
   updateWithKV
     [ Se.Set Beam.docType docType,
-      Se.Set Beam.documentNumberEncrypted (documentNumber <&> unEncrypted . (.encrypted)),
-      Se.Set Beam.documentNumberHash (documentNumber <&> (.hash)),
+      Se.Set Beam.documentNumberEncrypted (unEncrypted . (.encrypted) $ documentNumber),
+      Se.Set Beam.documentNumberHash ((.hash) documentNumber),
       Se.Set Beam.driverDateOfBirth driverDateOfBirth,
       Se.Set Beam.driverId (Kernel.Types.Id.getId driverId),
       Se.Set Beam.issueDateOnDoc issueDateOnDoc,
@@ -101,7 +101,7 @@ instance FromTType' Beam.MorthVerification Domain.Types.MorthVerification.MorthV
       Just
         Domain.Types.MorthVerification.MorthVerification
           { docType = docType,
-            documentNumber = EncryptedHashed <$> (Encrypted <$> documentNumberEncrypted) <*> documentNumberHash,
+            documentNumber = EncryptedHashed (Encrypted documentNumberEncrypted) documentNumberHash,
             driverDateOfBirth = driverDateOfBirth,
             driverId = Kernel.Types.Id.Id driverId,
             id = Kernel.Types.Id.Id id,
@@ -122,8 +122,8 @@ instance ToTType' Beam.MorthVerification Domain.Types.MorthVerification.MorthVer
   toTType' (Domain.Types.MorthVerification.MorthVerification {..}) = do
     Beam.MorthVerificationT
       { Beam.docType = docType,
-        Beam.documentNumberEncrypted = documentNumber <&> unEncrypted . (.encrypted),
-        Beam.documentNumberHash = documentNumber <&> (.hash),
+        Beam.documentNumberEncrypted = unEncrypted . (.encrypted) $ documentNumber,
+        Beam.documentNumberHash = (.hash) documentNumber,
         Beam.driverDateOfBirth = driverDateOfBirth,
         Beam.driverId = Kernel.Types.Id.getId driverId,
         Beam.id = Kernel.Types.Id.getId id,

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/AppInstalls.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/AppInstalls.yaml
@@ -19,6 +19,7 @@ AppInstalls:
 
   constraints:
     id: PrimaryKey
+    deviceToken: "!SecondaryKey"
 
   beamType:
     bundleVersion: Maybe Text

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/CallStatus.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/CallStatus.yaml
@@ -44,6 +44,7 @@ CallStatus:
   constraints:
     id: PrimaryKey
     callId: "!SecondaryKey" # forcing to be a secondary key
+    rideId: "!SecondaryKey" # forcing to be a secondary key
 
   queries:
     findById:

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/CrisRecon.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/CrisRecon.yaml
@@ -17,6 +17,10 @@ CrisRecon:
   sqlType:
     dateIst: "date"
 
+  constraints:
+    id: PrimaryKey
+    bppOrderId: SecondaryKey
+
   queries:
     findByBppOrderId:
       kvFunction: findOneWithKV

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/DeviceVehicleMapping.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/DeviceVehicleMapping.yaml
@@ -18,6 +18,7 @@ DeviceVehicleMapping:
   constraints:
     deviceId: PrimaryKey
     gtfsId: PrimaryKey
+    vehicleNo: SecondaryKey
 
   extraIndexes:
     - columns: [vehicleNo]

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
@@ -859,6 +859,10 @@ FRFSRecon:
     - Custom Kernel.Beam.Lib.UtilsTH.mkBeamInstancesForEnum <ReconStatus>
     - Custom Kernel.Utils.TH.mkFromHttpInstanceForEnum <ReconStatus>
 
+  constraints:
+    id: PrimaryKey
+    frfsTicketBookingId: SecondaryKey
+
   queries:
     updateTOrderValueAndSettlementAmountById:
       kvFunction: updateWithKV
@@ -1087,6 +1091,8 @@ StopFare:
     startStopCode: PrimaryKey
     endStopCode: PrimaryKey
     category: PrimaryKey
+  extraIndexes:
+    - columns: [startStopCode, endStopCode]
   queries:
     findByRouteCode:
       kvFunction: findAllWithKV
@@ -1109,6 +1115,9 @@ StopFare:
       params: [amount]
       where:
         and: [farePolicyId, startStopCode, endStopCode, category]
+
+  extraOperations:
+    - GENERATE_INDEXES
 
 
 FRFSStageFare:

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
@@ -837,6 +837,9 @@ FRFSRecon:
     reconStatus: Maybe ReconStatus
     paymentGateway: Maybe Text
 
+  constraints:
+    frfsTicketBookingId: SecondaryKey
+
   default:
     destinationStationCode: "'NA'" # Default For DSL
     sourceStationCode: "'NA'" # Default For DSL
@@ -1088,11 +1091,9 @@ StopFare:
     category: Kernel.Prelude.Just|I
   constraints:
     farePolicyId: PrimaryKey
-    startStopCode: PrimaryKey
-    endStopCode: PrimaryKey
     category: PrimaryKey
-  extraIndexes:
-    - columns: [startStopCode, endStopCode]
+    startStopCode: "PrimaryKey | CompositeSecondaryKey StopMapping"
+    endStopCode: "PrimaryKey | CompositeSecondaryKey StopMapping"
   queries:
     findByRouteCode:
       kvFunction: findAllWithKV

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/Person.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/Person.yaml
@@ -231,7 +231,8 @@ Person:
     deviceToken: SecondaryKey
     customerReferralCode: SecondaryKey
     operatorBadgeToken: SecondaryKey
-    deviceId: SecondaryKey
+    deviceId : SecondaryKey
+
 
   extraIndexes:
     - columns: [operatorBadgeToken, merchantId]

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/Person.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/Person.yaml
@@ -231,6 +231,7 @@ Person:
     deviceToken: SecondaryKey
     customerReferralCode: SecondaryKey
     operatorBadgeToken: SecondaryKey
+    deviceId: SecondaryKey
 
   extraIndexes:
     - columns: [operatorBadgeToken, merchantId]

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/RefundRequest.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/RefundRequest.yaml
@@ -33,6 +33,7 @@ RefundRequest:
   constraints:
     id: PrimaryKey
     orderId: SecondaryKey
+    refundsId: SecondaryKey
 
   types:
     RefundRequestStatus:

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/ticket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/ticket.yaml
@@ -555,7 +555,8 @@ SeatManagement:
 
   constraints:
     id: PrimaryKey
-    ticketServiceCategoryId: SecondaryKey
+    ticketServiceCategoryId: "CompositeSecondaryKey categoryDateGroup"
+    date: "CompositeSecondaryKey categoryDateGroup"
   queries:
     findByTicketServiceCategoryIdAndDate:
       kvFunction: findOneWithKV

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/ticket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/ticket.yaml
@@ -717,6 +717,10 @@ TicketBookingService:
     vendorSplitDetails: "Maybe [VendorSplitDetails]"
     assignmentId: Maybe Text
 
+  constraints:
+    shortId: SecondaryKey
+    visitDate: "!SecondaryKey"
+
   beamType:
     vendorSplitDetails: Maybe Value
   beamFields:

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/ticket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/ticket.yaml
@@ -327,6 +327,7 @@ SpecialOccasion:
   constraints:
     id: PrimaryKey
     entityId: SecondaryKey
+    placeId: SecondaryKey
 
   queries:
     findSpecialOccasionByEntityIdAndDate:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/AppInstalls.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/AppInstalls.hs
@@ -29,6 +29,6 @@ instance B.Table AppInstallsT where
 
 type AppInstalls = AppInstallsT Identity
 
-$(enableKVPG ''AppInstallsT ['id] [])
+$(enableKVPG ''AppInstallsT ['id] [['deviceToken]])
 
 $(mkTableInstances ''AppInstallsT "app_installs")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/CallStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/CallStatus.hs
@@ -38,6 +38,6 @@ instance B.Table CallStatusT where
 
 type CallStatus = CallStatusT Identity
 
-$(enableKVPG ''CallStatusT ['id] [['callId]])
+$(enableKVPG ''CallStatusT ['id] [['callId], ['rideId]])
 
 $(mkTableInstances ''CallStatusT "call_status")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/CrisRecon.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/CrisRecon.hs
@@ -12,14 +12,14 @@ import qualified Kernel.Types.Common
 import Tools.Beam.UtilsTH
 
 data CrisReconT f = CrisReconT
-  { bppOrderId :: (B.C f Kernel.Prelude.Text),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    dateIst :: (B.C f Kernel.Prelude.Text),
-    fareAmount :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    id :: (B.C f Kernel.Prelude.Text),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime),
-    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text)))
+  { bppOrderId :: B.C f Kernel.Prelude.Text,
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    dateIst :: B.C f Kernel.Prelude.Text,
+    fareAmount :: B.C f Kernel.Types.Common.HighPrecMoney,
+    id :: B.C f Kernel.Prelude.Text,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime,
+    merchantId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)
   }
   deriving (Generic, B.Beamable)
 
@@ -29,6 +29,6 @@ instance B.Table CrisReconT where
 
 type CrisRecon = CrisReconT Identity
 
-$(enableKVPG (''CrisReconT) [('id)] [])
+$(enableKVPG ''CrisReconT ['id] [['bppOrderId]])
 
-$(mkTableInstances (''CrisReconT) "cris_recon")
+$(mkTableInstances ''CrisReconT "cris_recon")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/DeviceVehicleMapping.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/DeviceVehicleMapping.hs
@@ -29,6 +29,6 @@ instance B.Table DeviceVehicleMappingT where
 
 type DeviceVehicleMapping = DeviceVehicleMappingT Identity
 
-$(enableKVPG ''DeviceVehicleMappingT ['deviceId, 'gtfsId] [])
+$(enableKVPG ''DeviceVehicleMappingT ['deviceId, 'gtfsId] [['vehicleNo]])
 
 $(mkTableInstances ''DeviceVehicleMappingT "device_vehicle_mapping")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/FRFSRecon.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/FRFSRecon.hs
@@ -14,43 +14,43 @@ import qualified Kernel.Types.Common
 import Tools.Beam.UtilsTH
 
 data FRFSReconT f = FRFSReconT
-  { beneficiaryBankAccount :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    beneficiaryIFSC :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    buyerFinderFee :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    collectorIFSC :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    collectorSubscriberId :: (B.C f Kernel.Prelude.Text),
-    date :: (B.C f Kernel.Prelude.Text),
-    destinationStationCode :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    differenceAmount :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecMoney)),
-    entityType :: (B.C f (Kernel.Prelude.Maybe Domain.Types.FRFSRecon.EntityType)),
-    currency :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.Currency)),
-    fare :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    frfsTicketBookingId :: (B.C f Kernel.Prelude.Text),
-    id :: (B.C f Kernel.Prelude.Text),
-    message :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    mobileNumber :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    networkOrderId :: (B.C f Kernel.Prelude.Text),
-    paymentGateway :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    providerId :: (B.C f Kernel.Prelude.Text),
-    providerName :: (B.C f Kernel.Prelude.Text),
-    receiverSubscriberId :: (B.C f Kernel.Prelude.Text),
-    reconStatus :: (B.C f (Kernel.Prelude.Maybe Domain.Types.FRFSRecon.ReconStatus)),
-    settlementAmount :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    settlementDate :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
-    settlementReferenceNumber :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    sourceStationCode :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    ticketNumber :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    ticketQty :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int)),
-    ticketStatus :: (B.C f (Kernel.Prelude.Maybe Domain.Types.FRFSTicketStatus.FRFSTicketStatus)),
-    time :: (B.C f Kernel.Prelude.Text),
-    totalOrderValue :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    transactionRefNumber :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    transactionUUID :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    txnId :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime)
+  { beneficiaryBankAccount :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    beneficiaryIFSC :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    buyerFinderFee :: B.C f Kernel.Types.Common.HighPrecMoney,
+    collectorIFSC :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    collectorSubscriberId :: B.C f Kernel.Prelude.Text,
+    date :: B.C f Kernel.Prelude.Text,
+    destinationStationCode :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    differenceAmount :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecMoney),
+    entityType :: B.C f (Kernel.Prelude.Maybe Domain.Types.FRFSRecon.EntityType),
+    currency :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.Currency),
+    fare :: B.C f Kernel.Types.Common.HighPrecMoney,
+    frfsTicketBookingId :: B.C f Kernel.Prelude.Text,
+    id :: B.C f Kernel.Prelude.Text,
+    message :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    mobileNumber :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    networkOrderId :: B.C f Kernel.Prelude.Text,
+    paymentGateway :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    providerId :: B.C f Kernel.Prelude.Text,
+    providerName :: B.C f Kernel.Prelude.Text,
+    receiverSubscriberId :: B.C f Kernel.Prelude.Text,
+    reconStatus :: B.C f (Kernel.Prelude.Maybe Domain.Types.FRFSRecon.ReconStatus),
+    settlementAmount :: B.C f Kernel.Types.Common.HighPrecMoney,
+    settlementDate :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime),
+    settlementReferenceNumber :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    sourceStationCode :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    ticketNumber :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    ticketQty :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int),
+    ticketStatus :: B.C f (Kernel.Prelude.Maybe Domain.Types.FRFSTicketStatus.FRFSTicketStatus),
+    time :: B.C f Kernel.Prelude.Text,
+    totalOrderValue :: B.C f Kernel.Types.Common.HighPrecMoney,
+    transactionRefNumber :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    transactionUUID :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    txnId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    merchantId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime
   }
   deriving (Generic, B.Beamable)
 
@@ -60,6 +60,6 @@ instance B.Table FRFSReconT where
 
 type FRFSRecon = FRFSReconT Identity
 
-$(enableKVPG (''FRFSReconT) [('id)] [])
+$(enableKVPG ''FRFSReconT ['id] [['frfsTicketBookingId]])
 
-$(mkTableInstances (''FRFSReconT) "frfs_recon")
+$(mkTableInstances ''FRFSReconT "frfs_recon")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/Person.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/Person.hs
@@ -121,6 +121,6 @@ instance B.Table PersonT where
 
 type Person = PersonT Identity
 
-$(enableKVPG (''PersonT) [('id)] [[('customerReferralCode)], [('deviceToken)], [('emailHash)], [('mobileNumberHash)], [('operatorBadgeToken)], [('referralCode)]])
+$(enableKVPG ''PersonT ['id] [['customerReferralCode], ['deviceId], ['deviceToken], ['emailHash], ['mobileNumberHash], ['operatorBadgeToken], ['referralCode]])
 
-$(mkTableInstances (''PersonT) "person")
+$(mkTableInstances ''PersonT "person")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/RefundRequest.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/RefundRequest.hs
@@ -44,6 +44,6 @@ instance B.Table RefundRequestT where
 
 type RefundRequest = RefundRequestT Identity
 
-$(enableKVPG ''RefundRequestT ['id] [['orderId]])
+$(enableKVPG ''RefundRequestT ['id] [['orderId], ['refundsId]])
 
 $(mkTableInstances ''RefundRequestT "refund_request")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/SeatManagement.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/SeatManagement.hs
@@ -31,6 +31,6 @@ instance B.Table SeatManagementT where
 
 type SeatManagement = SeatManagementT Identity
 
-$(enableKVPG ''SeatManagementT ['id] [['ticketServiceCategoryId]])
+$(enableKVPG ''SeatManagementT ['id] [['date, 'ticketServiceCategoryId]])
 
 $(mkTableInstances ''SeatManagementT "seat_management")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/SpecialOccasion.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/SpecialOccasion.hs
@@ -35,6 +35,6 @@ instance B.Table SpecialOccasionT where
 
 type SpecialOccasion = SpecialOccasionT Identity
 
-$(enableKVPG ''SpecialOccasionT ['id] [['entityId]])
+$(enableKVPG ''SpecialOccasionT ['id] [['entityId], ['placeId]])
 
 $(mkTableInstances ''SpecialOccasionT "special_occasion")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/StopFare.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/StopFare.hs
@@ -13,19 +13,19 @@ import qualified Kernel.Types.Common
 import Tools.Beam.UtilsTH
 
 data StopFareT f = StopFareT
-  { amount :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    bppItemId :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    category :: (B.C f (Kernel.Prelude.Maybe Domain.Types.FRFSQuoteCategoryType.FRFSQuoteCategoryType)),
-    currency :: (B.C f Kernel.Types.Common.Currency),
-    endStopCode :: (B.C f Kernel.Prelude.Text),
-    farePolicyId :: (B.C f Kernel.Prelude.Text),
-    integratedBppConfigId :: (B.C f Kernel.Prelude.Text),
-    merchantId :: (B.C f Kernel.Prelude.Text),
-    merchantOperatingCityId :: (B.C f Kernel.Prelude.Text),
-    offeredAmount :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecMoney)),
-    startStopCode :: (B.C f Kernel.Prelude.Text),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime)
+  { amount :: B.C f Kernel.Types.Common.HighPrecMoney,
+    bppItemId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    category :: B.C f (Kernel.Prelude.Maybe Domain.Types.FRFSQuoteCategoryType.FRFSQuoteCategoryType),
+    currency :: B.C f Kernel.Types.Common.Currency,
+    endStopCode :: B.C f Kernel.Prelude.Text,
+    farePolicyId :: B.C f Kernel.Prelude.Text,
+    integratedBppConfigId :: B.C f Kernel.Prelude.Text,
+    merchantId :: B.C f Kernel.Prelude.Text,
+    merchantOperatingCityId :: B.C f Kernel.Prelude.Text,
+    offeredAmount :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecMoney),
+    startStopCode :: B.C f Kernel.Prelude.Text,
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime
   }
   deriving (Generic, B.Beamable)
 
@@ -37,6 +37,6 @@ instance B.Table StopFareT where
 
 type StopFare = StopFareT Identity
 
-$(enableKVPG (''StopFareT) [('category), ('endStopCode), ('farePolicyId), ('startStopCode)] [])
+$(enableKVPG ''StopFareT ['category, 'endStopCode, 'farePolicyId, 'startStopCode] [['endStopCode, 'startStopCode]])
 
-$(mkTableInstances (''StopFareT) "route_stop_fare")
+$(mkTableInstances ''StopFareT "route_stop_fare")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/TicketBookingService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/TicketBookingService.hs
@@ -45,6 +45,6 @@ instance B.Table TicketBookingServiceT where
 
 type TicketBookingService = TicketBookingServiceT Identity
 
-$(enableKVPG ''TicketBookingServiceT ['id] [])
+$(enableKVPG ''TicketBookingServiceT ['id] [['shortId], ['visitDate]])
 
 $(mkTableInstances ''TicketBookingServiceT "ticket_booking_service")

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/document_verification_config.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/document_verification_config.sql
@@ -144,3 +144,8 @@ ALTER TABLE atlas_driver_offer_bpp.document_verification_config ADD COLUMN is_ap
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.document_verification_config ADD COLUMN only_image_verification_status_lookup_required boolean ;
+
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/driver_pan_card.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/driver_pan_card.sql
@@ -47,3 +47,8 @@ ALTER TABLE atlas_driver_offer_bpp.driver_pan_card ADD COLUMN pan_aadhaar_linkag
 
 ------- SQL updates -------
 
+
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/hyperverge_verification.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/hyperverge_verification.sql
@@ -26,3 +26,8 @@ ALTER TABLE atlas_driver_offer_bpp.hyperverge_verification ADD COLUMN merchant_o
 ALTER TABLE atlas_driver_offer_bpp.hyperverge_verification ADD COLUMN created_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
 ALTER TABLE atlas_driver_offer_bpp.hyperverge_verification ADD COLUMN updated_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
 ALTER TABLE atlas_driver_offer_bpp.hyperverge_verification ADD PRIMARY KEY ( id);
+
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/idfy_verification.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/idfy_verification.sql
@@ -53,3 +53,8 @@ ALTER TABLE atlas_driver_offer_bpp.idfy_verification ADD COLUMN air_conditioned 
 
 ALTER TABLE atlas_driver_offer_bpp.idfy_verification ADD COLUMN ventilator boolean ;
 ALTER TABLE atlas_driver_offer_bpp.idfy_verification ADD COLUMN oxygen boolean ;
+
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/payout_transaction.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/payout_transaction.sql
@@ -24,3 +24,9 @@ ALTER TABLE atlas_driver_offer_bpp.payout_transaction ADD COLUMN merchant_operat
 ALTER TABLE atlas_driver_offer_bpp.payout_transaction ADD COLUMN beneficiary_name text ;
 ALTER TABLE atlas_driver_offer_bpp.payout_transaction ADD COLUMN beneficiary_ifsc text ;
 ALTER TABLE atlas_driver_offer_bpp.payout_transaction ADD COLUMN beneficiary_account text ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.payout_transaction DROP CONSTRAINT payout_transaction_pkey;
+ALTER TABLE atlas_driver_offer_bpp.payout_transaction ADD PRIMARY KEY ( id);

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/rc_validation_rules.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/rc_validation_rules.sql
@@ -16,3 +16,7 @@ ALTER TABLE atlas_driver_offer_bpp.rc_validation_rules ADD PRIMARY KEY ( id);
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.rc_validation_rules ADD COLUMN enable_for_airport boolean ;
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/refunds.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/refunds.sql
@@ -46,3 +46,7 @@ ALTER TABLE atlas_driver_offer_bpp.refunds ADD COLUMN arn text ;
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.refunds ADD COLUMN completed_at timestamp with time zone ;
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/scheduled_payout.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/scheduled_payout.sql
@@ -37,3 +37,9 @@ ALTER TABLE atlas_driver_offer_bpp.scheduled_payout ADD COLUMN mark_cash_paid_by
 
 ------- SQL updates -------
 
+
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.scheduled_payout ADD COLUMN rc_id text ;

--- a/Backend/dev/migrations-read-only/rider-app/frfs_quote.sql
+++ b/Backend/dev/migrations-read-only/rider-app/frfs_quote.sql
@@ -144,3 +144,8 @@ ALTER TABLE atlas_app.frfs_quote ADD COLUMN vehicle_number text ;
 
 ------- SQL updates -------
 
+
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/rider-app/frfs_quote_category.sql
+++ b/Backend/dev/migrations-read-only/rider-app/frfs_quote_category.sql
@@ -217,3 +217,8 @@ ALTER TABLE atlas_app.frfs_quote_category ADD COLUMN hold_id text ;
 
 ------- SQL updates -------
 
+
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/rider-app/frfs_search.sql
+++ b/Backend/dev/migrations-read-only/rider-app/frfs_search.sql
@@ -150,3 +150,8 @@ ALTER TABLE atlas_app.frfs_search ADD COLUMN cloud_type text ;
 
 ------- SQL updates -------
 
+
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/rider-app/frfs_ticket_booking.sql
+++ b/Backend/dev/migrations-read-only/rider-app/frfs_ticket_booking.sql
@@ -188,3 +188,7 @@ ALTER TABLE atlas_app.frfs_ticket_booking ADD COLUMN cloud_type text ;
 ALTER TABLE atlas_app.frfs_ticket_booking ADD COLUMN seat_selection_type text ;
 ALTER TABLE atlas_app.frfs_ticket_booking ADD COLUMN driver_name text ;
 ALTER TABLE atlas_app.frfs_ticket_booking ADD COLUMN driver_mobile_number text ;
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/rider-app/payout_transaction.sql
+++ b/Backend/dev/migrations-read-only/rider-app/payout_transaction.sql
@@ -24,3 +24,9 @@ ALTER TABLE atlas_app.payout_transaction ADD COLUMN merchant_operating_city_id t
 ALTER TABLE atlas_app.payout_transaction ADD COLUMN beneficiary_name text ;
 ALTER TABLE atlas_app.payout_transaction ADD COLUMN beneficiary_ifsc text ;
 ALTER TABLE atlas_app.payout_transaction ADD COLUMN beneficiary_account text ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.payout_transaction DROP CONSTRAINT payout_transaction_pkey;
+ALTER TABLE atlas_app.payout_transaction ADD PRIMARY KEY ( id);

--- a/Backend/dev/migrations-read-only/rider-app/person.sql
+++ b/Backend/dev/migrations-read-only/rider-app/person.sql
@@ -290,3 +290,9 @@ ALTER TABLE atlas_app.person ADD COLUMN client_id text ;
 
 ------- SQL updates -------
 
+
+
+
+------- SQL updates -------
+
+CREATE INDEX CONCURRENTLY person_idx_device_id ON atlas_app.person USING btree (device_id);

--- a/Backend/dev/migrations-read-only/rider-app/person.sql
+++ b/Backend/dev/migrations-read-only/rider-app/person.sql
@@ -290,9 +290,10 @@ ALTER TABLE atlas_app.person ADD COLUMN client_id text ;
 
 ------- SQL updates -------
 
+CREATE INDEX CONCURRENTLY person_idx_device_id ON atlas_app.person USING btree (device_id);
+
 
 
 
 ------- SQL updates -------
 
-CREATE INDEX CONCURRENTLY person_idx_device_id ON atlas_app.person USING btree (device_id);

--- a/Backend/dev/migrations-read-only/rider-app/refunds.sql
+++ b/Backend/dev/migrations-read-only/rider-app/refunds.sql
@@ -45,3 +45,7 @@ ALTER TABLE atlas_app.refunds ADD COLUMN arn text ;
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.refunds ADD COLUMN completed_at timestamp with time zone ;
+
+
+------- SQL updates -------
+

--- a/Backend/dev/migrations-read-only/rider-app/route_stop_fare.sql
+++ b/Backend/dev/migrations-read-only/rider-app/route_stop_fare.sql
@@ -24,3 +24,8 @@ ALTER TABLE atlas_app.route_stop_fare ADD PRIMARY KEY ( category, end_stop_code,
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.route_stop_fare ADD COLUMN offered_amount double precision ;
+
+
+------- SQL updates -------
+
+CREATE INDEX CONCURRENTLY route_stop_fare_idx_end_stop_code_start_stop_code ON atlas_app.route_stop_fare USING btree (end_stop_code, start_stop_code);

--- a/Backend/lib/payment/spec/Storage/Payouts.yaml
+++ b/Backend/lib/payment/spec/Storage/Payouts.yaml
@@ -60,7 +60,7 @@ PayoutOrder:
     createdAt: timestamp with time zone
     updatedAt: timestamp with time zone
   constraints:
-    id: PrimaryKey
+    id: SecondaryKey
     orderId: PrimaryKey
   queries:
     findById:
@@ -121,7 +121,7 @@ PayoutTransaction:
     updatedAt: timestamp with time zone
   constraints:
     id: PrimaryKey
-    transactionRef: PrimaryKey
+    transactionRef: SecondaryKey
   beamFields:
     amount:
       currency: Maybe Currency

--- a/Backend/lib/payment/spec/Storage/Refunds.yaml
+++ b/Backend/lib/payment/spec/Storage/Refunds.yaml
@@ -28,6 +28,7 @@ Refunds:
 
   constraints:
     orderId: SecondaryKey
+    shortId: SecondaryKey
 
   sqlType:
     id: character varying(36)

--- a/Backend/lib/payment/spec/Storage/Wallet.yaml
+++ b/Backend/lib/payment/spec/Storage/Wallet.yaml
@@ -19,6 +19,9 @@ PersonWallet:
     createdAt: UTCTime
     updatedAt: UTCTime
 
+  constraints:
+    personId: SecondaryKey
+
   queries:
     findByPersonId:
       kvFunction: findOneWithKV
@@ -50,6 +53,9 @@ WalletRewardPosting:
     merchantOperatingCityId : Maybe Text
     createdAt: UTCTime
     updatedAt: UTCTime
+
+  constraints:
+    walletId: SecondaryKey
 
   queries:
     findByWalletIdAndStatus:

--- a/Backend/lib/payment/spec/Storage/Wallet.yaml
+++ b/Backend/lib/payment/spec/Storage/Wallet.yaml
@@ -24,6 +24,9 @@ PersonWallet:
       kvFunction: findOneWithKV
       where: personId
 
+  constraints:
+    personId: SecondaryKey
+
   defaultQueryTypeConstraint: "(Lib.Payment.Storage.Beam.BeamFlow.BeamFlow m r)"
   beamInstance: MakeTableInstancesGenericSchema
 

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Domain/Types/PersonWallet.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Domain/Types/PersonWallet.hs
@@ -7,6 +7,7 @@ import qualified Kernel.Beam.Lib.UtilsTH
 import Kernel.Prelude
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
+import qualified Tools.Beam.UtilsTH
 
 data PersonWallet = PersonWallet
   { cashAmount :: Kernel.Types.Common.HighPrecMoney,

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Domain/Types/Refunds.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Domain/Types/Refunds.hs
@@ -9,6 +9,7 @@ import Kernel.Prelude
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
 import qualified Lib.Payment.Domain.Types.PaymentOrder
+import qualified Tools.Beam.UtilsTH
 
 data Refunds = Refunds
   { arn :: Kernel.Prelude.Maybe Kernel.Prelude.Text,

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Domain/Types/WalletRewardPosting.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Domain/Types/WalletRewardPosting.hs
@@ -9,6 +9,7 @@ import Kernel.Prelude
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
 import qualified Lib.Payment.Domain.Types.PersonWallet
+import qualified Tools.Beam.UtilsTH
 
 data WalletRewardPosting = WalletRewardPosting
   { cashAmount :: Kernel.Types.Common.HighPrecMoney,
@@ -25,6 +26,6 @@ data WalletRewardPosting = WalletRewardPosting
   }
   deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
 
-data WalletPostingStatus = NEW | SUCCESS | FAILED deriving (Show, (Eq), (Ord), (Read), (Generic), (ToJSON), (FromJSON), (ToSchema))
+data WalletPostingStatus = NEW | SUCCESS | FAILED deriving (Show, Eq, Ord, Read, Generic, ToJSON, FromJSON, ToSchema)
 
-$(Kernel.Beam.Lib.UtilsTH.mkBeamInstancesForEnum (''Lib.Payment.Domain.Types.WalletRewardPosting.WalletPostingStatus))
+$(Kernel.Beam.Lib.UtilsTH.mkBeamInstancesForEnum ''Lib.Payment.Domain.Types.WalletRewardPosting.WalletPostingStatus)

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/PayoutOrder.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/PayoutOrder.hs
@@ -54,6 +54,6 @@ instance B.Table PayoutOrderT where
 
 type PayoutOrder = PayoutOrderT Identity
 
-$(enableKVPG ''PayoutOrderT ['id, 'orderId] [])
+$(enableKVPG ''PayoutOrderT ['id, 'orderId] [['id]])
 
 $(mkTableInstancesGenericSchema ''PayoutOrderT "payout_order")

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/PayoutTransaction.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/PayoutTransaction.hs
@@ -30,11 +30,11 @@ data PayoutTransactionT f = PayoutTransactionT
   deriving (Generic, B.Beamable)
 
 instance B.Table PayoutTransactionT where
-  data PrimaryKey PayoutTransactionT f = PayoutTransactionId (B.C f Kernel.Prelude.Text) (B.C f Kernel.Prelude.Text) deriving (Generic, B.Beamable)
-  primaryKey = PayoutTransactionId <$> id <*> transactionRef
+  data PrimaryKey PayoutTransactionT f = PayoutTransactionId (B.C f Kernel.Prelude.Text) deriving (Generic, B.Beamable)
+  primaryKey = PayoutTransactionId . id
 
 type PayoutTransaction = PayoutTransactionT Identity
 
-$(enableKVPG ''PayoutTransactionT ['id, 'transactionRef] [])
+$(enableKVPG ''PayoutTransactionT ['id] [['transactionRef]])
 
 $(mkTableInstancesGenericSchema ''PayoutTransactionT "payout_transaction")

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/PersonWallet.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/PersonWallet.hs
@@ -11,18 +11,18 @@ import qualified Kernel.Prelude
 import qualified Kernel.Types.Common
 
 data PersonWalletT f = PersonWalletT
-  { cashAmount :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    cashFromPointsRedemption :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    expiredBalance :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    id :: (B.C f Kernel.Prelude.Text),
-    merchantId :: (B.C f Kernel.Prelude.Text),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    personId :: (B.C f Kernel.Prelude.Text),
-    pointsAmount :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime),
-    usableCashAmount :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    usablePointsAmount :: (B.C f Kernel.Types.Common.HighPrecMoney)
+  { cashAmount :: B.C f Kernel.Types.Common.HighPrecMoney,
+    cashFromPointsRedemption :: B.C f Kernel.Types.Common.HighPrecMoney,
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    expiredBalance :: B.C f Kernel.Types.Common.HighPrecMoney,
+    id :: B.C f Kernel.Prelude.Text,
+    merchantId :: B.C f Kernel.Prelude.Text,
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    personId :: B.C f Kernel.Prelude.Text,
+    pointsAmount :: B.C f Kernel.Types.Common.HighPrecMoney,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime,
+    usableCashAmount :: B.C f Kernel.Types.Common.HighPrecMoney,
+    usablePointsAmount :: B.C f Kernel.Types.Common.HighPrecMoney
   }
   deriving (Generic, B.Beamable)
 
@@ -32,6 +32,6 @@ instance B.Table PersonWalletT where
 
 type PersonWallet = PersonWalletT Identity
 
-$(enableKVPG (''PersonWalletT) [('id)] [])
+$(enableKVPG ''PersonWalletT ['id] [['personId]])
 
-$(mkTableInstancesGenericSchema (''PersonWalletT) "person_wallet")
+$(mkTableInstancesGenericSchema ''PersonWalletT "person_wallet")

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/Refunds.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/Refunds.hs
@@ -36,6 +36,6 @@ instance B.Table RefundsT where
 
 type Refunds = RefundsT Identity
 
-$(enableKVPG ''RefundsT ['id] [['orderId]])
+$(enableKVPG ''RefundsT ['id] [['orderId], ['shortId]])
 
 $(mkTableInstancesGenericSchema ''RefundsT "refunds")

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/WalletRewardPosting.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Beam/WalletRewardPosting.hs
@@ -13,17 +13,17 @@ import qualified Kernel.Types.Common
 import qualified Lib.Payment.Domain.Types.WalletRewardPosting
 
 data WalletRewardPostingT f = WalletRewardPostingT
-  { cashAmount :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    createdAt :: (B.C f Kernel.Prelude.UTCTime),
-    id :: (B.C f Kernel.Prelude.Text),
-    merchantId :: (B.C f Kernel.Prelude.Text),
-    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    pointsAmount :: (B.C f Kernel.Types.Common.HighPrecMoney),
-    postingType :: (B.C f Kernel.External.Wallet.Interface.WalletPostingType),
-    shortId :: (B.C f Kernel.Prelude.Text),
-    status :: (B.C f Lib.Payment.Domain.Types.WalletRewardPosting.WalletPostingStatus),
-    updatedAt :: (B.C f Kernel.Prelude.UTCTime),
-    walletId :: (B.C f Kernel.Prelude.Text)
+  { cashAmount :: B.C f Kernel.Types.Common.HighPrecMoney,
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    id :: B.C f Kernel.Prelude.Text,
+    merchantId :: B.C f Kernel.Prelude.Text,
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    pointsAmount :: B.C f Kernel.Types.Common.HighPrecMoney,
+    postingType :: B.C f Kernel.External.Wallet.Interface.WalletPostingType,
+    shortId :: B.C f Kernel.Prelude.Text,
+    status :: B.C f Lib.Payment.Domain.Types.WalletRewardPosting.WalletPostingStatus,
+    updatedAt :: B.C f Kernel.Prelude.UTCTime,
+    walletId :: B.C f Kernel.Prelude.Text
   }
   deriving (Generic, B.Beamable)
 
@@ -33,6 +33,6 @@ instance B.Table WalletRewardPostingT where
 
 type WalletRewardPosting = WalletRewardPostingT Identity
 
-$(enableKVPG (''WalletRewardPostingT) [('id)] [])
+$(enableKVPG ''WalletRewardPostingT ['id] [['walletId]])
 
-$(mkTableInstancesGenericSchema (''WalletRewardPostingT) "wallet_reward_posting")
+$(mkTableInstancesGenericSchema ''WalletRewardPostingT "wallet_reward_posting")

--- a/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Queries/PayoutTransaction.hs
+++ b/Backend/lib/payment/src-read-only/Lib/Payment/Storage/Queries/PayoutTransaction.hs
@@ -38,8 +38,8 @@ updatePayoutTransactionStatus status transactionRef = do
 
 findByPrimaryKey ::
   (Lib.Payment.Storage.Beam.BeamFlow.BeamFlow m r) =>
-  (Kernel.Types.Id.Id Lib.Payment.Domain.Types.PayoutTransaction.PayoutTransaction -> Kernel.Prelude.Text -> m (Maybe Lib.Payment.Domain.Types.PayoutTransaction.PayoutTransaction))
-findByPrimaryKey id transactionRef = do findOneWithKV [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id), Se.Is Beam.transactionRef $ Se.Eq transactionRef]]
+  (Kernel.Types.Id.Id Lib.Payment.Domain.Types.PayoutTransaction.PayoutTransaction -> m (Maybe Lib.Payment.Domain.Types.PayoutTransaction.PayoutTransaction))
+findByPrimaryKey id = do findOneWithKV [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]]
 
 updateByPrimaryKey :: (Lib.Payment.Storage.Beam.BeamFlow.BeamFlow m r) => (Lib.Payment.Domain.Types.PayoutTransaction.PayoutTransaction -> m ())
 updateByPrimaryKey (Lib.Payment.Domain.Types.PayoutTransaction.PayoutTransaction {..}) = do
@@ -56,9 +56,10 @@ updateByPrimaryKey (Lib.Payment.Domain.Types.PayoutTransaction.PayoutTransaction
       Se.Set Beam.merchantOperatingCityId merchantOperatingCityId,
       Se.Set Beam.payoutOrderId (Kernel.Types.Id.getId payoutOrderId),
       Se.Set Beam.status status,
+      Se.Set Beam.transactionRef transactionRef,
       Se.Set Beam.updatedAt _now
     ]
-    [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id), Se.Is Beam.transactionRef $ Se.Eq transactionRef]]
+    [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]]
 
 instance FromTType' Beam.PayoutTransaction Lib.Payment.Domain.Types.PayoutTransaction.PayoutTransaction where
   fromTType' (Beam.PayoutTransactionT {..}) = do

--- a/Backend/lib/payment/src/Lib/Payment/Storage/Beam/PaymentTransaction.hs
+++ b/Backend/lib/payment/src/Lib/Payment/Storage/Beam/PaymentTransaction.hs
@@ -75,6 +75,6 @@ instance B.Table PaymentTransactionT where
 
 type PaymentTransaction = PaymentTransactionT Identity
 
-$(enableKVPG ''PaymentTransactionT ['id] [['txnUUID], ['orderId]])
+$(enableKVPG ''PaymentTransactionT ['id] [['txnUUID], ['orderId], ['txnId]])
 
 $(mkTableInstancesGenericSchema ''PaymentTransactionT "payment_transaction")

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/Issue/IssueChat.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/Issue/IssueChat.hs
@@ -41,6 +41,6 @@ instance B.Table IssueChatT where
 
 type IssueChat = IssueChatT Identity
 
-$(enableKVPG ''IssueChatT ['id] [['personId], ['issueReportId]])
+$(enableKVPG ''IssueChatT ['id] [['personId], ['issueReportId], ['ticketId]])
 
 $(mkTableInstancesGenericSchema ''IssueChatT "issue_chat")

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/Issue/IssueMessage.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/Issue/IssueMessage.hs
@@ -51,6 +51,6 @@ instance B.Table IssueMessageT where
 
 type IssueMessage = IssueMessageT Identity
 
-$(enableKVPG ''IssueMessageT ['id] [['message]])
+$(enableKVPG ''IssueMessageT ['id] [])
 
 $(mkTableInstancesGenericSchema ''IssueMessageT "issue_message")

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/Issue/IssueReport.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/Issue/IssueReport.hs
@@ -53,6 +53,6 @@ instance B.Table IssueReportT where
 
 type IssueReport = IssueReportT Identity
 
-$(enableKVPG ''IssueReportT ['id] [['personId], ['categoryId], ['ticketId]])
+$(enableKVPG ''IssueReportT ['id] [['personId], ['categoryId], ['ticketId], ['shortId]])
 
 $(mkTableInstancesGenericSchema ''IssueReportT "issue_report")

--- a/Backend/lib/yudhishthira/spec/Storage/UserData.yaml
+++ b/Backend/lib/yudhishthira/spec/Storage/UserData.yaml
@@ -15,6 +15,9 @@ UserData:
     batchNumber: Int
     userDataValue: Value
 
+  constraint:
+    userId: SecondaryKey
+
   sqlType:
     userDataValue: json
 


### PR DESCRIPTION
## What

Adds KV **secondary keys** (`enableKVPG`) to 20 rider + driver tables so more reads are served from KV and the tables become DB-independent. Part of the broader KV-enablement effort.

Each SK was verified against **euler-hs anchor semantics** — a `*WithKV` query is KV-served only if a full PK/SK group is a subset of its equality/IN where-columns.

### Key-syntax patterns used
- Plain `SecondaryKey` — field appears in a YAML-declared query's `where`.
- `"!SecondaryKey"` (forced) — field's only query lives in a hand-written Extra `.hs`.
- `"PrimaryKey|SecondaryKey"` — composite-PK member that is also queried alone (NammaDSL cannot express a composite SK; multiple SK fields generate separate single SKs).

### Tables
**Rider (8 specs):** `cris_recon`(bppOrderId), `frfs_recon`(frfsTicketBookingId), `person`(deviceId), `refund_request`(refundsId), `call_status`(rideId), `special_occasion`(placeId), `person_wallet`(personId), `refunds`(shortId). `route_stop_fare` gets a **DB composite index** (`startStopCode+endStopCode`) instead of a KV SK.

**Driver (6 specs):** `business_license`(driverId), `vehicle_permit`/`vehicle_puc`(documentImageId), `fleet_rc_association`(fleetOwnerId), `aadhaar_card`(front/back image + numberHash), `vehicle_registration_certificate`(documentImageId, fleetOwnerId), `feedback`(rideId, driverId), `fleet_booking_assignments`(vehicleNo), `lms_certificate`(driverId), `ride`(shortId), `call_status`(entityId).

## ⚠️ Monitor (high fan-out SKs)
These work but can build large Redis SETs — watch SET size:
- `call_status.entityId` — column defaults to `'UNKNOWN'`; unset rows collapse into one large SET.
- `message_report.messageId` *(reverted out of this PR)*, `feedback.driverId`, `fleet_rc_association.fleetOwnerId`, `vehicle_registration_certificate.fleetOwnerId`.

## Notes
- DB-fallback path: most new SK columns are **not yet indexed in code** (only `person.device_id` and `route_stop_fare` here). Cross-check against the prod-index inventory and add migrations for large tables before/after enabling.
- A few non-target migration files carry empty regeneration markers (no real SQL) and can be dropped for a tighter diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new payout/beneficiary and scheduled payout fields to improve payout tracking.
  * Added device and indexable identifiers for faster lookups (deviceId, deviceToken, shortId, refundsId, placeId).

* **Chores**
  * Expanded and refined secondary/index keys across many tables to improve query performance and lookup reliability.
  * Added/updated DB migrations and indexes for improved retrieval and integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->