### PR TITLE
Backend/fix: footnotes parsing logic update

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
@@ -23,13 +23,17 @@ where
 
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A
+import qualified Data.ByteString.Lazy as LBS
 import Data.Functor ((<&>))
 import qualified Data.HashMap.Strict as HM
 import Data.List (find, nub, partition, sort)
-import Data.Maybe (catMaybes, fromMaybe, listToMaybe)
+import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
 import Data.OpenApi (ToSchema)
+import qualified Data.Scientific as Sci
 import Data.Text (Text, pack)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import Data.Time (UTCTime, diffUTCTime)
 import qualified Domain.Action.UI.Location as DLocUI
 import qualified Domain.Types as DTC
@@ -225,7 +229,7 @@ data FareUIComponent = FareUIComponent
 
 data UiTranslationRaw
   = UiTrPlain Text
-  | UiTrByKey Text (HM.HashMap Text Text)
+  | UiTrByKey Text (HM.HashMap Text A.Value)
   deriving stock (Show, Generic)
 
 instance FromJSON UiTranslationRaw where
@@ -316,8 +320,13 @@ buildFootnotes lang booking ride fp = do
                 language = pack (show lang)
               }
       resp <- LYTU.runLogics logics logicInput
-      case A.fromJSON resp.result :: A.Result [FareUIComponentRaw] of
-        A.Success rawItems -> do
+      let rawValues = case A.fromJSON resp.result :: A.Result [A.Value] of
+            A.Success vs -> vs
+            A.Error _ -> [resp.result]
+          rawItems = mapMaybe (A.parseMaybe A.parseJSON) rawValues
+      if null rawItems
+        then pure []
+        else do
           let allKeys = nub $
                 flip concatMap rawItems $ \raw -> case raw.uiTranslation of
                   Just (UiTrByKey k _) -> [k]
@@ -331,8 +340,7 @@ buildFootnotes lang booking ride fp = do
                 HM.union
                   (HM.fromList [(t.messageKey, t.message) | t <- preferred])
                   (HM.fromList [(t.messageKey, t.message) | t <- fallbacks])
-          pure $ catMaybes $ map (resolveRawComponent txMap) rawItems
-        A.Error _ -> pure []
+          pure $ mapMaybe (resolveRawComponent txMap) rawItems
 
 resolveRawComponent :: HM.HashMap Text Text -> FareUIComponentRaw -> Maybe FareUIComponent
 resolveRawComponent txMap raw =
@@ -356,8 +364,18 @@ resolveUiTranslationFromMap txMap titleKey = \case
      in Just (substituteVars template vs)
   Nothing -> HM.lookup titleKey txMap
 
-substituteVars :: Text -> HM.HashMap Text Text -> Text
-substituteVars = HM.foldrWithKey (\k v acc -> T.replace ("{{" <> k <> "}}") v acc)
+substituteVars :: Text -> HM.HashMap Text A.Value -> Text
+substituteVars = HM.foldrWithKey (\k v acc -> T.replace ("{{" <> k <> "}}") (valueToText v) acc)
+
+valueToText :: A.Value -> Text
+valueToText = \case
+  A.String s -> s
+  A.Number n -> case Sci.floatingOrInteger n of
+    Right (i :: Integer) -> T.pack (show i)
+    Left (d :: Double) -> T.pack (show d)
+  A.Bool b -> if b then "true" else "false"
+  A.Null -> ""
+  other -> TE.decodeUtf8 . LBS.toStrict $ A.encode other
 
 resolveLabel ::
   (CacheFlow m r, EsqDBFlow m r) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Cabal Clean" remote maintenance action with a dedicated terminal panel and button; backend and local API now support starting cabal-clean sessions.

* **Bug Fixes**
  * Improved ride UI translation and footnote handling to accept numbers, booleans, nulls and complex template values; unresolved items are dropped to avoid leftover placeholders.
  * Xterm/terminal robustness improvements and suppression of a specific dev-mode terminal error to avoid noisy overlays.
  * Top-bar now retries fetching sync environments until available.

* **Chores**
  * Switched to scoped xterm package and updated related assets.
  * Removed several dev/test config inputs from preset specs; small build/tooling script and service wiring tweaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->