### PR TITLE
backend/feat: add driver_identity_info table for nominee+address (backward-compatible fallback)

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -500,6 +500,7 @@ library
       SharedLogic.DriverFee
       SharedLogic.DriverFleetOperatorAssociation
       SharedLogic.DriverFlowStatus
+      SharedLogic.DriverIdentityInfo
       SharedLogic.DriverOnboarding
       SharedLogic.DriverOnboarding.Digilocker
       SharedLogic.DriverOnboarding.Status
@@ -1166,6 +1167,7 @@ library
       Domain.Types.DriverGstin
       Domain.Types.DriverGullakAssociation
       Domain.Types.DriverHomeLocation
+      Domain.Types.DriverIdentityInfo
       Domain.Types.DriverInformation
       Domain.Types.DriverIntelligentPoolConfig
       Domain.Types.DriverLicense
@@ -1349,6 +1351,7 @@ library
       Storage.Beam.DriverGstin
       Storage.Beam.DriverGullakAssociation
       Storage.Beam.DriverHomeLocation
+      Storage.Beam.DriverIdentityInfo
       Storage.Beam.DriverInformation
       Storage.Beam.DriverIntelligentPoolConfig
       Storage.Beam.DriverLicense
@@ -1537,6 +1540,7 @@ library
       Storage.Queries.DriverGstin
       Storage.Queries.DriverGullakAssociation
       Storage.Queries.DriverHomeLocation
+      Storage.Queries.DriverIdentityInfo
       Storage.Queries.DriverInformation
       Storage.Queries.DriverIntelligentPoolConfig
       Storage.Queries.DriverLicense
@@ -1638,6 +1642,7 @@ library
       Storage.Queries.OrphanInstances.DriverGoHomeRequest
       Storage.Queries.OrphanInstances.DriverGstin
       Storage.Queries.OrphanInstances.DriverHomeLocation
+      Storage.Queries.OrphanInstances.DriverIdentityInfo
       Storage.Queries.OrphanInstances.DriverInformation
       Storage.Queries.OrphanInstances.DriverLicense
       Storage.Queries.OrphanInstances.DriverOperatorAssociation

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverIdentityInfo.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverIdentityInfo.yaml
@@ -1,0 +1,33 @@
+imports:
+  Merchant: Domain.Types.Merchant
+  MerchantOperatingCity: Domain.Types.MerchantOperatingCity
+  Person: Domain.Types.Person
+  AddressDocumentType: Domain.Types.DriverInformation
+  Day: Data.Time
+  IndianState: Kernel.Types.Beckn.Context
+
+DriverIdentityInfo:
+  tableName: driver_identity_info
+
+  fields:
+    driverId: Id Person
+    nomineeName: Maybe Text
+    nomineeRelationship: Maybe Text
+    nomineeDob: Maybe Day
+    address: Maybe Text
+    addressDocumentType: Maybe AddressDocumentType
+    addressState: Maybe IndianState
+    merchantId: Id Merchant
+    merchantOperatingCityId: Id MerchantOperatingCity
+    createdAt: UTCTime
+    updatedAt: UTCTime
+
+  constraints:
+    driverId: PrimaryKey
+
+  queries:
+    findByDriverId:
+      kvFunction: findOneWithKV
+      where: driverId
+
+  excludedFields: [merchantId, merchantOperatingCityId, createdAt, updatedAt]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverInformation.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/DriverInformation.yaml
@@ -157,10 +157,10 @@ DriverInformation:
     onboardingAs: Maybe OnboardingAs
     approved: Maybe Bool
     docsVerificationStatus: Maybe DocsVerificationStatus
-    address: Maybe Text
-    addressDocumentType: Maybe AddressDocumentType
-    nomineeName: Maybe Text
-    nomineeRelationship: Maybe Text
+    address: Maybe Text # deprecated: moved to driver_identity_info;
+    addressDocumentType: Maybe AddressDocumentType # deprecated: moved to driver_identity_info;
+    nomineeName: Maybe Text # deprecated: moved to driver_identity_info;
+    nomineeRelationship: Maybe Text # deprecated: moved to driver_identity_info;
 
   default:
     active: "false"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/DriverIdentityInfo.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/DriverIdentityInfo.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Domain.Types.DriverIdentityInfo where
