### PR TITLE
provider/feat: add net driver earnings to fare breakup items

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
@@ -265,7 +265,8 @@ buildRideEarnings lang labels booking ride fp = do
       tips = fromMaybe 0 ride.tipAmount
       cur = ride.currency
       amountPaidByCustomer = fare - discount + tips
-      EarningsLabels {lblAmountPaid, lblDiscount, lblTips, lblCommission, lblFare} = labels
+      netDriverEarnings = fare - commission + tips
+      EarningsLabels {lblAmountPaid, lblDiscount, lblTips, lblCommission, lblNetEarnings, lblFare} = labels
       cancellationDues = fromMaybe 0 fp.customerCancellationDues -- we will deccide where to fetch this ?
   let mkComp sec key mbLabel value applicable =
         if applicable
@@ -283,8 +284,9 @@ buildRideEarnings lang labels booking ride fp = do
           [ mkComp FareBreakup "AMOUNT_PAID_BY_CUSTOMER" lblAmountPaid amountPaidByCustomer True,
             mkComp FareBreakup "DISCOUNT" lblDiscount discount (discount > 0),
             mkComp FareBreakup "TIPS" lblTips tips (tips > 0),
-            mkComp FareBreakup "COMMISSION" lblCommission commission (commission /= 0),
-            mkComp FareBreakup "CUSTOMER_CANCELLATION_CHARGE" lblFare cancellationDues (cancellationDues > 0)
+            mkComp FareBreakup "COMMISSION" lblCommission (if commission > 0 then negate commission else commission) (commission /= 0),
+            mkComp FareBreakup "CUSTOMER_CANCELLATION_CHARGE" lblFare cancellationDues (cancellationDues > 0),
+            mkComp FareBreakup "NET_DRIVER_EARNINGS" lblNetEarnings netDriverEarnings True
           ]
   footnoteItems <- buildFootnotes lang booking ride fp
 


### PR DESCRIPTION
## Summary

- Add `NET_DRIVER_EARNINGS` fare breakup item computed as `fare - commission + tips`
- Commission is now displayed as a negative value when `> 0` to correctly reflect it as a deduction from driver earnings
- Destructure `lblNetEarnings` from `EarningsLabels` (the field and its translation label `NET_DRIVER_EARNINGS` already existed in the type and `fetchEarningsLabels`)

## Test plan

- [ ] Verify `NET_DRIVER_EARNINGS` appears in the fare breakup response after a completed ride
- [ ] Verify commission shows as a negative value (e.g. `-50`) when driver has a positive commission deduction
- [ ] Verify commission shows as-is when commission is already ≤ 0 (e.g. incentive case)
- [ ] Verify `netDriverEarnings` value equals `fare - commission + tips`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Net driver earnings now displayed in ride fare breakdown, calculated as fare minus commission plus tips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->