### PR TITLE
Revert "backend/feat: apply currency-based rounding in finance kernel on all DB writes (#14911)"

### DIFF
--- a/Backend/lib/finance-kernel/src/Lib/Finance/Account/Service.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Account/Service.hs
@@ -27,7 +27,6 @@ import Kernel.Types.Common ()
 import Kernel.Types.Id (Id (..))
 import Kernel.Utils.Common
 import Lib.Finance.Account.Interface
-import Lib.Finance.Core.Money (roundAmount)
 import Lib.Finance.Domain.Types.Account
 import Lib.Finance.Error.Types
 import qualified Lib.Finance.Storage.Beam.BeamFlow as BeamFlow

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Account/Service.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Account/Service.hs
@@ -118,10 +118,10 @@ updateBalanceByDelta accountId delta = do
   case mbAccount of
     Nothing -> pure $ Left $ AccountError AccountNotFound (show accountId)
     Just account -> do
-      let roundedDelta = roundAmount delta
-          newBalance = roundAmount (account.balance + roundedDelta)
+      let newBalance = account.balance + delta
+      -- Check for negative balance on liability accounts
       when (account.accountType == Liability && newBalance < 0) $
-        pure ()
+        pure () -- Could enforce business rules here
       QAccount.updateBalance newBalance accountId
       pure $ Right newBalance
 

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Core/Money.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Core/Money.hs
@@ -13,13 +13,11 @@ module Lib.Finance.Core.Money
     isZero,
     isPositive,
     isNegative,
-    roundAmount,
   )
 where
 
 import Kernel.Prelude
 import Kernel.Types.Common (Currency, HighPrecMoney)
-import Kernel.Types.Price (roundHighPrecMoney)
 
 -- | MonetaryAmount represents money with currency and amount
 data MonetaryAmount = MonetaryAmount
@@ -63,8 +61,3 @@ isPositive m = m.amount > 0
 -- | Check if amount is negative
 isNegative :: MonetaryAmount -> Bool
 isNegative m = m.amount < 0
-
--- | Round a monetary amount to 2 decimal places.
--- Finance kernel always stores amounts at 2 decimal precision regardless of currency.
-roundAmount :: HighPrecMoney -> HighPrecMoney
-roundAmount = roundHighPrecMoney @HighPrecMoney 2

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Invoice/Service.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Invoice/Service.hs
@@ -38,7 +38,6 @@ import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Types.Id (Id (..))
 import Kernel.Utils.Common
-import Lib.Finance.Core.Money (roundAmount)
 import Lib.Finance.Domain.Types.Account (CounterpartyType (..))
 import Lib.Finance.Domain.Types.DirectTaxTransaction (DirectTaxTransaction (..))
 import qualified Lib.Finance.Domain.Types.DirectTaxTransaction as DirectTax

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Invoice/Service.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Invoice/Service.hs
@@ -89,13 +89,12 @@ createInvoice input entryIds = do
   -- Calculate totals from line items
   -- subtotal: excludes external charges (toll, parking) and tax line items
   -- totalAmount: sum of all line items (what rider pays)