+
+import Data.Aeson
+import qualified Data.Time
+import qualified Domain.Types.DriverInformation
+import qualified Domain.Types.Merchant
+import qualified Domain.Types.MerchantOperatingCity
+import qualified Domain.Types.Person
+import Kernel.Prelude
+import qualified Kernel.Types.Beckn.Context
+import qualified Kernel.Types.Id
+import qualified Tools.Beam.UtilsTH
+
+data DriverIdentityInfo = DriverIdentityInfo
+  { address :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    addressDocumentType :: Kernel.Prelude.Maybe Domain.Types.DriverInformation.AddressDocumentType,
+    addressState :: Kernel.Prelude.Maybe Kernel.Types.Beckn.Context.IndianState,
+    createdAt :: Kernel.Prelude.UTCTime,
+    driverId :: Kernel.Types.Id.Id Domain.Types.Person.Person,
+    merchantId :: Kernel.Types.Id.Id Domain.Types.Merchant.Merchant,
+    merchantOperatingCityId :: Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity,
+    nomineeDob :: Kernel.Prelude.Maybe Data.Time.Day,
+    nomineeName :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    nomineeRelationship :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    updatedAt :: Kernel.Prelude.UTCTime
+  }
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/DriverIdentityInfo.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/DriverIdentityInfo.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Beam.DriverIdentityInfo where
+
+import qualified Data.Time
+import qualified Database.Beam as B
+import Domain.Types.Common ()
+import qualified Domain.Types.DriverInformation
+import Kernel.External.Encryption
+import Kernel.Prelude
+import qualified Kernel.Prelude
+import qualified Kernel.Types.Beckn.Context
+import Tools.Beam.UtilsTH
+
+data DriverIdentityInfoT f = DriverIdentityInfoT
+  { address :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    addressDocumentType :: B.C f (Kernel.Prelude.Maybe Domain.Types.DriverInformation.AddressDocumentType),
+    addressState :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Beckn.Context.IndianState),
+    createdAt :: B.C f Kernel.Prelude.UTCTime,
+    driverId :: B.C f Kernel.Prelude.Text,
+    merchantId :: B.C f Kernel.Prelude.Text,
+    merchantOperatingCityId :: B.C f Kernel.Prelude.Text,
+    nomineeDob :: B.C f (Kernel.Prelude.Maybe Data.Time.Day),
+    nomineeName :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    nomineeRelationship :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    updatedAt :: B.C f Kernel.Prelude.UTCTime
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table DriverIdentityInfoT where
+  data PrimaryKey DriverIdentityInfoT f = DriverIdentityInfoId (B.C f Kernel.Prelude.Text) deriving (Generic, B.Beamable)
+  primaryKey = DriverIdentityInfoId . driverId
+
+type DriverIdentityInfo = DriverIdentityInfoT Identity
+
+$(enableKVPG ''DriverIdentityInfoT ['driverId] [])
+
+$(mkTableInstances ''DriverIdentityInfoT "driver_identity_info")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/DriverIdentityInfo.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/DriverIdentityInfo.hs
@@ -1,0 +1,45 @@
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Queries.DriverIdentityInfo where
+
+import qualified Domain.Types.DriverIdentityInfo
+import qualified Domain.Types.Person
+import Kernel.Beam.Functions
+import Kernel.External.Encryption
+import Kernel.Prelude
+import Kernel.Types.Error
+import qualified Kernel.Types.Id
+import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
+import qualified Sequelize as Se
+import qualified Storage.Beam.DriverIdentityInfo as Beam
+import Storage.Queries.OrphanInstances.DriverIdentityInfo ()
+
+create :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.DriverIdentityInfo.DriverIdentityInfo -> m ())
+create = createWithKV
+
+createMany :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => ([Domain.Types.DriverIdentityInfo.DriverIdentityInfo] -> m ())
+createMany = traverse_ create
+
+findByDriverId :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Types.Id.Id Domain.Types.Person.Person -> m (Maybe Domain.Types.DriverIdentityInfo.DriverIdentityInfo))
+findByDriverId driverId = do findOneWithKV [Se.Is Beam.driverId $ Se.Eq (Kernel.Types.Id.getId driverId)]
+
+findByPrimaryKey :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Types.Id.Id Domain.Types.Person.Person -> m (Maybe Domain.Types.DriverIdentityInfo.DriverIdentityInfo))
+findByPrimaryKey driverId = do findOneWithKV [Se.And [Se.Is Beam.driverId $ Se.Eq (Kernel.Types.Id.getId driverId)]]
+
+updateByPrimaryKey :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.DriverIdentityInfo.DriverIdentityInfo -> m ())
+updateByPrimaryKey (Domain.Types.DriverIdentityInfo.DriverIdentityInfo {..}) = do
+  _now <- getCurrentTime
+  updateWithKV
+    [ Se.Set Beam.address address,
+      Se.Set Beam.addressDocumentType addressDocumentType,
+      Se.Set Beam.addressState addressState,
+      Se.Set Beam.merchantId (Kernel.Types.Id.getId merchantId),
+      Se.Set Beam.merchantOperatingCityId (Kernel.Types.Id.getId merchantOperatingCityId),
+      Se.Set Beam.nomineeDob nomineeDob,
+      Se.Set Beam.nomineeName nomineeName,
+      Se.Set Beam.nomineeRelationship nomineeRelationship,
+      Se.Set Beam.updatedAt _now
+    ]
+    [Se.And [Se.Is Beam.driverId $ Se.Eq (Kernel.Types.Id.getId driverId)]]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/DriverIdentityInfo.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/DriverIdentityInfo.hs
@@ -1,0 +1,47 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Queries.OrphanInstances.DriverIdentityInfo where
+
+import qualified Domain.Types.DriverIdentityInfo
+import Kernel.Beam.Functions
+import Kernel.External.Encryption
+import Kernel.Prelude
+import Kernel.Types.Error
+import qualified Kernel.Types.Id
+import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
+import qualified Storage.Beam.DriverIdentityInfo as Beam
+
+instance FromTType' Beam.DriverIdentityInfo Domain.Types.DriverIdentityInfo.DriverIdentityInfo where
+  fromTType' (Beam.DriverIdentityInfoT {..}) = do
+    pure $
+      Just
+        Domain.Types.DriverIdentityInfo.DriverIdentityInfo
+          { address = address,
+            addressDocumentType = addressDocumentType,
+            addressState = addressState,
+            createdAt = createdAt,
+            driverId = Kernel.Types.Id.Id driverId,
+            merchantId = Kernel.Types.Id.Id merchantId,
+            merchantOperatingCityId = Kernel.Types.Id.Id merchantOperatingCityId,
+            nomineeDob = nomineeDob,
+            nomineeName = nomineeName,
+            nomineeRelationship = nomineeRelationship,
+            updatedAt = updatedAt
+          }
+
+instance ToTType' Beam.DriverIdentityInfo Domain.Types.DriverIdentityInfo.DriverIdentityInfo where
+  toTType' (Domain.Types.DriverIdentityInfo.DriverIdentityInfo {..}) = do
+    Beam.DriverIdentityInfoT
+      { Beam.address = address,
+        Beam.addressDocumentType = addressDocumentType,
+        Beam.addressState = addressState,
+        Beam.createdAt = createdAt,
+        Beam.driverId = Kernel.Types.Id.getId driverId,
+        Beam.merchantId = Kernel.Types.Id.getId merchantId,
+        Beam.merchantOperatingCityId = Kernel.Types.Id.getId merchantOperatingCityId,
+        Beam.nomineeDob = nomineeDob,
+        Beam.nomineeName = nomineeName,
+        Beam.nomineeRelationship = nomineeRelationship,
+        Beam.updatedAt = updatedAt
+      }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
@@ -192,6 +192,7 @@ import SharedLogic.AnalyticsExtra as AnalyticsExtra
 import qualified SharedLogic.Booking as SBooking
 import qualified SharedLogic.DriverFleetOperatorAssociation as SA
 import qualified SharedLogic.DriverFlowStatus as SDF
