### PR TITLE
backend/fix: surface cumulative offer on standalone FRFS (transit leg for policy)

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -74,6 +74,7 @@ import qualified Kernel.Utils.CalculateDistance as CD
 import Kernel.Utils.Common hiding (mkPrice)
 import Kernel.Utils.SlidingWindowLimiter (checkSlidingWindowLimitWithOptions)
 import qualified Lib.JourneyModule.RouteServiceability as JMRouteServiceability
+import qualified Lib.JourneyModule.Types as JMTypes
 import qualified Lib.JourneyModule.Utils as JMU
 import qualified Lib.JourneyModule.Utils as JourneyUtils
 import qualified Lib.Payment.Domain.Action as DPayment
@@ -678,22 +679,17 @@ getFrfsSearchQuote (mbPersonId, merchantId_) searchId_ = do
           )
           routeFilteredQuotesWithCategories
   let mbReprAdultPrice = listToMaybe sortedQuotesWithCategories >>= \(_, qcs) -> find (\c -> c.category == ADULT) qcs <&> (.price)
-  -- Cumulative offer is surfaced on standalone FRFS quotes only. When this search is
-  -- a leg of a multimodal journey, the offer is computed once at the journey level
-  -- (generateJourneyInfoResponse), so skip it here to avoid a redundant fetch.
-  -- This is keyed off the journey leg, NOT the config's platform type: a standalone
-  -- purchase can resolve a MULTIMODAL-platform config (e.g. Chennai bus has no
-  -- APPLICATION config), and the offer must still surface there.
   mbOffer <-
     if isJust mbJourneyLeg
       then pure Nothing
       else case mbReprAdultPrice of
         Nothing -> pure Nothing
-        Just reprPrice ->
+        Just reprPrice -> do
+          standaloneLeg <- JMTypes.mkStandaloneFrfsMinimalLegInfo search
           withTryCatch
             "getFrfsSearchQuote:cumulativeOffer"
             ( SOffer.offerListCache merchantId_ personId search.merchantOperatingCityId (FRFSUtils.getPaymentType False search.vehicleType) reprPrice Nothing
-                >>= \offersResp -> SOffer.mkCumulativeOfferResp search.merchantOperatingCityId offersResp [] Nothing
+                >>= \offersResp -> SOffer.mkCumulativeOfferResp search.merchantOperatingCityId offersResp [standaloneLeg] Nothing
             )
             >>= \case
               Left _ -> pure Nothing

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
@@ -1195,6 +1195,133 @@ castCategoryToMode Spec.METRO = DTrip.Metro
 castCategoryToMode Spec.SUBWAY = DTrip.Subway
 castCategoryToMode Spec.BUS = DTrip.Bus
 
