### PR TITLE
backend/feat: surface CUMTA cumulative offer on FRFS search quotes

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -511,6 +511,7 @@ library
       SharedLogic.NyRegularSubscriptionHasher
       SharedLogic.NySubscription
       SharedLogic.Offer
+      SharedLogic.OfferTypes
       SharedLogic.OTP
       SharedLogic.PassExpiryReminder
       SharedLogic.PassRestore

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/FrfsTicket.yaml
@@ -37,6 +37,7 @@ imports:
   SeatType: Domain.Types.Seat
   Person: Domain.Types.Person
   FleetOperatorTripAction: Domain.Types.FleetOperatorTripAction
+  CumulativeOfferResp: SharedLogic.OfferTypes
 
 module: FRFSTicketService
 types:
@@ -79,6 +80,7 @@ types:
     serviceTierType: Maybe ServiceTierType
     routeCode: Maybe Text
     serviceTierName: Maybe Text
+    offer: Maybe CumulativeOfferResp
 
     derive: "Show"
 

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/FRFSTicketService.hs
@@ -30,6 +30,7 @@ import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
 import qualified Kernel.Types.TimeBound
 import Servant
+import qualified SharedLogic.OfferTypes
 import Tools.Auth
 
 data ActiveRouteRes = ActiveRouteRes {lastScheduleTime :: Data.Text.Text, routeId :: Data.Text.Text}
@@ -157,6 +158,7 @@ data FRFSQuoteAPIRes = FRFSQuoteAPIRes
     eventDiscountAmount :: Data.Maybe.Maybe Kernel.Types.Common.HighPrecMoney,
     integratedBppConfigId :: Kernel.Types.Id.Id Domain.Types.IntegratedBPPConfig.IntegratedBPPConfig,
     observingFailures :: Data.Maybe.Maybe Kernel.Prelude.Bool,
+    offer :: Data.Maybe.Maybe SharedLogic.OfferTypes.CumulativeOfferResp,
     price :: Kernel.Types.Common.HighPrecMoney,
     priceWithCurrency :: Kernel.Types.Common.PriceAPIEntity,
     quantity :: Kernel.Prelude.Int,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -90,6 +90,7 @@ import SharedLogic.FRFSStatus
 import SharedLogic.FRFSUtils
 import SharedLogic.FRFSUtils as FRFSUtils
 import qualified SharedLogic.IntegratedBPPConfig as SIBC
+import qualified SharedLogic.Offer as SOffer
 import qualified SharedLogic.PTCircuitBreaker as PTCircuitBreaker
 import qualified SharedLogic.Scheduler.Jobs.FRFSSeatHoldReaper as SeatHold
 import Storage.Beam.Payment ()
@@ -634,7 +635,7 @@ postFrfsSearchHandler (personId, merchantId) merchantOperatingCity integratedBPP
   return $ FRFSSearchAPIRes quotes searchReqId
 
 getFrfsSearchQuote :: (CallExternalBPP.FRFSSearchFlow m r, HasShortDurationRetryCfg r c) => (Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant) -> Kernel.Types.Id.Id Domain.Types.FRFSSearch.FRFSSearch -> m [API.Types.UI.FRFSTicketService.FRFSQuoteAPIRes]
-getFrfsSearchQuote (mbPersonId, _) searchId_ = do
+getFrfsSearchQuote (mbPersonId, merchantId_) searchId_ = do
   personId <- fromMaybeM (InvalidRequest "Invalid person id") mbPersonId
   search <- QFRFSSearch.findById searchId_ >>= fromMaybeM (InvalidRequest "Invalid search id")
   integratedBppConfig <- SIBC.findIntegratedBPPConfigFromEntity search
@@ -676,6 +677,27 @@ getFrfsSearchQuote (mbPersonId, _) searchId_ = do
                in compare (maybe 0 (.amount) mbAdultPrice1) (maybe 0 (.amount) mbAdultPrice2)
           )
           routeFilteredQuotesWithCategories
+  let mbReprAdultPrice = listToMaybe sortedQuotesWithCategories >>= \(_, qcs) -> find (\c -> c.category == ADULT) qcs <&> (.price)
+  -- Cumulative offer is surfaced on standalone FRFS quotes only. When this search is
+  -- a leg of a multimodal journey, the offer is computed once at the journey level
+  -- (generateJourneyInfoResponse), so skip it here to avoid a redundant fetch.
+  -- This is keyed off the journey leg, NOT the config's platform type: a standalone
+  -- purchase can resolve a MULTIMODAL-platform config (e.g. Chennai bus has no
+  -- APPLICATION config), and the offer must still surface there.
+  mbOffer <-
+    if isJust mbJourneyLeg
+      then pure Nothing
+      else case mbReprAdultPrice of
+        Nothing -> pure Nothing
+        Just reprPrice ->
+          withTryCatch
+            "getFrfsSearchQuote:cumulativeOffer"
+            ( SOffer.offerListCache merchantId_ personId search.merchantOperatingCityId (FRFSUtils.getPaymentType False search.vehicleType) reprPrice Nothing
+                >>= \offersResp -> SOffer.mkCumulativeOfferResp search.merchantOperatingCityId offersResp [] Nothing
+            )
+            >>= \case
+              Left _ -> pure Nothing
+              Right mbResp -> pure mbResp
   mapM
     ( \(quote, quoteCategories) -> do
         let decodedRouteStations :: Maybe [FRFSRouteStationsAPI] = decodeFromText =<< quote.routeStationsJson
@@ -706,6 +728,7 @@ getFrfsSearchQuote (mbPersonId, _) searchId_ = do
               integratedBppConfigId = quote.integratedBppConfigId,
               stations = fromMaybe [] stations,
               observingFailures = Just observingFailures,
+              offer = mbOffer,
               ..
             }
     )

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerOrganizationFRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerOrganizationFRFS.hs
@@ -589,6 +589,7 @@ mkQuoteRes (quote, quoteCategories) = do
         eventDiscountAmount = quote.eventDiscountAmount,
         integratedBppConfigId = quote.integratedBppConfigId,
         observingFailures = Nothing,