+import qualified SharedLogic.DriverIdentityInfo as DIInfo
 import SharedLogic.DriverOnboarding
 import qualified SharedLogic.DriverOnboarding.Status as SStatus
 import qualified SharedLogic.External.LocationTrackingService.Flow as LF
@@ -228,6 +229,7 @@ import qualified Storage.Queries.AlertRequest as QAR
 import qualified Storage.Queries.Booking as QRB
 import qualified Storage.Queries.DriverBankAccount as QDBA
 import qualified Storage.Queries.DriverGstinExtra as QDGExtra
+import qualified Storage.Queries.DriverIdentityInfo as QDII
 import qualified Storage.Queries.DriverInformation as QDriverInfo
 import qualified Storage.Queries.DriverLicense as QDriverLicense
 import qualified Storage.Queries.DriverOperatorAssociation as DOV
@@ -4530,9 +4532,10 @@ postDriverFleetDriverUpdate merchantShortId opCity driverId requestorId req = do
         DP.DRIVER -> do
           driverInfo <- QDriverInfo.findById personId >>= fromMaybeM DriverInfoNotFound
           let dob = fmap (\d -> UTCTime d 0) req.dob <|> driverInfo.driverDob
-              address = req.address <|> driverInfo.address
-              addressDocumentType = castAddressDocumentType <$> req.addressDocumentType <|> driverInfo.addressDocumentType
-          QDriverInfo.updateDriverDobAndAddress dob address addressDocumentType personId
+          Redis.withLockRedis (DIInfo.driverIdentityInfoLockKey personId) 10 $ do
+            mbExisting <- QDII.findByDriverId personId
+            void $ DIInfo.upsertDriverIdentityInfo mbExisting personId driver.merchantId driver.merchantOperatingCityId driverInfo Nothing Nothing Nothing req.address (castAddressDocumentType <$> req.addressDocumentType) Nothing
+          QDriverInfo.updateDriverDobAndAddress dob Nothing Nothing personId
         role | DCommon.checkFleetOwnerRole role -> do
           fleetOwnerInfo <- B.runInReplica (FOI.findByPrimaryKey personId) >>= fromMaybeM (InvalidRequest "Fleet owner information does not exist")
           reqStripeIdNumber <- forM req.stripeIdNumber encrypt

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -257,6 +257,7 @@ import SharedLogic.CallBAP (sendDriverOffer, sendRideAssignedUpdateToBAP)
 import qualified SharedLogic.CallInternalMLPricing as ML
 import qualified SharedLogic.DeleteDriver as DeleteDriverOnCheck
 import qualified SharedLogic.DriverFee as SLDriverFee