+mkStandaloneFrfsMinimalLegInfo :: (MonadFlow m) => FRFSSR.FRFSSearch -> m LegInfo
+mkStandaloneFrfsMinimalLegInfo frfsSearch = do
+  now <- getCurrentTime
+  legId <- generateGUID
+  let mkStation stopCode mbName mbPoint mbAddr =
+        FRFSStationAPI
+          { name = fromMaybe "" mbName,
+            code = stopCode,
+            lat = mbPoint <&> (.lat),
+            lon = mbPoint <&> (.lon),
+            address = mbAddr,
+            regionalName = Nothing,
+            hindiName = Nothing,
+            integratedBppConfigId = cast frfsSearch.integratedBppConfigId
+          }
+      originStop = mkStation frfsSearch.fromStationCode frfsSearch.fromStationName frfsSearch.fromStationPoint frfsSearch.fromStationAddress
+      destinationStop = mkStation frfsSearch.toStationCode frfsSearch.toStationName frfsSearch.toStationPoint frfsSearch.toStationAddress
+      legExtraInfo = case frfsSearch.vehicleType of
+        Spec.BUS ->
+          Bus
+            BusLegExtraInfo
+              { originStop = originStop,
+                destinationStop = destinationStop,
+                routeCode = fromMaybe "" frfsSearch.routeCode,
+                bookingId = Nothing,
+                tickets = Nothing,
+                ticketValidity = Nothing,
+                ticketsCreatedAt = Nothing,
+                routeName = Nothing,
+                providerName = Nothing,
+                selectedServiceTier = Nothing,
+                frequency = Nothing,
+                alternateShortNames = [],
+                ticketNo = Nothing,
+                adultTicketQuantity = Nothing,
+                childTicketQuantity = Nothing,
+                refund = Nothing,
+                refunds = [],
+                trackingStatus = JMState.InPlan,
+                trackingStatusLastUpdatedAt = now,
+                fleetNo = Nothing,
+                legStartTime = Nothing,
+                legEndTime = Nothing,
+                discounts = Nothing,
+                categories = [],
+                categoryBookingDetails = Nothing,
+                busConductorId = Nothing,
+                busDriverId = Nothing,
+                busTagNumber = Nothing,
+                tripId = Nothing,
+                tripStartTime = Nothing,
+                bookedStopETA = Nothing,
+                driverName = Nothing,
+                driverMobileNumber = Nothing,
+                seatSelectionType = Nothing
+              }
+        Spec.METRO ->
+          Metro
+            MetroLegExtraInfo
+              { routeInfo = [],
+                bookingId = Nothing,
+                tickets = Nothing,
+                ticketValidity = Nothing,
+                ticketsCreatedAt = Nothing,
+                providerName = Nothing,
+                ticketNo = Nothing,
+                adultTicketQuantity = Nothing,
+                childTicketQuantity = Nothing,
+                refund = Nothing,
+                refunds = [],
+                categories = [],
+                categoryBookingDetails = Nothing
+              }
+        Spec.SUBWAY ->
+          Subway
+            SubwayLegExtraInfo
+              { routeInfo = [],
+                bookingId = Nothing,
+                tickets = Nothing,
+                ticketValidity = Nothing,
+                ticketsCreatedAt = Nothing,
+                ticketValidityHours = [],
+                providerName = Nothing,
+                providerRouteId = Nothing,
+                deviceId = Nothing,
+                ticketTypeCode = Nothing,
+                selectedServiceTier = Nothing,
+                ticketNo = Nothing,
+                adultTicketQuantity = Nothing,
+                childTicketQuantity = Nothing,
+                refund = Nothing,
+                refunds = [],
+                categories = [],
+                categoryBookingDetails = Nothing
+              }
+  pure
+    LegInfo
+      { journeyLegId = legId,
+        skipBooking = False,
+        bookingAllowed = True,
+        pricingId = Nothing,
+        searchId = frfsSearch.id.getId,
+        travelMode = castCategoryToMode frfsSearch.vehicleType,
+        startTime = now,
+        order = 0,
+        status = InPlan,
+        bookingStatus = JMState.Initial JMState.BOOKING_PENDING,
+        estimatedDuration = Nothing,
+        estimatedMinFare = Nothing,
+        estimatedMaxFare = Nothing,
+        estimatedChildFare = Nothing,
+        estimatedTotalFare = Nothing,
+        estimatedDistance = Nothing,
+        legExtraInfo = legExtraInfo,
+        merchantId = frfsSearch.merchantId,
+        merchantOperatingCityId = frfsSearch.merchantOperatingCityId,
+        personId = frfsSearch.riderId,
+        actualDistance = Nothing,
+        totalFare = Nothing,
+        entrance = Nothing,
+        exit = Nothing,
+        validTill = frfsSearch.validTill,
+        hasApplicablePasses = Nothing,
+        observingFailures = Nothing,
+        isCancellable = Nothing
+      }
+
 mkLegInfoFromFrfsSearchRequest :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, HasShortDurationRetryCfg r c) => FRFSSR.FRFSSearch -> DJourneyLeg.JourneyLeg -> [DJourneyLeg.JourneyLeg] -> m LegInfo
 mkLegInfoFromFrfsSearchRequest frfsSearch@FRFSSR.FRFSSearch {..} journeyLeg journeyLegs = do
   let fallbackFare = journeyLeg.estimatedMinFare


### PR DESCRIPTION
## What

Follow-up to #15081. That PR added \`offer\` to \`FRFSQuoteAPIRes\` and the gating fix (\`isJust mbJourneyLeg\`), but \`getFrfsSearchQuote\` still passed \`[]\` legs to \`mkCumulativeOfferResp\`. \`CUMULATIVE_OFFER_POLICY\` gates display on:

```
showOffer    = transitLegs AND hasRupeeOffer
transitLegs  = filter(extraParams, legExtraInfo.tag ∈ {Subway, Metro, Bus})
```

With \`[]\` legs, \`transitLegs\` is always empty → \`showOffer = false\` → the offer **never renders on the standalone FRFS path** (the bus OTP-scan flow), even when the offer is present in the list. The journey path works only because it passes its real legs. So the merged feature silently shows nothing on the very flow it targets.

## Fix

\`mkStandaloneFrfsMinimalLegInfo\` (in \`Lib/JourneyModule/Types.hs\`) synthesises a single minimal transit \`LegInfo\` from the \`FRFSSearch\` row, tagged from \`search.vehicleType\` (BUS→Bus, METRO→Metro, SUBWAY→Subway). \`getFrfsSearchQuote\` passes \`[standaloneLeg]\` so the policy's \`transitLegs\` filter matches.

- The leg is **throwaway input** to the dynamic-logic call — never stored, never returned, never seen by the app. The policy reads only \`legExtraInfo.tag\`; the rest is filler (real stop codes from the search for the meaningful fields, \`Nothing\`/\`[]\` otherwise).
- **No DB reads, no side effects.** (Reusing \`mkLegInfoFromFrfsSearchRequest\` was rejected: it needs a real \`journey_leg\`, fires ~8 DB/Redis lookups, and mutates PT-booking circuit-breaker state.)
- **No Control Center / policy change required** — the existing \`transitLegs\` filter matches the synthesised tag.

## Why standalone has no journey leg

Path B (\`postFrfsSearch\`) calls \`postFrfsSearchHandler\` with a no-op journey-leg upsert (\`\\_ -> pure ()\`) and \`isSingleMode = True\` — no \`journey_leg\` row by design. So there is no real leg to reuse; the synthetic one is correct, not a workaround.

Builds clean under \`-Werror\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search quote generation for standalone searches to include all necessary offer information. The system now properly constructs complete data when processing independent searches, ensuring users receive more accurate and comprehensive results.

* **Improvements**
  * Optimized internal data handling to enhance overall search reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->