+        offer = Nothing,
         ..
       }
 

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Types.hs
@@ -3,6 +3,7 @@ module ExternalBPP.CallAPI.Types where
 import Kernel.External.Types (SchedulerFlow, ServiceFlow)
 import Kernel.Prelude
 import Kernel.Sms.Config (SmsConfig)
+import Kernel.Storage.Clickhouse.Config (ClickhouseFlow)
 import Kernel.Storage.Esqueleto.Config
 import Kernel.Storage.Hedis
 import Kernel.Utils.Common
@@ -17,7 +18,8 @@ type FRFSSearchFlow m r =
     EsqDBReplicaFlow m r,
     Metrics.HasBAPMetrics m r,
     CallFRFSBPP.BecknAPICallFlow m r,
-    EncFlow m r
+    EncFlow m r,
+    ClickhouseFlow m r
   )
 
 type FRFSConfirmFlow m r c =

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Offer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Offer.hs
@@ -1,6 +1,10 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module SharedLogic.Offer where
+module SharedLogic.Offer
+  ( module SharedLogic.Offer,
+    module Reexport,
+  )
+where
 
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as A
@@ -37,6 +41,7 @@ import qualified Lib.Yudhishthira.Tools.DebugLog as LYDL
 import qualified Lib.Yudhishthira.Tools.Utils as LYTUtils
 import qualified Lib.Yudhishthira.Types as LYT
 import qualified Lib.Yudhishthira.TypesTH as YTH
+import SharedLogic.OfferTypes as Reexport
 import qualified SharedLogic.Utils as SLUtils
 import Storage.Beam.Payment ()
 import qualified Storage.CachedQueries.Translations as CQTranslations
@@ -57,16 +62,6 @@ data CumulativeOfferRespI = CumulativeOfferRespI
     offerSponsoredBy :: [Text],
     offerIds :: [Text],
     offerListResp :: Payment.OfferListResp
-  }
-  deriving (Generic, Show)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
-
-data CumulativeOfferResp = CumulativeOfferResp
-  { offerTitle :: Text,
-    offerDescription :: Text,
-    offerSponsoredBy :: [Text],
-    offerIds :: [Text],
-    offerListResp :: [OfferRespAPIEntity]
   }
   deriving (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -98,23 +93,6 @@ data OffersFraudChecksResp = OffersFraudChecksResp
   }
   deriving (Generic, Show)
   deriving anyclass (FromJSON, ToJSON)
-
-data OfferRespAPIEntity = OfferRespAPIEntity
-  { offerId :: Text,
-    offerTitle :: Maybe Text,
-    offerDescription :: Maybe Text,
-    offerTnc :: Maybe Text,
-    offerSponsoredBy :: Maybe Text,
-    offerCode :: Text,
-    autoApply :: Bool,
-    isHidden :: Bool,
-    amountSaved :: HighPrecMoney,
-    postOfferAmount :: HighPrecMoney,
-    estimatedAmountSaved :: HighPrecMoney,
-    estimatedPostOfferAmount :: HighPrecMoney
-  }
-  deriving (Generic, Show)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data OffersRespAPIEntity = OffersRespAPIEntity
   { offers :: [OfferRespAPIEntity],

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/OfferTypes.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/OfferTypes.hs
@@ -1,0 +1,31 @@
+module SharedLogic.OfferTypes where
+
+import Kernel.Prelude
+import Kernel.Types.Common (HighPrecMoney)
+
+data CumulativeOfferResp = CumulativeOfferResp
+  { offerTitle :: Text,
+    offerDescription :: Text,
+    offerSponsoredBy :: [Text],
+    offerIds :: [Text],
+    offerListResp :: [OfferRespAPIEntity]
+  }
+  deriving (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+data OfferRespAPIEntity = OfferRespAPIEntity
+  { offerId :: Text,
+    offerTitle :: Maybe Text,
+    offerDescription :: Maybe Text,
+    offerTnc :: Maybe Text,
+    offerSponsoredBy :: Maybe Text,
+    offerCode :: Text,
+    autoApply :: Bool,
+    isHidden :: Bool,
+    amountSaved :: HighPrecMoney,
+    postOfferAmount :: HighPrecMoney,
+    estimatedAmountSaved :: HighPrecMoney,
+    estimatedPostOfferAmount :: HighPrecMoney
+  }
+  deriving (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)


### PR DESCRIPTION
Add `offer` to FRFSQuoteAPIRes, populated in getFrfsSearchQuote via offerListCache + mkCumulativeOfferResp using the vehicle-derived payment service type (getPaymentType). Split the offer response types into a SharedLogic.OfferTypes leaf to break the FRFSUtils -> FRFSTicketService -> Offer -> JourneyModule import cycle; SharedLogic.Offer re-exports them. Add ClickhouseFlow to the FRFSSearchFlow alias (mkCumulativeOfferResp requires it).

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FRFS ticket quote responses now include an optional cumulative offer object (title, description, sponsors, IDs, per-offer savings and post-offer prices).
  * FRFS search may surface cached cumulative offers in responses when available, improving offer visibility for standalone search legs.

* **Bug Fixes / Consistency**
  * Partner/alternate quote paths now explicitly return no offer (null) when none is available for consistent API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->