+import qualified SharedLogic.DriverIdentityInfo as DIInfo
 import SharedLogic.DriverOnboarding
 import SharedLogic.DriverPool as DP
 import qualified SharedLogic.EventTracking as ET
@@ -300,6 +301,7 @@ import qualified Storage.Queries.DriverFee as QDF
 import qualified Storage.Queries.DriverGoHomeRequest as QDGR
 import qualified Storage.Queries.DriverGstinExtra as QDGExtra
 import qualified Storage.Queries.DriverHomeLocation as QDHL
+import qualified Storage.Queries.DriverIdentityInfo as QDII
 import qualified Storage.Queries.DriverInformation as QDriverInformation
 import qualified Storage.Queries.DriverOperatorAssociationExtra as QDOA
 import qualified Storage.Queries.DriverPanCard as QPanCard
@@ -476,7 +478,8 @@ data DriverInformationRes = DriverInformationRes
     membershipId :: Maybe (Id DStclMembership.StclMembership),
     createdAt :: UTCTime,
     role :: SP.Role,
-    operatorBadgeToken :: Maybe Text
+    operatorBadgeToken :: Maybe Text,
+    nomineeDob :: Maybe Day
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
 
@@ -564,7 +567,8 @@ data DriverEntityRes = DriverEntityRes
     vehicleImageUploadedAt :: Maybe UTCTime,
     subscriptionCreditBalance :: Maybe HighPrecMoney,
     role :: SP.Role,
-    operatorBadgeToken :: Maybe Text
+    operatorBadgeToken :: Maybe Text,
+    nomineeDob :: Maybe Day
   }
   deriving (Show, Generic, FromJSON, ToJSON, ToSchema)
 
@@ -601,7 +605,9 @@ data UpdateDriverReq = UpdateDriverReq
     address :: Maybe Text,
     addressDocumentType :: Maybe DriverInfo.AddressDocumentType,
     nomineeName :: Maybe Text,
-    nomineeRelationship :: Maybe Text
+    nomineeRelationship :: Maybe Text,
+    nomineeDob :: Maybe Day,
+    addressState :: Maybe Context.IndianState
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema, Show)
 
@@ -906,7 +912,8 @@ getInformation (personId, merchantId, merchantOpCityId) mbClientId toss tnant' c
   merchant <-
     CQM.findById merchantId
       >>= fromMaybeM (MerchantNotFound merchantId.getId)
-  driverEntity <- buildDriverEntityRes (person, driverInfo, driverStats, merchantOpCityId) merchant serviceName
+  mbIdentity <- QDII.findByDriverId person.id
+  driverEntity <- buildDriverEntityRes (person, driverInfo, driverStats, merchantOpCityId, DIInfo.getIdentityInfo mbIdentity driverInfo) merchant serviceName
   dues <- QDF.findAllFeeByTypeServiceStatusAndDriver serviceName driverId [DDF.RECURRING_INVOICE, DDF.RECURRING_EXECUTION_INVOICE] [DDF.PAYMENT_PENDING, DDF.PAYMENT_OVERDUE]
   let currentDues = sum $ map (\dueInvoice -> SLDriverFee.roundToHalf dueInvoice.currency (dueInvoice.govtCharges + dueInvoice.platformFee.fee + dueInvoice.platformFee.cgst + dueInvoice.platformFee.sgst)) dues
   let manualDues = sum $ map (\dueInvoice -> SLDriverFee.roundToHalf dueInvoice.currency (dueInvoice.govtCharges + dueInvoice.platformFee.fee + dueInvoice.platformFee.cgst + dueInvoice.platformFee.sgst)) $ filter (\due -> due.status == DDF.PAYMENT_OVERDUE) dues
@@ -1150,11 +1157,11 @@ buildDriverEntityRes ::
     Redis.HedisLTSFlowEnv r,
     EsqDBFlow m r
   ) =>
-  (SP.Person, DriverInformation, DStats.DriverStats, Id DMOC.MerchantOperatingCity) ->
+  (SP.Person, DriverInformation, DStats.DriverStats, Id DMOC.MerchantOperatingCity, DIInfo.IdentityInfo) ->
   DM.Merchant ->
   Plan.ServiceNames ->
   m DriverEntityRes
