### PR TITLE
rider-app/feat: BHIM PWA Journey partner-auth facade (verify token + fetch user)

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/package.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/package.yaml
@@ -233,6 +233,7 @@ tests:
     dependencies:
       - rider-app
       - mobility-core
+      - external
       - tasty
       - tasty-hunit
       - tasty-quickcheck

--- a/Backend/app/rider-platform/rider-app/Main/package.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/package.yaml
@@ -191,6 +191,7 @@ library:
     - finance-kernel
     - utils
     - external
+    - safe-exceptions
 
 executables:
   rider-app-exe:

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -75,6 +75,7 @@ library
       API.Types.Dashboard.AppManagement.OrphanInstances.MerchantOnboarding
       API.Types.Dashboard.AppManagement.OrphanInstances.TicketDashboard
       API.Types.Dashboard.AppManagement.OrphanInstances.TransitOperator
+      API.Types.UI.PartnerAuthExtra
       API.Types.UI.PartnerBookingStatementExtra
       API.Types.UI.Payment
       API.UI
@@ -306,6 +307,7 @@ library
       Domain.Action.UI.NyRegularSubscription
       Domain.Action.UI.Offers
       Domain.Action.UI.ParkingBooking
+      Domain.Action.UI.PartnerAuth
       Domain.Action.UI.PartnerBookingStatement
       Domain.Action.UI.PartnerOrganizationFRFS
       Domain.Action.UI.Pass
@@ -782,6 +784,7 @@ library
       Tools.Metrics.BAPMetrics.Types
       Tools.MultiModal
       Tools.Notifications
+      Tools.PartnerAuth
       Tools.Payment
       Tools.Payout
       Tools.Schema
@@ -870,6 +873,7 @@ library
       API.Action.UI.NyRegularSubscription
       API.Action.UI.Offers
       API.Action.UI.ParkingBooking
+      API.Action.UI.PartnerAuth
       API.Action.UI.PartnerBookingStatement
       API.Action.UI.Pass
       API.Action.UI.PassDetails
@@ -972,6 +976,7 @@ library
       API.Types.UI.NearbyDrivers
       API.Types.UI.NyRegularSubscription
       API.Types.UI.ParkingBooking
+      API.Types.UI.PartnerAuth
       API.Types.UI.PartnerBookingStatement
       API.Types.UI.Pass
       API.Types.UI.PassDetails
@@ -1847,6 +1852,7 @@ test-suite rider-app-test
   main-is: Main.hs
   other-modules:
       FRFS.DirectQR
+      PartnerAuth.BhimAES
       Paths_rider_app
   hs-source-dirs:
       test
@@ -1908,6 +1914,7 @@ test-suite rider-app-test
     , data-default-class
     , directory
     , euler-hs
+    , external
     , extra
     , filepath
     , geohash ==1.0.1

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -1853,6 +1853,7 @@ test-suite rider-app-test
   other-modules:
       FRFS.DirectQR
       PartnerAuth.BhimAES
+      PartnerAuth.MobileNormalize
       Paths_rider_app
   hs-source-dirs:
       test

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -1667,6 +1667,7 @@ library
     , regex-compat
     , regex-posix
     , resource-pool
+    , safe-exceptions
     , scheduler
     , scientific
     , sequelize

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/PartnerAuth.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/PartnerAuth.yaml
@@ -1,0 +1,28 @@
+module: PartnerAuth
+
+types:
+  PartnerSessionReq:
+    token: Text
+    derive': "Generic,Show,ToSchema"
+
+  PartnerSessionRes:
+    isValid: Bool
+    sessionToken: Maybe Text
+    mobileNumber: Maybe Text
+    name: Maybe Text
+    derive': "Generic,Show,ToSchema"
+
+apis:
+  # Generic partner embedded-auth session endpoint.
+  # provider is captured from the path (e.g. "bhim") and resolved to a
+  # PartnerAuthService; the handler verifies the partner token (S2S), fetches
+  # user details, and issues a NammaYatri session under the NAMMA_YATRI merchant.
+  - POST:
+      endpoint: /partner/{provider}/session
+      auth: NoAuth
+      params:
+        provider: Text
+      request:
+        type: PartnerSessionReq
+      response:
+        type: PartnerSessionRes

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/PartnerAuth.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/PartnerAuth.yaml
@@ -22,6 +22,10 @@ apis:
       auth: NoAuth
       params:
         provider: Text
+      headers:
+        # Client IP (set by the gateway) so the handler can enforce the same
+        # SMC.isIPBlocked fraud gate as /auth before resolving/creating a Person.
+        x-forwarded-for: Text
       request:
         type: PartnerSessionReq
       response:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/PartnerAuth.hs