-  let roundedLineItems = map (\li -> li {unitPrice = roundAmount li.unitPrice, lineTotal = roundAmount li.lineTotal}) input.lineItems
-      lineItemsJson = Aeson.toJSON roundedLineItems
-      totalAmount = roundAmount $ sum $ map (.lineTotal) roundedLineItems
-      externalTotal = roundAmount $ sum $ map (.lineTotal) $ filter (.isExternalCharge) roundedLineItems
-      taxTotal = roundAmount $ sum $ map (.lineTotal) $ filter (\li -> not li.isExternalCharge && li.itemType == Just Tax) roundedLineItems
-      subtotal = roundAmount $ totalAmount - externalTotal - taxTotal
-  logDebug $ "Sum of unit price of all line items: " <> show (sum $ map (.unitPrice) roundedLineItems)
+  let lineItemsJson = Aeson.toJSON input.lineItems
+      totalAmount = sum $ map (.lineTotal) input.lineItems
+      externalTotal = sum $ map (.lineTotal) $ filter (.isExternalCharge) input.lineItems
+      taxTotal = sum $ map (.lineTotal) $ filter (\li -> not li.isExternalCharge && li.itemType == Just Tax) input.lineItems
+      subtotal = totalAmount - externalTotal - taxTotal
+  logDebug $ "Sum of unit price of all line items: " <> show (sum $ map (.unitPrice) input.lineItems)
   let invoice =
         Invoice
           { id = Id invoiceId,
@@ -161,14 +160,14 @@ createInvoice input entryIds = do
     case mbToAccount of
       Just toAccount
         | toAccount.counterpartyType == Just GOVERNMENT_INDIRECT -> do
-          let extCharges = roundAmount $ sum $ map (.lineTotal) $ filter (.isExternalCharge) roundedLineItems
+          let extCharges = sum $ map (.lineTotal) $ filter (.isExternalCharge) input.lineItems
               txnType = invoiceTypeToTransactionType input.invoiceType
               isVat = input.isVat
               indirectTaxInput =
                 IndirectTaxInput
                   { transactionType = txnType,
                     referenceId = entry.referenceId,
-                    taxableValue = roundAmount $ totalAmount - entry.amount - extCharges,
+                    taxableValue = totalAmount - entry.amount - extCharges,
                     totalTaxAmount = entry.amount,
                     gstBreakdown = input.gstBreakdown,
                     taxCreditType = Output,
@@ -185,8 +184,8 @@ createInvoice input entryIds = do
                   }
           void $ createIndirectTaxEntry indirectTaxInput
         | toAccount.counterpartyType == Just GOVERNMENT_DIRECT -> do
-          let extCharges = roundAmount $ sum $ map (.lineTotal) $ filter (.isExternalCharge) roundedLineItems
-              gstAmount = roundAmount $ case input.gstBreakdown of
+          let extCharges = sum $ map (.lineTotal) $ filter (.isExternalCharge) input.lineItems
+              gstAmount = case input.gstBreakdown of
                 Just breakdown -> fromMaybe 0 breakdown.cgstAmount + fromMaybe 0 breakdown.sgstAmount + fromMaybe 0 breakdown.igstAmount
                 Nothing -> 0
               txnType = invoiceTypeToDirectTransactionType input.invoiceType
@@ -194,7 +193,7 @@ createInvoice input entryIds = do
                 DirectTaxInput
                   { transactionType = txnType,
                     referenceId = entry.referenceId,
-                    grossAmount = roundAmount $ totalAmount - extCharges - gstAmount,
+                    grossAmount = totalAmount - extCharges - gstAmount,
                     tdsAmount = entry.amount,
                     tdsTreatment = DirectTax.Deducted,
                     counterpartyId = input.counterpartyId,
@@ -222,19 +221,19 @@ createIndirectTaxEntry ::
 createIndirectTaxEntry input = do
   now <- getCurrentTime
   taxTxnId <- generateGUID
-  let taxAmount = roundAmount input.totalTaxAmount
+  let taxAmount = input.totalTaxAmount
       -- GST-specific fields: zero for VAT, normal split for GST
       (cgstAmt, sgstAmt, igstAmt) =
         if input.isVat
           then (0, 0, 0) -- no CGST/SGST/IGST for VAT
           else case input.gstBreakdown of
             Just breakdown ->
-              ( roundAmount $ fromMaybe 0 breakdown.cgstAmount,
-                roundAmount $ fromMaybe 0 breakdown.sgstAmount,
-                roundAmount $ fromMaybe 0 breakdown.igstAmount
+              ( fromMaybe 0 breakdown.cgstAmount,
+                fromMaybe 0 breakdown.sgstAmount,
+                fromMaybe 0 breakdown.igstAmount
               )
             Nothing ->
-              let cg = roundAmount $ taxAmount / 2.0
+              let cg = taxAmount / 2.0
                in (cg, taxAmount - cg, 0)
       computedTaxRate = if input.taxableValue > 0 then realToFrac (taxAmount / input.taxableValue) * 100.0 else 0.0
       saleType = if input.isVat then Nothing else Just (if isJust input.gstinOfParty then B2B else B2C)
@@ -244,7 +243,7 @@ createIndirectTaxEntry input = do
             transactionDate = now,
             transactionType = input.transactionType,
             referenceId = input.referenceId,
-            taxableValue = roundAmount input.taxableValue,
+            taxableValue = input.taxableValue,
             -- OLD GST columns (backward compat: zeroed for VAT)
             gstRate = if input.isVat then 0 else computedTaxRate,
             cgstAmount = cgstAmt,
@@ -282,7 +281,7 @@ createDirectTaxEntry ::
 createDirectTaxEntry input = do
   now <- getCurrentTime
   taxTxnId <- generateGUID
-  let netAmountPaid = roundAmount $ input.grossAmount - input.tdsAmount
+  let netAmountPaid = input.grossAmount - input.tdsAmount
       tdsRate = if input.grossAmount > 0 then realToFrac (input.tdsAmount / input.grossAmount) * 100.0 else 0.0
       directTaxTxn =
         DirectTaxTransaction
@@ -290,9 +289,9 @@ createDirectTaxEntry input = do
             transactionDate = now,
             transactionType = input.transactionType,
             referenceId = input.referenceId,
-            grossAmount = roundAmount input.grossAmount,
+            grossAmount = input.grossAmount,
             tdsRate = tdsRate,
-            tdsAmount = roundAmount input.tdsAmount,
+            tdsAmount = input.tdsAmount,
             netAmountPaid = netAmountPaid,
             tdsTreatment = input.tdsTreatment,
             tdsSection = input.tdsSection,

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Ledger/Service.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Ledger/Service.hs
@@ -64,7 +64,6 @@ import Kernel.Prelude
 import Kernel.Types.Common ()
 import Kernel.Types.Id (Id (..))
 import Kernel.Utils.Common
-import Lib.Finance.Core.Money (roundAmount)
 import Lib.Finance.Core.Types (TimeRange (..))
 import Lib.Finance.Domain.Types.Account (Account)
 import qualified Lib.Finance.Domain.Types.Account as Account
@@ -90,14 +89,13 @@ createEntry ::
 createEntry input = do
   now <- getCurrentTime
   entryId <- generateGUID
-  let roundedAmount = roundAmount input.amount
-      entry =
+  let entry =
         LedgerEntry
           { id = Id entryId,
             fromAccountId = input.fromAccountId,
             toAccountId = input.toAccountId,
             concernedIndividualId = input.concernedIndividualId,
-            amount = roundedAmount,
+            amount = input.amount,
             currency = input.currency,
             entryType = input.entryType,
             status = input.status,
@@ -141,7 +139,7 @@ createEntryWithBalanceUpdate input = do
     (Just fromAccount, Just toAccount) -> do
       now <- getCurrentTime
       entryId <- generateGUID
-      let amount = roundAmount input.amount
+      let amount = input.amount
           fromStartBal = fromAccount.balance
           toStartBal = toAccount.balance
           isAssetOrExpenseAccount acc = acc.accountType == Account.Asset || acc.accountType == Account.Expense
@@ -240,8 +238,8 @@ createReversal originalId reason = do
       -- Update account balances (reverse the original transaction)
       mbFrom <- QAccount.findById original.fromAccountId
       mbTo <- QAccount.findById original.toAccountId
-      forM_ mbFrom $ \a -> QAccount.updateBalance (roundAmount (a.balance + original.amount)) original.fromAccountId
-      forM_ mbTo $ \a -> QAccount.updateBalance (roundAmount (a.balance - original.amount)) original.toAccountId
+      forM_ mbFrom $ \a -> QAccount.updateBalance (a.balance + original.amount) original.fromAccountId
+      forM_ mbTo $ \a -> QAccount.updateBalance (a.balance - original.amount) original.toAccountId
 
       pure $ Right reversal
 
@@ -281,15 +279,13 @@ settleEntry entryId = do
               fromStartBal = fromAccount.balance
               toStartBal = toAccount.balance
               fromEndBal =
-                roundAmount $
-                  if isAssetOrExpenseAccount fromAccount
-                    then fromStartBal + amount
-                    else fromStartBal - amount
+                if isAssetOrExpenseAccount fromAccount
+                  then fromStartBal + amount
+                  else fromStartBal - amount
               toEndBal =
-                roundAmount $
-                  if isAssetOrExpenseAccount toAccount
-                    then toStartBal - amount
-                    else toStartBal + amount
+                if isAssetOrExpenseAccount toAccount
+                  then toStartBal - amount
+                  else toStartBal + amount
           _ <- QAccount.updateBalance fromEndBal entry.fromAccountId
           _ <- QAccount.updateBalance toEndBal entry.toAccountId
           let updatedEntry =
@@ -319,10 +315,9 @@ settleEntryWithBalancesAndAmount entryId settledAmount fromStartBal fromEndBal t
   now <- getCurrentTime
   mbEntry <- QLedger.findById entryId
   forM_ mbEntry $ \entry -> do
-    let roundedSettledAmount = roundAmount settledAmount
-        updatedEntry =
+    let updatedEntry =
           entry
-            { amount = roundedSettledAmount,
+            { amount = settledAmount,
               status = SETTLED,
               settledAt = Just now,
               fromStartingBalance = Just fromStartBal,

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Settlement/Transformer.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Settlement/Transformer.hs
@@ -10,7 +10,6 @@ import qualified Kernel.External.Settlement.Interface.Types as Ext
 import Kernel.Prelude
 import Kernel.Types.Id (Id (..))
 import Kernel.Utils.Common (generateGUID, getCurrentTime)
-import Lib.Finance.Core.Money (roundAmount)
 import qualified Lib.Finance.Domain.Types.PgPaymentSettlementReport as Dom
 import qualified Lib.Finance.Storage.Beam.BeamFlow as BeamFlow
 
@@ -30,7 +29,7 @@ toPgPaymentSettlementReport merchantId merchantOperatingCityId referenceId refer
           ( report.disputeId,
             Nothing,
             Just "INITIATED",
-            Just (roundAmount report.txnAmount)
+            Just report.txnAmount
           )
         _ -> (Nothing, Nothing, Nothing, Nothing)
   pure
@@ -47,10 +46,10 @@ toPgPaymentSettlementReport merchantId merchantOperatingCityId referenceId refer
         txnType = mapTxnType report.txnType,
         txnStatus = mapTxnStatus report.txnStatus,
         txnDate = report.txnDate,
-        txnAmount = roundAmount report.txnAmount,
-        pgBaseFee = roundAmount report.pgBaseFee,
-        pgTax = roundAmount report.pgTax,
-        settlementAmount = roundAmount report.settlementAmount,
+        txnAmount = report.txnAmount,
+        pgBaseFee = report.pgBaseFee,
+        pgTax = report.pgTax,
+        settlementAmount = report.settlementAmount,
         currency = report.currency,
         vendorId = report.vendorId,
         uniqueSplitId = report.uniqueSplitId,
@@ -67,9 +66,9 @@ toPgPaymentSettlementReport merchantId merchantOperatingCityId referenceId refer
         refundId = report.refundId,
         refundArn = report.refundArn,
         refundDate = report.refundDate,
-        refundAmount = fmap roundAmount report.refundAmount,
-        refundBaseFee = fmap roundAmount report.refundBaseFee,
-        refundTax = fmap roundAmount report.refundTax,
+        refundAmount = report.refundAmount,
+        refundBaseFee = report.refundBaseFee,
+        refundTax = report.refundTax,
         refundReasonCode = Nothing,
         refundMethod = Nothing,
         chargebackId = chargebackId,


### PR DESCRIPTION
## Summary

Reverts #14911 (squash-merge commit `6cf0b16`).

That PR introduced `roundAmount` / `roundAmountByCurrency'` calls across the Finance Kernel — `Account/Service.hs`, `Core/Money.hs`, `Invoice/Service.hs`, `Ledger/Service.hs`, `Settlement/Transformer.hs`. This PR removes them and restores the unrounded amounts written before that change.

Conflict in `Ledger/Service.hs` (`settleEntry`'s `fromEndBal` / `toEndBal`) was resolved by taking the pre-PR form (no `roundAmount` wrapper).

## Test plan

- [ ] `cabal build all` passes
- [ ] Verify no remaining references to `roundAmount` from the reverted call sites
- [ ] Spot-check that ledger entries / account balances / invoice totals / settlement amounts now store unrounded values (matches behaviour prior to #14911)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed intermediate rounding from core finance flows: account balance updates, invoice totals and line-item calculations, tax transaction computations, ledger entry creation and reversals, settlement writes, and payment-settlement reporting. Monetary values are now carried and stored as computed (unrounded) amounts throughout these operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/nammayatri/pull/14990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->