-buildDriverEntityRes (person, driverInfo, driverStats, merchantOpCityId) merchant serviceName = do
+buildDriverEntityRes (person, driverInfo, driverStats, merchantOpCityId, identityInfo) merchant serviceName = do
   transporterConfig <- getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) (Just (SCTC.findByMerchantOpCityId person.merchantOperatingCityId Nothing)) >>= fromMaybeM (TransporterConfigNotFound person.merchantOperatingCityId.getId)
   vehicleMB <- QVehicle.findById person.id
   DriverSpecificSubscriptionData {mbDriverPlan = driverPlan, ..} <- getDriverSpecificSubscriptionDataWithSubsConfig (person.id, transporterConfig.merchantId, merchantOpCityId) transporterConfig driverInfo vehicleMB serviceName
@@ -1309,8 +1316,9 @@ buildDriverEntityRes (person, driverInfo, driverStats, merchantOpCityId) merchan
         isTTSEnabled = driverInfo.isTTSEnabled,
         isHighAccuracyLocationEnabled = driverInfo.isHighAccuracyLocationEnabled,
         rideRequestVolumeEnabled = driverInfo.rideRequestVolumeEnabled,
-        nomineeName = driverInfo.nomineeName,
-        nomineeRelationship = driverInfo.nomineeRelationship,
+        nomineeName = identityInfo.nomineeName,
+        nomineeRelationship = identityInfo.nomineeRelationship,
+        nomineeDob = identityInfo.nomineeDob,
         subscriptionCreditBalance = subsCreditBalance,
         role = person.role,
         operatorBadgeToken = if person.role `elem` [SP.BUS_CONDUCTOR, SP.BUS_DRIVER] then person.operatorBadgeToken else Nothing,
@@ -1403,10 +1411,6 @@ updateDriver (personId, _, merchantOpCityId) mbBundleVersion mbClientVersion mbC
       isHighAccuracyLocationEnabled = req.isHighAccuracyLocationEnabled <|> driverInfo.isHighAccuracyLocationEnabled
       rideRequestVolumeEnabled = req.rideRequestVolumeEnabled <|> driverInfo.rideRequestVolumeEnabled
       onboardingAs = req.onboardingAs <|> driverInfo.onboardingAs
-      address = req.address <|> driverInfo.address
-      addressDocumentType = req.addressDocumentType <|> driverInfo.addressDocumentType
-      nomineeName = req.nomineeName <|> driverInfo.nomineeName
-      nomineeRelationship = req.nomineeRelationship <|> driverInfo.nomineeRelationship
   -- Compute vehicle-related fields (use existing values if no vehicle or no request)
   (canDowngradeToSedan, canDowngradeToHatchback, canDowngradeToTaxi, canSwitchToRental, canSwitchToInterCity, canSwitchToIntraCity, availableUpiApps) <-
     case mVehicle of
@@ -1464,9 +1468,20 @@ updateDriver (personId, _, merchantOpCityId) mbBundleVersion mbClientVersion mbC
               DV.AUTO_LITE -> [DVST.AUTO_LITE]
               DV.PINK_AUTO -> [DVST.PINK_AUTO]
       QVehicle.updateSelectedServiceTiers selectedServiceTiers person.id
+  let nomineeOrAddressChanged = isJust req.nomineeName || isJust req.nomineeRelationship || isJust req.nomineeDob || isJust req.address || isJust req.addressDocumentType || isJust req.addressState
+  mbIdentityInfo <-
+    if nomineeOrAddressChanged
+      then Redis.withLockRedisAndReturnValue (DIInfo.driverIdentityInfoLockKey personId) 10 $ do
+        mbExisting <- QDII.findByDriverId personId
+        Just <$> DIInfo.upsertDriverIdentityInfo mbExisting personId person.merchantId merchantOpCityId driverInfo req.nomineeName req.nomineeRelationship req.nomineeDob req.address req.addressDocumentType req.addressState
+      else QDII.findByDriverId personId
+  let (legacyAddress, legacyAddressDocumentType, legacyNomineeName, legacyNomineeRelationship) =
+        if nomineeOrAddressChanged
+          then (Nothing, Nothing, Nothing, Nothing)
+          else (driverInfo.address, driverInfo.addressDocumentType, driverInfo.nomineeName, driverInfo.nomineeRelationship)
   -- Update driver information (works for both cases: with or without vehicle)
   when (isJust req.canDowngradeToSedan || isJust req.canDowngradeToHatchback || isJust req.canDowngradeToTaxi || isJust req.canSwitchToRental || isJust req.canSwitchToInterCity || isJust req.availableUpiApps || isJust req.isPetModeEnabled || isJust req.tripDistanceMaxThreshold || isJust req.tripDistanceMinThreshold || isJust req.maxPickupRadius || isJust req.isSilentModeEnabled || isJust req.rideRequestVolume || isJust req.isTTSEnabled || isJust req.isHighAccuracyLocationEnabled || isJust req.rideRequestVolumeEnabled || isJust req.onboardingAs || isJust req.address || isJust req.addressDocumentType || isJust req.nomineeName || isJust req.nomineeRelationship) $ do
