### PR TITLE
backend/fix/fix-pkey-violation-for-vendor-fee

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
@@ -44,6 +44,7 @@ import Domain.Types.Plan (BasedOnEntity (..), PaymentMode (AUTOPAY, MANUAL), Pla
 import Domain.Types.SubscriptionConfig
 import Domain.Types.TransporterConfig (TransporterConfig)
 import qualified Domain.Types.VendorFee as DVF
+import Kernel.Beam.Functions (runInMasterDbAndRedis)
 import Kernel.External.Encryption
 import qualified Kernel.External.Payment.Interface as PaymentInterface
 import qualified Kernel.External.Payment.Interface.Types as Payment
@@ -934,15 +935,27 @@ makeVendorFeeForCancellationPenalty ::
   TransporterConfig ->
   m ()
 makeVendorFeeForCancellationPenalty driverFee subscriptionConfig transporterConfig = when (fromMaybe False subscriptionConfig.isVendorSplitEnabled && isJust transporterConfig.cancellationFeeVendor && fromMaybe 0 driverFee.cancellationPenaltyAmount > 0) $ do
-  let vendorFee =
-        DVF.VendorFee
-          { driverFeeId = driverFee.id,
-            vendorId = fromMaybe "CANCELLATION_PENALTY_VENDOR" transporterConfig.cancellationFeeVendor,
-            amount = fromMaybe 0 driverFee.cancellationPenaltyAmount,
-            createdAt = driverFee.createdAt,
-            updatedAt = driverFee.updatedAt
-          }
-  QVF.create vendorFee
+  let vendorId = fromMaybe "CANCELLATION_PENALTY_VENDOR" transporterConfig.cancellationFeeVendor
+      cancellationAmount = fromMaybe 0 driverFee.cancellationPenaltyAmount
+      cancellationVendorFeeGuardKey = "VendorFee:CancellationApplied:" <> driverFee.id.getId
+  -- Guard against scheduler retries double-adding. Set after write so a crash re-applies, not skips.
+  alreadyApplied <- Hedis.get cancellationVendorFeeGuardKey
+  case (alreadyApplied :: Maybe Bool) of
+    Just True -> logError $ "makeVendorFeeForCancellationPenalty: cancellation already applied for driverFee " <> driverFee.id.getId <> ", skipping"
+    _ -> do
+      mbExisting <- runInMasterDbAndRedis $ QVF.findByVendorAndDriverFeeId vendorId driverFee.id
+      case mbExisting of
+        Just existing -> QVF.updateAmount driverFee.id vendorId (existing.amount + cancellationAmount)
+        Nothing ->
+          QVF.create
+            DVF.VendorFee
+              { driverFeeId = driverFee.id,
+                vendorId = vendorId,
+                amount = cancellationAmount,
+                createdAt = driverFee.createdAt,
+                updatedAt = driverFee.updatedAt
+              }
+      Hedis.setExp cancellationVendorFeeGuardKey True (3600 * 24)
 
 updateCancellationPenaltyAccumulationFees :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r, EncFlow m r, HasKafkaProducer r) => ServiceNames -> TransporterConfig -> Id Merchant -> Id MerchantOperatingCity -> m ()
 updateCancellationPenaltyAccumulationFees serviceName transporterConfig merchantId merchantOperatingCityId = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/VendorFeeExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/VendorFeeExtra.hs
@@ -172,3 +172,16 @@ updateVendorId driverFeeId oldVendorId newVendorId = do
           Se.Is Beam.vendorId $ Se.Eq oldVendorId
         ]
     ]
+
+updateAmount :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => Id DriverFee -> Text -> HighPrecMoney -> m ()
+updateAmount driverFeeId vendorId newAmount = do
+  now <- getCurrentTime
+  updateWithKV
+    [ Se.Set Beam.amount (roundToTwoDecimalPlaces newAmount),
+      Se.Set Beam.updatedAt now
+    ]
+    [ Se.And
+        [ Se.Is Beam.driverFeeId $ Se.Eq driverFeeId.getId,
+          Se.Is Beam.vendorId $ Se.Eq vendorId
+        ]
+    ]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
## Summary

Cancellation penalty share was silently dropped from `VendorFee` in the EOD `CalculateDriverFees` job, so the cancellation amount that should have gone to the vendor stayed with the marketplace at split settlement.

## Root cause

`makeVendorFeeForCancellationPenalty` called `QVF.create` blindly. When ride-end had already written a `VendorFee` row for the same `(driverFeeId, vendorId)`:

- KV `SETEX` overwrote the ride-end row with one holding only the cancellation amount.
- Postgres drainer's `INSERT ... ON CONFLICT DO NOTHING` swallowed the conflict.

Net: `VendorFee.amount` ended up = regular ride share only, missing the cancellation portion.

**Evidence:** `DriverFee 567cbf46...` had `cancellation_penalty_amount = ₹10`, but its `NAMMAYATRI` `VendorFee.amount = ₹8.02` (per-ride share only). Expected ≈ ₹18.02.

## Fix

Replace blind `QVF.create` with an upsert keyed on `(driverFeeId, vendorId)`:

1. Read existing `VendorFee` via `runInMasterDbAndRedis` (master read; the EOD job can race a recent ride-end write).
2. If exists → `QVF.updateAmount` summing onto existing amount.
3. If not → `QVF.create` a fresh row.

## Scope

- MANUAL parent flow only. AUTOPAY uses a freshly-generated child `driverFeeId`, so no collision is possible.
- Ride-end hot path untouched.

## Files

- `SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs` — rewrite `makeVendorFeeForCancellationPenalty`.
- `Storage/Queries/VendorFeeExtra.hs` — add `updateAmount :: Id DriverFee -> Text -> HighPrecMoney -> m ()`.



### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
