### PR TITLE
backend/fix: rename conductor_token and driver_token for domain consi…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/FRFSFleetOperator.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/FRFSFleetOperator.yaml
@@ -52,8 +52,8 @@ types:
 
   FleetOperatorTripActionReq:
     action: FleetOperatorTripAction
-    conductorToken: Maybe Text
-    driverToken: Maybe Text
+    gimsConductorId: Maybe Text
+    gimsDriverId: Maybe Text
     vehicleNumber: Maybe Text
     derive: "Show"
 
@@ -63,8 +63,8 @@ types:
     derive: "Show"
 
   FleetOperatorCurrentOperationReq:
-    conductorToken: Maybe Text
-    driverToken: Maybe Text
+    gimsConductorId: Maybe Text
+    gimsDriverId: Maybe Text
     vehicleNumber: Maybe Text
     derive: "Show"
 
@@ -72,8 +72,8 @@ types:
     waybillNo: Text
     vehicleNumber: Text
     gtfsId: Text
-    conductorToken: Maybe Text
-    driverToken: Maybe Text
+    gimsConductorId: Maybe Text
+    gimsDriverId: Maybe Text
     history: "[OperatorTripInfo]"
     current: Maybe OperatorTripInfo
     upcoming: "[OperatorTripInfo]"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/FRFSFleetOperator.hs