-    QDriverInformation.updateDriverInformation canDowngradeToSedan canDowngradeToHatchback canDowngradeToTaxi canSwitchToRental canSwitchToInterCity canSwitchToIntraCity availableUpiApps isPetModeEnabled tripDistanceMaxThreshold tripDistanceMinThreshold maxPickupRadius isSilentModeEnabled rideRequestVolume isTTSEnabled isHighAccuracyLocationEnabled rideRequestVolumeEnabled onboardingAs address addressDocumentType nomineeName nomineeRelationship person.id
+    QDriverInformation.updateDriverInformation canDowngradeToSedan canDowngradeToHatchback canDowngradeToTaxi canSwitchToRental canSwitchToInterCity canSwitchToIntraCity availableUpiApps isPetModeEnabled tripDistanceMaxThreshold tripDistanceMinThreshold maxPickupRadius isSilentModeEnabled rideRequestVolume isTTSEnabled isHighAccuracyLocationEnabled rideRequestVolumeEnabled onboardingAs legacyAddress legacyAddressDocumentType legacyNomineeName legacyNomineeRelationship person.id
 
   let petTag = Yudhishthira.TagNameValue "PetDriver#\"true\""
   when (isPetModeEnabled && maybe False (Yudhishthira.elemTagNameValue petTag) person.driverTag) $
@@ -1486,8 +1501,8 @@ updateDriver (personId, _, merchantOpCityId) mbBundleVersion mbClientVersion mbC
   when (isJust req.vehicleName) $ QVehicle.updateVehicleName req.vehicleName personId
   QPerson.updatePersonRec personId updPerson
   driverStats <- runInReplica $ QDriverStats.findById (cast personId) >>= fromMaybeM DriverInfoNotFound
-  let driverEntityArg :: (SP.Person, DriverInformation, DStats.DriverStats, Id DMOC.MerchantOperatingCity)
-      driverEntityArg = (updPerson, updatedDriverInfo, driverStats, merchantOpCityId)
+  let driverEntityArg :: (SP.Person, DriverInformation, DStats.DriverStats, Id DMOC.MerchantOperatingCity, DIInfo.IdentityInfo)
+      driverEntityArg = (updPerson, updatedDriverInfo, driverStats, merchantOpCityId, DIInfo.getIdentityInfo mbIdentityInfo updatedDriverInfo)
   let merchantId = person.merchantId
   org <-
     CQM.findById merchantId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverIdentityInfo.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverIdentityInfo.hs