@@ -1,0 +1,31 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module API.Action.UI.PartnerAuth
+  ( API,
+    handler,
+  )
+where
+
+import qualified API.Types.UI.PartnerAuth
+import qualified Domain.Action.UI.PartnerAuth
+import qualified Environment
+import EulerHS.Prelude
+import qualified Kernel.Prelude
+import Kernel.Utils.Common
+import Servant
+import Storage.Beam.SystemConfigs ()
+import Tools.Auth
+
+type API =
+  ( "partner" :> Capture "provider" Kernel.Prelude.Text :> "session" :> ReqBody ('[JSON]) API.Types.UI.PartnerAuth.PartnerSessionReq
+      :> Post
+           ('[JSON])
+           API.Types.UI.PartnerAuth.PartnerSessionRes
+  )
+
+handler :: Environment.FlowServer API
+handler = postPartnerSession
+
+postPartnerSession :: (Kernel.Prelude.Text -> API.Types.UI.PartnerAuth.PartnerSessionReq -> Environment.FlowHandler API.Types.UI.PartnerAuth.PartnerSessionRes)
+postPartnerSession a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.PartnerAuth.postPartnerSession a2 a1

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/PartnerAuth.hs
@@ -18,14 +18,15 @@ import Storage.Beam.SystemConfigs ()
 import Tools.Auth
 
 type API =
-  ( "partner" :> Capture "provider" Kernel.Prelude.Text :> "session" :> ReqBody ('[JSON]) API.Types.UI.PartnerAuth.PartnerSessionReq
-      :> Post
+  ( "partner" :> Capture "provider" Kernel.Prelude.Text :> "session" :> Header "x-forwarded-for" Kernel.Prelude.Text
+      :> ReqBody
            ('[JSON])
-           API.Types.UI.PartnerAuth.PartnerSessionRes
+           API.Types.UI.PartnerAuth.PartnerSessionReq
+      :> Post ('[JSON]) API.Types.UI.PartnerAuth.PartnerSessionRes
   )
 
 handler :: Environment.FlowServer API
 handler = postPartnerSession
 
-postPartnerSession :: (Kernel.Prelude.Text -> API.Types.UI.PartnerAuth.PartnerSessionReq -> Environment.FlowHandler API.Types.UI.PartnerAuth.PartnerSessionRes)
-postPartnerSession a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.PartnerAuth.postPartnerSession a2 a1
+postPartnerSession :: (Kernel.Prelude.Text -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> API.Types.UI.PartnerAuth.PartnerSessionReq -> Environment.FlowHandler API.Types.UI.PartnerAuth.PartnerSessionRes)
+postPartnerSession a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.PartnerAuth.postPartnerSession a3 a2 a1

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/PartnerAuth.hs
@@ -1,0 +1,22 @@
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module API.Types.UI.PartnerAuth where
+
+import Data.OpenApi (ToSchema)
+import EulerHS.Prelude hiding (id)
+import qualified Kernel.Prelude
+import Servant
+import Tools.Auth
+
+data PartnerSessionReq = PartnerSessionReq {token :: Kernel.Prelude.Text}
+  deriving stock (Generic, Show)
+  deriving anyclass (ToSchema)
+
+data PartnerSessionRes = PartnerSessionRes
+  { isValid :: Kernel.Prelude.Bool,
+    mobileNumber :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    name :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    sessionToken :: Kernel.Prelude.Maybe Kernel.Prelude.Text
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (ToSchema)

--- a/Backend/app/rider-platform/rider-app/Main/src/API/Types/UI/PartnerAuthExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Types/UI/PartnerAuthExtra.hs
@@ -1,0 +1,27 @@
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | JSON instances for the generated PartnerAuth API types. The generated types
+-- (src-read-only) only derive Generic/Show/ToSchema; Servant '[JSON] needs
+-- FromJSON/ToJSON. Default (camelCase) encoding matches the PWA contract
+-- ({ token } / { isValid, sessionToken, mobileNumber, name }).
+module API.Types.UI.PartnerAuthExtra
+  ( module API.Types.UI.PartnerAuth,
+    module API.Types.UI.PartnerAuthExtra,
+  )
+where
+
+import API.Types.UI.PartnerAuth
+import Data.Aeson
+
+instance FromJSON PartnerSessionReq where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON PartnerSessionReq where
+  toJSON = genericToJSON defaultOptions
+
+instance FromJSON PartnerSessionRes where
+  parseJSON = genericParseJSON defaultOptions
+
+instance ToJSON PartnerSessionRes where
+  toJSON = genericToJSON defaultOptions

--- a/Backend/app/rider-platform/rider-app/Main/src/API/UI.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/UI.hs
@@ -30,6 +30,7 @@ import qualified API.Action.UI.NearbyBuses as NearbyBuses
 import qualified API.Action.UI.NearbyDrivers as NearbyDrivers
 import qualified API.Action.UI.NyRegularSubscription as NYRegular
 import qualified API.Action.UI.Offers as Offers
+import qualified API.Action.UI.PartnerAuth as PartnerAuth
 import qualified API.Action.UI.PartnerBookingStatement as PartnerBookingStatement
 import qualified API.Action.UI.PassDetails as PassDetails
 import qualified API.Action.UI.PickupInstructions as PickupInstructions
@@ -169,6 +170,7 @@ type API =
            :<|> SVP.API
            :<|> ChangeServiceTier.API
            :<|> AddBaggage.API
+           :<|> PartnerAuth.API
        )
 
 handler :: FlowServer API
@@ -253,3 +255,4 @@ handler =
     :<|> SVP.handler
     :<|> ChangeServiceTier.handler
     :<|> AddBaggage.handler
+    :<|> PartnerAuth.handler

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
@@ -8,6 +8,7 @@ module Domain.Action.UI.PartnerAuth (postPartnerSession, normalizeIndianMobile) 
 
 import qualified API.Types.UI.PartnerAuth as APT
 import API.Types.UI.PartnerAuthExtra ()
+import qualified Control.Exception.Safe as CES
 import Data.Char (isDigit)
 import qualified Data.Text as T
 import qualified Domain.Action.UI.Registration as DRegistration
@@ -19,14 +20,16 @@ import qualified PartnerAuth.Interface as PartnerAuth
 import qualified PartnerAuth.Types as PartnerAuth
 import qualified Storage.CachedQueries.Merchant as QMerchant
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
-import qualified Tools.PartnerAuth as TPartnerAuth
 import Tools.Error
+import qualified Tools.PartnerAuth as TPartnerAuth
 
 postPartnerSession :: Text -> APT.PartnerSessionReq -> Environment.Flow APT.PartnerSessionRes
 postPartnerSession providerTxt req = do
   -- Wrap the entire partner interaction: invalid token, unknown/unconfigured
-  -- provider, or any thrown error all map to 200 {isValid:false} + a log line.
-  result <- try @_ @SomeException issueSession
+  -- provider, or any thrown (synchronous) error all map to 200 {isValid:false} +
+  -- a log line. Control.Exception.Safe.try lets async exceptions (shutdown,
+  -- timeouts) propagate instead of being swallowed.
+  result <- CES.try @_ @SomeException issueSession
   case result of
     Right res -> pure res
     Left err -> do

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
@@ -22,6 +22,7 @@ import Kernel.Utils.Common
 import Kernel.Utils.SlidingWindowLimiter (checkSlidingWindowLimitWithOptions)
 import qualified PartnerAuth.Interface as PartnerAuth
 import qualified PartnerAuth.Types as PartnerAuth
+import qualified SharedLogic.MerchantConfig as SMC
 import qualified Storage.CachedQueries.Merchant as QMerchant
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import Tools.Error
@@ -43,13 +44,13 @@ partnerAuthRateLimitOptions = APIRateLimitOptions {limit = 10, limitResetTimeInS
 tokenDigest :: Text -> Text
 tokenDigest = T.pack . show . Hash.hashWith Hash.SHA256 . TE.encodeUtf8
 
-postPartnerSession :: Text -> APT.PartnerSessionReq -> Environment.Flow APT.PartnerSessionRes
-postPartnerSession providerTxt req = do
+postPartnerSession :: Text -> Maybe Text -> APT.PartnerSessionReq -> Environment.Flow APT.PartnerSessionRes
+postPartnerSession providerTxt mbXForwardedFor req = do
   -- Wrap the entire partner interaction: invalid token, unknown/unconfigured
-  -- provider, rate-limit breach, or any thrown (synchronous) error all map to
-  -- 200 {isValid:false} + a log line, preserving the never-500 contract.
-  -- Control.Exception.Safe.try lets async exceptions (shutdown, timeouts)
-  -- propagate instead of being swallowed.
+  -- provider, blocked IP, rate-limit breach, or any thrown (synchronous) error
+  -- all map to 200 {isValid:false} + a log line, preserving the never-500
+  -- contract. Control.Exception.Safe.try lets async exceptions (shutdown,
+  -- timeouts) propagate instead of being swallowed.
   result <- CES.try @_ @SomeException issueSession
   case result of
     Right res -> pure res
@@ -62,8 +63,17 @@ postPartnerSession providerTxt req = do
     -- a Redis key.
     providerKey = T.take 32 (T.toLower providerTxt)
     issueSession = do
-      -- Throttle first, before parsing/lookup/S2S, so even unknown providers and
-      -- repeated tokens are cheap to reject and cannot amplify into BHIM.
+      -- IP fraud gate first — mirror Registration.auth: reject a client IP that
+      -- the merchant has flagged BEFORE any S2S call or Person resolve/create, so
+      -- a blocked IP can neither create an account nor amplify into BHIM. The
+      -- throw is caught by the wrapper above and surfaces as isValid:false (we
+      -- deliberately don't reveal the block to the caller).
+      whenJust (clientIpFromXForwardedFor mbXForwardedFor) $ \clientIP -> do
+        ipBlocked <- SMC.isIPBlocked clientIP
+        when ipBlocked $ throwError IpHitsLimitExceeded
+      -- Then throttle per (provider, token), before parsing/lookup/S2S, so even
+      -- unknown providers and repeated tokens are cheap to reject and cannot
+      -- amplify into BHIM.
       checkSlidingWindowLimitWithOptions
         ("BAP:PartnerAuth:" <> providerKey <> ":token:" <> tokenDigest req.token)
         partnerAuthRateLimitOptions
@@ -119,6 +129,16 @@ postPartnerSession providerTxt req = do
             Nothing -> do
               logError $ "PartnerAuth: no session issued (blocked user?) for provider " <> providerKey
               pure invalidRes
+
+-- | Extract the client IP from an X-Forwarded-For header value: first hop, port
+-- stripped. Mirrors the derivation in 'Domain.Action.UI.Registration.auth' so the
+-- partner facade applies the same fraud gate.
+clientIpFromXForwardedFor :: Maybe Text -> Maybe Text
+clientIpFromXForwardedFor mbXForwardedFor =
+  mbXForwardedFor >>= \headerValue ->
+    listToMaybe (T.splitOn "," headerValue) >>= \firstIP ->
+      let ipWithoutPort = T.takeWhile (/= ':') (T.strip firstIP)
+       in if T.null ipWithoutPort then Nothing else Just ipWithoutPort
 
 -- | Normalise an Indian mobile number from a partner to ("+91", <local 10-digit>),
 -- tolerating bare, "91…", "+91…", "0091…" and spaced formats. Returns Nothing for

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
@@ -1,0 +1,72 @@
+-- | BHIM "PWA Journey" auth facade — generic over partner providers.
+-- POST /v2/partner/{provider}/session : verify the partner token (S2S), fetch
+-- the user, and issue a NammaYatri session (reusing the /auth/signature
+-- person-resolution + token-issuance path) under the NAMMA_YATRI merchant.
+-- Invalid token, unknown provider, or ANY error/exception -> 200 {isValid:false}
+-- (logged); never a 500 to the PWA.
+module Domain.Action.UI.PartnerAuth (postPartnerSession) where
+
+import qualified API.Types.UI.PartnerAuth as APT
+import API.Types.UI.PartnerAuthExtra ()
+import qualified Domain.Action.UI.Registration as DRegistration
+import qualified Environment
+import Kernel.Prelude
+import Kernel.Types.Id (ShortId (..))
+import Kernel.Utils.Common
+import qualified PartnerAuth.Interface as PartnerAuth
+import qualified PartnerAuth.Types as PartnerAuth
+import qualified Storage.CachedQueries.Merchant as QMerchant
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import qualified Tools.PartnerAuth as TPartnerAuth
+import Tools.Error
+
+postPartnerSession :: Text -> APT.PartnerSessionReq -> Environment.Flow APT.PartnerSessionRes
+postPartnerSession providerTxt req = do
+  -- Wrap the entire partner interaction: invalid token, unknown/unconfigured
+  -- provider, or any thrown error all map to 200 {isValid:false} + a log line.
+  result <- try @_ @SomeException issueSession
+  case result of
+    Right res -> pure res
+    Left err -> do
+      logError $ "PartnerAuth session failed for provider " <> providerTxt <> ": " <> show err
+      pure invalidRes
+  where
+    invalidRes = APT.PartnerSessionRes {isValid = False, sessionToken = Nothing, mobileNumber = Nothing, name = Nothing}
+    issueSession = do
+      provider <-
+        PartnerAuth.parsePartnerAuthService providerTxt
+          & fromMaybeM (InvalidRequest $ "Unknown partner auth provider: " <> providerTxt)
+      merchant <-
+        QMerchant.findByShortId (ShortId "NAMMA_YATRI")
+          >>= fromMaybeM (MerchantNotFound "NAMMA_YATRI")
+      merchantOpCity <-
+        CQMOC.findByMerchantShortIdAndCity (ShortId "NAMMA_YATRI") merchant.defaultCity
+          >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantShortId: NAMMA_YATRI ,city: " <> show merchant.defaultCity)
+      cfg <-
+        TPartnerAuth.getPartnerAuthConfig merchant.id merchantOpCity.id provider
+          >>= fromMaybeM (InternalError $ "PartnerAuth config not found for provider: " <> providerTxt)
+      valid <- PartnerAuth.verifyToken cfg req.token
+      if not valid
+        then pure invalidRes
+        else do
+          userDetails <- PartnerAuth.getUserDetails cfg req.token
+          authRes <-
+            -- BHIM is an India-only (UPI) app, so the country code is fixed to "+91".
+            -- Derive/configure this when a non-India provider is onboarded.
+            DRegistration.resolveAndIssueDirectSession
+              merchant
+              "+91"
+              userDetails.mobileNumber
+              (Just userDetails.name)
+              Nothing
+              Nothing
+              Nothing
+              Nothing
+              Nothing
+          pure
+            APT.PartnerSessionRes
+              { isValid = True,
+                sessionToken = authRes.token,
+                mobileNumber = Just userDetails.mobileNumber,
+                name = Just userDetails.name
+              }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
@@ -9,13 +9,17 @@ module Domain.Action.UI.PartnerAuth (postPartnerSession, normalizeIndianMobile) 
 import qualified API.Types.UI.PartnerAuth as APT
 import API.Types.UI.PartnerAuthExtra ()
 import qualified Control.Exception.Safe as CES
+import qualified Crypto.Hash as Hash
 import Data.Char (isDigit)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import qualified Domain.Action.UI.Registration as DRegistration
 import qualified Environment
 import Kernel.Prelude
 import Kernel.Types.Id (ShortId (..))
+import Kernel.Types.SlidingWindowLimiter (APIRateLimitOptions (..))
 import Kernel.Utils.Common
+import Kernel.Utils.SlidingWindowLimiter (checkSlidingWindowLimitWithOptions)
 import qualified PartnerAuth.Interface as PartnerAuth
 import qualified PartnerAuth.Types as PartnerAuth
 import qualified Storage.CachedQueries.Merchant as QMerchant
@@ -23,12 +27,29 @@ import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import Tools.Error
 import qualified Tools.PartnerAuth as TPartnerAuth
 
+-- | The NammaYatri merchant under which partner sessions are issued.
+nammaYatriShortId :: ShortId a
+nammaYatriShortId = ShortId "NAMMA_YATRI"
+
+-- | Per-(provider, token) throttle applied BEFORE any partner S2S call. This
+-- caps token replay and the 1->2 S2S amplification a single token can drive.
+-- Per-IP / global flood protection is the API gateway's responsibility (this
+-- service sits behind it) and is intentionally not duplicated here.
+partnerAuthRateLimitOptions :: APIRateLimitOptions
+partnerAuthRateLimitOptions = APIRateLimitOptions {limit = 10, limitResetTimeInSec = 60}
+
+-- | Non-reversible digest of the partner token, used only to namespace the
+-- rate-limit key in Redis (never store the raw bearer token in a key).
+tokenDigest :: Text -> Text
+tokenDigest = T.pack . show . Hash.hashWith Hash.SHA256 . TE.encodeUtf8
+
 postPartnerSession :: Text -> APT.PartnerSessionReq -> Environment.Flow APT.PartnerSessionRes
 postPartnerSession providerTxt req = do
   -- Wrap the entire partner interaction: invalid token, unknown/unconfigured
-  -- provider, or any thrown (synchronous) error all map to 200 {isValid:false} +
-  -- a log line. Control.Exception.Safe.try lets async exceptions (shutdown,
-  -- timeouts) propagate instead of being swallowed.
+  -- provider, rate-limit breach, or any thrown (synchronous) error all map to
+  -- 200 {isValid:false} + a log line, preserving the never-500 contract.
+  -- Control.Exception.Safe.try lets async exceptions (shutdown, timeouts)
+  -- propagate instead of being swallowed.
   result <- CES.try @_ @SomeException issueSession
   case result of
     Right res -> pure res
@@ -37,34 +58,48 @@ postPartnerSession providerTxt req = do
       pure invalidRes
   where
     invalidRes = APT.PartnerSessionRes {isValid = False, sessionToken = Nothing, mobileNumber = Nothing, name = Nothing}
+    -- Bound the attacker-controlled path segment before it reaches a log line or
+    -- a Redis key.
+    providerKey = T.take 32 (T.toLower providerTxt)
     issueSession = do
+      -- Throttle first, before parsing/lookup/S2S, so even unknown providers and
+      -- repeated tokens are cheap to reject and cannot amplify into BHIM.
+      checkSlidingWindowLimitWithOptions
+        ("BAP:PartnerAuth:" <> providerKey <> ":token:" <> tokenDigest req.token)
+        partnerAuthRateLimitOptions
       provider <-
         PartnerAuth.parsePartnerAuthService providerTxt
-          & fromMaybeM (InvalidRequest $ "Unknown partner auth provider: " <> providerTxt)
+          & fromMaybeM (InvalidRequest $ "Unknown partner auth provider: " <> providerKey)
       merchant <-
-        QMerchant.findByShortId (ShortId "NAMMA_YATRI")
+        QMerchant.findByShortId nammaYatriShortId
           >>= fromMaybeM (MerchantNotFound "NAMMA_YATRI")
       merchantOpCity <-
-        CQMOC.findByMerchantShortIdAndCity (ShortId "NAMMA_YATRI") merchant.defaultCity
+        CQMOC.findByMerchantShortIdAndCity nammaYatriShortId merchant.defaultCity
           >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantShortId: NAMMA_YATRI ,city: " <> show merchant.defaultCity)
       cfg <-
         TPartnerAuth.getPartnerAuthConfig merchant.id merchantOpCity.id provider
-          >>= fromMaybeM (InternalError $ "PartnerAuth config not found for provider: " <> providerTxt)
+          >>= fromMaybeM (InternalError $ "PartnerAuth config not found for provider: " <> providerKey)
       valid <- PartnerAuth.verifyToken cfg req.token
       if not valid
         then pure invalidRes
         else do
           userDetails <- PartnerAuth.getUserDetails cfg req.token
-          -- BHIM is an India-only (UPI) app; normalise the number to ("+91", <local>)
-          -- so we match an existing Person instead of forking a duplicate account when
-          -- BHIM sends it with a 91 / +91 / 0091 prefix.
-          let (countryCode, localMobile) = normalizeIndianMobile userDetails.mobileNumber
+          -- BHIM is an India-only (UPI) app; normalise the number to
+          -- ("+91", <local 10-digit>) so we match an existing Person rather than
+          -- forking a duplicate account. A number we cannot validate as a plausible
+          -- Indian mobile fails closed (isValid:false) instead of creating a
+          -- Person under a malformed identifier.
+          (countryCode, localMobile) <-
+            normalizeIndianMobile userDetails.mobileNumber
+              & fromMaybeM (InvalidRequest "PartnerAuth: partner returned an unparseable Indian mobile number")
+          -- Don't overwrite an existing NY user's display name with a blank.
+          let mbName = let n = T.strip userDetails.name in if T.null n then Nothing else Just n
           authRes <-
             DRegistration.resolveAndIssueDirectSession
               merchant
               countryCode
               localMobile
-              (Just userDetails.name)
+              mbName
               Nothing
               Nothing
               Nothing
@@ -82,11 +117,18 @@ postPartnerSession providerTxt req = do
                     name = Just userDetails.name
                   }
             Nothing -> do
-              logError $ "PartnerAuth: no session issued (blocked user?) for provider " <> providerTxt
+              logError $ "PartnerAuth: no session issued (blocked user?) for provider " <> providerKey
               pure invalidRes
 
--- | Normalise an Indian mobile number from BHIM to ("+91", <local 10-digit>),
--- tolerating bare, "91…", "+91…", "0091…" and spaced formats. Kept separate so
--- the country-code/format assumption lives in one unit-tested place.
-normalizeIndianMobile :: Text -> (Text, Text)
-normalizeIndianMobile raw = ("+91", T.takeEnd 10 (T.filter isDigit raw))
+-- | Normalise an Indian mobile number from a partner to ("+91", <local 10-digit>),
+-- tolerating bare, "91…", "+91…", "0091…" and spaced formats. Returns Nothing for
+-- anything that is not a plausible Indian mobile (after stripping a country prefix,
+-- exactly 10 digits beginning 6–9), so callers can fail closed instead of matching
+-- or creating a Person under a malformed identifier. Kept separate so the
+-- country-code/format assumption lives in one unit-tested place.
+normalizeIndianMobile :: Text -> Maybe (Text, Text)
+normalizeIndianMobile raw =
+  let localDigits = T.takeEnd 10 (T.filter isDigit raw)
+   in if T.length localDigits == 10 && maybe False ((`elem` ['6' .. '9']) . fst) (T.uncons localDigits)
+        then Just ("+91", localDigits)
+        else Nothing

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerAuth.hs
@@ -4,10 +4,12 @@
 -- person-resolution + token-issuance path) under the NAMMA_YATRI merchant.
 -- Invalid token, unknown provider, or ANY error/exception -> 200 {isValid:false}
 -- (logged); never a 500 to the PWA.
-module Domain.Action.UI.PartnerAuth (postPartnerSession) where
+module Domain.Action.UI.PartnerAuth (postPartnerSession, normalizeIndianMobile) where
 
 import qualified API.Types.UI.PartnerAuth as APT
 import API.Types.UI.PartnerAuthExtra ()
+import Data.Char (isDigit)
+import qualified Data.Text as T
 import qualified Domain.Action.UI.Registration as DRegistration
 import qualified Environment
 import Kernel.Prelude
@@ -50,23 +52,38 @@ postPartnerSession providerTxt req = do
         then pure invalidRes
         else do
           userDetails <- PartnerAuth.getUserDetails cfg req.token
+          -- BHIM is an India-only (UPI) app; normalise the number to ("+91", <local>)
+          -- so we match an existing Person instead of forking a duplicate account when
+          -- BHIM sends it with a 91 / +91 / 0091 prefix.
+          let (countryCode, localMobile) = normalizeIndianMobile userDetails.mobileNumber
           authRes <-
-            -- BHIM is an India-only (UPI) app, so the country code is fixed to "+91".
-            -- Derive/configure this when a non-India provider is onboarded.
             DRegistration.resolveAndIssueDirectSession
               merchant
-              "+91"
-              userDetails.mobileNumber
+              countryCode
+              localMobile
               (Just userDetails.name)
               Nothing
               Nothing
               Nothing
               Nothing
               Nothing
-          pure
-            APT.PartnerSessionRes
-              { isValid = True,
-                sessionToken = authRes.token,
-                mobileNumber = Just userDetails.mobileNumber,
-                name = Just userDetails.name
-              }
+          -- A verified BHIM token can still map to a blocked NY user, for whom no
+          -- session token is issued. Never return isValid:true with a null token.
+          case authRes.token of
+            Just tok ->
+              pure
+                APT.PartnerSessionRes
+                  { isValid = True,
+                    sessionToken = Just tok,
+                    mobileNumber = Just userDetails.mobileNumber,
+                    name = Just userDetails.name
+                  }
+            Nothing -> do
+              logError $ "PartnerAuth: no session issued (blocked user?) for provider " <> providerTxt
+              pure invalidRes
+
+-- | Normalise an Indian mobile number from BHIM to ("+91", <local 10-digit>),
+-- tolerating bare, "91…", "+91…", "0091…" and spaced formats. Kept separate so
+-- the country-code/format assumption lives in one unit-tested place.
+normalizeIndianMobile :: Text -> (Text, Text)
+normalizeIndianMobile raw = ("+91", T.takeEnd 10 (T.filter isDigit raw))

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
@@ -30,6 +30,7 @@ module Domain.Action.UI.Registration
     VerifyBusinessEmailRes (..),
     auth,
     signatureAuth,
+    resolveAndIssueDirectSession,
     createPerson,
     verify,
     resend,
@@ -568,6 +569,85 @@ mobileSignatureAuth req mbBundleVersion mbClientVersion mbClientConfigVersion mb
   mobileNumberDecrypted <- decryptAES128 merchant.cipherText mobileNumber
   let reqWithMobileNumebr = req {mobileNumber = Just mobileNumberDecrypted}
   notificationToken <- mapM (decryptAES128 merchant.cipherText) req.notificationToken
+  mobileNumberHash <- getDbHash mobileNumberDecrypted
+  person <-
+    Person.findByRoleAndMobileNumberAndMerchantId SP.USER countryCode mobileNumberHash merchant.id
+      >>= maybe (createPerson reqWithMobileNumebr SP.MOBILENUMBER notificationToken mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion (getDeviceFromText mbDevice) mbCloudType merchant Nothing Nothing) return
+  let entityId = getId $ person.id
+      useFakeOtpM = (show <$> useFakeSms smsCfg) <|> person.useFakeOtp
+      scfg = sessionConfig smsCfg
+  let mkId = getId $ merchant.id
+  regToken <- makeSession SR.SIGNATURE scfg entityId mkId useFakeOtpM False
+  if not person.blocked
+    then do
+      deploymentVersion <- asks (.version)
+      void $ Person.updatePersonVersions person mbBundleVersion mbClientVersion mbClientConfigVersion (getDeviceFromText mbDevice) deploymentVersion.getDeploymentVersion mbRnVersion mbCloudType
+      _ <- RegistrationToken.create regToken
+      mbEncEmail <- encrypt `mapM` reqWithMobileNumebr.email
+      mbEncBusinessEmail <- encrypt `mapM` reqWithMobileNumebr.businessEmail
+      _ <- RegistrationToken.setDirectAuth regToken.id SR.SIGNATURE
+      _ <- Person.updatePersonalInfo person.id (reqWithMobileNumebr.firstName <|> person.firstName <|> Just "User") reqWithMobileNumebr.middleName reqWithMobileNumebr.lastName mbEncEmail mbEncBusinessEmail deviceToken notificationToken (reqWithMobileNumebr.language <|> person.language <|> Just Language.ENGLISH) (reqWithMobileNumebr.gender <|> Just person.gender) mbRnVersion (mbClientVersion <|> Nothing) (mbBundleVersion <|> Nothing) mbClientConfigVersion (getDeviceFromText mbDevice) deploymentVersion.getDeploymentVersion person.enableOtpLessRide Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing person Nothing Nothing Nothing Nothing mbCloudType
+      personAPIEntity <- verifyFlow person regToken reqWithMobileNumebr.whatsappNotificationEnroll deviceToken
+      return $ AuthRes regToken.id regToken.attempts SR.DIRECT (Just regToken.token) (Just personAPIEntity) person.blocked Nothing Nothing
+    else return $ AuthRes regToken.id regToken.attempts regToken.authType Nothing Nothing person.blocked Nothing Nothing
+
+-- | Resolve-or-create a Person by (plaintext) mobile number under the given
+-- merchant and issue a verified DIRECT session — the exact path
+-- 'mobileSignatureAuth' uses after it decrypts the mobile number. Exposed as a
+-- standalone entry point for partner auth facades (e.g. embedded-PWA partners)
+-- that already hold a plaintext mobile number and have verified the user out of
+-- band. The existing signature-auth flow is intentionally left untouched.
+resolveAndIssueDirectSession ::
+  ( HasFlowEnv m r '["smsCfg" ::: SmsConfig, "version" ::: DeploymentVersion, "cloudType" ::: Maybe CloudType],
+    CacheFlow m r,
+    DB.EsqDBReplicaFlow m r,
+    EsqDBFlow m r,
+    EncFlow m r,
+    HasKafkaProducer r,
+    ClickhouseFlow m r
+  ) =>
+  Merchant ->
+  Text ->
+  Text ->
+  Maybe Text ->
+  Maybe Version ->
+  Maybe Version ->
+  Maybe Version ->
+  Maybe Text ->
+  Maybe Text ->
+  m AuthRes
+resolveAndIssueDirectSession merchant countryCode mobileNumberDecrypted mbName mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDevice = do
+  smsCfg <- asks (.smsCfg)
+  mbCloudType <- asks (.cloudType)
+  let reqWithMobileNumebr =
+        AuthReq
+          { mobileNumber = Just mobileNumberDecrypted,
+            mobileCountryCode = Just countryCode,
+            identifierType = Just SP.MOBILENUMBER,
+            merchantId = merchant.shortId,
+            deviceToken = Nothing,
+            notificationToken = Nothing,
+            whatsappNotificationEnroll = Nothing,
+            firstName = mbName,
+            middleName = Nothing,
+            lastName = Nothing,
+            email = Nothing,
+            businessEmail = Nothing,
+            language = Nothing,
+            gender = Nothing,
+            otpChannel = Nothing,
+            registrationLat = Nothing,
+            registrationLon = Nothing,
+            enableOtpLessRide = Nothing,
+            allowBlockedUserLogin = Nothing,
+            isOperatorReq = Nothing,
+            reuseToken = Nothing,
+            operatorBadgeToken = Nothing,
+            deviceSerialNumber = Nothing,
+            vehicleType = Nothing
+          }
+      deviceToken = reqWithMobileNumebr.deviceToken
+      notificationToken = reqWithMobileNumebr.notificationToken
   mobileNumberHash <- getDbHash mobileNumberDecrypted
   person <-
     Person.findByRoleAndMobileNumberAndMerchantId SP.USER countryCode mobileNumberHash merchant.id

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
@@ -558,8 +558,6 @@ mobileSignatureAuth ::
   m AuthRes
 mobileSignatureAuth req mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDevice = do
   runRequestValidation validateSignatureAuthReq req
-  smsCfg <- asks (.smsCfg)
-  mbCloudType <- asks (.cloudType)
   countryCode <- req.mobileCountryCode & fromMaybeM (InvalidRequest "MobileCountryCode is required for signature auth")
   mobileNumber <- req.mobileNumber & fromMaybeM (InvalidRequest "MobileCountryCode is required for signature auth")
   let deviceToken = req.deviceToken
@@ -569,27 +567,9 @@ mobileSignatureAuth req mbBundleVersion mbClientVersion mbClientConfigVersion mb
   mobileNumberDecrypted <- decryptAES128 merchant.cipherText mobileNumber
   let reqWithMobileNumebr = req {mobileNumber = Just mobileNumberDecrypted}
   notificationToken <- mapM (decryptAES128 merchant.cipherText) req.notificationToken
-  mobileNumberHash <- getDbHash mobileNumberDecrypted
-  person <-
-    Person.findByRoleAndMobileNumberAndMerchantId SP.USER countryCode mobileNumberHash merchant.id
-      >>= maybe (createPerson reqWithMobileNumebr SP.MOBILENUMBER notificationToken mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion (getDeviceFromText mbDevice) mbCloudType merchant Nothing Nothing) return
-  let entityId = getId $ person.id
-      useFakeOtpM = (show <$> useFakeSms smsCfg) <|> person.useFakeOtp
-      scfg = sessionConfig smsCfg
-  let mkId = getId $ merchant.id
-  regToken <- makeSession SR.SIGNATURE scfg entityId mkId useFakeOtpM False
-  if not person.blocked
-    then do
-      deploymentVersion <- asks (.version)
-      void $ Person.updatePersonVersions person mbBundleVersion mbClientVersion mbClientConfigVersion (getDeviceFromText mbDevice) deploymentVersion.getDeploymentVersion mbRnVersion mbCloudType
-      _ <- RegistrationToken.create regToken
-      mbEncEmail <- encrypt `mapM` reqWithMobileNumebr.email
-      mbEncBusinessEmail <- encrypt `mapM` reqWithMobileNumebr.businessEmail
-      _ <- RegistrationToken.setDirectAuth regToken.id SR.SIGNATURE
-      _ <- Person.updatePersonalInfo person.id (reqWithMobileNumebr.firstName <|> person.firstName <|> Just "User") reqWithMobileNumebr.middleName reqWithMobileNumebr.lastName mbEncEmail mbEncBusinessEmail deviceToken notificationToken (reqWithMobileNumebr.language <|> person.language <|> Just Language.ENGLISH) (reqWithMobileNumebr.gender <|> Just person.gender) mbRnVersion (mbClientVersion <|> Nothing) (mbBundleVersion <|> Nothing) mbClientConfigVersion (getDeviceFromText mbDevice) deploymentVersion.getDeploymentVersion person.enableOtpLessRide Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing person Nothing Nothing Nothing Nothing mbCloudType
-      personAPIEntity <- verifyFlow person regToken reqWithMobileNumebr.whatsappNotificationEnroll deviceToken
-      return $ AuthRes regToken.id regToken.attempts SR.DIRECT (Just regToken.token) (Just personAPIEntity) person.blocked Nothing Nothing
-    else return $ AuthRes regToken.id regToken.attempts regToken.authType Nothing Nothing person.blocked Nothing Nothing
+  -- preserveExistingName=False keeps the historic signature-auth behaviour: the
+  -- request's firstName takes precedence over the stored one.
+  issueDirectSessionForReq False merchant countryCode mobileNumberDecrypted reqWithMobileNumebr notificationToken deviceToken mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDevice
 
 -- | Resolve-or-create a Person by (plaintext) mobile number under the given
 -- merchant and issue a verified DIRECT session — the exact path
@@ -617,8 +597,6 @@ resolveAndIssueDirectSession ::
   Maybe Text ->
   m AuthRes
 resolveAndIssueDirectSession merchant countryCode mobileNumberDecrypted mbName mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDevice = do
-  smsCfg <- asks (.smsCfg)
-  mbCloudType <- asks (.cloudType)
   let reqWithMobileNumebr =
         AuthReq
           { mobileNumber = Just mobileNumberDecrypted,
@@ -646,8 +624,45 @@ resolveAndIssueDirectSession merchant countryCode mobileNumberDecrypted mbName m
             deviceSerialNumber = Nothing,
             vehicleType = Nothing
           }
-      deviceToken = reqWithMobileNumebr.deviceToken
-      notificationToken = reqWithMobileNumebr.notificationToken
+  -- preserveExistingName=True: a partner login must not clobber an existing NY
+  -- user's chosen display name. The partner-supplied name is used only when a
+  -- new Person is created (via createPerson) or when no stored name exists.
+  issueDirectSessionForReq True merchant countryCode mobileNumberDecrypted reqWithMobileNumebr Nothing Nothing mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDevice
+
+-- | Shared tail of the DIRECT (verified, OTP-less) session flow: resolve-or-create
+-- the Person by (plaintext) mobile number, mint a verified SIGNATURE session, and
+-- run the post-login bookkeeping (versions, personal info, verifyFlow). Used by
+-- both 'mobileSignatureAuth' and 'resolveAndIssueDirectSession' so the
+-- security-sensitive issuance logic lives in exactly one place.
+--
+-- preserveExistingName: when True, an existing Person's stored firstName wins over
+-- the request's (partner facades must not overwrite a user's chosen name); when
+-- False, the request's firstName wins (historic signature-auth behaviour).
+issueDirectSessionForReq ::
+  ( HasFlowEnv m r '["smsCfg" ::: SmsConfig, "version" ::: DeploymentVersion, "cloudType" ::: Maybe CloudType],
+    CacheFlow m r,
+    DB.EsqDBReplicaFlow m r,
+    EsqDBFlow m r,
+    EncFlow m r,
+    HasKafkaProducer r,
+    ClickhouseFlow m r
+  ) =>
+  Bool ->
+  Merchant ->
+  Text ->
+  Text ->
+  AuthReq ->
+  Maybe Text ->
+  Maybe Text ->
+  Maybe Version ->
+  Maybe Version ->
+  Maybe Version ->
+  Maybe Text ->
+  Maybe Text ->
+  m AuthRes
+issueDirectSessionForReq preserveExistingName merchant countryCode mobileNumberDecrypted reqWithMobileNumebr notificationToken deviceToken mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDevice = do
+  smsCfg <- asks (.smsCfg)
+  mbCloudType <- asks (.cloudType)
   mobileNumberHash <- getDbHash mobileNumberDecrypted
   person <-
     Person.findByRoleAndMobileNumberAndMerchantId SP.USER countryCode mobileNumberHash merchant.id
@@ -665,7 +680,11 @@ resolveAndIssueDirectSession merchant countryCode mobileNumberDecrypted mbName m
       mbEncEmail <- encrypt `mapM` reqWithMobileNumebr.email
       mbEncBusinessEmail <- encrypt `mapM` reqWithMobileNumebr.businessEmail
       _ <- RegistrationToken.setDirectAuth regToken.id SR.SIGNATURE
-      _ <- Person.updatePersonalInfo person.id (reqWithMobileNumebr.firstName <|> person.firstName <|> Just "User") reqWithMobileNumebr.middleName reqWithMobileNumebr.lastName mbEncEmail mbEncBusinessEmail deviceToken notificationToken (reqWithMobileNumebr.language <|> person.language <|> Just Language.ENGLISH) (reqWithMobileNumebr.gender <|> Just person.gender) mbRnVersion (mbClientVersion <|> Nothing) (mbBundleVersion <|> Nothing) mbClientConfigVersion (getDeviceFromText mbDevice) deploymentVersion.getDeploymentVersion person.enableOtpLessRide Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing person Nothing Nothing Nothing Nothing mbCloudType
+      let resolvedFirstName =
+            if preserveExistingName
+              then person.firstName <|> reqWithMobileNumebr.firstName <|> Just "User"
+              else reqWithMobileNumebr.firstName <|> person.firstName <|> Just "User"
+      _ <- Person.updatePersonalInfo person.id resolvedFirstName reqWithMobileNumebr.middleName reqWithMobileNumebr.lastName mbEncEmail mbEncBusinessEmail deviceToken notificationToken (reqWithMobileNumebr.language <|> person.language <|> Just Language.ENGLISH) (reqWithMobileNumebr.gender <|> Just person.gender) mbRnVersion (mbClientVersion <|> Nothing) (mbBundleVersion <|> Nothing) mbClientConfigVersion (getDeviceFromText mbDevice) deploymentVersion.getDeploymentVersion person.enableOtpLessRide Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing person Nothing Nothing Nothing Nothing mbCloudType
       personAPIEntity <- verifyFlow person regToken reqWithMobileNumebr.whatsappNotificationEnroll deviceToken
       return $ AuthRes regToken.id regToken.attempts SR.DIRECT (Just regToken.token) (Just personAPIEntity) person.blocked Nothing Nothing
     else return $ AuthRes regToken.id regToken.attempts regToken.authType Nothing Nothing person.blocked Nothing Nothing

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
@@ -27,6 +27,8 @@ import qualified Kernel.External.Ticket.Interface.Types as Ticket
 import qualified Kernel.External.Tokenize as Tokenize
 import Kernel.External.Whatsapp.Interface as Whatsapp
 import Kernel.Prelude
+import qualified PartnerAuth.Interface.Types as PartnerAuth
+import qualified PartnerAuth.Types as PartnerAuth
 import qualified Text.Show as Show
 import Tools.Beam.UtilsTH
 import Utils.Common.JWT.Config as GW
@@ -59,12 +61,14 @@ data ServiceName
   | SOSService SOS.SOSService
   | SettlementService Settlement.SettlementService
   | EventTrackingService EventTracking.EventTrackingService
+  | PartnerAuthService PartnerAuth.PartnerAuthService
   deriving stock (Eq, Ord, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 $(mkBeamInstancesForEnum ''ServiceName)
 
 instance Show ServiceName where
+  show (PartnerAuthService s) = "PartnerAuth_" <> show s
   show (MapsService s) = "Maps_" <> show s
   show (SmsService s) = "Sms_" <> show s
   show (WhatsappService s) = "Whatsapp_" <> show s
@@ -201,6 +205,10 @@ instance Read ServiceName where
                  | r1 <- stripPrefix "EventTracking_" r,
                    (v1, r2) <- readsPrec (app_prec + 1) r1
                ]
+            ++ [ (PartnerAuthService v1, r2)
+                 | r1 <- stripPrefix "PartnerAuth_" r,
+                   (v1, r2) <- readsPrec (app_prec + 1) r1
+               ]
       )
     where
       app_prec = 10
@@ -233,6 +241,7 @@ data ServiceConfigD (s :: UsageSafety)
   | SOSServiceConfig !SOSInterface.SOSServiceConfig
   | SettlementServiceConfig !Settlement.SettlementServiceConfig
   | EventTrackingServiceConfig !EventTrackingInterface.EventTrackingServiceConfig
+  | PartnerAuthServiceConfig !PartnerAuth.PartnerAuthServiceConfig
   deriving (Generic, Eq)
 
 type ServiceConfig = ServiceConfigD 'Safe
@@ -246,6 +255,7 @@ instance FromJSON (ServiceConfigD 'Safe)
 instance ToJSON (ServiceConfigD 'Safe)
 
 instance Show (ServiceConfigD 'Safe) where
+  show (PartnerAuthServiceConfig cfg) = "PartnerAuthServiceConfig " <> show cfg
   show (MapsServiceConfig cfg) = "MapsServiceConfig " <> show cfg
   show (SmsServiceConfig cfg) = "SmsServiceConfig " <> show cfg
   show (WhatsappServiceConfig cfg) = "WhatsappServiceConfig " <> show cfg
@@ -274,6 +284,7 @@ instance Show (ServiceConfigD 'Safe) where
   show (EventTrackingServiceConfig cfg) = "EventTrackingServiceConfig " <> show cfg
 
 instance Show (ServiceConfigD 'Unsafe) where
+  show (PartnerAuthServiceConfig cfg) = "PartnerAuthServiceConfig " <> show cfg
   show (MapsServiceConfig cfg) = "MapsServiceConfig " <> show cfg
   show (SmsServiceConfig cfg) = "SmsServiceConfig " <> show cfg
   show (WhatsappServiceConfig cfg) = "WhatsappServiceConfig " <> show cfg

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MerchantServiceConfig.hs
@@ -58,6 +58,8 @@ import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Hedis
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import qualified PartnerAuth.Interface.Types as PartnerAuth
+import qualified PartnerAuth.Types as PartnerAuth
 import qualified Storage.Queries.MerchantServiceConfig as Queries
 import qualified Utils.Common.JWT.Config as GW
 
@@ -217,6 +219,8 @@ getServiceName msc = case msc.serviceConfig of
   SettlementServiceConfig cfg -> SettlementService cfg.settlementService
   EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
     EventTrackingInterface.MoengageConfig _ -> EventTrackingService EventTracking.Moengage
+  PartnerAuthServiceConfig partnerAuthCfg -> case partnerAuthCfg of
+    PartnerAuth.BHIMConfig _ -> PartnerAuthService PartnerAuth.BHIM
 
 upsertMerchantServiceConfig :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => MerchantServiceConfig -> m ()
 upsertMerchantServiceConfig cfg = do

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/PlaceBasedServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/PlaceBasedServiceConfig.hs
@@ -36,6 +36,8 @@ import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Hedis
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import qualified PartnerAuth.Interface.Types as PartnerAuth
+import qualified PartnerAuth.Types as PartnerAuth
 import qualified Storage.Queries.PlaceBasedServiceConfig as Queries
 import Utils.Common.JWT.Config as GW
 
@@ -159,3 +161,5 @@ getServiceNameFromPlaceBasedConfigs msc = case msc.serviceConfig of
   SettlementServiceConfig cfg -> SettlementService cfg.settlementService
   EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
     EventTrackingInterface.MoengageConfig _ -> EventTrackingService EventTracking.Moengage
+  PartnerAuthServiceConfig partnerAuthCfg -> case partnerAuthCfg of
+    PartnerAuth.BHIMConfig _ -> PartnerAuthService PartnerAuth.BHIM

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/MerchantServiceConfigExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/MerchantServiceConfigExtra.hs
@@ -33,6 +33,8 @@ import Kernel.Types.Error
 import Kernel.Types.Id
 import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
 import Kernel.Utils.Logging
+import qualified PartnerAuth.Interface.Types as PartnerAuth
+import qualified PartnerAuth.Types as PartnerAuth
 import qualified Sequelize as Se
 import qualified Storage.Beam.MerchantServiceConfig as BeamMSC
 import qualified Storage.CachedQueries.Merchant as CQM
@@ -203,3 +205,5 @@ getServiceNameConfigJSON = \case
   Domain.SettlementServiceConfig cfg -> (Domain.SettlementService cfg.settlementService, toJSON cfg)
   Domain.EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
     EventTrackingInterface.MoengageConfig cfg -> (Domain.EventTrackingService EventTracking.Moengage, toJSON cfg)
+  Domain.PartnerAuthServiceConfig partnerAuthCfg -> case partnerAuthCfg of
+    PartnerAuth.BHIMConfig cfg -> (Domain.PartnerAuthService PartnerAuth.BHIM, toJSON cfg)

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
@@ -30,6 +30,8 @@ import Kernel.Prelude
 import Kernel.Types.Error
 import Kernel.Utils.Common
 import Kernel.Utils.JSON (valueToMaybe)
+import qualified PartnerAuth.Interface.Types as PartnerAuth
+import qualified PartnerAuth.Types as PartnerAuth
 import qualified Utils.Common.JWT.Config as GW
 
 getServiceConfigFromDomain :: (MonadFlow m) => Domain.ServiceName -> A.Value -> m Domain.ServiceConfig
@@ -94,6 +96,7 @@ getServiceConfigFromDomain serviceName configJSON = do
       Just cfg | cfg.settlementService == svc -> Just $ Domain.SettlementServiceConfig cfg
       _ -> Nothing
     Domain.EventTrackingService EventTracking.Moengage -> Domain.EventTrackingServiceConfig . EventTrackingInterface.MoengageConfig <$> valueToMaybe configJSON
+    Domain.PartnerAuthService PartnerAuth.BHIM -> Domain.PartnerAuthServiceConfig . PartnerAuth.BHIMConfig <$> valueToMaybe configJSON
 
 mkPaymentServiceConfig :: A.Value -> Payment.PaymentService -> Maybe Payment.PaymentServiceConfig
 mkPaymentServiceConfig configJSON = \case
@@ -188,6 +191,8 @@ getServiceNameConfigJson = \case
   Domain.SettlementServiceConfig cfg -> (Domain.SettlementService cfg.settlementService, toJSON cfg)
   Domain.EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
     EventTrackingInterface.MoengageConfig cfg -> (Domain.EventTrackingService EventTracking.Moengage, toJSON cfg)
+  Domain.PartnerAuthServiceConfig partnerAuthCfg -> case partnerAuthCfg of
+    PartnerAuth.BHIMConfig cfg -> (Domain.PartnerAuthService PartnerAuth.BHIM, toJSON cfg)
 
 getPaymentServiceConfigJson :: Payment.PaymentServiceConfig -> (Payment.PaymentService, A.Value)
 getPaymentServiceConfigJson = \case

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/PartnerAuth.hs
@@ -1,0 +1,39 @@
+module Tools.PartnerAuth
+  ( getPartnerAuthConfig,
+  )
+where
+
+import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.MerchantServiceConfig as DMSC
+import Kernel.Prelude
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import qualified PartnerAuth.Interface.Types as PartnerAuth
+import qualified PartnerAuth.Types as PartnerAuth
+import Storage.ConfigPilot.Config.MerchantServiceConfig (MerchantServiceConfigDimensions (..))
+import Storage.ConfigPilot.Interface.Types (getOneConfig)
+
+-- | Fetch the active partner-auth provider config (DB-backed MerchantServiceConfig)
+-- for the given merchant/op-city and provider. Returns Nothing if no config row
+-- exists or the stored config is of an unexpected service type.
+getPartnerAuthConfig ::
+  (EncFlow m r, EsqDBFlow m r, CacheFlow m r) =>
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
+  PartnerAuth.PartnerAuthService ->
+  m (Maybe PartnerAuth.PartnerAuthServiceConfig)
+getPartnerAuthConfig merchantId merchantOperatingCityId provider = do
+  mbConfig <-
+    getOneConfig
+      ( MerchantServiceConfigDimensions
+          { merchantOperatingCityId = merchantOperatingCityId.getId,
+            merchantId = merchantId.getId,
+            serviceName = Just (DMSC.PartnerAuthService provider)
+          }
+      )
+  pure $ case mbConfig of
+    Just config -> case config.serviceConfig of
+      DMSC.PartnerAuthServiceConfig msc -> Just msc
+      _ -> Nothing
+    Nothing -> Nothing

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/PartnerAuth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/PartnerAuth.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Tools.PartnerAuth
   ( getPartnerAuthConfig,
   )
@@ -11,27 +13,23 @@ import Kernel.Types.Id
 import Kernel.Utils.Common
 import qualified PartnerAuth.Interface.Types as PartnerAuth
 import qualified PartnerAuth.Types as PartnerAuth
-import Storage.ConfigPilot.Config.MerchantServiceConfig (MerchantServiceConfigDimensions (..))
-import Storage.ConfigPilot.Interface.Types (getOneConfig)
+import qualified Storage.CachedQueries.Merchant.MerchantServiceConfig as CQMSC
 
 -- | Fetch the active partner-auth provider config (DB-backed MerchantServiceConfig)
--- for the given merchant/op-city and provider. Returns Nothing if no config row
--- exists or the stored config is of an unexpected service type.
+-- for the given merchant/op-city and provider.
+--
+-- Uses the EXACT (merchant, op-city, serviceName) lookup rather than ConfigPilot's
+-- getOneConfig, so no city-level fallback can select a different city's credentials
+-- for partner auth. Returns Nothing if no row exists or the stored config is of an
+-- unexpected service type.
 getPartnerAuthConfig ::
-  (EncFlow m r, EsqDBFlow m r, CacheFlow m r) =>
+  (EsqDBFlow m r, CacheFlow m r) =>
   Id DM.Merchant ->
   Id DMOC.MerchantOperatingCity ->
   PartnerAuth.PartnerAuthService ->
   m (Maybe PartnerAuth.PartnerAuthServiceConfig)
 getPartnerAuthConfig merchantId merchantOperatingCityId provider = do
-  mbConfig <-
-    getOneConfig
-      ( MerchantServiceConfigDimensions
-          { merchantOperatingCityId = merchantOperatingCityId.getId,
-            merchantId = merchantId.getId,
-            serviceName = Just (DMSC.PartnerAuthService provider)
-          }
-      )
+  mbConfig <- CQMSC.findByMerchantOpCityIdAndService merchantId merchantOperatingCityId (DMSC.PartnerAuthService provider)
   pure $ case mbConfig of
     Just config -> case config.serviceConfig of
       DMSC.PartnerAuthServiceConfig msc -> Just msc

--- a/Backend/app/rider-platform/rider-app/Main/test/Main.hs
+++ b/Backend/app/rider-platform/rider-app/Main/test/Main.hs
@@ -1,35 +1,8 @@
-import App
-import qualified Data.Text as T
-import Environment
-import qualified EulerHS.Language as L
-import EulerHS.Prelude
-import EulerHS.Runtime (withFlowRuntime)
-import qualified FRFS.DirectQR as DirectQR
-import Kernel.Beam.Types (KafkaConn (..))
-import Kernel.Exit
-import Kernel.Tools.Metrics.CoreMetrics.Types
-import Kernel.Types.Flow
-import Kernel.Utils.App
-import Kernel.Utils.Common
-import Kernel.Utils.Dhall
-import Kernel.Utils.FlowLogging
-import System.Environment (lookupEnv)
-import System.Environment as Env (setEnv)
+module Main (main) where
+
+import qualified PartnerAuth.BhimAES as BhimAES
+import Test.Tasty
+import Prelude
 
 main :: IO ()
-main = do
-  -- setEnv "RIDER_APP_CONFIG_PATH" "../../../../dhall-configs/dev/rider-app.dhall"
-  -- appCfg <- readDhallConfigDefault "rider-app"
-  -- hostname <- (T.pack <$>) <$> lookupEnv "POD_NAME"
-  -- let loggerRt = getEulerLoggerRuntime hostname $ appCfg.loggerConfig
-  -- appEnv <- try (buildAppEnv appCfg) >>= handleLeftIO @SomeException exitBuildingAppEnvFailure "Couldn't build AppEnv: "
-
-  -- withFlowRuntime (Just loggerRt) $ \flowRt -> do
-  --   runFlowR flowRt appEnv $ do
-  --     logInfo "Starting Direct QR tests..."
-  --     DirectQR.tests flowRt appEnv
-  --     logInfo "Finished Direct QR tests"
-
-  -- -- Let the Logs be flushed
-  -- threadDelaySec (Seconds 10)
-  pure ()
+main = defaultMain $ testGroup "rider-app-tests" [BhimAES.tests]

--- a/Backend/app/rider-platform/rider-app/Main/test/Main.hs
+++ b/Backend/app/rider-platform/rider-app/Main/test/Main.hs
@@ -1,8 +1,9 @@
 module Main (main) where
 
 import qualified PartnerAuth.BhimAES as BhimAES
+import qualified PartnerAuth.MobileNormalize as MobileNormalize
 import Test.Tasty
 import Prelude
 
 main :: IO ()
-main = defaultMain $ testGroup "rider-app-tests" [BhimAES.tests]
+main = defaultMain $ testGroup "rider-app-tests" [BhimAES.tests, MobileNormalize.tests]

--- a/Backend/app/rider-platform/rider-app/Main/test/PartnerAuth/BhimAES.hs
+++ b/Backend/app/rider-platform/rider-app/Main/test/PartnerAuth/BhimAES.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Unit tests for the BHIM AES envelope (PartnerAuth.BHIM.Encryption).
+-- Uses the deterministic, pure core (encryptEnvelopeWithIV) so no Flow runtime
+-- is needed. The random-IV behaviour is covered by encrypting the same
+-- plaintext under two different IVs.
+module PartnerAuth.BhimAES (tests) where
+
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import PartnerAuth.BHIM.Encryption (decryptEnvelope, encryptEnvelopeWithIV)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Prelude
+
+-- A 32-byte (256-bit) AES key.
+testKey :: Text
+testKey = "0123456789abcdef0123456789abcdef"
+
+iv1, iv2 :: BS.ByteString
+iv1 = BS.pack [0 .. 15]
+iv2 = BS.pack [16 .. 31]
+
+samplePlaintext :: Text
+samplePlaintext = "{\"token\":\"bhim-test-token-123\"}"
+
+tests :: TestTree
+tests =
+  testGroup
+    "PartnerAuth.BHIM AES envelope"
+    [ testCase "round-trips plaintext (encrypt then decrypt)" $ do
+        enc <- either (assertFailure . ("encrypt failed: " <>)) pure (encryptEnvelopeWithIV testKey iv1 samplePlaintext)
+        dec <- either (assertFailure . ("decrypt failed: " <>)) pure (decryptEnvelope testKey enc)
+        dec @?= samplePlaintext,
+      testCase "different IVs => different ciphertext, both decrypt back" $ do
+        enc1 <- either (assertFailure . ("encrypt1 failed: " <>)) pure (encryptEnvelopeWithIV testKey iv1 samplePlaintext)
+        enc2 <- either (assertFailure . ("encrypt2 failed: " <>)) pure (encryptEnvelopeWithIV testKey iv2 samplePlaintext)
+        assertBool "ciphertexts should differ for different IVs" (enc1 /= enc2)
+        d1 <- either (assertFailure . ("decrypt1 failed: " <>)) pure (decryptEnvelope testKey enc1)
+        d2 <- either (assertFailure . ("decrypt2 failed: " <>)) pure (decryptEnvelope testKey enc2)
+        d1 @?= samplePlaintext
+        d2 @?= samplePlaintext,
+      testCase "rejects a non-32-byte key" $
+        case encryptEnvelopeWithIV "tooshortkey" iv1 samplePlaintext of
+          Left _ -> pure ()
+          Right _ -> assertFailure "expected failure for non-32-byte key"
+          -- TODO: once BHIM provides an official sample vector
+          -- { key, plaintext, ciphertext }, assert
+          -- decryptEnvelope key sampleCiphertext == plaintext to confirm
+          -- cross-implementation interop (mode / IV layout / padding).
+    ]

--- a/Backend/app/rider-platform/rider-app/Main/test/PartnerAuth/MobileNormalize.hs
+++ b/Backend/app/rider-platform/rider-app/Main/test/PartnerAuth/MobileNormalize.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Unit tests for BHIM mobile-number normalisation. Guards against the
+-- duplicate-account risk: BHIM may send the number bare, or with a 91 / +91 /
+-- 0091 prefix, and it must normalise to the same ("+91", <local 10-digit>) used
+-- to look up / create the Person.
+module PartnerAuth.MobileNormalize (tests) where
+
+import Domain.Action.UI.PartnerAuth (normalizeIndianMobile)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Prelude
+
+tests :: TestTree
+tests =
+  testGroup
+    "normalizeIndianMobile"
+    [ testCase "bare 10-digit" $ normalizeIndianMobile "9876543210" @?= ("+91", "9876543210"),
+      testCase "91 prefix" $ normalizeIndianMobile "919876543210" @?= ("+91", "9876543210"),
+      testCase "+91 prefix" $ normalizeIndianMobile "+919876543210" @?= ("+91", "9876543210"),
+      testCase "+91 with spaces" $ normalizeIndianMobile "+91 98765 43210" @?= ("+91", "9876543210"),
+      testCase "0091 prefix" $ normalizeIndianMobile "00919876543210" @?= ("+91", "9876543210")
+    ]

--- a/Backend/app/rider-platform/rider-app/Main/test/PartnerAuth/MobileNormalize.hs
+++ b/Backend/app/rider-platform/rider-app/Main/test/PartnerAuth/MobileNormalize.hs
@@ -3,7 +3,8 @@
 -- | Unit tests for BHIM mobile-number normalisation. Guards against the
 -- duplicate-account risk: BHIM may send the number bare, or with a 91 / +91 /
 -- 0091 prefix, and it must normalise to the same ("+91", <local 10-digit>) used
--- to look up / create the Person.
+-- to look up / create the Person. Malformed numbers must fail closed (Nothing)
+-- so the facade never creates a Person under a junk identifier.
 module PartnerAuth.MobileNormalize (tests) where
 
 import Domain.Action.UI.PartnerAuth (normalizeIndianMobile)
@@ -15,9 +16,21 @@ tests :: TestTree
 tests =
   testGroup
     "normalizeIndianMobile"
-    [ testCase "bare 10-digit" $ normalizeIndianMobile "9876543210" @?= ("+91", "9876543210"),
-      testCase "91 prefix" $ normalizeIndianMobile "919876543210" @?= ("+91", "9876543210"),
-      testCase "+91 prefix" $ normalizeIndianMobile "+919876543210" @?= ("+91", "9876543210"),
-      testCase "+91 with spaces" $ normalizeIndianMobile "+91 98765 43210" @?= ("+91", "9876543210"),
-      testCase "0091 prefix" $ normalizeIndianMobile "00919876543210" @?= ("+91", "9876543210")
+    [ testGroup
+        "accepts plausible Indian mobiles"
+        [ testCase "bare 10-digit" $ normalizeIndianMobile "9876543210" @?= Just ("+91", "9876543210"),
+          testCase "91 prefix" $ normalizeIndianMobile "919876543210" @?= Just ("+91", "9876543210"),
+          testCase "+91 prefix" $ normalizeIndianMobile "+919876543210" @?= Just ("+91", "9876543210"),
+          testCase "+91 with spaces" $ normalizeIndianMobile "+91 98765 43210" @?= Just ("+91", "9876543210"),
+          testCase "0091 prefix" $ normalizeIndianMobile "00919876543210" @?= Just ("+91", "9876543210"),
+          testCase "leading 6 boundary" $ normalizeIndianMobile "6000000000" @?= Just ("+91", "6000000000")
+        ],
+      testGroup
+        "rejects malformed numbers (fail closed)"
+        [ testCase "too few digits" $ normalizeIndianMobile "12345" @?= Nothing,
+          testCase "empty" $ normalizeIndianMobile "" @?= Nothing,
+          testCase "non-mobile leading digit (0)" $ normalizeIndianMobile "0123456789" @?= Nothing,
+          testCase "non-mobile leading digit (5)" $ normalizeIndianMobile "5123456789" @?= Nothing,
+          testCase "all non-digits" $ normalizeIndianMobile "not-a-number" @?= Nothing
+        ]
     ]

--- a/Backend/dev/feature-migrations/0013-partner-auth-bhim-seed.sql
+++ b/Backend/dev/feature-migrations/0013-partner-auth-bhim-seed.sql
@@ -1,0 +1,50 @@
+-- Seed PartnerAuth_BHIM merchant_service_config row for the NAMMA_YATRI merchant
+-- (default operating city) so the BHIM PWA-journey facade can resolve its
+-- provider config via MerchantServiceConfig.
+--
+-- NOTE: `aesKey` is an EncryptedField — the { "encrypted", "hash" } values below
+-- are PLACEHOLDERS. Before any real use, replace them with the BHIM AES key
+-- encrypted via the configured encryption service (passetto), and set
+-- baseUrl / partnerId to the real per-environment values (UAT / prod).
+-- The build does not depend on these values.
+
+DO $$
+DECLARE
+  v_merchant_id TEXT;
+  v_city_id TEXT;
+BEGIN
+  SELECT moc.merchant_id, moc.id INTO v_merchant_id, v_city_id
+  FROM atlas_app.merchant_operating_city moc
+  JOIN atlas_app.merchant m ON m.id = moc.merchant_id
+  WHERE m.short_id = 'NAMMA_YATRI'
+    AND moc.city = m.default_city -- runtime resolves config by the merchant's default city
+  LIMIT 1;
+
+  IF v_merchant_id IS NULL OR v_city_id IS NULL THEN
+    RAISE NOTICE 'NAMMA_YATRI merchant_operating_city not found; skipping PartnerAuth_BHIM config seed';
+    RETURN;
+  END IF;
+
+  INSERT INTO atlas_app.merchant_service_config
+    (merchant_id, merchant_operating_city_id, service_name, config_json, created_at, updated_at)
+  VALUES
+    ( v_merchant_id,
+      v_city_id,
+      'PartnerAuth_BHIM',
+      jsonb_build_object(
+        'baseUrl',   'https://uat.bhim.example.com',           -- PLACEHOLDER (per-env BHIM base URL)
+        'partnerId', 'REPLACE_WITH_BHIM_PARTNER_ID',           -- PLACEHOLDER (per-env)
+        'aesKey',    jsonb_build_object(                        -- EncryptedField 'AsEncrypted Text
+          'encrypted', 'REPLACE_WITH_ENCRYPTED_BHIM_AES_KEY',  -- PLACEHOLDER (passetto-encrypted)
+          'hash',      'REPLACE_WITH_AES_KEY_HASH'              -- PLACEHOLDER
+        )
+      )::json,
+      now(),
+      now()
+    )
+  ON CONFLICT (service_name, merchant_operating_city_id) DO UPDATE SET -- matches the city-aware PK
+    config_json = EXCLUDED.config_json,
+    updated_at = now();
+
+  RAISE NOTICE 'Seeded PartnerAuth_BHIM merchant_service_config for NAMMA_YATRI (merchant %, city %)', v_merchant_id, v_city_id;
+END $$;

--- a/Backend/lib/external/external.cabal
+++ b/Backend/lib/external/external.cabal
@@ -42,6 +42,14 @@ library
       Email.GCP.Flow
       Email.Types
       KafkaLogs.TransactionLogs
+      PartnerAuth.BHIM.API
+      PartnerAuth.BHIM.Config
+      PartnerAuth.BHIM.Encryption
+      PartnerAuth.BHIM.Types
+      PartnerAuth.Interface
+      PartnerAuth.Interface.BHIM
+      PartnerAuth.Interface.Types
+      PartnerAuth.Types
       Slack.AWS.Flow
       Slack.Flow
       Slack.GCP.Flow

--- a/Backend/lib/external/src/PartnerAuth/BHIM/API.hs
+++ b/Backend/lib/external/src/PartnerAuth/BHIM/API.hs
@@ -1,0 +1,40 @@
+module PartnerAuth.BHIM.API where
+
+import EulerHS.Types (EulerClient, client)
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+import Kernel.Types.Error
+import Kernel.Utils.Common
+import PartnerAuth.BHIM.Types
+import Servant hiding (throwError)
+
+-- Common envelope: POST {BHIM_BASE}/<path> with header partnerID and body
+-- { encRequest }, response { encResponseBody }.
+type VerifyTokenAPI =
+  "pwa" :> "api" :> "v2" :> "verify-token"
+    :> Header "partnerID" Text
+    :> ReqBody '[JSON] EncEnvelope
+    :> Post '[JSON] EncEnvelopeRes
+
+type UserDetailsAPI =
+  "pwa" :> "api" :> "v2" :> "user-details"
+    :> Header "partnerID" Text
+    :> ReqBody '[JSON] EncEnvelope
+    :> Post '[JSON] EncEnvelopeRes
+
+verifyTokenClient :: Maybe Text -> EncEnvelope -> EulerClient EncEnvelopeRes
+verifyTokenClient = client (Proxy :: Proxy VerifyTokenAPI)
+
+userDetailsClient :: Maybe Text -> EncEnvelope -> EulerClient EncEnvelopeRes
+userDetailsClient = client (Proxy :: Proxy UserDetailsAPI)
+
+callVerifyToken :: (CoreMetrics m, MonadFlow m, HasRequestId r, MonadReader r m) => BaseUrl -> Maybe Text -> EncEnvelope -> m EncEnvelopeRes
+callVerifyToken url partnerId req =
+  callAPI url (verifyTokenClient partnerId req) "bhimVerifyToken" (Proxy :: Proxy VerifyTokenAPI)
+    >>= fromEitherM (\err -> InternalError $ "Failed to call BHIM verify-token API: " <> show err)
+
+callUserDetails :: (CoreMetrics m, MonadFlow m, HasRequestId r, MonadReader r m) => BaseUrl -> Maybe Text -> EncEnvelope -> m EncEnvelopeRes
+callUserDetails url partnerId req =
+  callAPI url (userDetailsClient partnerId req) "bhimUserDetails" (Proxy :: Proxy UserDetailsAPI)
+    >>= fromEitherM (\err -> InternalError $ "Failed to call BHIM user-details API: " <> show err)

--- a/Backend/lib/external/src/PartnerAuth/BHIM/Config.hs
+++ b/Backend/lib/external/src/PartnerAuth/BHIM/Config.hs
@@ -1,0 +1,14 @@
+module PartnerAuth.BHIM.Config where
+
+import Kernel.External.Encryption
+import Kernel.Prelude
+
+-- | BHIM provider configuration, stored per merchant/op-city in
+-- MerchantServiceConfig.config_json. The AES key is encrypted at rest
+-- (EncryptedField) and decrypted only at call time.
+data BhimCfg = BhimCfg
+  { baseUrl :: BaseUrl,
+    partnerId :: Text,
+    aesKey :: EncryptedField 'AsEncrypted Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)

--- a/Backend/lib/external/src/PartnerAuth/BHIM/Encryption.hs
+++ b/Backend/lib/external/src/PartnerAuth/BHIM/Encryption.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Single home for BHIM's AES envelope crypto. Working assumption (confirm
+-- with BHIM before prod): AES-256-CBC, random 16-byte IV prepended to the
+-- ciphertext, base64 over (IV ‖ ciphertext), PKCS7 padding, key = BHIM AES key.
+-- A change of mode/IV/padding should only touch this module.
+module PartnerAuth.BHIM.Encryption
+  ( encryptEnvelope,
+    encryptEnvelopeWithIV,
+    decryptEnvelope,
+  )
+where
+
+import qualified Crypto.Cipher.AES as AES
+import qualified Crypto.Cipher.Types as CT
+import qualified Crypto.Error as CE
+import Crypto.Random (getRandomBytes)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import EulerHS.Prelude
+import Kernel.Types.Error
+import Kernel.Utils.Common
+
+pkcs7Pad :: BS.ByteString -> BS.ByteString
+pkcs7Pad input =
+  let blockSize = 16
+      padLen = blockSize - (BS.length input `mod` blockSize)
+   in input <> BS.replicate padLen (fromIntegral padLen)
+
+pkcs7Unpad :: BS.ByteString -> Either String BS.ByteString
+pkcs7Unpad bs
+  | BS.null bs = Left "Empty plaintext"
+  | otherwise =
+    let padLen = fromIntegral (BS.last bs)
+        len = BS.length bs
+     in if padLen <= 0 || padLen > 16 || padLen > len
+          then Left "Invalid PKCS7 padding length"
+          else
+            let (content, padding) = BS.splitAt (len - padLen) bs
+             in if BS.all (== fromIntegral padLen) padding
+                  then Right content
+                  else Left "Invalid PKCS7 padding"
+
+initCipher :: Text -> Either String AES.AES256
+initCipher key = do
+  let keyBytes = TE.encodeUtf8 key
+  if BS.length keyBytes /= 32
+    then Left "AES-256 requires a 32-byte (256-bit) key"
+    else case CT.cipherInit keyBytes :: CE.CryptoFailable AES.AES256 of
+      CE.CryptoPassed cipher -> Right cipher
+      CE.CryptoFailed err -> Left $ "Cipher init failed: " <> show err
+
+-- | Pure core: AES-256-CBC encrypt with a caller-supplied 16-byte IV.
+-- Returns base64(IV ‖ ciphertext). Deterministic — used by tests.
+encryptEnvelopeWithIV :: Text -> BS.ByteString -> Text -> Either String Text
+encryptEnvelopeWithIV key ivBytes plaintext = do
+  cipher <- initCipher key
+  iv <- maybe (Left "Invalid IV (need 16 bytes)") Right (CT.makeIV ivBytes)
+  let padded = pkcs7Pad (TE.encodeUtf8 plaintext)
+      ciphertext = CT.cbcEncrypt cipher iv padded
+  Right $ TE.decodeUtf8 (B64.encode (ivBytes <> ciphertext))
+
+-- | Encrypt with a fresh random 16-byte IV (prepended), base64-encoded.
+encryptEnvelope :: (MonadFlow m) => Text -> Text -> m Text
+encryptEnvelope key plaintext = do
+  ivBytes :: BS.ByteString <- liftIO (getRandomBytes 16)
+  case encryptEnvelopeWithIV key ivBytes plaintext of
+    Left err -> throwError $ InternalError ("PartnerAuth.BHIM AES encrypt failed: " <> T.pack err)
+    Right enc -> pure enc
+
+-- | Decrypt base64(IV ‖ ciphertext). Pure.
+decryptEnvelope :: Text -> Text -> Either String Text
+decryptEnvelope key encryptedText = do
+  cipher <- initCipher key
+  raw <- case B64.decode (TE.encodeUtf8 encryptedText) of
+    Left err -> Left $ "Base64 decode failed: " <> err
+    Right b -> Right b
+  when (BS.length raw < 16) $ Left "Ciphertext too short (missing IV)"
+  let (ivBytes, ciphertext) = BS.splitAt 16 raw
+  iv <- maybe (Left "Invalid IV") Right (CT.makeIV ivBytes)
+  let decrypted = CT.cbcDecrypt cipher iv ciphertext
+  unpadded <- pkcs7Unpad decrypted
+  case TE.decodeUtf8' unpadded of
+    Left err -> Left $ "UTF-8 decode failed: " <> show err
+    Right txt -> Right txt

--- a/Backend/lib/external/src/PartnerAuth/BHIM/Types.hs
+++ b/Backend/lib/external/src/PartnerAuth/BHIM/Types.hs
@@ -1,0 +1,36 @@
+module PartnerAuth.BHIM.Types where
+
+import Kernel.Prelude
+
+-- | S2S AES-encrypted envelope (request body).
+newtype EncEnvelope = EncEnvelope {encRequest :: Text}
+  deriving (Show, Generic, ToJSON, FromJSON)
+
+-- | S2S AES-encrypted envelope (response body).
+newtype EncEnvelopeRes = EncEnvelopeRes {encResponseBody :: Text}
+  deriving (Show, Generic, ToJSON, FromJSON)
+
+-- | Inner (decrypted) request for both verify-token and user-details.
+newtype TokenReq = TokenReq {token :: Text}
+  deriving (Show, Generic, ToJSON, FromJSON)
+
+-- | Inner (decrypted) response of verify-token.
+newtype VerifyTokenInnerRes = VerifyTokenInnerRes {isValid :: Bool}
+  deriving (Show, Generic, ToJSON, FromJSON)
+
+-- | Inner (decrypted) response of user-details.
+data UserDetailsInnerRes = UserDetailsInnerRes
+  { name :: Text,
+    mobileNumber :: Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON)
+
+-- | Inner (decrypted) error body. BHIM returns errors as HTTP 200 with an
+-- encrypted body that decrypts to this shape (errorCode in "400"|"401"|"500").
+data BhimErrorBody = BhimErrorBody
+  { userMessage :: Maybe Text,
+    message :: Maybe Text,
+    timeout :: Maybe Int,
+    errorCode :: Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON)

--- a/Backend/lib/external/src/PartnerAuth/Interface.hs
+++ b/Backend/lib/external/src/PartnerAuth/Interface.hs
@@ -1,0 +1,24 @@
+-- | Provider-agnostic dispatch for the partner embedded-auth integration.
+-- Add a new provider by adding a constructor to PartnerAuthServiceConfig and a
+-- case here. Mirrors ChatCompletion.Interface.
+module PartnerAuth.Interface
+  ( verifyToken,
+    getUserDetails,
+  )
+where
+
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+import Kernel.Utils.Servant.Client (HasRequestId)
+import qualified PartnerAuth.Interface.BHIM as BHIM
+import PartnerAuth.Interface.Types
+import qualified PartnerAuth.Types as PT
+
+verifyToken :: (EncFlow m r, CoreMetrics m, Log m, HasRequestId r, MonadReader r m) => PartnerAuthServiceConfig -> Text -> m Bool
+verifyToken serviceConfig token = case serviceConfig of
+  BHIMConfig cfg -> BHIM.verifyToken cfg token
+
+getUserDetails :: (EncFlow m r, CoreMetrics m, Log m, HasRequestId r, MonadReader r m) => PartnerAuthServiceConfig -> Text -> m PT.PartnerUserDetails
+getUserDetails serviceConfig token = case serviceConfig of
+  BHIMConfig cfg -> BHIM.getUserDetails cfg token

--- a/Backend/lib/external/src/PartnerAuth/Interface/BHIM.hs
+++ b/Backend/lib/external/src/PartnerAuth/Interface/BHIM.hs
@@ -1,0 +1,62 @@
+module PartnerAuth.Interface.BHIM
+  ( verifyToken,
+    getUserDetails,
+  )
+where
+
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Kernel.External.Encryption (decrypt)
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+import Kernel.Types.Error
+import Kernel.Utils.Common
+import qualified PartnerAuth.BHIM.API as API
+import PartnerAuth.BHIM.Config (BhimCfg)
+import PartnerAuth.BHIM.Encryption (decryptEnvelope, encryptEnvelope)
+import PartnerAuth.BHIM.Types
+import qualified PartnerAuth.Types as PT
+
+-- | Verify a BHIM token via the S2S verify-token API. Returns the partner's
+-- isValid verdict. A BHIM error body (errorCode) is logged and surfaced as a
+-- thrown error (the caller maps any failure to isValid:false).
+verifyToken :: (EncFlow m r, CoreMetrics m, Log m, HasRequestId r, MonadReader r m) => BhimCfg -> Text -> m Bool
+verifyToken cfg token = do
+  key <- decrypt cfg.aesKey
+  enc <- encryptEnvelope key (encodeToText (TokenReq token))
+  resp <- API.callVerifyToken cfg.baseUrl (Just cfg.partnerId) (EncEnvelope enc)
+  decrypted <- decryptOrThrow key resp.encResponseBody "verify-token"
+  case A.decode (toLBS decrypted) :: Maybe VerifyTokenInnerRes of
+    Just r -> pure r.isValid
+    Nothing -> handleErrorBody "verify-token" decrypted
+
+-- | Fetch user details via the S2S user-details API.
+getUserDetails :: (EncFlow m r, CoreMetrics m, Log m, HasRequestId r, MonadReader r m) => BhimCfg -> Text -> m PT.PartnerUserDetails
+getUserDetails cfg token = do
+  key <- decrypt cfg.aesKey
+  enc <- encryptEnvelope key (encodeToText (TokenReq token))
+  resp <- API.callUserDetails cfg.baseUrl (Just cfg.partnerId) (EncEnvelope enc)
+  decrypted <- decryptOrThrow key resp.encResponseBody "user-details"
+  case A.decode (toLBS decrypted) :: Maybe UserDetailsInnerRes of
+    Just r -> pure $ PT.PartnerUserDetails {name = r.name, mobileNumber = r.mobileNumber}
+    Nothing -> handleErrorBody "user-details" decrypted
+
+decryptOrThrow :: (MonadFlow m) => Text -> Text -> Text -> m Text
+decryptOrThrow key enc label =
+  case decryptEnvelope key enc of
+    Left err -> throwError $ InternalError ("BHIM " <> label <> " decrypt failed: " <> T.pack err)
+    Right t -> pure t
+
+handleErrorBody :: (MonadFlow m, Log m) => Text -> Text -> m a
+handleErrorBody label decrypted = do
+  let mbErr = A.decode (toLBS decrypted) :: Maybe BhimErrorBody
+  -- Log only safe metadata (endpoint label + error code). Never log the
+  -- decrypted body: for user-details it contains PII (name / mobile number).
+  logError $ "BHIM " <> label <> " returned error" <> maybe " (unparseable body)" (\e -> ", errorCode=" <> e.errorCode) mbErr
+  throwError $ InternalError ("BHIM " <> label <> " failed")
+
+toLBS :: Text -> BL.ByteString
+toLBS = BL.fromStrict . TE.encodeUtf8

--- a/Backend/lib/external/src/PartnerAuth/Interface/Types.hs
+++ b/Backend/lib/external/src/PartnerAuth/Interface/Types.hs
@@ -1,0 +1,8 @@
+module PartnerAuth.Interface.Types where
+
+import Kernel.Prelude
+import qualified PartnerAuth.BHIM.Config as BHIM
+
+-- | Sum of all provider configs. One constructor per PartnerAuthService.
+data PartnerAuthServiceConfig = BHIMConfig BHIM.BhimCfg
+  deriving (Show, Eq, Generic, FromJSON, ToJSON)

--- a/Backend/lib/external/src/PartnerAuth/Types.hs
+++ b/Backend/lib/external/src/PartnerAuth/Types.hs
@@ -1,0 +1,33 @@
+module PartnerAuth.Types
+  ( PartnerAuthService (..),
+    availablePartnerAuthServices,
+    parsePartnerAuthService,
+    PartnerUserDetails (..),
+  )
+where
+
+import qualified Data.Text as T
+import Kernel.Prelude
+
+-- | The set of supported partner embedded-auth providers.
+-- Add a new constructor here (and a matching provider module + Interface case)
+-- to onboard another partner. BHIM is the first provider.
+data PartnerAuthService = BHIM
+  deriving (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON, ToSchema, ToParamSchema)
+
+availablePartnerAuthServices :: [PartnerAuthService]
+availablePartnerAuthServices = [BHIM]
+
+-- | Parse the provider from the request path segment (case-insensitive).
+-- e.g. "bhim" -> Just BHIM. Unknown providers return Nothing.
+parsePartnerAuthService :: Text -> Maybe PartnerAuthService
+parsePartnerAuthService provider = case T.toLower provider of
+  "bhim" -> Just BHIM
+  _ -> Nothing
+
+-- | Provider-agnostic user details returned by a partner after token verification.
+data PartnerUserDetails = PartnerUserDetails
+  { name :: Text,
+    mobileNumber :: Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)


### PR DESCRIPTION
## What

Implements the **BHIM "PWA Journey" auth facade** — **Verify Token + Fetch User Details only** (payment stays on Juspay; no transaction/offline-status, deep-link, or partner-secret-key path).

Built as a **generic, provider-pluggable partner embedded-auth integration** (per review), with **BHIM as the first provider** and generic naming — BHIM-specific code is confined to `lib/external/src/PartnerAuth/BHIM/*`.

**Endpoint:** `POST /v2/partner/{provider}/session`
Request `{ token }` → response `{ isValid, sessionToken?, mobileNumber?, name? }`

Flow: parse `provider` → load its DB config (`MerchantServiceConfig`) → **verify token** (S2S, AES) → **fetch user details** (S2S, AES) → resolve/create the NammaYatri user by mobile number and issue an NY session **reusing the exact `/auth/signature` path**, under the **NAMMA_YATRI** merchant.

## How

- **`lib/external/src/PartnerAuth/`** — `PartnerAuthService` enum, `PartnerAuthServiceConfig` sum, a `case`-dispatch `Interface` exposing `verifyToken` / `getUserDetails` (mirrors `ChatCompletion`). BHIM provider: AES-256-CBC **random-IV** envelope (`encryptEnvelope`/`decryptEnvelope`, single home for mode/IV/padding), `partnerID`-header S2S client, and error-body (`errorCode`) handling → logged + mapped to `isValid:false`.
- **DB config** via `MerchantServiceConfig` (`service_name = PartnerAuth_BHIM`); AES key stored as `EncryptedField` (encrypted at rest), decrypted per call. Provider selected from the request path.
- **Session reuse:** new **additive** `resolveAndIssueDirectSession` in `Registration.hs` (plaintext-mobile entry point into the signature flow's person-resolution + DIRECT token issuance). `mobileSignatureAuth` and existing flows are **untouched**.
- **Never a 500:** the whole interaction is wrapped in `try @SomeException`; invalid token / unknown provider / any error → `200 {isValid:false}` + `logError`.

## Verification

- `cabal build all` passes under **`-Werror`** (whole monorepo).
- AES round-trip unit tests pass (`rider-app-test`): round-trip, random-IV differs + both decrypt, rejects non-32-byte key.

## Follow-ups before prod (flagged)

- **Real secrets** — `partnerId`, the encrypted `aesKey`, and UAT/prod base URLs in the seed migration (`dev/feature-migrations/0010-…`) are placeholders.
- **AES assumption** (AES-256-CBC, random 16-byte prepended IV, PKCS7, base64 over `IV‖ct`) is unconfirmed — `BHIM/Encryption.hs` isolates it to one file; a BHIM sample-vector interop test is stubbed (`TODO`) pending the real key.
- **Runtime smoke** (valid token → working `sessionToken` for getProfile) needs a real/mock BHIM + running stack; the reference mock (`ny-react-native` `web/mocks/bhim/server.js`) wasn't available in this repo, so the facade was built from the written spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added partner authentication integration supporting BHIM provider.
  * New endpoint `POST /partner/{provider}/session` enables seamless user authentication through partner platforms.
  * Partner-authenticated users receive session tokens and direct app access without OTP verification.
  * Added AES encryption for secure partner communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->