@@ -51,14 +51,14 @@ data FRFSTripPassengerManifestResp = FRFSTripPassengerManifestResp {manifest :: 
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data FleetOperatorCurrentOperationReq = FleetOperatorCurrentOperationReq {conductorToken :: Kernel.Prelude.Maybe Data.Text.Text, driverToken :: Kernel.Prelude.Maybe Data.Text.Text, vehicleNumber :: Kernel.Prelude.Maybe Data.Text.Text}
+data FleetOperatorCurrentOperationReq = FleetOperatorCurrentOperationReq {gimsConductorId :: Kernel.Prelude.Maybe Data.Text.Text, gimsDriverId :: Kernel.Prelude.Maybe Data.Text.Text, vehicleNumber :: Kernel.Prelude.Maybe Data.Text.Text}
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data FleetOperatorCurrentOperationResp = FleetOperatorCurrentOperationResp
-  { conductorToken :: Kernel.Prelude.Maybe Data.Text.Text,
-    current :: Kernel.Prelude.Maybe OperatorTripInfo,
-    driverToken :: Kernel.Prelude.Maybe Data.Text.Text,
+  { current :: Kernel.Prelude.Maybe OperatorTripInfo,
+    gimsConductorId :: Kernel.Prelude.Maybe Data.Text.Text,
+    gimsDriverId :: Kernel.Prelude.Maybe Data.Text.Text,
     gtfsId :: Data.Text.Text,
     history :: [OperatorTripInfo],
     upcoming :: [OperatorTripInfo],
@@ -70,8 +70,8 @@ data FleetOperatorCurrentOperationResp = FleetOperatorCurrentOperationResp
 
 data FleetOperatorTripActionReq = FleetOperatorTripActionReq
   { action :: Domain.Types.FleetOperatorTripAction.FleetOperatorTripAction,
-    conductorToken :: Kernel.Prelude.Maybe Data.Text.Text,
-    driverToken :: Kernel.Prelude.Maybe Data.Text.Text,
+    gimsConductorId :: Kernel.Prelude.Maybe Data.Text.Text,
+    gimsDriverId :: Kernel.Prelude.Maybe Data.Text.Text,
     vehicleNumber :: Kernel.Prelude.Maybe Data.Text.Text
   }
   deriving stock (Generic, Show)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
@@ -178,9 +178,9 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
   let gtfsId = DIBC.feedKey integratedBPPConfig
       anchor =
         GimsOperationAnchor
-          { conductor_token = req.conductorToken,
-            driver_token = req.driverToken,
-            vehicle_number = req.vehicleNumber
+          { gimsConductorId = req.gimsConductorId,
+            gimsDriverId = req.gimsDriverId,
+            vehicleNumber = req.vehicleNumber
           }
   gimsOps <- NandiFlow.gimsCurrentOperation baseUrl gtfsId anchor
   let GimsCurrentOperationResp {waybill_no = wbNo, number_of_trips = numTrips} = gimsOps
@@ -207,7 +207,7 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
         void $ Hedis.del lockKey
         throwError $ InvalidRequest "No more trips available for this waybill"
       let nextTrip = currentTrip + 1
-          GimsOperationAnchor {conductor_token = ct, driver_token = dt, vehicle_number = vn} = anchor
+          GimsOperationAnchor {gimsConductorId = ct, gimsDriverId = dt, vehicleNumber = vn} = anchor
       flip finally (void $ Hedis.del lockKey) $ do
         void $
           NandiFlow.gimsTripAction
@@ -215,11 +215,11 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
             gtfsId
             GimsTripActionReq
               { action = GimsTripActionStart,
-                trip_number = Just nextTrip,
+                tripNumber = Just nextTrip,
                 timestamp = Just epochNow,
-                conductor_token = ct,
-                driver_token = dt,
-                vehicle_number = vn
+                gimsConductorId = ct,
+                gimsDriverId = dt,
+                vehicleNumber = vn
               }
         Hedis.setExp redisKey nextTrip 172800
         logInfo $ "FRFSFleetOperator: Trip start successful - trip " <> show nextTrip
@@ -240,7 +240,7 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
       when (currentTrip == 0) $ do
         void $ Hedis.del lockKey
         throwError $ InvalidRequest "No active trip to end"
-      let GimsOperationAnchor {conductor_token = ct, driver_token = dt, vehicle_number = vn} = anchor
+      let GimsOperationAnchor {gimsConductorId = ct, gimsDriverId = dt, vehicleNumber = vn} = anchor
       flip finally (void $ Hedis.del lockKey) $ do
         void $
           NandiFlow.gimsTripAction
@@ -248,11 +248,11 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
             gtfsId
             GimsTripActionReq
               { action = GimsTripActionEnd,
-                trip_number = Just currentTrip,
+                tripNumber = Just currentTrip,
                 timestamp = Nothing,
-                conductor_token = ct,
-                driver_token = dt,
-                vehicle_number = vn
+                gimsConductorId = ct,
+                gimsDriverId = dt,
+                vehicleNumber = vn
               }
         logInfo $ "FRFSFleetOperator: Trip end successful - trip " <> show currentTrip
         return $
@@ -267,7 +267,7 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
       unless lockAcquired $ do
         logError $ "FRFSFleetOperator: Could not acquire lock for trip reset - " <> redisKey
         throwError $ InvalidRequest "Could not acquire lock for trip action"
-      let GimsOperationAnchor {conductor_token = ct, driver_token = dt, vehicle_number = vn} = anchor
+      let GimsOperationAnchor {gimsConductorId = ct, gimsDriverId = dt, vehicleNumber = vn} = anchor
       flip finally (void $ Hedis.del lockKey) $ do
         void $
           NandiFlow.gimsTripAction
@@ -275,11 +275,11 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
             gtfsId
             GimsTripActionReq
               { action = GimsTripActionReset,
-                trip_number = Nothing,
+                tripNumber = Nothing,
                 timestamp = Nothing,
-                conductor_token = ct,
-                driver_token = dt,
-                vehicle_number = vn
+                gimsConductorId = ct,
+                gimsDriverId = dt,
+                vehicleNumber = vn
               }
         void $ Hedis.del redisKey
         return $
@@ -300,7 +300,7 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
         void $ Hedis.del lockKey
         throwError $ InvalidRequest "No trip to rollback"
       let rolledBackTrip = currentTrip - 1
-          GimsOperationAnchor {conductor_token = ct, driver_token = dt, vehicle_number = vn} = anchor
+          GimsOperationAnchor {gimsConductorId = ct, gimsDriverId = dt, vehicleNumber = vn} = anchor
       flip finally (void $ Hedis.del lockKey) $ do
         void $
           NandiFlow.gimsTripAction
@@ -308,11 +308,11 @@ postFrfsFleetOperatorTripAction (_, _merchantId, merchantOpCityId) req = do
             gtfsId
             GimsTripActionReq
               { action = GimsTripActionStart,
-                trip_number = Just rolledBackTrip,
+                tripNumber = Just rolledBackTrip,
                 timestamp = Just epochNow,
-                conductor_token = ct,
-                driver_token = dt,
-                vehicle_number = vn
+                gimsConductorId = ct,
+                gimsDriverId = dt,
+                vehicleNumber = vn
               }
         Hedis.setExp redisKey rolledBackTrip 172800
         logInfo $ "FRFSFleetOperator: Trip rollback successful - trip " <> show rolledBackTrip
@@ -341,9 +341,9 @@ postFrfsFleetOperatorCurrentOperation (_, _merchantId, merchantOpCityId) req = d
   let gtfsId = DIBC.feedKey integratedBPPConfig
       anchor =
         GimsOperationAnchor
-          { conductor_token = req.conductorToken,
-            driver_token = req.driverToken,
-            vehicle_number = req.vehicleNumber
+          { gimsConductorId = req.gimsConductorId,
+            gimsDriverId = req.gimsDriverId,
+            vehicleNumber = req.vehicleNumber
           }
   gimsOps <- NandiFlow.gimsCurrentOperation baseUrl gtfsId anchor
   let configId = getId integratedBPPConfig.id
@@ -355,19 +355,19 @@ postFrfsFleetOperatorCurrentOperation (_, _merchantId, merchantOpCityId) req = d
       baseUrl
       gtfsId
       GimsCurrentTripDetailsReq
-        { previous_trip_number = prevTrip,
-          conductor_token = req.conductorToken,
-          driver_token = req.driverToken,
-          vehicle_number = req.vehicleNumber
+        { previousTripNumber = prevTrip,
+          gimsConductorId = req.gimsConductorId,
+          gimsDriverId = req.gimsDriverId,
+          vehicleNumber = req.vehicleNumber
         }
-  let GimsCurrentTripDetailsResp {waybill_no = wNo, vehicle_number = vNum, conductor_token = cToken, driver_token = dToken, history = hist, current = curr, upcoming = upc} = tripResp
+  let GimsCurrentTripDetailsResp {waybillNo = wNo, vehicleNumber = vNum, gimsConductorId = cToken, gimsDriverId = dToken, history = hist, current = curr, upcoming = upc} = tripResp
   return $
     FleetOperatorCurrentOperationResp
       { waybillNo = wNo,
         vehicleNumber = vNum,
         gtfsId = gtfsId,
-        conductorToken = cToken,
-        driverToken = dToken,
+        gimsConductorId = cToken,
+        gimsDriverId = dToken,
         history = map transformTripInfo hist,
         current = transformTripInfo <$> curr,
         upcoming = map transformTripInfo upc

--- a/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
+++ b/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
@@ -221,13 +221,34 @@ instance FromJSON GimsTripAction where
 
 data GimsTripActionReq = GimsTripActionReq
   { action :: GimsTripAction,
-    trip_number :: Maybe Int,
+    tripNumber :: Maybe Int,
     timestamp :: Maybe Int64,
-    conductor_token :: Maybe Text,
-    driver_token :: Maybe Text,
-    vehicle_number :: Maybe Text
+    gimsConductorId :: Maybe Text,
+    gimsDriverId :: Maybe Text,
+    vehicleNumber :: Maybe Text
   }
-  deriving (Generic, FromJSON, ToJSON, Show)
+  deriving (Generic, Show)
+
+instance FromJSON GimsTripActionReq where
+  parseJSON = withObject "GimsTripActionReq" $ \o ->
+    GimsTripActionReq
+      <$> o .: "action"
+      <*> o .:? "trip_number"
+      <*> o .:? "timestamp"
+      <*> o .:? "conductor_token"
+      <*> o .:? "driver_token"
+      <*> o .:? "vehicle_number"
+
+instance ToJSON GimsTripActionReq where
+  toJSON GimsTripActionReq {..} =
+    object
+      [ "action" .= action,
+        "trip_number" .= tripNumber,
+        "timestamp" .= timestamp,
+        "conductor_token" .= gimsConductorId,
+        "driver_token" .= gimsDriverId,
+        "vehicle_number" .= vehicleNumber
+      ]
 
 data GimsCurrentOperationResp = GimsCurrentOperationResp
   { waybill_no :: Text,
@@ -236,12 +257,29 @@ data GimsCurrentOperationResp = GimsCurrentOperationResp
   deriving (Generic, FromJSON, ToJSON, Show)
 
 data GimsCurrentTripDetailsReq = GimsCurrentTripDetailsReq
-  { previous_trip_number :: Int,
-    conductor_token :: Maybe Text,
-    driver_token :: Maybe Text,
-    vehicle_number :: Maybe Text
+  { previousTripNumber :: Int,
+    gimsConductorId :: Maybe Text,
+    gimsDriverId :: Maybe Text,
+    vehicleNumber :: Maybe Text
   }
-  deriving (Generic, FromJSON, ToJSON, Show)
+  deriving (Generic, Show)
+
+instance FromJSON GimsCurrentTripDetailsReq where
+  parseJSON = withObject "GimsCurrentTripDetailsReq" $ \o ->
+    GimsCurrentTripDetailsReq
+      <$> o .: "previous_trip_number"
+      <*> o .:? "conductor_token"
+      <*> o .:? "driver_token"
+      <*> o .:? "vehicle_number"
+
+instance ToJSON GimsCurrentTripDetailsReq where
+  toJSON GimsCurrentTripDetailsReq {..} =
+    object
+      [ "previous_trip_number" .= previousTripNumber,
+        "conductor_token" .= gimsConductorId,
+        "driver_token" .= gimsDriverId,
+        "vehicle_number" .= vehicleNumber
+      ]
 
 data GimsTripInfo = GimsTripInfo
   { trip_number :: Int,
@@ -269,22 +307,60 @@ instance FromJSON GimsTripInfo where
     return GimsTripInfo {..}
 
 data GimsCurrentTripDetailsResp = GimsCurrentTripDetailsResp
-  { waybill_no :: Text,
-    vehicle_number :: Text,
-    conductor_token :: Maybe Text,
-    driver_token :: Maybe Text,
+  { waybillNo :: Text,
+    vehicleNumber :: Text,
+    gimsConductorId :: Maybe Text,
+    gimsDriverId :: Maybe Text,
     history :: [GimsTripInfo],
     current :: Maybe GimsTripInfo,
     upcoming :: [GimsTripInfo]
   }
-  deriving (Generic, FromJSON, ToJSON, Show)
+  deriving (Generic, Show)
+
+instance FromJSON GimsCurrentTripDetailsResp where
+  parseJSON = withObject "GimsCurrentTripDetailsResp" $ \o ->
+    GimsCurrentTripDetailsResp
+      <$> o .: "waybill_no"
+      <*> o .: "vehicle_number"
+      <*> o .:? "conductor_token"
+      <*> o .:? "driver_token"
+      <*> o .: "history"
+      <*> o .:? "current"
+      <*> o .: "upcoming"
+
+instance ToJSON GimsCurrentTripDetailsResp where
+  toJSON GimsCurrentTripDetailsResp {..} =
+    object
+      [ "waybill_no" .= waybillNo,
+        "vehicle_number" .= vehicleNumber,
+        "conductor_token" .= gimsConductorId,
+        "driver_token" .= gimsDriverId,
+        "history" .= history,
+        "current" .= current,
+        "upcoming" .= upcoming
+      ]
 
 data GimsOperationAnchor = GimsOperationAnchor
-  { conductor_token :: Maybe Text,
-    driver_token :: Maybe Text,
-    vehicle_number :: Maybe Text
+  { gimsConductorId :: Maybe Text,
+    gimsDriverId :: Maybe Text,
+    vehicleNumber :: Maybe Text
   }
-  deriving (Generic, FromJSON, ToJSON, Show)
+  deriving (Generic, Show)
+
+instance FromJSON GimsOperationAnchor where
+  parseJSON = withObject "GimsOperationAnchor" $ \o ->
+    GimsOperationAnchor
+      <$> o .:? "conductor_token"
+      <*> o .:? "driver_token"
+      <*> o .:? "vehicle_number"
+
+instance ToJSON GimsOperationAnchor where
+  toJSON GimsOperationAnchor {..} =
+    object
+      [ "conductor_token" .= gimsConductorId,
+        "driver_token" .= gimsDriverId,
+        "vehicle_number" .= vehicleNumber
+      ]
 
 instance HideSecrets GimsOperationAnchor where
   hideSecrets = identity


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated fleet operator API to use GIMS-based conductor and driver identifiers instead of token-based authentication for trip action and current operation requests and responses. The `gimsConductorId` and `gimsDriverId` fields now replace the previous token fields, enabling improved integration with GIMS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->