@@ -1,0 +1,79 @@
+module SharedLogic.DriverIdentityInfo
+  ( IdentityInfo (..),
+    getIdentityInfo,
+    upsertDriverIdentityInfo,
+    driverIdentityInfoLockKey,
+  )
+where
+
+import Control.Applicative ((<|>))
+import Data.Time (Day)
+import qualified Domain.Types.DriverIdentityInfo as DII
+import qualified Domain.Types.DriverInformation as DI
+import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Person as DP
+import Kernel.Prelude
+import Kernel.Types.Beckn.Context (IndianState)
+import Kernel.Types.Id (Id)
+import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, getCurrentTime)
+import qualified Storage.Queries.DriverIdentityInfo as QDII
+
+data IdentityInfo = IdentityInfo
+  { nomineeName :: Maybe Text,
+    nomineeRelationship :: Maybe Text,
+    nomineeDob :: Maybe Day,
+    address :: Maybe Text,
+    addressDocumentType :: Maybe DI.AddressDocumentType,
+    addressState :: Maybe IndianState
+  }
+
+getIdentityInfo :: Maybe DII.DriverIdentityInfo -> DI.DriverInformation -> IdentityInfo
+getIdentityInfo mbInfo driverInfo =
+  IdentityInfo
+    { nomineeName = (mbInfo >>= (.nomineeName)) <|> driverInfo.nomineeName,
+      nomineeRelationship = (mbInfo >>= (.nomineeRelationship)) <|> driverInfo.nomineeRelationship,
+      nomineeDob = mbInfo >>= (.nomineeDob),
+      address = (mbInfo >>= (.address)) <|> driverInfo.address,
+      addressDocumentType = (mbInfo >>= (.addressDocumentType)) <|> driverInfo.addressDocumentType,
+      addressState = mbInfo >>= (.addressState)
+    }
+
+driverIdentityInfoLockKey :: Id DP.Person -> Text
+driverIdentityInfoLockKey driverId = "driver_identity_info_upsert:" <> driverId.getId
+
+-- Caller must run this inside `withLockRedis (driverIdentityInfoLockKey driverId)` with mbExisting read inside that lock.
+upsertDriverIdentityInfo ::
+  (MonadFlow m, CacheFlow m r, EsqDBFlow m r) =>
+  Maybe DII.DriverIdentityInfo ->
+  Id DP.Person ->
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
+  DI.DriverInformation ->
+  Maybe Text ->
+  Maybe Text ->
+  Maybe Day ->
+  Maybe Text ->
+  Maybe DI.AddressDocumentType ->
+  Maybe IndianState ->
+  m DII.DriverIdentityInfo
+upsertDriverIdentityInfo mbExisting driverId merchantId mocId driverInfo pName pRel pDob pAddr pAddrDoc pState = do
+  now <- getCurrentTime
+  let row =
+        DII.DriverIdentityInfo
+          { driverId = driverId,
+            nomineeName = pName <|> (mbExisting >>= (.nomineeName)) <|> driverInfo.nomineeName,
+            nomineeRelationship = pRel <|> (mbExisting >>= (.nomineeRelationship)) <|> driverInfo.nomineeRelationship,
+            nomineeDob = pDob <|> (mbExisting >>= (.nomineeDob)),
+            address = pAddr <|> (mbExisting >>= (.address)) <|> driverInfo.address,
+            addressDocumentType = pAddrDoc <|> (mbExisting >>= (.addressDocumentType)) <|> driverInfo.addressDocumentType,
+            addressState = pState <|> (mbExisting >>= (.addressState)),
+            merchantId = merchantId,
+            merchantOperatingCityId = mocId,
+            createdAt = maybe now (.createdAt) mbExisting,
+            updatedAt = now
+          }
+  case mbExisting of
+    Just _ -> QDII.updateByPrimaryKey row
+    Nothing -> QDII.create row
+  pure row

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/IffcoTokioInsurance.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/IffcoTokioInsurance.hs
@@ -24,9 +24,11 @@ import Kernel.Types.Id
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import Servant.Client.Core ()
+import qualified SharedLogic.DriverIdentityInfo as DIInfo
 import qualified Storage.Cac.TransporterConfig as SCTC
 import qualified Storage.CachedQueries.Merchant.MerchantServiceConfig as CQMSC
 import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions (..))
+import qualified Storage.Queries.DriverIdentityInfo as QDII
 import qualified Storage.Queries.DriverInformation as QDI
 import qualified Storage.Queries.DriverLicense as QDL
 import qualified Storage.Queries.IffcoTokioInsurance as QIffco
@@ -78,8 +80,10 @@ triggerIffcoTokioInsurance driverId merchantId merchantOpCityId = do
     unless alreadyInsured $ do
       person <- QPerson.findById (cast driverId) >>= fromMaybeM (PersonNotFound driverId.getId)
       driverInfo <- QDI.findByPrimaryKey (cast driverId) >>= fromMaybeM DriverInfoNotFound
-      let nomineeName = driverInfo.nomineeName
-          nomineeRelationship = driverInfo.nomineeRelationship
+      mbIdentity <- QDII.findByDriverId (cast driverId)
+      let identityInfo = DIInfo.getIdentityInfo mbIdentity driverInfo
+          nomineeName = identityInfo.nomineeName
+          nomineeRelationship = identityInfo.nomineeRelationship
       if isNothing nomineeName || isNothing nomineeRelationship
         then logInfo $ "IffcoTokio: skipping insurance for driver=" <> driverId.getId <> " nomineeName or nomineeRelationship is missing"
         else do

