### PR TITLE
backend/fix: Image upload in sync s3 - onboarding

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
@@ -216,9 +216,15 @@ validateImageHandler isDashboard mbUploaderRole mbDocConfigs (personId, _, merch
         $ throwError $ DocumentAlreadyValidated (show imageType)
 
       imagePath <- createPath personId.getId merchantId.getId imageType fileExtension
-      fork "S3 Put Image" do
-        Redis.withLockRedis (imageS3Lock imagePath) 5 $
-          S3.put (T.unpack imagePath) image
+      s3Result <-
+        withTryCatch "S3:put:uploadImage" $
+          Redis.withLockRedis (imageS3Lock imagePath) 5 $
+            S3.put (T.unpack imagePath) image
+      case s3Result of
+        Left err -> do
+          logError $ "Image upload failed to S3:" <> show err
+          throwError $ InternalError ("Image upload failed. Please try again")
+        Right _ -> pure ()
       imageEntity <- mkImage personId merchantId (Just merchantOpCityId) imagePath imageType mbRcId (convertValidationStatusToVerificationStatus <$> validationStatus) workflowTransactionId sdkFailureReason
       Query.create imageEntity
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image uploads during driver onboarding now surface errors instead of failing silently — users will see a clear "please try again" message when an upload fails.
  * Uploads are now completed within the onboarding flow (no longer fire-and-forget), ensuring failures are detected and reported before the process continues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->