### PR TITLE
fix: parse routeStations and check requested routeId to filter quotes

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -646,6 +646,14 @@ getFrfsSearchQuote (mbPersonId, _) searchId_ = do
   let cbConfig = PTCircuitBreaker.parseCircuitBreakerConfig (mbRiderConfig >>= (.ptCircuitBreakerConfig))
       ptMode = PTCircuitBreaker.vehicleCategoryToPTMode search.vehicleType
   observingFailures <- PTCircuitBreaker.checkObservingFailures ptMode PTCircuitBreaker.BookingAPI search.merchantOperatingCityId cbConfig
+  let routeFilteredQuotesWithCategories =
+        case search.routeCode of
+          Just searchRouteCode ->
+            let quoteRouteCode (quote, _) = (decodeFromText =<< quote.routeStationsJson :: Maybe [FRFSRouteStationsAPI]) >>= listToMaybe <&> (.code)
+                matchingQuotesWithCategories = filter (\qc -> quoteRouteCode qc == Just searchRouteCode) quotesWithCategories
+             in if null matchingQuotesWithCategories then quotesWithCategories else matchingQuotesWithCategories
+          Nothing -> quotesWithCategories
+  logInfo $ "getFrfsSearchQuote searchId=" <> searchId_.getId <> " requestedRouteCode=" <> show search.routeCode <> " totalQuotes=" <> show (length quotesWithCategories) <> " quotesAfterRouteFilter=" <> show (length routeFilteredQuotesWithCategories)
   sortedQuotesWithCategories <- case search.vehicleType of
     Spec.BUS -> do
       let cfgMap = maybe (JourneyUtils.toCfgMap JourneyUtils.defaultBusTierSortingConfig) JourneyUtils.toCfgMap (mbRiderConfig >>= (.busTierSortingConfig))
@@ -658,7 +666,7 @@ getFrfsSearchQuote (mbPersonId, _) searchId_ = do
                 (maybe maxBound (JourneyUtils.tierRank cfgMap') (serviceTierTypeFromQuote quote1 quoteCategories1))
                 (maybe maxBound (JourneyUtils.tierRank cfgMap') (serviceTierTypeFromQuote quote2 quoteCategories2))
           )
-          quotesWithCategories
+          routeFilteredQuotesWithCategories
     _ ->
       return $
         sortBy
@@ -667,7 +675,7 @@ getFrfsSearchQuote (mbPersonId, _) searchId_ = do
                   mbAdultPrice2 = find (\category -> category.category == ADULT) quoteCategories2 <&> (.price)
                in compare (maybe 0 (.amount) mbAdultPrice1) (maybe 0 (.amount) mbAdultPrice2)
           )
-          quotesWithCategories
+          routeFilteredQuotesWithCategories
   mapM
     ( \(quote, quoteCategories) -> do
         let decodedRouteStations :: Maybe [FRFSRouteStationsAPI] = decodeFromText =<< quote.routeStationsJson


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result accuracy by filtering FRFS transit quotes based on the requested route code, ensuring more relevant results are displayed to users.
  * Added enhanced logging to track search filtering metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->