--- a/Backend/dev/integration-tests/collections/DriverProfileNomineeFlow/01-DriverProfileNomineeFlow.json
+++ b/Backend/dev/integration-tests/collections/DriverProfileNomineeFlow/01-DriverProfileNomineeFlow.json
@@ -1,0 +1,197 @@
+{
+  "info": {
+    "name": "DriverProfileNomineeFlow",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "E2E for the DriverIdentityInfo cohort: nominee+address moved off driver_information. Random driver per run (idempotent, repeatable on any device). Covers full update (incl. addressState), migrated read, and partial-merge."
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "if (!pm.collectionVariables.get('_test_driver_number')) {",
+          "  var rNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+          "  pm.collectionVariables.set('_test_driver_number', rNum);",
+          "}",
+          "// mock-server auto-skip (per Rules.md): skip mock-only requests on non-Local envs",
+          "var envType = pm.environment.get('envType') || 'Local';",
+          "var url = (pm.request && pm.request.url) ? pm.request.url.toString() : '';",
+          "var mockUrl = pm.environment.get('mockServerUrl') || '__no_mock__';",
+          "if (envType !== 'Local' && url.indexOf(mockUrl) !== -1 && pm.execution && pm.execution.skipRequest) {",
+          "  pm.execution.skipRequest();",
+          "}"
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "_test_driver_number",
+      "value": ""
+    }
+  ],
+  "item": [
+    {
+      "name": "Driver Auth",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": "{{baseURL_namma_P}}/auth",
+        "body": {
+          "mode": "raw",
+          "raw": "{\"mobileNumber\": \"{{_test_driver_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{driver_merchant_id}}\", \"merchantOperatingCity\": \"{{city}}\"}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('auth 200', function(){ pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.expect(d.authId, 'authId').to.be.a('string');",
+              "pm.collectionVariables.set('driver_authId', d.authId);"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Driver OTP",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": "{{baseURL_namma_P}}/auth/{{driver_authId}}/verify",
+        "body": {
+          "mode": "raw",
+          "raw": "{\"otp\": \"{{login_otp}}\", \"deviceToken\": \"test-device-nominee\"}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('verify 200', function(){ pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.expect(d.token, 'token').to.be.a('string');",
+              "pm.collectionVariables.set('driver_token', d.token);"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Update Nominee And Address (Full)",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": "{{baseURL_namma_P}}/driver/profile",
+        "body": {
+          "mode": "raw",
+          "raw": "{\"nomineeName\": \"Asha Devi\", \"nomineeRelationship\": \"Spouse\", \"nomineeDob\": \"1990-05-15\", \"address\": \"12 MG Road, Bangalore, Karnataka 560001\", \"addressDocumentType\": \"Passport\", \"addressState\": \"Karnataka\"}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('update 200', function(){ pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.test('nomineeName echoed', function(){ pm.expect(d.nomineeName).to.eql('Asha Devi'); });",
+              "pm.test('nomineeRelationship echoed', function(){ pm.expect(d.nomineeRelationship).to.eql('Spouse'); });",
+              "pm.test('nomineeDob set', function(){ pm.expect(d.nomineeDob).to.eql('1990-05-15'); });"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Get Profile (Migrated Read)",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "url": "{{baseURL_namma_P}}/driver/profile"
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('get 200', function(){ pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.test('nominee from new table', function(){ pm.expect(d.nomineeName).to.eql('Asha Devi'); pm.expect(d.nomineeRelationship).to.eql('Spouse'); });",
+              "pm.test('nomineeDob from new table', function(){ pm.expect(d.nomineeDob).to.eql('1990-05-15'); });"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Partial Update (Name Only)",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": "{{baseURL_namma_P}}/driver/profile",
+        "body": {
+          "mode": "raw",
+          "raw": "{\"nomineeName\": \"Asha Updated\"}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('partial update 200', function(){ pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.test('name updated', function(){ pm.expect(d.nomineeName).to.eql('Asha Updated'); });",
+              "pm.test('relationship preserved (merge over current)', function(){ pm.expect(d.nomineeRelationship).to.eql('Spouse'); });",
+              "pm.test('dob preserved', function(){ pm.expect(d.nomineeDob).to.eql('1990-05-15'); });"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/Backend/dev/integration-tests/collections/DriverProfileNomineeFlow/Local/Local_NY_Bangalore.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/DriverProfileNomineeFlow/Local/Local_NY_Bangalore.postman_environment.json
@@ -1,0 +1,43 @@
+{
+  "id": "driver-profile-nominee-local-ny-bangalore",
+  "name": "Local_NY_Bangalore_Nominee",
+  "values": [
+    {
+      "key": "baseURL_namma_P",
+      "value": "http://localhost:8016/ui",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "driver_merchant_id",
+      "value": "7f7896dd-787e-4a0b-8675-e9e6fe93bb8f",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "city",
+      "value": "Bangalore",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "login_otp",
+      "value": "7891",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "mockServerUrl",
+      "value": "http://localhost:8080",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "envType",
+      "value": "Local",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/driver_identity_info.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/driver_identity_info.sql
@@ -1,0 +1,23 @@
+CREATE TABLE atlas_driver_offer_bpp.driver_identity_info ();
+
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN address text ;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN address_document_type text ;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN created_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN driver_id character varying(36) NOT NULL;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN merchant_id character varying(36) NOT NULL;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN merchant_operating_city_id character varying(36) NOT NULL;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN nominee_dob date ;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN nominee_name text ;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN nominee_relationship text ;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN updated_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD PRIMARY KEY ( driver_id);
+
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.driver_identity_info ADD COLUMN address_state text ;
+
+
+------- SQL updates -------
+


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drivers can add/update nominee DOB and address state; profile responses surface nominee DOB and computed nominee age.
  * Nominee/address data moved to a dedicated identity cohort with read/merge and upsert semantics; insurance and profile reads prefer cohort data.

* **Bug Fixes / Validation**
  * Validation for nominee relationship and age (18–99).
  * Legacy nominee/address fields marked deprecated.

* **Tests**
  * End-to-end integration tests for the nominee/profile flow added.

* **Chores**
  * New DB table and migration for driver identity cohort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->