### PR TITLE
backend/fix: Fix rideList and communication template handling

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Communication.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Communication.hs
@@ -41,6 +41,7 @@ import qualified IssueManagement.Storage.Queries.MediaFile as MFQuery
 import Kernel.Beam.Functions as B
 import Kernel.External.Encryption (decrypt, getDbHash)
 import Kernel.External.Notification.FCM.Types as FCM
+import qualified Kernel.External.SMS.Interface as SmsInterface
 import Kernel.Sms.Config (SmsConfig)
 import qualified Kernel.Storage.Hedis as Hedis
 import Kernel.Streaming.Kafka.Producer (produceMessage)
@@ -57,6 +58,7 @@ import qualified Storage.Cac.TransporterConfig as SCTC
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.CachedQueries.Merchant.MerchantMessage as CMM
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import qualified Storage.CachedQueries.Merchant.MerchantServiceUsageConfig as CQMSUC
 import qualified Storage.Queries.Communication as QComm
 import qualified Storage.Queries.CommunicationDelivery as QDelivery
 import qualified Storage.Queries.FleetDriverAssociationExtra as QFDA
@@ -967,23 +969,33 @@ getCommunicationTemplate ::
 getCommunicationTemplate merchantShortId opCity apiDomain apiChannel = do
   merchant <- CQM.findByShortId merchantShortId >>= fromMaybeM (MerchantNotFound merchantShortId.getShortId)
   merchantOpCityId <- CQMOC.getMerchantOpCityId Nothing merchant (Just opCity)
-  let mmDomain :: DMM.MessageDomain
-      mmDomain =
-        case apiDomain of
-          CommAPI.COMM_FLEET -> DMM.FLEET
-          CommAPI.COMM_RIDE_HAILING -> DMM.RIDE_HAILING
-          CommAPI.COMM_GENERAL -> DMM.GENERAL
-      mmChannel :: DMM.MediaChannel
-      mmChannel =
-        case apiChannel of
-          CommAPI.CH_SMS -> DMM.SMS
-          CommAPI.CH_WHATSAPP -> DMM.WHATSAPP
-          _ -> DMM.SMS -- fallback for unsupported channels
-  mbTemplate <- QMM.findByMerchantOpCityIdDomainAndChannel merchantOpCityId (Just mmDomain) (Just mmChannel)
-  template <- fromMaybeM (InvalidRequest "Template not found for given domain & channel") mbTemplate
-  pure
-    CommAPI.CommunicationTemplateResponse
-      { templateId = template.templateId,
-        messageBody = template.message,
-        templateName = template.templateName
-      }
+  merchantServiceUsageConfig <- CQMSUC.findByMerchantOpCityId merchantOpCityId >>= fromMaybeM (MerchantServiceUsageConfigNotFound merchantOpCityId.getId)
+  if SmsInterface.TwillioSms `elem` merchantServiceUsageConfig.smsProvidersPriorityList
+    then
+      pure
+        CommAPI.CommunicationTemplateResponse
+          { templateId = "",
+            messageBody = "",
+            templateName = Nothing
+          }
+    else do
+      let mmDomain :: DMM.MessageDomain
+          mmDomain =
+            case apiDomain of
+              CommAPI.COMM_FLEET -> DMM.FLEET
+              CommAPI.COMM_RIDE_HAILING -> DMM.RIDE_HAILING
+              CommAPI.COMM_GENERAL -> DMM.GENERAL
+          mmChannel :: DMM.MediaChannel
+          mmChannel =
+            case apiChannel of
+              CommAPI.CH_SMS -> DMM.SMS
+              CommAPI.CH_WHATSAPP -> DMM.WHATSAPP
+              _ -> DMM.SMS -- fallback for unsupported channels
+      mbTemplate <- QMM.findByMerchantOpCityIdDomainAndChannel merchantOpCityId (Just mmDomain) (Just mmChannel)
+      template <- fromMaybeM (InvalidRequest "Template not found for given domain & channel") mbTemplate
+      pure
+        CommAPI.CommunicationTemplateResponse
+          { templateId = template.templateId,
+            messageBody = template.message,
+            templateName = template.templateName
+          }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Ride.hs
@@ -34,6 +34,7 @@ where
 
 import qualified "dashboard-helper-api" API.Types.ProviderPlatform.Management.Ride as Common
 import Data.Coerce (coerce)
+import qualified Domain.Action.Dashboard.Common as DCommon
 import qualified Domain.Action.Dashboard.Ride as DRide
 import qualified Domain.Action.Dashboard.RideFlowDebug as RideFlowDebug
 import qualified Domain.Action.UI.Ride.CancelRide as CHandler
@@ -82,7 +83,9 @@ getRideList ::
   Flow Common.RideListRes
 getRideList merchantShortId opCity requestorId mbBookingStatus mbCurrency mbCustomerCountryCode mbCustomerPhone mbDriverCountryCode mbDriverId mbDriverPhone mbFleetOwnerId mbfrom mbFromAmount mbLimit mbOffset mbPaymentMode mbRideId mbReqShortRideId mbto mbToAmount = do
   logInfo $ "Ride list requested by: " <> requestorId
-  DRide.getRideList merchantShortId opCity mbBookingStatus mbCurrency mbCustomerPhone mbDriverPhone mbfrom mbLimit mbOffset mbPaymentMode mbRideId mbReqShortRideId mbto mbFleetOwnerId mbFromAmount mbToAmount (getId <$> mbDriverId) mbCustomerCountryCode mbDriverCountryCode requestorId
+  let customerCountryCode = DCommon.appendPlusInMobileCountryCode mbCustomerCountryCode
+      driverCountryCode = DCommon.appendPlusInMobileCountryCode mbDriverCountryCode
+  DRide.getRideList merchantShortId opCity mbBookingStatus mbCurrency mbCustomerPhone mbDriverPhone mbfrom mbLimit mbOffset mbPaymentMode mbRideId mbReqShortRideId mbto mbFleetOwnerId mbFromAmount mbToAmount (getId <$> mbDriverId) customerCountryCode driverCountryCode requestorId
 
 getRideAgentList ::
   ShortId DM.Merchant ->


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SMS communication handling for merchants using specific SMS service providers
  * Improved mobile country code formatting in ride listing and management features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->