### PR TITLE
backend/test: fix FleetManagementFlow — routing and fleet hierarchy i…

### DIFF
--- a/Backend/dev/feature-migrations/0012-fix-helsinki-local-moc-resilience.sql
+++ b/Backend/dev/feature-migrations/0012-fix-helsinki-local-moc-resilience.sql
@@ -1,0 +1,36 @@
+-- MOC 391b4b7a exists in merchant_operating_city (from prod_international config-sync)
+-- but has no matching merchant_service_usage_config, causing MERCHANT_SERVICE_USAGE_CONFIG_NOT_FOUND
+-- on rider OTP verification. Copy the config from f9903ef6 (prod Helsinki MOC).
+
+INSERT INTO atlas_app.merchant_service_usage_config (
+  aadhaar_verification_service, auto_complete, created_at, enable_dashboard_sms,
+  get_distances, get_distances_for_cancel_ride, get_exophone, get_pickup_routes,
+  get_place_details, get_place_name, get_routes, get_trip_routes, initiate_call,
+  issue_ticket_service, merchant_id, merchant_operating_city_id, notify_person,
+  sms_providers_priority_list, snap_to_road, updated_at, use_fraud_detection,
+  whatsapp_providers_priority_list, update_payment_method_in_intent,
+  update_amount_in_payment_intent, get_card_list, create_setup_intent,
+  create_payment_intent, create_payment_customer, create_ephemeral_keys,
+  capture_payment_intent, delete_card, get_distances_for_scheduled_rides,
+  cancel_payment_intent, get_frfs_autocomplete_distances, get_multi_modal_service,
+  get_first_pickup_route, get_multimodal_walk_distance, insurance_service,
+  create_refunds, get_refunds, get_instruction_route, payout_order_status,
+  create_payout_order, event_tracking_providers
+)
+SELECT
+  aadhaar_verification_service, auto_complete, NOW(), enable_dashboard_sms,
+  get_distances, get_distances_for_cancel_ride, get_exophone, get_pickup_routes,
+  get_place_details, get_place_name, get_routes, get_trip_routes, initiate_call,
+  issue_ticket_service, merchant_id, '391b4b7a-3cc2-429d-b18f-034dbab6e90d',
+  notify_person, sms_providers_priority_list, snap_to_road, NOW(), use_fraud_detection,
+  whatsapp_providers_priority_list, update_payment_method_in_intent,
+  update_amount_in_payment_intent, get_card_list, create_setup_intent,
+  create_payment_intent, create_payment_customer, create_ephemeral_keys,
+  capture_payment_intent, delete_card, get_distances_for_scheduled_rides,
+  cancel_payment_intent, get_frfs_autocomplete_distances, get_multi_modal_service,
+  get_first_pickup_route, get_multimodal_walk_distance, insurance_service,
+  create_refunds, get_refunds, get_instruction_route, payout_order_status,
+  create_payout_order, event_tracking_providers
+FROM atlas_app.merchant_service_usage_config
+WHERE merchant_operating_city_id = 'f9903ef6-f595-428e-b5ac-e8816cbdf979'
+ON CONFLICT (merchant_operating_city_id) DO NOTHING;

--- a/Backend/dev/feature-migrations/0019-enable-verify-fleet-while-login-local.sql
+++ b/Backend/dev/feature-migrations/0019-enable-verify-fleet-while-login-local.sql
@@ -1,0 +1,9 @@
+-- Enable auto-verification of fleet owners on login for local dev.
+-- Without this, fleet owners are created with verified=false and "Add Vehicle for Driver"
+-- fails with INVALID_REQUEST: "Fleet owner is not verified".
+-- Applies to all merchants that run fleet dashboard tests (NY, YS, BT partners).
+
+UPDATE atlas_bpp_dashboard.merchant
+SET verify_fleet_while_login = true
+WHERE verify_fleet_while_login = false
+  AND short_id IN ('NAMMA_YATRI_PARTNER', 'JATRI_SAATHI_PARTNER', 'BHARAT_TAXI_PARTNER', 'YATRI_PARTNER', 'BRIDGE_FINLAND_PARTNER', 'MSIL_PARTNER');

--- a/Backend/dev/feature-migrations/0020-fix-chennai-search-repeat-limit-local.sql
+++ b/Backend/dev/feature-migrations/0020-fix-chennai-search-repeat-limit-local.sql
@@ -1,0 +1,10 @@
+-- Issue: Chennai (NAMMA_YATRI_PARTNER) has search_repeat_limit = 0 in production config.
+-- The reallocation condition is (searchRepeatCounter < searchRepeatLimit), so with limit=0
+-- the check (0 < 0) is always false — reallocation never triggers for Chennai.
+-- This causes the "NY Auto Driver Cancellation + Reallocation" suite in RideBookingFlow
+-- to fail at "D2 Get Nearby Ride Requests" with an empty response.
+-- Fix: Set search_repeat_limit = 3 for Chennai locally (same as Bangalore) so that
+-- driver cancellation correctly triggers reallocation and D2 receives the search request.
+UPDATE atlas_driver_offer_bpp.transporter_config
+SET search_repeat_limit = 3
+WHERE merchant_operating_city_id = 'f8e9db0a-96c8-49e4-942a-3e3f7265d2da';

--- a/Backend/dev/integration-tests/collections/FleetManagementFlow/01-DriverNameAndAssociation.json
+++ b/Backend/dev/integration-tests/collections/FleetManagementFlow/01-DriverNameAndAssociation.json
@@ -1,0 +1,498 @@
+{
+  "info": {
+    "name": "Fleet Driver Name & Association",
+    "description": "End-to-end test: registers driver + fleet owner, creates fleet association via joining OTP, then tests updateName set/clear/restore and verifies driverAssociation response includes firstName, middleName, lastName fields",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "exec": [
+          "// Auto-skip mock-server requests when envType is not Local.",
+          "(function () {",
+          "  var envType = pm.environment.get('envType') || 'Local';",
+          "  if (envType === 'Local') return;",
+          "  var raw = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
+          "  if (raw.indexOf('mockServerUrl') !== -1 || raw.indexOf('mock_fcm_url') !== -1) {",
+          "    console.log('[skip] mock-only request on envType=' + envType + ': ' + (pm.info && pm.info.requestName));",
+          "    if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+          "      pm.execution.skipRequest();",
+          "    }",
+          "  }",
+          "})();",
+          "",
+          "// Generate random values ONCE per collection run",
+          "if (!pm.collectionVariables.get('_test_driver_number')) {",
+          "    var dNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+          "    var fleetNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+          "    pm.collectionVariables.set('_test_driver_number', dNum);",
+          "    pm.collectionVariables.set('_test_fleet_owner_number', fleetNum);",
+          "    console.log('Test driver:', dNum, 'fleet owner:', fleetNum);",
+          "}"
+        ],
+        "type": "text/javascript"
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "01 - Driver Auth",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json();",
+              "pm.environment.set('driver_authId', d.authId);",
+              "pm.test('Driver auth returns 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"mobileNumber\": \"{{_test_driver_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{driver_merchant_id}}\",\n    \"merchantOperatingCity\": \"{{city}}\"\n}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/auth",
+          "host": ["{{baseURL_namma_P}}"],
+          "path": ["auth"]
+        }
+      }
+    },
+    {
+      "name": "02 - Driver OTP Verify",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json();",
+              "pm.environment.set('driver_token', d.token);",
+              "pm.environment.set('driver_id', d.person.id);",
+              "console.log('Driver ID:', d.person.id);",
+              "pm.test('Driver OTP verify returns 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"otp\": \"{{login_otp}}\",\n    \"deviceToken\": \"test-device\"\n}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/auth/{{driver_authId}}/verify",
+          "host": ["{{baseURL_namma_P}}"],
+          "path": ["auth", "{{driver_authId}}", "verify"]
+        }
+      }
+    },
+    {
+      "name": "03 - Switch City (Dashboard)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json();",
+              "pm.environment.set('dashboard_token', d.authToken);",
+              "console.log('Switched to', d.merchantId, d.city);",
+              "pm.test('Switch city returns 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{dashboard_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"merchantId\": \"{{dashboard_merchant_id}}\", \"city\": \"{{city}}\"}"
+        },
+        "url": {
+          "raw": "{{dashboard_base_url}}/user/switchMerchantAndCity",
+          "host": ["{{dashboard_base_url}}"],
+          "path": ["user", "switchMerchantAndCity"]
+        }
+      }
+    },
+    {
+      "name": "04 - Fleet Owner Login OTP",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Fleet owner login OTP returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "console.log('Fleet V2 login response:', JSON.stringify(d));",
+              "var fid = d.personId || d.getId || d.id || (typeof d === 'string' ? d : null);",
+              "pm.environment.set('fleet_owner_id', fid);",
+              "console.log('Fleet Owner ID:', fid);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"mobileNumber\": \"{{_test_fleet_owner_number}}\", \"mobileCountryCode\": \"+91\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/fleet/v2/login/otp",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["bpp", "driver-offer", "{{dashboard_merchant_id}}", "{{dashboard_city}}", "fleet", "v2", "login", "otp"]
+        }
+      }
+    },
+    {
+      "name": "05 - Fleet Owner Verify OTP",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Fleet owner verify OTP returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "console.log('Fleet owner verify OTP response:', JSON.stringify(d));",
+              "pm.environment.set('fleet_owner_dashboard_token', d.authToken);",
+              "pm.test('authToken is set', function () { pm.expect(d.authToken).to.be.a('string'); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"mobileNumber\": \"{{_test_fleet_owner_number}}\", \"mobileCountryCode\": \"+91\", \"otp\": \"{{login_otp}}\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/fleet/v2/verify/otp",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["bpp", "driver-offer", "{{dashboard_merchant_id}}", "{{dashboard_city}}", "fleet", "v2", "verify", "otp"]
+        }
+      }
+    },
+    {
+      "name": "06 - Send Fleet Joining OTP",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Send joining OTP returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "console.log('Send joining OTP response:', JSON.stringify(d));",
+              "pm.test('Response has authId', function () { pm.expect(d).to.have.property('authId'); });",
+              "pm.environment.set('fleet_joining_auth_id', d.authId);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{fleet_owner_dashboard_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"mobileNumber\": \"{{_test_driver_number}}\", \"mobileCountryCode\": \"+91\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/sendJoiningOtp",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["bpp", "driver-offer", "{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "sendJoiningOtp"]
+        }
+      }
+    },
+    {
+      "name": "07 - Verify Fleet Joining OTP",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Verify joining OTP returns 200', function () { pm.response.to.have.status(200); });",
+              "console.log('Fleet driver association created successfully');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{fleet_owner_dashboard_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"mobileCountryCode\": \"+91\", \"mobileNumber\": \"{{_test_driver_number}}\", \"otp\": \"{{login_otp}}\", \"deviceToken\": \"test-device-token\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/verifyJoiningOtp",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["bpp", "driver-offer", "{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "verifyJoiningOtp"]
+        }
+      }
+    },
+    {
+      "name": "08 - Update Name (Set All Fields)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Update name returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.test('Update name succeeds', function () { pm.expect(d.result).to.eql('Success'); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{dashboard_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"firstName\": \"TestFirst\", \"middleName\": \"TestMiddle\", \"lastName\": \"TestLast\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/updateName",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "{{driver_id}}", "updateName"]
+        }
+      }
+    },
+    {
+      "name": "09 - Get Driver Association (Verify Name Fields Set)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('driverAssociation returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.test('Response has listItem', function () { pm.expect(d).to.have.property('listItem'); });",
+              "var driver = d.listItem.find(function(item) { return item.driverId === pm.environment.get('driver_id'); });",
+              "pm.test('Driver found in association list', function () { pm.expect(driver).to.not.be.undefined; });",
+              "if (driver) {",
+              "  pm.test('driverName is TestFirst', function () { pm.expect(driver.driverName).to.eql('TestFirst'); });",
+              "  pm.test('firstName is TestFirst', function () { pm.expect(driver.firstName).to.eql('TestFirst'); });",
+              "  pm.test('middleName is TestMiddle', function () { pm.expect(driver.middleName).to.eql('TestMiddle'); });",
+              "  pm.test('lastName is TestLast', function () { pm.expect(driver.lastName).to.eql('TestLast'); });",
+              "  pm.test('conductorName is TestLast', function () { pm.expect(driver.conductorName).to.eql('TestLast'); });",
+              "  pm.test('firstName field exists as separate field', function () { pm.expect(driver).to.have.property('firstName'); });",
+              "  pm.test('middleName field exists as separate field', function () { pm.expect(driver).to.have.property('middleName'); });",
+              "  pm.test('lastName field exists as separate field', function () { pm.expect(driver).to.have.property('lastName'); });",
+              "}"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "token", "value": "{{fleet_owner_dashboard_token}}" }
+        ],
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/driverAssociation?Limit=10&Offset=0&fleetOwnerId={{fleet_owner_id}}&mbRequestorId={{fleet_owner_id}}&hasFleetMemberHierarchy=false&isRequestorFleerOwner=true",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "driverAssociation"],
+          "query": [
+            { "key": "Limit", "value": "10" },
+            { "key": "Offset", "value": "0" },
+            { "key": "fleetOwnerId", "value": "{{fleet_owner_id}}" },
+            { "key": "mbRequestorId", "value": "{{fleet_owner_id}}" },
+            { "key": "hasFleetMemberHierarchy", "value": "false" },
+            { "key": "isRequestorFleerOwner", "value": "true" }
+          ]
+        }
+      }
+    },
+    {
+      "name": "10 - Update Name (Null preserves existing middleName and lastName)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Update name returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.test('Update name succeeds', function () { pm.expect(d.result).to.eql('Success'); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{dashboard_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"firstName\": \"OnlyFirst\", \"middleName\": null, \"lastName\": null}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/updateName",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "{{driver_id}}", "updateName"]
+        }
+      }
+    },
+    {
+      "name": "11 - Get Driver Association (Verify Null Preserves Fields)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('driverAssociation returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "var driver = d.listItem.find(function(item) { return item.driverId === pm.environment.get('driver_id'); });",
+              "pm.test('Driver found in association list', function () { pm.expect(driver).to.not.be.undefined; });",
+              "if (driver) {",
+              "  pm.test('driverName is OnlyFirst', function () { pm.expect(driver.driverName).to.eql('OnlyFirst'); });",
+              "  pm.test('firstName is OnlyFirst', function () { pm.expect(driver.firstName).to.eql('OnlyFirst'); });",
+              "  pm.test('middleName preserved as TestMiddle', function () { pm.expect(driver.middleName).to.eql('TestMiddle'); });",
+              "  pm.test('lastName preserved as TestLast', function () { pm.expect(driver.lastName).to.eql('TestLast'); });",
+              "  pm.test('conductorName preserved as TestLast', function () { pm.expect(driver.conductorName).to.eql('TestLast'); });",
+              "}"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "token", "value": "{{fleet_owner_dashboard_token}}" }
+        ],
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/driverAssociation?Limit=10&Offset=0&fleetOwnerId={{fleet_owner_id}}&mbRequestorId={{fleet_owner_id}}&hasFleetMemberHierarchy=false&isRequestorFleerOwner=true",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "driverAssociation"],
+          "query": [
+            { "key": "Limit", "value": "10" },
+            { "key": "Offset", "value": "0" },
+            { "key": "fleetOwnerId", "value": "{{fleet_owner_id}}" },
+            { "key": "mbRequestorId", "value": "{{fleet_owner_id}}" },
+            { "key": "hasFleetMemberHierarchy", "value": "false" },
+            { "key": "isRequestorFleerOwner", "value": "true" }
+          ]
+        }
+      }
+    },
+    {
+      "name": "12 - Update Name (Clear middleName via empty string, update lastName)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Update name returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.test('Update name succeeds', function () { pm.expect(d.result).to.eql('Success'); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{dashboard_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"firstName\": \"Restored\", \"middleName\": \"\", \"lastName\": \"NewLast\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/updateName",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "{{driver_id}}", "updateName"]
+        }
+      }
+    },
+    {
+      "name": "13 - Get Driver Association (Verify middleName Cleared, lastName Updated)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('driverAssociation returns 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "var driver = d.listItem.find(function(item) { return item.driverId === pm.environment.get('driver_id'); });",
+              "pm.test('Driver found in association list', function () { pm.expect(driver).to.not.be.undefined; });",
+              "if (driver) {",
+              "  pm.test('driverName is Restored', function () { pm.expect(driver.driverName).to.eql('Restored'); });",
+              "  pm.test('firstName is Restored', function () { pm.expect(driver.firstName).to.eql('Restored'); });",
+              "  pm.test('middleName is null after clearing via empty string', function () { pm.expect(driver.middleName).to.be.null; });",
+              "  pm.test('lastName is NewLast', function () { pm.expect(driver.lastName).to.eql('NewLast'); });",
+              "  pm.test('conductorName is NewLast', function () { pm.expect(driver.conductorName).to.eql('NewLast'); });",
+              "}"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "token", "value": "{{fleet_owner_dashboard_token}}" }
+        ],
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard}}/bpp/driver-offer/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/driverAssociation?Limit=10&Offset=0&fleetOwnerId={{fleet_owner_id}}&mbRequestorId={{fleet_owner_id}}&hasFleetMemberHierarchy=false&isRequestorFleerOwner=true",
+          "host": ["{{baseURL_BPP_Dashboard}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "driverAssociation"],
+          "query": [
+            { "key": "Limit", "value": "10" },
+            { "key": "Offset", "value": "0" },
+            { "key": "fleetOwnerId", "value": "{{fleet_owner_id}}" },
+            { "key": "mbRequestorId", "value": "{{fleet_owner_id}}" },
+            { "key": "hasFleetMemberHierarchy", "value": "false" },
+            { "key": "isRequestorFleerOwner", "value": "true" }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Backend/dev/integration-tests/collections/FleetManagementFlow/Local/Local_NY_Bangalore.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/FleetManagementFlow/Local/Local_NY_Bangalore.postman_environment.json
@@ -1,0 +1,109 @@
+{
+  "id": "local-fleet-ny-bangalore",
+  "name": "Local - Fleet Management NY Bangalore",
+  "values": [
+    {
+      "key": "envType",
+      "value": "Local",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "baseURL_namma_P",
+      "value": "http://localhost:8016/ui",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "baseURL_BPP_Dashboard",
+      "value": "http://localhost:8018",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "dashboard_base_url",
+      "value": "http://localhost:8018",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "dashboard_token",
+      "value": "local-admin-token-bangalore-namma-yatri",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "dashboard_merchant_id",
+      "value": "NAMMA_YATRI_PARTNER",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "dashboard_city",
+      "value": "Bangalore",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "driver_merchant_id",
+      "value": "7f7896dd-787e-4a0b-8675-e9e6fe93bb8f",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "city",
+      "value": "Bangalore",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "login_otp",
+      "value": "7891",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "mockServerUrl",
+      "value": "http://localhost:8080",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "driver_token",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
+      "key": "driver_id",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
+      "key": "bpp_dashboard_token",
+      "value": "some-secret-dashboard-token-for-driver-offer-bpp",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "fleet_owner_id",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
+      "key": "fleet_joining_auth_id",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
+      "key": "fleet_owner_dashboard_token",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/Backend/dev/integration-tests/collections/IntercityRideFlow/01-IntercityRideFlow.json
+++ b/Backend/dev/integration-tests/collections/IntercityRideFlow/01-IntercityRideFlow.json
@@ -1,0 +1,1067 @@
+{
+	"info": {
+		"name": "NY Intercity Ride Flow (Bangalore -> Mysore, OneWay)",
+		"description": "End-to-end Intercity flow (one-way Bangalore -> Mysore):\n  Driver onboard -> Rider auth -> InterCity search -> Get quotes (onIntercityCab) -> Confirm quote -> Driver gets OTP from booking -> Driver OTP-starts ride -> End ride -> Verify completed.\n\nPrerequisites:\n- Bangalore intercity FarePolicy + fare_product seeded for the chosen vehicle variant (auto-synced from prod via config-sync/prod_to_local_sql).\n- Special-zone OTP path: Intercity_OneWayRideOtp trip category must resolve to a quote for the chosen origin/destination pair.\n",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"exec": [
+					"(function () {",
+					"  var envType = pm.environment.get('envType') || 'Local';",
+					"  if (envType === 'Local') return;",
+					"  var raw = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
+					"  if (raw.indexOf('mockServerUrl') !== -1 || raw.indexOf('mock_fcm_url') !== -1) {",
+					"    if (pm.execution && typeof pm.execution.skipRequest === 'function') pm.execution.skipRequest();",
+					"  }",
+					"})();",
+					"if (!pm.collectionVariables.get('_test_driver_number')) {",
+					"    var dNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+					"    var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+					"    var regNo = 'KA' + String(Math.floor(10 + Math.random() * 89)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String(Math.floor(1000 + Math.random() * 8999));",
+					"    pm.collectionVariables.set('_test_driver_number', dNum);",
+					"    pm.collectionVariables.set('_test_rider_number', rNum);",
+					"    pm.collectionVariables.set('_test_reg_no', regNo);",
+					"    console.log('Test driver:', dNum, 'rider:', rNum, 'reg:', regNo);",
+					"}"
+				],
+				"type": "text/javascript"
+			}
+		}
+	],
+	"item": [
+		{
+			"name": "Driver Auth",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"// Always generate fresh numbers so each run uses a new driver/rider.",
+							"// Without this the collection-level guard reuses the same driver,",
+							"// leaving stale Redis state that causes empty searchRequestsForDriver.",
+							"var city = pm.environment.get('dashboard_city') || 'Bangalore';",
+							"var rcMap = {Bangalore:'KA',Chennai:'TN',Kolkata:'WB',Delhi:'DL',Hyderabad:'TS',Mumbai:'MH',Mysore:'KA'};",
+							"var prefix = rcMap[city] || 'KA';",
+							"var dNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+							"var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+							"var regNo = prefix + String(Math.floor(10 + Math.random() * 89)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String(Math.floor(1000 + Math.random() * 8999));",
+							"pm.collectionVariables.set('_test_driver_number', dNum);",
+							"pm.collectionVariables.set('_test_rider_number', rNum);",
+							"pm.collectionVariables.set('_test_reg_no', regNo);",
+							"pm.collectionVariables.set('_nearby_retries', 0);",
+							"console.log('Fresh run: driver=' + dNum + ' rider=' + rNum + ' reg=' + regNo + ' (' + city + ')');"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json(); pm.environment.set('driver_authId', d.authId); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"mobileNumber\": \"{{_test_driver_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{driver_merchant_id}}\", \"merchantOperatingCity\": \"{{city}}\"}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/auth",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"auth"
+					]
+				}
+			}
+		},
+		{
+			"name": "Driver OTP",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json(); pm.environment.set('driver_token', d.token); pm.environment.set('driver_id', d.person.id); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"otp\": \"{{login_otp}}\", \"deviceToken\": \"test-device\"}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/auth/{{driver_authId}}/verify",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"auth",
+						"{{driver_authId}}",
+						"verify"
+					]
+				}
+			}
+		},
+		{
+			"name": "Add Vehicle (Dashboard)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{dashboard_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"variant\": \"{{vehicle_variant}}\", \"registrationNo\": \"{{_test_reg_no}}\", \"vehicleClass\": \"{{vehicle_class}}\", \"vehicleCategory\": \"{{vehicle_category}}\", \"make\": \"{{vehicle_make}}\", \"model\": \"{{vehicle_model}}\", \"driverName\": \"Test Intercity Driver\", \"colour\": \"White\"}"
+				},
+				"url": {
+					"raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/addVehicle",
+					"host": [
+						"{{baseURL_BPP_Dashboard_Internal}}"
+					],
+					"path": [
+						"{{dashboard_merchant_id}}",
+						"{{dashboard_city}}",
+						"driver",
+						"{{driver_id}}",
+						"addVehicle"
+					]
+				}
+			}
+		},
+		{
+			"name": "Enable Driver (Dashboard)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{dashboard_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"canDowngradeToSedan\": false, \"canDowngradeToHatchback\": false, \"canDowngradeToTaxi\": false}"
+				},
+				"url": {
+					"raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/enable",
+					"host": [
+						"{{baseURL_BPP_Dashboard_Internal}}"
+					],
+					"path": [
+						"{{dashboard_merchant_id}}",
+						"{{dashboard_city}}",
+						"driver",
+						"{{driver_id}}",
+						"enable"
+					]
+				}
+			}
+		},
+		{
+			"name": "Subscribe Plan (Driver)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/plan/{{plan_id}}/subscribe",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"plan",
+						"{{plan_id}}",
+						"subscribe"
+					]
+				}
+			}
+		},
+		{
+			"name": "Enable Intercity Switch (Driver Profile)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('canSwitchToInterCity set to true');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"canSwitchToInterCity\": true}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/profile",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"profile"
+					]
+				}
+			}
+		},
+		{
+			"name": "Set Driver Online",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); while(Date.now()-s<2000){}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/setActivity?active=true&mode=%22ONLINE%22",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"setActivity"
+					],
+					"query": [
+						{
+							"key": "active",
+							"value": "true"
+						},
+						{
+							"key": "mode",
+							"value": "%22ONLINE%22"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Driver Set Location",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					},
+					{
+						"key": "vt",
+						"value": "{{vehicle_variant}}"
+					},
+					{
+						"key": "dm",
+						"value": "ONLINE"
+					},
+					{
+						"key": "mId",
+						"value": "{{driver_merchant_id}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "[{\"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"ts\": \"{{current_time}}\"}]"
+				},
+				"url": {
+					"raw": "{{baseUrl_lts}}/driver/location",
+					"host": [
+						"{{baseUrl_lts}}"
+					],
+					"path": [
+						"driver",
+						"location"
+					]
+				}
+			}
+		},
+		{
+			"name": "Rider Auth",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json(); pm.environment.set('rider_authId', d.authId); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"mobileNumber\": \"{{_test_rider_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{bap_short_id}}\"}"
+				},
+				"url": {
+					"raw": "{{baseUrl_app}}/auth",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"auth"
+					]
+				}
+			}
+		},
+		{
+			"name": "Rider OTP",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json(); pm.environment.set('rider_token', d.token); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"otp\": \"{{login_otp}}\", \"deviceToken\": \"test-rider-device\"}"
+				},
+				"url": {
+					"raw": "{{baseUrl_app}}/auth/{{rider_authId}}/verify",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"auth",
+						"{{rider_authId}}",
+						"verify"
+					]
+				}
+			}
+		},
+		{
+			"name": "Driver Location Update",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					},
+					{
+						"key": "vt",
+						"value": "{{vehicle_variant}}"
+					},
+					{
+						"key": "dm",
+						"value": "ONLINE"
+					},
+					{
+						"key": "mId",
+						"value": "{{driver_merchant_id}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "[{\"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"ts\": \"{{current_time}}\"}]"
+				},
+				"url": {
+					"raw": "{{baseUrl_lts}}/driver/location",
+					"host": [
+						"{{baseUrl_lts}}"
+					],
+					"path": [
+						"driver",
+						"location"
+					]
+				}
+			}
+		},
+		{
+			"name": "Ride Search (Intercity Bangalore -> Mysore)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Schedule the trip 30 minutes in the future, no return time (one-way)",
+							"var startTs = new Date(Date.now() + 30 * 60 * 1000).toISOString();",
+							"pm.environment.set('_intercity_start_time', startTs);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json(); pm.environment.set('searchId', d.searchId); console.log('Intercity Search ID:', d.searchId); pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); const w=parseInt(pm.environment.get('search_wait_ms')||'8000',10); while(Date.now()-s<w){}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"fareProductType\": \"INTER_CITY\", \"contents\": {\"origin\": {\"address\": {\"area\": \"Bangalore Origin\", \"areaCode\": \"560001\", \"city\": \"{{city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}}, \"stops\": [{\"address\": {\"area\": \"{{intercity_dest_city}}\", \"areaCode\": \"570001\", \"city\": \"{{intercity_dest_city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{intercity_dest_lat}}, \"lon\": {{intercity_dest_lon}}}}], \"roundTrip\": false, \"isSourceManuallyMoved\": false, \"isDestinationManuallyMoved\": false, \"startTime\": \"{{_intercity_start_time}}\"}}"
+				},
+				"url": {
+					"raw": "{{baseUrl_app}}/rideSearch",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideSearch"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Intercity Quotes",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const s=Date.now(); while(Date.now()-s<3000){}"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+							"var quotes = d.quotes || [];",
+							"var want = pm.environment.get('vehicle_variant') || 'SEDAN';",
+							"var pick = null;",
+							"for (var i=0; i<quotes.length; i++) {",
+							"  var inner = quotes[i].onIntercityCab || quotes[i].onDemandCab;",
+							"  if (!inner) continue;",
+							"  if (inner.vehicleVariant === want) { pick = inner; break; }",
+							"}",
+							"if (!pick && quotes.length > 0) pick = quotes[0].onIntercityCab || quotes[0].onDemandCab;",
+							"if (pick) {",
+							"  pm.environment.set('quoteId', pick.id);",
+							"  console.log('Intercity Quote:', pick.id, 'variant:', pick.vehicleVariant, 'fare:', pick.estimatedTotalFare);",
+							"  console.log('All quotes:', quotes.map(function(q){var i=q.onIntercityCab||q.onDemandCab; return i?i.vehicleVariant+'='+i.estimatedTotalFare:'?';}).join(', '));",
+							"}",
+							"pm.test('Has intercity quotes', function () { pm.expect(pm.environment.get('quoteId')).to.be.a('string').that.is.not.empty; });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl_app}}/rideSearch/{{searchId}}/results",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideSearch",
+						"{{searchId}}",
+						"results"
+					]
+				}
+			}
+		},
+		{
+			"name": "Confirm Intercity Quote",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json(); pm.environment.set('customer_bookingId', d.bookingId); console.log('Booking:', d.bookingId); pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); while(Date.now()-s<10000){}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{}"
+				},
+				"url": {
+					"raw": "{{baseUrl_app}}/rideSearch/quotes/{{quoteId}}/confirm",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideSearch",
+						"quotes",
+						"{{quoteId}}",
+						"confirm"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Nearby Ride Requests (Driver)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"// Wait 8s for the BPP to dispatch the intercity SearchTry to the driver.",
+							"// The dispatch after Confirm Intercity Quote is async; a single shot",
+							"// without any wait returns empty. The test script retries up to 3 times.",
+							"const s = Date.now(); while (Date.now() - s < 8000) {}"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+							"if (d.searchRequestsForDriver && d.searchRequestsForDriver.length > 0) {",
+							"    var req = d.searchRequestsForDriver[0];",
+							"    pm.environment.set('searchTryId', req.searchTryId);",
+							"    pm.collectionVariables.set('_nearby_retries', 0);",
+							"    console.log('Got intercity search request, searchTryId:', req.searchTryId, 'baseFare:', req.baseFare);",
+							"    pm.test('Has search requests', function () { pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty; });",
+							"} else {",
+							"    var retries = parseInt(pm.collectionVariables.get('_nearby_retries') || '0');",
+							"    console.log('WARNING: No nearby ride requests (attempt ' + (retries + 1) + '/3)');",
+							"    if (retries < 2) {",
+							"        pm.collectionVariables.set('_nearby_retries', retries + 1);",
+							"        pm.execution.setNextRequest('Get Nearby Ride Requests (Driver)');",
+							"    } else {",
+							"        pm.collectionVariables.set('_nearby_retries', 0);",
+							"        pm.test('Has search requests', function () { pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty; });",
+							"    }",
+							"}"
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/nearbyRideRequest",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"nearbyRideRequest"
+					]
+				}
+			}
+		},
+		{
+			"name": "Driver Accept Intercity Ride",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Driver accepted intercity ride!');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"searchTryId\": \"{{searchTryId}}\", \"offeredFare\": null, \"response\": \"Accept\"}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/searchRequest/quote/respond",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"searchRequest",
+						"quote",
+						"respond"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Booking (Verify Intercity, Extract OTP)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const s=Date.now(); while(Date.now()-s<5000){}"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+							"if (d.list && d.list.length > 0) {",
+							"  var booking = d.list[0];",
+							"  pm.environment.set('customer_bookingId', booking.id);",
+							"  var otp = booking.rideOtp;",
+							"  if (!otp && booking.rideList && booking.rideList.length > 0) {",
+							"    otp = booking.rideList[0].rideOtp;",
+							"  }",
+							"  pm.environment.set('ride_otp', otp || '');",
+							"  console.log('Booking:', booking.id, 'Status:', booking.status, 'OTP:', otp, 'tripCategory:', JSON.stringify(booking.tripCategory));",
+							"  pm.test('Booking is intercity', function () { pm.expect(JSON.stringify(booking.tripCategory)).to.include('InterCity'); });",
+							"  pm.test('Has rideOtp', function () { pm.expect(pm.environment.get('ride_otp')).to.be.a('string').that.is.not.empty; });",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl_app}}/rideBooking/list?limit=1&onlyActive=true&offset=0",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideBooking",
+						"list"
+					],
+					"query": [
+						{
+							"key": "limit",
+							"value": "1"
+						},
+						{
+							"key": "onlyActive",
+							"value": "true"
+						},
+						{
+							"key": "offset",
+							"value": "0"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Ride (Driver)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"if (d.list && d.list.length > 0) {",
+							"    pm.environment.set('driver_ride_id', d.list[0].id);",
+							"    console.log('Intercity Ride:', d.list[0].id, 'Status:', d.list[0].status);",
+							"}",
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/ride/list?limit=1&isActive=true",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"ride",
+						"list"
+					],
+					"query": [
+						{
+							"key": "limit",
+							"value": "1"
+						},
+						{
+							"key": "isActive",
+							"value": "true"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Driver Start Intercity Ride",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Intercity ride started!');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"rideOtp\": \"{{ride_otp}}\", \"point\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"odometer\": {\"value\": 0, \"fileId\": \"test-odometer-start\"}}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/start",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"ride",
+						"{{driver_ride_id}}",
+						"start"
+					]
+				}
+			}
+		},
+		{
+			"name": "End Ride (At Mysore)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const s=Date.now(); while(Date.now()-s<1500){}"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Intercity ride ended at Mysore');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"point\": {\"lat\": {{intercity_dest_lat}}, \"lon\": {{intercity_dest_lon}}}, \"odometer\": {\"value\": 150, \"fileId\": \"test-odometer-end\"}}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/end",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"ride",
+						"{{driver_ride_id}}",
+						"end"
+					]
+				}
+			}
+		},
+		{
+			"name": "Verify Booking Completed (Rider)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const s=Date.now(); while(Date.now()-s<3000){}"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json(); pm.test('Status 200', function () { pm.response.to.have.status(200); }); pm.test('Booking COMPLETED', function () { pm.expect(d.bookingStatus).to.equal('COMPLETED'); }); pm.test('Ride COMPLETED', function () { pm.expect(d.rideStatus).to.equal('COMPLETED'); }); console.log('Intercity flow done! Booking:', d.bookingStatus, 'Ride:', d.rideStatus);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl_app}}/rideBooking/v2/{{customer_bookingId}}",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideBooking",
+						"v2",
+						"{{customer_bookingId}}"
+					]
+				}
+			}
+		}
+	]
+}

--- a/Backend/dev/integration-tests/collections/IntercityRideFlow/01-IntercityRideFlow.json
+++ b/Backend/dev/integration-tests/collections/IntercityRideFlow/01-IntercityRideFlow.json
@@ -1,1067 +1,1070 @@
 {
-	"info": {
-		"name": "NY Intercity Ride Flow (Bangalore -> Mysore, OneWay)",
-		"description": "End-to-end Intercity flow (one-way Bangalore -> Mysore):\n  Driver onboard -> Rider auth -> InterCity search -> Get quotes (onIntercityCab) -> Confirm quote -> Driver gets OTP from booking -> Driver OTP-starts ride -> End ride -> Verify completed.\n\nPrerequisites:\n- Bangalore intercity FarePolicy + fare_product seeded for the chosen vehicle variant (auto-synced from prod via config-sync/prod_to_local_sql).\n- Special-zone OTP path: Intercity_OneWayRideOtp trip category must resolve to a quote for the chosen origin/destination pair.\n",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-	},
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"exec": [
-					"(function () {",
-					"  var envType = pm.environment.get('envType') || 'Local';",
-					"  if (envType === 'Local') return;",
-					"  var raw = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
-					"  if (raw.indexOf('mockServerUrl') !== -1 || raw.indexOf('mock_fcm_url') !== -1) {",
-					"    if (pm.execution && typeof pm.execution.skipRequest === 'function') pm.execution.skipRequest();",
-					"  }",
-					"})();",
-					"if (!pm.collectionVariables.get('_test_driver_number')) {",
-					"    var dNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
-					"    var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
-					"    var regNo = 'KA' + String(Math.floor(10 + Math.random() * 89)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String(Math.floor(1000 + Math.random() * 8999));",
-					"    pm.collectionVariables.set('_test_driver_number', dNum);",
-					"    pm.collectionVariables.set('_test_rider_number', rNum);",
-					"    pm.collectionVariables.set('_test_reg_no', regNo);",
-					"    console.log('Test driver:', dNum, 'rider:', rNum, 'reg:', regNo);",
-					"}"
-				],
-				"type": "text/javascript"
-			}
-		}
-	],
-	"item": [
-		{
-			"name": "Driver Auth",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							"// Always generate fresh numbers so each run uses a new driver/rider.",
-							"// Without this the collection-level guard reuses the same driver,",
-							"// leaving stale Redis state that causes empty searchRequestsForDriver.",
-							"var city = pm.environment.get('dashboard_city') || 'Bangalore';",
-							"var rcMap = {Bangalore:'KA',Chennai:'TN',Kolkata:'WB',Delhi:'DL',Hyderabad:'TS',Mumbai:'MH',Mysore:'KA'};",
-							"var prefix = rcMap[city] || 'KA';",
-							"var dNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
-							"var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
-							"var regNo = prefix + String(Math.floor(10 + Math.random() * 89)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String(Math.floor(1000 + Math.random() * 8999));",
-							"pm.collectionVariables.set('_test_driver_number', dNum);",
-							"pm.collectionVariables.set('_test_rider_number', rNum);",
-							"pm.collectionVariables.set('_test_reg_no', regNo);",
-							"pm.collectionVariables.set('_nearby_retries', 0);",
-							"console.log('Fresh run: driver=' + dNum + ' rider=' + rNum + ' reg=' + regNo + ' (' + city + ')');"
-						]
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json(); pm.environment.set('driver_authId', d.authId); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"mobileNumber\": \"{{_test_driver_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{driver_merchant_id}}\", \"merchantOperatingCity\": \"{{city}}\"}"
-				},
-				"url": {
-					"raw": "{{baseURL_namma_P}}/auth",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"auth"
-					]
-				}
-			}
-		},
-		{
-			"name": "Driver OTP",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json(); pm.environment.set('driver_token', d.token); pm.environment.set('driver_id', d.person.id); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"otp\": \"{{login_otp}}\", \"deviceToken\": \"test-device\"}"
-				},
-				"url": {
-					"raw": "{{baseURL_namma_P}}/auth/{{driver_authId}}/verify",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"auth",
-						"{{driver_authId}}",
-						"verify"
-					]
-				}
-			}
-		},
-		{
-			"name": "Add Vehicle (Dashboard)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{dashboard_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"variant\": \"{{vehicle_variant}}\", \"registrationNo\": \"{{_test_reg_no}}\", \"vehicleClass\": \"{{vehicle_class}}\", \"vehicleCategory\": \"{{vehicle_category}}\", \"make\": \"{{vehicle_make}}\", \"model\": \"{{vehicle_model}}\", \"driverName\": \"Test Intercity Driver\", \"colour\": \"White\"}"
-				},
-				"url": {
-					"raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/addVehicle",
-					"host": [
-						"{{baseURL_BPP_Dashboard_Internal}}"
-					],
-					"path": [
-						"{{dashboard_merchant_id}}",
-						"{{dashboard_city}}",
-						"driver",
-						"{{driver_id}}",
-						"addVehicle"
-					]
-				}
-			}
-		},
-		{
-			"name": "Enable Driver (Dashboard)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{dashboard_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"canDowngradeToSedan\": false, \"canDowngradeToHatchback\": false, \"canDowngradeToTaxi\": false}"
-				},
-				"url": {
-					"raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/enable",
-					"host": [
-						"{{baseURL_BPP_Dashboard_Internal}}"
-					],
-					"path": [
-						"{{dashboard_merchant_id}}",
-						"{{dashboard_city}}",
-						"driver",
-						"{{driver_id}}",
-						"enable"
-					]
-				}
-			}
-		},
-		{
-			"name": "Subscribe Plan (Driver)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{}"
-				},
-				"url": {
-					"raw": "{{baseURL_namma_P}}/plan/{{plan_id}}/subscribe",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"plan",
-						"{{plan_id}}",
-						"subscribe"
-					]
-				}
-			}
-		},
-		{
-			"name": "Enable Intercity Switch (Driver Profile)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('canSwitchToInterCity set to true');"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"canSwitchToInterCity\": true}"
-				},
-				"url": {
-					"raw": "{{baseURL_namma_P}}/driver/profile",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"driver",
-						"profile"
-					]
-				}
-			}
-		},
-		{
-			"name": "Set Driver Online",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); while(Date.now()-s<2000){}"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{}"
-				},
-				"url": {
-					"raw": "{{baseURL_namma_P}}/driver/setActivity?active=true&mode=%22ONLINE%22",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"driver",
-						"setActivity"
-					],
-					"query": [
-						{
-							"key": "active",
-							"value": "true"
-						},
-						{
-							"key": "mode",
-							"value": "%22ONLINE%22"
-						}
-					]
-				}
-			}
-		},
-		{
-			"name": "Driver Set Location",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					},
-					{
-						"key": "vt",
-						"value": "{{vehicle_variant}}"
-					},
-					{
-						"key": "dm",
-						"value": "ONLINE"
-					},
-					{
-						"key": "mId",
-						"value": "{{driver_merchant_id}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "[{\"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"ts\": \"{{current_time}}\"}]"
-				},
-				"url": {
-					"raw": "{{baseUrl_lts}}/driver/location",
-					"host": [
-						"{{baseUrl_lts}}"
-					],
-					"path": [
-						"driver",
-						"location"
-					]
-				}
-			}
-		},
-		{
-			"name": "Rider Auth",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json(); pm.environment.set('rider_authId', d.authId); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"mobileNumber\": \"{{_test_rider_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{bap_short_id}}\"}"
-				},
-				"url": {
-					"raw": "{{baseUrl_app}}/auth",
-					"host": [
-						"{{baseUrl_app}}"
-					],
-					"path": [
-						"auth"
-					]
-				}
-			}
-		},
-		{
-			"name": "Rider OTP",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json(); pm.environment.set('rider_token', d.token); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"otp\": \"{{login_otp}}\", \"deviceToken\": \"test-rider-device\"}"
-				},
-				"url": {
-					"raw": "{{baseUrl_app}}/auth/{{rider_authId}}/verify",
-					"host": [
-						"{{baseUrl_app}}"
-					],
-					"path": [
-						"auth",
-						"{{rider_authId}}",
-						"verify"
-					]
-				}
-			}
-		},
-		{
-			"name": "Driver Location Update",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					},
-					{
-						"key": "vt",
-						"value": "{{vehicle_variant}}"
-					},
-					{
-						"key": "dm",
-						"value": "ONLINE"
-					},
-					{
-						"key": "mId",
-						"value": "{{driver_merchant_id}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "[{\"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"ts\": \"{{current_time}}\"}]"
-				},
-				"url": {
-					"raw": "{{baseUrl_lts}}/driver/location",
-					"host": [
-						"{{baseUrl_lts}}"
-					],
-					"path": [
-						"driver",
-						"location"
-					]
-				}
-			}
-		},
-		{
-			"name": "Ride Search (Intercity Bangalore -> Mysore)",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"// Schedule the trip 30 minutes in the future, no return time (one-way)",
-							"var startTs = new Date(Date.now() + 30 * 60 * 1000).toISOString();",
-							"pm.environment.set('_intercity_start_time', startTs);"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json(); pm.environment.set('searchId', d.searchId); console.log('Intercity Search ID:', d.searchId); pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); const w=parseInt(pm.environment.get('search_wait_ms')||'8000',10); while(Date.now()-s<w){}"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{rider_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"fareProductType\": \"INTER_CITY\", \"contents\": {\"origin\": {\"address\": {\"area\": \"Bangalore Origin\", \"areaCode\": \"560001\", \"city\": \"{{city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}}, \"stops\": [{\"address\": {\"area\": \"{{intercity_dest_city}}\", \"areaCode\": \"570001\", \"city\": \"{{intercity_dest_city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{intercity_dest_lat}}, \"lon\": {{intercity_dest_lon}}}}], \"roundTrip\": false, \"isSourceManuallyMoved\": false, \"isDestinationManuallyMoved\": false, \"startTime\": \"{{_intercity_start_time}}\"}}"
-				},
-				"url": {
-					"raw": "{{baseUrl_app}}/rideSearch",
-					"host": [
-						"{{baseUrl_app}}"
-					],
-					"path": [
-						"rideSearch"
-					]
-				}
-			}
-		},
-		{
-			"name": "Get Intercity Quotes",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"const s=Date.now(); while(Date.now()-s<3000){}"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json();",
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });",
-							"var quotes = d.quotes || [];",
-							"var want = pm.environment.get('vehicle_variant') || 'SEDAN';",
-							"var pick = null;",
-							"for (var i=0; i<quotes.length; i++) {",
-							"  var inner = quotes[i].onIntercityCab || quotes[i].onDemandCab;",
-							"  if (!inner) continue;",
-							"  if (inner.vehicleVariant === want) { pick = inner; break; }",
-							"}",
-							"if (!pick && quotes.length > 0) pick = quotes[0].onIntercityCab || quotes[0].onDemandCab;",
-							"if (pick) {",
-							"  pm.environment.set('quoteId', pick.id);",
-							"  console.log('Intercity Quote:', pick.id, 'variant:', pick.vehicleVariant, 'fare:', pick.estimatedTotalFare);",
-							"  console.log('All quotes:', quotes.map(function(q){var i=q.onIntercityCab||q.onDemandCab; return i?i.vehicleVariant+'='+i.estimatedTotalFare:'?';}).join(', '));",
-							"}",
-							"pm.test('Has intercity quotes', function () { pm.expect(pm.environment.get('quoteId')).to.be.a('string').that.is.not.empty; });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "token",
-						"value": "{{rider_token}}"
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl_app}}/rideSearch/{{searchId}}/results",
-					"host": [
-						"{{baseUrl_app}}"
-					],
-					"path": [
-						"rideSearch",
-						"{{searchId}}",
-						"results"
-					]
-				}
-			}
-		},
-		{
-			"name": "Confirm Intercity Quote",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json(); pm.environment.set('customer_bookingId', d.bookingId); console.log('Booking:', d.bookingId); pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); while(Date.now()-s<10000){}"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{rider_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{}"
-				},
-				"url": {
-					"raw": "{{baseUrl_app}}/rideSearch/quotes/{{quoteId}}/confirm",
-					"host": [
-						"{{baseUrl_app}}"
-					],
-					"path": [
-						"rideSearch",
-						"quotes",
-						"{{quoteId}}",
-						"confirm"
-					]
-				}
-			}
-		},
-		{
-			"name": "Get Nearby Ride Requests (Driver)",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							"// Wait 8s for the BPP to dispatch the intercity SearchTry to the driver.",
-							"// The dispatch after Confirm Intercity Quote is async; a single shot",
-							"// without any wait returns empty. The test script retries up to 3 times.",
-							"const s = Date.now(); while (Date.now() - s < 8000) {}"
-						]
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							"var d = pm.response.json();",
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });",
-							"if (d.searchRequestsForDriver && d.searchRequestsForDriver.length > 0) {",
-							"    var req = d.searchRequestsForDriver[0];",
-							"    pm.environment.set('searchTryId', req.searchTryId);",
-							"    pm.collectionVariables.set('_nearby_retries', 0);",
-							"    console.log('Got intercity search request, searchTryId:', req.searchTryId, 'baseFare:', req.baseFare);",
-							"    pm.test('Has search requests', function () { pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty; });",
-							"} else {",
-							"    var retries = parseInt(pm.collectionVariables.get('_nearby_retries') || '0');",
-							"    console.log('WARNING: No nearby ride requests (attempt ' + (retries + 1) + '/3)');",
-							"    if (retries < 2) {",
-							"        pm.collectionVariables.set('_nearby_retries', retries + 1);",
-							"        pm.execution.setNextRequest('Get Nearby Ride Requests (Driver)');",
-							"    } else {",
-							"        pm.collectionVariables.set('_nearby_retries', 0);",
-							"        pm.test('Has search requests', function () { pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty; });",
-							"    }",
-							"}"
-						]
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					}
-				],
-				"url": {
-					"raw": "{{baseURL_namma_P}}/driver/nearbyRideRequest",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"driver",
-						"nearbyRideRequest"
-					]
-				}
-			}
-		},
-		{
-			"name": "Driver Accept Intercity Ride",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Driver accepted intercity ride!');"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"searchTryId\": \"{{searchTryId}}\", \"offeredFare\": null, \"response\": \"Accept\"}"
-				},
-				"url": {
-					"raw": "{{baseURL_namma_P}}/driver/searchRequest/quote/respond",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"driver",
-						"searchRequest",
-						"quote",
-						"respond"
-					]
-				}
-			}
-		},
-		{
-			"name": "Get Booking (Verify Intercity, Extract OTP)",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"const s=Date.now(); while(Date.now()-s<5000){}"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json();",
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });",
-							"if (d.list && d.list.length > 0) {",
-							"  var booking = d.list[0];",
-							"  pm.environment.set('customer_bookingId', booking.id);",
-							"  var otp = booking.rideOtp;",
-							"  if (!otp && booking.rideList && booking.rideList.length > 0) {",
-							"    otp = booking.rideList[0].rideOtp;",
-							"  }",
-							"  pm.environment.set('ride_otp', otp || '');",
-							"  console.log('Booking:', booking.id, 'Status:', booking.status, 'OTP:', otp, 'tripCategory:', JSON.stringify(booking.tripCategory));",
-							"  pm.test('Booking is intercity', function () { pm.expect(JSON.stringify(booking.tripCategory)).to.include('InterCity'); });",
-							"  pm.test('Has rideOtp', function () { pm.expect(pm.environment.get('ride_otp')).to.be.a('string').that.is.not.empty; });",
-							"}"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "token",
-						"value": "{{rider_token}}"
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl_app}}/rideBooking/list?limit=1&onlyActive=true&offset=0",
-					"host": [
-						"{{baseUrl_app}}"
-					],
-					"path": [
-						"rideBooking",
-						"list"
-					],
-					"query": [
-						{
-							"key": "limit",
-							"value": "1"
-						},
-						{
-							"key": "onlyActive",
-							"value": "true"
-						},
-						{
-							"key": "offset",
-							"value": "0"
-						}
-					]
-				}
-			}
-		},
-		{
-			"name": "Get Ride (Driver)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json();",
-							"if (d.list && d.list.length > 0) {",
-							"    pm.environment.set('driver_ride_id', d.list[0].id);",
-							"    console.log('Intercity Ride:', d.list[0].id, 'Status:', d.list[0].status);",
-							"}",
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); });"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					}
-				],
-				"url": {
-					"raw": "{{baseURL_namma_P}}/driver/ride/list?limit=1&isActive=true",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"driver",
-						"ride",
-						"list"
-					],
-					"query": [
-						{
-							"key": "limit",
-							"value": "1"
-						},
-						{
-							"key": "isActive",
-							"value": "true"
-						}
-					]
-				}
-			}
-		},
-		{
-			"name": "Driver Start Intercity Ride",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Intercity ride started!');"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"rideOtp\": \"{{ride_otp}}\", \"point\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"odometer\": {\"value\": 0, \"fileId\": \"test-odometer-start\"}}"
-				},
-				"url": {
-					"raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/start",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"driver",
-						"ride",
-						"{{driver_ride_id}}",
-						"start"
-					]
-				}
-			}
-		},
-		{
-			"name": "End Ride (At Mysore)",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"const s=Date.now(); while(Date.now()-s<1500){}"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Intercity ride ended at Mysore');"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "token",
-						"value": "{{driver_token}}"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"point\": {\"lat\": {{intercity_dest_lat}}, \"lon\": {{intercity_dest_lon}}}, \"odometer\": {\"value\": 150, \"fileId\": \"test-odometer-end\"}}"
-				},
-				"url": {
-					"raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/end",
-					"host": [
-						"{{baseURL_namma_P}}"
-					],
-					"path": [
-						"driver",
-						"ride",
-						"{{driver_ride_id}}",
-						"end"
-					]
-				}
-			}
-		},
-		{
-			"name": "Verify Booking Completed (Rider)",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"const s=Date.now(); while(Date.now()-s<3000){}"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var d = pm.response.json(); pm.test('Status 200', function () { pm.response.to.have.status(200); }); pm.test('Booking COMPLETED', function () { pm.expect(d.bookingStatus).to.equal('COMPLETED'); }); pm.test('Ride COMPLETED', function () { pm.expect(d.rideStatus).to.equal('COMPLETED'); }); console.log('Intercity flow done! Booking:', d.bookingStatus, 'Ride:', d.rideStatus);"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "token",
-						"value": "{{rider_token}}"
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl_app}}/rideBooking/v2/{{customer_bookingId}}",
-					"host": [
-						"{{baseUrl_app}}"
-					],
-					"path": [
-						"rideBooking",
-						"v2",
-						"{{customer_bookingId}}"
-					]
-				}
-			}
-		}
-	]
+  "info": {
+    "name": "NY Intercity Ride Flow (Bangalore -> Mysore, OneWay)",
+    "description": "End-to-end Intercity flow (one-way Bangalore -> Mysore):\n  Driver onboard -> Rider auth -> InterCity search -> Get quotes (onIntercityCab) -> Confirm quote -> Driver gets OTP from booking -> Driver OTP-starts ride -> End ride -> Verify completed.\n\nPrerequisites:\n- Bangalore intercity FarePolicy + fare_product seeded for the chosen vehicle variant (auto-synced from prod via config-sync/prod_to_local_sql).\n- Special-zone OTP path: Intercity_OneWayRideOtp trip category must resolve to a quote for the chosen origin/destination pair.\n",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "exec": [
+          "(function () {",
+          "  var envType = pm.environment.get('envType') || 'Local';",
+          "  if (envType === 'Local') return;",
+          "  var raw = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
+          "  if (raw.indexOf('mockServerUrl') !== -1 || raw.indexOf('mock_fcm_url') !== -1) {",
+          "    if (pm.execution && typeof pm.execution.skipRequest === 'function') pm.execution.skipRequest();",
+          "  }",
+          "})();",
+          "if (!pm.collectionVariables.get('_test_driver_number')) {",
+          "    var dNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+          "    var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+          "    var regNo = 'KA' + String(Math.floor(10 + Math.random() * 89)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String(Math.floor(1000 + Math.random() * 8999));",
+          "    pm.collectionVariables.set('_test_driver_number', dNum);",
+          "    pm.collectionVariables.set('_test_rider_number', rNum);",
+          "    pm.collectionVariables.set('_test_reg_no', regNo);",
+          "    console.log('Test driver:', dNum, 'rider:', rNum, 'reg:', regNo);",
+          "}"
+        ],
+        "type": "text/javascript"
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "Driver Auth",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// Always generate fresh numbers so each run uses a new driver/rider.",
+              "// Without this the collection-level guard reuses the same driver,",
+              "// leaving stale Redis state that causes empty searchRequestsForDriver.",
+              "var city = pm.environment.get('dashboard_city') || 'Bangalore';",
+              "var rcMap = {Bangalore:'KA',Chennai:'TN',Kolkata:'WB',Delhi:'DL',Hyderabad:'TS',Mumbai:'MH',Mysore:'KA'};",
+              "var prefix = rcMap[city] || 'KA';",
+              "var dNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+              "var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+              "var regNo = prefix + String(Math.floor(10 + Math.random() * 89)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String.fromCharCode(65 + Math.floor(Math.random() * 26)) + String(Math.floor(1000 + Math.random() * 8999));",
+              "pm.collectionVariables.set('_test_driver_number', dNum);",
+              "pm.collectionVariables.set('_test_rider_number', rNum);",
+              "pm.collectionVariables.set('_test_reg_no', regNo);",
+              "pm.collectionVariables.set('_nearby_retries', 0);",
+              "console.log('Fresh run: driver=' + dNum + ' rider=' + rNum + ' reg=' + regNo + ' (' + city + ')');"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json(); pm.environment.set('driver_authId', d.authId); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"mobileNumber\": \"{{_test_driver_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{driver_merchant_id}}\", \"merchantOperatingCity\": \"{{city}}\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/auth",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "auth"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Driver OTP",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json(); pm.environment.set('driver_token', d.token); pm.environment.set('driver_id', d.person.id); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"otp\": \"{{login_otp}}\", \"deviceToken\": \"test-device\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/auth/{{driver_authId}}/verify",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "auth",
+            "{{driver_authId}}",
+            "verify"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Add Vehicle (Dashboard)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{dashboard_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"variant\": \"{{vehicle_variant}}\", \"registrationNo\": \"{{_test_reg_no}}\", \"vehicleClass\": \"{{vehicle_class}}\", \"vehicleCategory\": \"{{vehicle_category}}\", \"make\": \"{{vehicle_make}}\", \"model\": \"{{vehicle_model}}\", \"driverName\": \"Test Intercity Driver\", \"colour\": \"White\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/addVehicle",
+          "host": [
+            "{{baseURL_BPP_Dashboard_Internal}}"
+          ],
+          "path": [
+            "{{dashboard_merchant_id}}",
+            "{{dashboard_city}}",
+            "driver",
+            "{{driver_id}}",
+            "addVehicle"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Enable Driver (Dashboard)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{dashboard_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"canDowngradeToSedan\": false, \"canDowngradeToHatchback\": false, \"canDowngradeToTaxi\": false}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/enable",
+          "host": [
+            "{{baseURL_BPP_Dashboard_Internal}}"
+          ],
+          "path": [
+            "{{dashboard_merchant_id}}",
+            "{{dashboard_city}}",
+            "driver",
+            "{{driver_id}}",
+            "enable"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Subscribe Plan (Driver)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/plan/{{plan_id}}/subscribe",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "plan",
+            "{{plan_id}}",
+            "subscribe"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Enable Intercity Switch (Driver Profile)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('canSwitchToInterCity set to true');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"canSwitchToInterCity\": true}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/profile",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "profile"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Set Driver Online",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); while(Date.now()-s<2000){}"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/setActivity?active=true&mode=%22ONLINE%22",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "setActivity"
+          ],
+          "query": [
+            {
+              "key": "active",
+              "value": "true"
+            },
+            {
+              "key": "mode",
+              "value": "%22ONLINE%22"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Driver Set Location",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          },
+          {
+            "key": "vt",
+            "value": "{{vehicle_variant}}"
+          },
+          {
+            "key": "dm",
+            "value": "ONLINE"
+          },
+          {
+            "key": "mId",
+            "value": "{{driver_merchant_id}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "[{\"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"ts\": \"{{current_time}}\"}]"
+        },
+        "url": {
+          "raw": "{{baseUrl_lts}}/driver/location",
+          "host": [
+            "{{baseUrl_lts}}"
+          ],
+          "path": [
+            "driver",
+            "location"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Rider Auth",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json(); pm.environment.set('rider_authId', d.authId); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"mobileNumber\": \"{{_test_rider_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{bap_short_id}}\"}"
+        },
+        "url": {
+          "raw": "{{baseUrl_app}}/auth",
+          "host": [
+            "{{baseUrl_app}}"
+          ],
+          "path": [
+            "auth"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Rider OTP",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json(); pm.environment.set('rider_token', d.token); pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"otp\": \"{{login_otp}}\", \"deviceToken\": \"test-rider-device\"}"
+        },
+        "url": {
+          "raw": "{{baseUrl_app}}/auth/{{rider_authId}}/verify",
+          "host": [
+            "{{baseUrl_app}}"
+          ],
+          "path": [
+            "auth",
+            "{{rider_authId}}",
+            "verify"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Driver Location Update",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          },
+          {
+            "key": "vt",
+            "value": "{{vehicle_variant}}"
+          },
+          {
+            "key": "dm",
+            "value": "ONLINE"
+          },
+          {
+            "key": "mId",
+            "value": "{{driver_merchant_id}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "[{\"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"ts\": \"{{current_time}}\"}]"
+        },
+        "url": {
+          "raw": "{{baseUrl_lts}}/driver/location",
+          "host": [
+            "{{baseUrl_lts}}"
+          ],
+          "path": [
+            "driver",
+            "location"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Ride Search (Intercity Bangalore -> Mysore)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "// Use a slightly past startTime so BPP marks the booking as on-demand (not scheduled).",
+              "// BPP check: isScheduled = startTime > now. With startTime = now - 30s,",
+              "// BPP always sees startTime < now_bpp \u2192 isScheduled=false \u2192 immediate dispatch.",
+              "// BAP validation allows startTime >= now - 120s, so now-30s is safe.",
+              "var startTs = new Date(Date.now() - 30 * 1000).toISOString();",
+              "pm.environment.set('_intercity_start_time', startTs);"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json(); pm.environment.set('searchId', d.searchId); console.log('Intercity Search ID:', d.searchId); pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); const w=parseInt(pm.environment.get('search_wait_ms')||'8000',10); while(Date.now()-s<w){}"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{rider_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"fareProductType\": \"INTER_CITY\", \"contents\": {\"origin\": {\"address\": {\"area\": \"Bangalore Origin\", \"areaCode\": \"560001\", \"city\": \"{{city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}}, \"stops\": [{\"address\": {\"area\": \"{{intercity_dest_city}}\", \"areaCode\": \"570001\", \"city\": \"{{intercity_dest_city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{intercity_dest_lat}}, \"lon\": {{intercity_dest_lon}}}}], \"roundTrip\": false, \"isSourceManuallyMoved\": false, \"isDestinationManuallyMoved\": false, \"startTime\": \"{{_intercity_start_time}}\"}}"
+        },
+        "url": {
+          "raw": "{{baseUrl_app}}/rideSearch",
+          "host": [
+            "{{baseUrl_app}}"
+          ],
+          "path": [
+            "rideSearch"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Get Intercity Quotes",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "const s=Date.now(); while(Date.now()-s<3000){}"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json();",
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+              "var quotes = d.quotes || [];",
+              "var want = pm.environment.get('vehicle_variant') || 'SEDAN';",
+              "var pick = null;",
+              "for (var i=0; i<quotes.length; i++) {",
+              "  var inner = quotes[i].onIntercityCab || quotes[i].onDemandCab;",
+              "  if (!inner) continue;",
+              "  if (inner.vehicleVariant === want) { pick = inner; break; }",
+              "}",
+              "if (!pick && quotes.length > 0) pick = quotes[0].onIntercityCab || quotes[0].onDemandCab;",
+              "if (pick) {",
+              "  pm.environment.set('quoteId', pick.id);",
+              "  console.log('Intercity Quote:', pick.id, 'variant:', pick.vehicleVariant, 'fare:', pick.estimatedTotalFare);",
+              "  console.log('All quotes:', quotes.map(function(q){var i=q.onIntercityCab||q.onDemandCab; return i?i.vehicleVariant+'='+i.estimatedTotalFare:'?';}).join(', '));",
+              "}",
+              "pm.test('Has intercity quotes', function () { pm.expect(pm.environment.get('quoteId')).to.be.a('string').that.is.not.empty; });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "token",
+            "value": "{{rider_token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl_app}}/rideSearch/{{searchId}}/results",
+          "host": [
+            "{{baseUrl_app}}"
+          ],
+          "path": [
+            "rideSearch",
+            "{{searchId}}",
+            "results"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Confirm Intercity Quote",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json(); pm.environment.set('customer_bookingId', d.bookingId); console.log('Booking:', d.bookingId); pm.test('Status 200', function () { pm.response.to.have.status(200); }); const s=Date.now(); while(Date.now()-s<10000){}"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{rider_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{baseUrl_app}}/rideSearch/quotes/{{quoteId}}/confirm",
+          "host": [
+            "{{baseUrl_app}}"
+          ],
+          "path": [
+            "rideSearch",
+            "quotes",
+            "{{quoteId}}",
+            "confirm"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Get Nearby Ride Requests (Driver)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// Wait 8s for the BPP to dispatch the intercity SearchTry to the driver.",
+              "// The dispatch after Confirm Intercity Quote is async; a single shot",
+              "// without any wait returns empty. The test script retries up to 3 times.",
+              "const s = Date.now(); while (Date.now() - s < 8000) {}"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var d = pm.response.json();",
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+              "if (d.searchRequestsForDriver && d.searchRequestsForDriver.length > 0) {",
+              "    var req = d.searchRequestsForDriver[0];",
+              "    pm.environment.set('searchTryId', req.searchTryId);",
+              "    pm.collectionVariables.set('_nearby_retries', 0);",
+              "    console.log('Got intercity search request, searchTryId:', req.searchTryId, 'baseFare:', req.baseFare);",
+              "    pm.test('Has search requests', function () { pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty; });",
+              "} else {",
+              "    var retries = parseInt(pm.collectionVariables.get('_nearby_retries') || '0');",
+              "    console.log('WARNING: No nearby ride requests (attempt ' + (retries + 1) + '/3)');",
+              "    if (retries < 2) {",
+              "        pm.collectionVariables.set('_nearby_retries', retries + 1);",
+              "        pm.execution.setNextRequest('Get Nearby Ride Requests (Driver)');",
+              "    } else {",
+              "        pm.collectionVariables.set('_nearby_retries', 0);",
+              "        pm.test('Has search requests', function () { pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty; });",
+              "    }",
+              "}"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/nearbyRideRequest",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "nearbyRideRequest"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Driver Accept Intercity Ride",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Driver accepted intercity ride!');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"searchTryId\": \"{{searchTryId}}\", \"offeredFare\": null, \"response\": \"Accept\"}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/searchRequest/quote/respond",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "searchRequest",
+            "quote",
+            "respond"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Get Booking (Verify Intercity, Extract OTP)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "const s=Date.now(); while(Date.now()-s<5000){}"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json();",
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+              "if (d.list && d.list.length > 0) {",
+              "  var booking = d.list[0];",
+              "  pm.environment.set('customer_bookingId', booking.id);",
+              "  var otp = booking.rideOtp;",
+              "  if (!otp && booking.rideList && booking.rideList.length > 0) {",
+              "    otp = booking.rideList[0].rideOtp;",
+              "  }",
+              "  pm.environment.set('ride_otp', otp || '');",
+              "  console.log('Booking:', booking.id, 'Status:', booking.status, 'OTP:', otp, 'tripCategory:', JSON.stringify(booking.tripCategory));",
+              "  pm.test('Booking is intercity', function () { pm.expect(JSON.stringify(booking.tripCategory)).to.include('InterCity'); });",
+              "  pm.test('Has rideOtp', function () { pm.expect(pm.environment.get('ride_otp')).to.be.a('string').that.is.not.empty; });",
+              "}"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "token",
+            "value": "{{rider_token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl_app}}/rideBooking/list?limit=1&onlyActive=true&offset=0",
+          "host": [
+            "{{baseUrl_app}}"
+          ],
+          "path": [
+            "rideBooking",
+            "list"
+          ],
+          "query": [
+            {
+              "key": "limit",
+              "value": "1"
+            },
+            {
+              "key": "onlyActive",
+              "value": "true"
+            },
+            {
+              "key": "offset",
+              "value": "0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Get Ride (Driver)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json();",
+              "if (d.list && d.list.length > 0) {",
+              "    pm.environment.set('driver_ride_id', d.list[0].id);",
+              "    console.log('Intercity Ride:', d.list[0].id, 'Status:', d.list[0].status);",
+              "}",
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/ride/list?limit=1&isActive=true",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "ride",
+            "list"
+          ],
+          "query": [
+            {
+              "key": "limit",
+              "value": "1"
+            },
+            {
+              "key": "isActive",
+              "value": "true"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Driver Start Intercity Ride",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Intercity ride started!');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"rideOtp\": \"{{ride_otp}}\", \"point\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}, \"odometer\": {\"value\": 0, \"fileId\": \"test-odometer-start\"}}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/start",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "ride",
+            "{{driver_ride_id}}",
+            "start"
+          ]
+        }
+      }
+    },
+    {
+      "name": "End Ride (At Mysore)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "const s=Date.now(); while(Date.now()-s<1500){}"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status 200', function () { pm.response.to.have.status(200); }); console.log('Intercity ride ended at Mysore');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"point\": {\"lat\": {{intercity_dest_lat}}, \"lon\": {{intercity_dest_lon}}}, \"odometer\": {\"value\": 150, \"fileId\": \"test-odometer-end\"}}"
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/end",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "ride",
+            "{{driver_ride_id}}",
+            "end"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Verify Booking Completed (Rider)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "const s=Date.now(); while(Date.now()-s<3000){}"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "var d = pm.response.json(); pm.test('Status 200', function () { pm.response.to.have.status(200); }); pm.test('Booking COMPLETED', function () { pm.expect(d.bookingStatus).to.equal('COMPLETED'); }); pm.test('Ride COMPLETED', function () { pm.expect(d.rideStatus).to.equal('COMPLETED'); }); console.log('Intercity flow done! Booking:', d.bookingStatus, 'Ride:', d.rideStatus);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "token",
+            "value": "{{rider_token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl_app}}/rideBooking/v2/{{customer_bookingId}}",
+          "host": [
+            "{{baseUrl_app}}"
+          ],
+          "path": [
+            "rideBooking",
+            "v2",
+            "{{customer_bookingId}}"
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/01-AutoRideFlow.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/01-AutoRideFlow.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "NY Auto Ride Flow",
-    "description": "End-to-end auto ride: fresh driver + rider -> onboard -> search -> auto-assign -> start -> end",
+    "description": "End-to-end auto ride: fresh driver + rider -> onboard -> search -> auto-assign -> start -> end | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [
@@ -440,7 +440,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"NAMMA_YATRI\"\n}"
+          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{bap_short_id}}\"\n}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/02-AutoUserCancellation.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/02-AutoUserCancellation.json
@@ -626,8 +626,12 @@
             "exec": [
               "var d = pm.response.json();",
               "if (d.estimates && d.estimates.length > 0) {",
-              "    pm.environment.set('estimateId', d.estimates[0].id);",
-              "    console.log('Estimate:', d.estimates[0].id, d.estimates[0].vehicleVariant, d.estimates[0].estimatedFare);",
+              "    var want = pm.environment.get('auto_vehicle_variant') || 'AUTO_RICKSHAW';",
+              "    var est = d.estimates.find(e => e.vehicleVariant === want)",
+              "           || d.estimates.find(e => e.vehicleServiceTierType === want)",
+              "           || d.estimates[0];",
+              "    pm.environment.set('estimateId', est.id);",
+              "    console.log('Estimate:', est.id, est.vehicleVariant, est.estimatedFare, '(wanted', want + ')');",
               "}",
               "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
               "pm.test('Has estimates', function () { pm.expect(d, 'response body').to.be.an('object'); pm.expect(d.estimates, 'estimates field').to.be.an('array'); pm.expect(d.estimates.length, 'estimate count').to.be.above(0); });"

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/02-AutoUserCancellation.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/02-AutoUserCancellation.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "NY Auto User Cancellation",
-    "description": "Auto ride with rider cancellation after assignment",
+    "description": "Auto ride with rider cancellation after assignment | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [
@@ -440,7 +440,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"NAMMA_YATRI\"\n}"
+          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{bap_short_id}}\"\n}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/03-AutoDriverCancellation.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/03-AutoDriverCancellation.json
@@ -1,1810 +1,1824 @@
 {
-  "info": {
-    "name": "NY Auto Driver Cancellation + Reallocation",
-    "description": "2 drivers: D1 gets ride, cancels -> D2 gets reallocated ride -> completes | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-  },
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "exec": [
-          "// Auto-skip mock-server requests when envType is not Local.",
-          "// Set envType=Local in Local env files; omit / set to 'Master' otherwise.",
-          "(function () {",
-          "  var envType = pm.environment.get('envType') || 'Local';",
-          "  if (envType === 'Local') return;",
-          "  var raw = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
-          "  if (raw.indexOf('mockServerUrl') !== -1 || raw.indexOf('mock_fcm_url') !== -1) {",
-          "    console.log('[skip] mock-only request on envType=' + envType + ': ' + (pm.info && pm.info.requestName));",
-          "    if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
-          "      pm.execution.skipRequest();",
-          "    }",
-          "  }",
-          "})();",
-          "",
-          "if (!pm.collectionVariables.get('_test_driver_number')) {",
-          "    var d1 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
-          "    var d2 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
-          "    var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
-          "    var reg1 = 'KA' + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
-          "    var reg2 = 'KA' + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
-          "    pm.collectionVariables.set('_test_driver_number', d1);",
-          "    pm.collectionVariables.set('_test_driver2_number', d2);",
-          "    pm.collectionVariables.set('_test_rider_number', rNum);",
-          "    pm.collectionVariables.set('_test_reg_no', reg1);",
-          "    pm.collectionVariables.set('_test_reg_no2', reg2);",
-          "    console.log('D1:', d1, 'D2:', d2, 'Rider:', rNum);",
-          "}"
-        ],
-        "type": "text/javascript"
-      }
-    }
-  ],
-  "item": [
-    {
-      "name": "D1 Auth",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "pm.environment.set('driver_authId', d.authId);",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "prerequest",
-          "script": {
-            "type": "text/javascript",
-            "exec": [
-              "// Reset all test-run variables so this run gets fresh drivers/riders.",
-              "// Without this, collection variables persist and D1/D2 reuse the same",
-              "// phone numbers across runs, causing stale ride/booking state conflicts.",
-              "var city = pm.environment.get('dashboard_city') || 'Bangalore';",
-              "var rcPrefixMap = {Bangalore:'KA',Chennai:'TN',Kolkata:'WB',Delhi:'DL',Hyderabad:'TS',Mumbai:'MH',Mysore:'KA'};",
-              "var rcPrefix = rcPrefixMap[city] || 'KA';",
-              "var d1 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
-              "var d2 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
-              "var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
-              "var reg1 = rcPrefix + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
-              "var reg2 = rcPrefix + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
-              "pm.collectionVariables.set('_test_driver_number', d1);",
-              "pm.collectionVariables.set('_test_driver2_number', d2);",
-              "pm.collectionVariables.set('_test_rider_number', rNum);",
-              "pm.collectionVariables.set('_test_reg_no', reg1);",
-              "pm.collectionVariables.set('_test_reg_no2', reg2);",
-              "console.log('Fresh run: D1=' + d1 + ' D2=' + d2 + ' Rider=' + rNum + ' Reg1=' + reg1 + ' (' + city + ')');"
-            ]
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_driver_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{driver_merchant_id}}\",\n    \"merchantOperatingCity\": \"{{city}}\"\n}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/auth",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "auth"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 OTP",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "pm.environment.set('driver_token', d.token);",
-              "pm.environment.set('driver_id', d.person.id);",
-              "console.log('Driver ID:', d.person.id);",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"otp\": \"{{login_otp}}\",\n    \"deviceToken\": \"test-device\"\n}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/auth/{{driver_authId}}/verify",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "auth",
-            "{{driver_authId}}",
-            "verify"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Add Vehicle",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Vehicle added', function () { pm.response.to.have.status(200); });",
-              "console.log('AddVehicle:', pm.response.text());"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{dashboard_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"registrationNo\": \"{{_test_reg_no}}\",\n  \"vehicleClass\": \"3w\",\n  \"colour\": \"Green\",\n  \"model\": \"AUTO RICKSHAW\",\n  \"make\": \"Bajaj\",\n  \"vehicleCategory\": \"AUTO_CATEGORY\"\n}"
-        },
-        "url": {
-          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/addVehicle",
-          "host": [
-            "{{baseURL_BPP_Dashboard_Internal}}"
-          ],
-          "path": [
-            "{{dashboard_merchant_id}}",
-            "{{dashboard_city}}",
-            "driver",
-            "{{driver_id}}",
-            "addVehicle"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Enable",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Driver enabled', function () { pm.response.to.have.status(200); });",
-              "console.log('Enable:', pm.response.text());"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{dashboard_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/enable",
-          "host": [
-            "{{baseURL_BPP_Dashboard_Internal}}"
-          ],
-          "path": [
-            "{{dashboard_merchant_id}}",
-            "{{dashboard_city}}",
-            "driver",
-            "{{driver_id}}",
-            "enable"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Subscribe Plan",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Plan subscribed', function () { pm.expect(pm.response.code).to.be.oneOf([200, 500]); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/plan/18911beb-28ba-456d-8cca-4d019461d2b0/subscribe?serviceName=%22YATRI_SUBSCRIPTION%22",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "plan",
-            "18911beb-28ba-456d-8cca-4d019461d2b0",
-            "subscribe"
-          ],
-          "query": [
-            {
-              "key": "serviceName",
-              "value": "%22YATRI_SUBSCRIPTION%22"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Set Location",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver_id}}"
-          },
-          {
-            "key": "vt",
-            "value": "AUTO_RICKSHAW"
-          },
-          {
-            "key": "dm",
-            "value": "ONLINE"
-          },
-          {
-            "key": "mId",
-            "value": "{{driver_merchant_id}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "[\n    {\n        \"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}},\n        \"ts\": \"{{current_time}}\"\n    }\n]"
-        },
-        "url": {
-          "raw": "{{baseUrl_lts}}/driver/location",
-          "host": [
-            "{{baseUrl_lts}}"
-          ],
-          "path": [
-            "driver",
-            "location"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Set Online",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/setActivity?active=true&mode=%22ONLINE%22",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "setActivity"
-          ],
-          "query": [
-            {
-              "key": "active",
-              "value": "true"
-            },
-            {
-              "key": "mode",
-              "value": "%22ONLINE%22"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Auth",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "pm.environment.set('driver2_authId', d.authId);",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_driver2_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{driver_merchant_id}}\",\n    \"merchantOperatingCity\": \"{{city}}\"\n}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/auth",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "auth"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 OTP",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "pm.environment.set('driver2_token', d.token);",
-              "pm.environment.set('driver2_id', d.person.id);",
-              "console.log('Driver2 ID:', d.person.id);",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"otp\": \"{{login_otp}}\",\n    \"deviceToken\": \"test-device\"\n}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/auth/{{driver2_authId}}/verify",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "auth",
-            "{{driver2_authId}}",
-            "verify"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Add Vehicle",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Vehicle added', function () { pm.response.to.have.status(200); });",
-              "console.log('AddVehicle:', pm.response.text());"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{dashboard_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\"registrationNo\": \"{{_test_reg_no2}}\", \"vehicleClass\": \"3w\", \"colour\": \"Green\", \"model\": \"AUTO RICKSHAW\", \"make\": \"Bajaj\", \"vehicleCategory\": \"AUTO_CATEGORY\"}"
-        },
-        "url": {
-          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver2_id}}/addVehicle",
-          "host": [
-            "{{baseURL_BPP_Dashboard_Internal}}"
-          ],
-          "path": [
-            "{{dashboard_merchant_id}}",
-            "{{dashboard_city}}",
-            "driver",
-            "{{driver2_id}}",
-            "addVehicle"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Enable",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Driver enabled', function () { pm.response.to.have.status(200); });",
-              "console.log('Enable:', pm.response.text());"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{dashboard_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver2_id}}/enable",
-          "host": [
-            "{{baseURL_BPP_Dashboard_Internal}}"
-          ],
-          "path": [
-            "{{dashboard_merchant_id}}",
-            "{{dashboard_city}}",
-            "driver",
-            "{{driver2_id}}",
-            "enable"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Subscribe Plan",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Plan subscribed', function () { pm.expect(pm.response.code).to.be.oneOf([200, 500]); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver2_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/plan/18911beb-28ba-456d-8cca-4d019461d2b0/subscribe?serviceName=%22YATRI_SUBSCRIPTION%22",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "plan",
-            "18911beb-28ba-456d-8cca-4d019461d2b0",
-            "subscribe"
-          ],
-          "query": [
-            {
-              "key": "serviceName",
-              "value": "%22YATRI_SUBSCRIPTION%22"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "Rider Auth",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "pm.environment.set('rider_authId', d.authId);",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{bap_short_id}}\"\n}"
-        },
-        "url": {
-          "raw": "{{baseUrl_app}}/auth",
-          "host": [
-            "{{baseUrl_app}}"
-          ],
-          "path": [
-            "auth"
-          ]
-        }
-      }
-    },
-    {
-      "name": "Rider OTP",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "pm.environment.set('rider_token', d.token);",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"otp\": \"{{login_otp}}\",\n    \"deviceToken\": \"test-rider\"\n}"
-        },
-        "url": {
-          "raw": "{{baseUrl_app}}/auth/{{rider_authId}}/verify",
-          "host": [
-            "{{baseUrl_app}}"
-          ],
-          "path": [
-            "auth",
-            "{{rider_authId}}",
-            "verify"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Location Update",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver_id}}"
-          },
-          {
-            "key": "vt",
-            "value": "AUTO_RICKSHAW"
-          },
-          {
-            "key": "dm",
-            "value": "ONLINE"
-          },
-          {
-            "key": "mId",
-            "value": "{{driver_merchant_id}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "[\n    {\n        \"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}},\n        \"ts\": \"{{current_time}}\"\n    }\n]"
-        },
-        "url": {
-          "raw": "{{baseUrl_lts}}/driver/location",
-          "host": [
-            "{{baseUrl_lts}}"
-          ],
-          "path": [
-            "driver",
-            "location"
-          ]
-        }
-      }
-    },
-    {
-      "name": "Ride Search",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "setTimeout(function(){}, 2000);"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "pm.environment.set('searchId', d.searchId);",
-              "console.log('Search ID:', d.searchId);",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "// Wait for async beckn search processing across services\nconst _delay = 5000; const _start = Date.now(); while (Date.now() - _start < _delay) {}"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{rider_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\"fareProductType\": \"ONE_WAY\", \"contents\": {\"origin\": {\"address\": {\"area\": \"Test Origin\", \"areaCode\": \"000000\", \"city\": \"{{city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}}, \"destination\": {\"address\": {\"area\": \"Test Destination\", \"areaCode\": \"000000\", \"city\": \"{{city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{dest_lat}}, \"lon\": {{dest_lon}}}}, \"isReallocationEnabled\": true}}"
-        },
-        "url": {
-          "raw": "{{baseUrl_app}}/rideSearch",
-          "host": [
-            "{{baseUrl_app}}"
-          ],
-          "path": [
-            "rideSearch"
-          ]
-        }
-      }
-    },
-    {
-      "name": "Get Search Results",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "setTimeout(function(){}, 5000);"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "if (d.estimates && d.estimates.length > 0) {",
-              "    var want = pm.environment.get('auto_vehicle_variant') || 'AUTO_RICKSHAW';",
-              "    var est = d.estimates.find(e => e.vehicleVariant === want)",
-              "           || d.estimates.find(e => e.vehicleServiceTierType === want)",
-              "           || d.estimates[0];",
-              "    pm.environment.set('estimateId', est.id);",
-              "    console.log('Estimate:', est.id, est.vehicleVariant, est.estimatedFare, '(wanted', want + ')');",
-              "}",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "pm.test('Has estimates', function () { pm.expect(d, 'response body').to.be.an('object'); pm.expect(d.estimates, 'estimates field').to.be.an('array'); pm.expect(d.estimates.length, 'estimate count').to.be.above(0); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "token",
-            "value": "{{rider_token}}"
-          }
-        ],
-        "url": {
-          "raw": "{{baseUrl_app}}/rideSearch/{{searchId}}/results",
-          "host": [
-            "{{baseUrl_app}}"
-          ],
-          "path": [
-            "rideSearch",
-            "{{searchId}}",
-            "results"
-          ]
-        }
-      }
-    },
-    {
-      "name": "Select Estimate (Auto Assign)",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "// Wait for async select processing before next step\nconst _sel_delay = 8000; const _sel_start = Date.now(); while (Date.now() - _sel_start < _sel_delay) {}"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{rider_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\"autoAssignEnabled\": true, \"autoAssignEnabledV2\": true}"
-        },
-        "url": {
-          "raw": "{{baseUrl_app}}/estimate/{{estimateId}}/select2",
-          "host": [
-            "{{baseUrl_app}}"
-          ],
-          "path": [
-            "estimate",
-            "{{estimateId}}",
-            "select2"
-          ]
-        }
-      }
-    },
-    {
-      "name": "Get Nearby Ride Requests (Driver)",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "// Wait briefly before checking nearby requests",
-              "const start = Date.now();",
-              "while (Date.now() - start < 1000) { /* busy wait */ }"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "if (d.searchRequestsForDriver && d.searchRequestsForDriver.length > 0) {",
-              "    var req = d.searchRequestsForDriver[0];",
-              "    pm.environment.set('searchTryId', req.searchTryId);",
-              "    console.log('Got search request, searchTryId:', req.searchTryId, 'baseFare:', req.baseFare, 'variant:', req.requestedVehicleVariant);",
-              "} else {",
-              "    console.log('WARNING: No nearby ride requests found for driver. Response:', JSON.stringify(d));",
-              "}",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "pm.test('Has search requests', function () {",
-              "    pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty;",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "token",
-            "value": "{{driver_token}}"
-          }
-        ],
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/nearbyRideRequest",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "nearbyRideRequest"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Accept Ride",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "console.log('Driver accepted ride!');"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\"searchTryId\": \"{{searchTryId}}\", \"offeredFare\": null, \"response\": \"Accept\"}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/searchRequest/quote/respond",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "searchRequest",
-            "quote",
-            "respond"
-          ]
-        }
-      }
-    },
-    {
-      "name": "Get Booking (Rider)",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "// Wait for booking to be created after driver acceptance",
-              "const delay = pm.environment.get('booking_wait_ms') || 5000;",
-              "const start = Date.now();",
-              "while (Date.now() - start < delay) { /* busy wait */ }"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "if (d.list && d.list.length > 0) {",
-              "    var booking = d.list[0];",
-              "    pm.environment.set('customer_bookingId', booking.id);",
-              "    var otp = booking.rideOtp;",
-              "    if (!otp && booking.rideList && booking.rideList.length > 0) {",
-              "        otp = booking.rideList[0].rideOtp;",
-              "    }",
-              "    pm.environment.set('ride_otp', otp);",
-              "    console.log('Booking:', booking.id, 'OTP:', otp, 'Status:', booking.status);",
-              "}",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "token",
-            "value": "{{rider_token}}"
-          }
-        ],
-        "url": {
-          "raw": "{{baseUrl_app}}/rideBooking/list?limit=1&onlyActive=true&offset=0",
-          "host": [
-            "{{baseUrl_app}}"
-          ],
-          "path": [
-            "rideBooking",
-            "list"
-          ],
-          "query": [
-            {
-              "key": "limit",
-              "value": "1"
-            },
-            {
-              "key": "onlyActive",
-              "value": "true"
-            },
-            {
-              "key": "offset",
-              "value": "0"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Get Ride",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "if (d.list && d.list.length > 0) {",
-              "    pm.environment.set('driver_ride_id', d.list[0].id);",
-              "    console.log('Ride:', d.list[0].id, 'Status:', d.list[0].status);",
-              "}",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "token",
-            "value": "{{driver_token}}"
-          }
-        ],
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/ride/list?limit=1&isActive=true",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "ride",
-            "list"
-          ],
-          "query": [
-            {
-              "key": "limit",
-              "value": "1"
-            },
-            {
-              "key": "isActive",
-              "value": "true"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Set Location",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver2_id}}"
-          },
-          {
-            "key": "vt",
-            "value": "AUTO_RICKSHAW"
-          },
-          {
-            "key": "dm",
-            "value": "ONLINE"
-          },
-          {
-            "key": "mId",
-            "value": "{{driver_merchant_id}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "[\n    {\n        \"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}},\n        \"ts\": \"{{current_time}}\"\n    }\n]"
-        },
-        "url": {
-          "raw": "{{baseUrl_lts}}/driver/location",
-          "host": [
-            "{{baseUrl_lts}}"
-          ],
-          "path": [
-            "driver",
-            "location"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Set Online",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver2_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/setActivity?active=true&mode=%22ONLINE%22",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "setActivity"
-          ],
-          "query": [
-            {
-              "key": "active",
-              "value": "true"
-            },
-            {
-              "key": "mode",
-              "value": "%22ONLINE%22"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Location Update",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver2_id}}"
-          },
-          {
-            "key": "vt",
-            "value": "AUTO_RICKSHAW"
-          },
-          {
-            "key": "dm",
-            "value": "ONLINE"
-          },
-          {
-            "key": "mId",
-            "value": "{{driver_merchant_id}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "[\n    {\n        \"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}},\n        \"ts\": \"{{current_time}}\"\n    }\n]"
-        },
-        "url": {
-          "raw": "{{baseUrl_lts}}/driver/location",
-          "host": [
-            "{{baseUrl_lts}}"
-          ],
-          "path": [
-            "driver",
-            "location"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Cancel Ride",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "const start = Date.now();",
-              "while (Date.now() - start < 1000) {}"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "console.log('D1 cancelled ride!');"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\"reasonCode\": \"OTHER\", \"additionalInfo\": \"test cancellation\"}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/cancel",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "ride",
-            "{{driver_ride_id}}",
-            "cancel"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D1 Set Offline",
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/setActivity?active=false&mode=%22OFFLINE%22",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "setActivity"
-          ],
-          "query": [
-            {
-              "key": "active",
-              "value": "false"
-            },
-            {
-              "key": "mode",
-              "value": "%22OFFLINE%22"
-            }
-          ]
-        }
-      },
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "type": "text/javascript",
-            "exec": [
-              "// Set D1 offline immediately after cancellation so D1 cannot",
-              "// accept the reallocated ride before D2. Without this, both",
-              "// D1 and D2 receive the reallocation request and D1 often wins,",
-              "// causing D2 to get RIDE_REQUEST_ALREADY_ACCEPTED.",
-              "pm.test('Status code is 200', function () {",
-              "    pm.response.to.have.status(200);",
-              "});"
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "name": "D2 Get Nearby Ride Requests",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "// Wait briefly before checking nearby requests",
-              "const start = Date.now();",
-              "while (Date.now() - start < 1000) { /* busy wait */ }"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "if (d.searchRequestsForDriver && d.searchRequestsForDriver.length > 0) {",
-              "    var req = d.searchRequestsForDriver[0];",
-              "    pm.environment.set('searchTryId', req.searchTryId);",
-              "    console.log('Got search request, searchTryId:', req.searchTryId, 'baseFare:', req.baseFare, 'variant:', req.requestedVehicleVariant);",
-              "} else {",
-              "    console.log('WARNING: No nearby ride requests found for driver. Response:', JSON.stringify(d));",
-              "}",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "pm.test('Has search requests', function () {",
-              "    pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty;",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "token",
-            "value": "{{driver2_token}}"
-          }
-        ],
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/nearbyRideRequest",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "nearbyRideRequest"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Accept Ride",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "console.log('Driver accepted ride!');"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver2_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\"searchTryId\": \"{{searchTryId}}\", \"offeredFare\": null, \"response\": \"Accept\"}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/searchRequest/quote/respond",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "searchRequest",
-            "quote",
-            "respond"
-          ]
-        }
-      }
-    },
-    {
-      "name": "Get Booking After Reallocation",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "// Wait for booking to be created after driver acceptance",
-              "const delay = pm.environment.get('booking_wait_ms') || 5000;",
-              "const start = Date.now();",
-              "while (Date.now() - start < delay) { /* busy wait */ }"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "if (d.list && d.list.length > 0) {",
-              "    var booking = d.list[0];",
-              "    pm.environment.set('customer_bookingId', booking.id);",
-              "    var otp = booking.rideOtp;",
-              "    if (!otp && booking.rideList && booking.rideList.length > 0) {",
-              "        otp = booking.rideList[0].rideOtp;",
-              "    }",
-              "    pm.environment.set('ride_otp', otp);",
-              "    console.log('Booking:', booking.id, 'OTP:', otp, 'Status:', booking.status);",
-              "}",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "token",
-            "value": "{{rider_token}}"
-          }
-        ],
-        "url": {
-          "raw": "{{baseUrl_app}}/rideBooking/list?limit=1&onlyActive=true&offset=0",
-          "host": [
-            "{{baseUrl_app}}"
-          ],
-          "path": [
-            "rideBooking",
-            "list"
-          ],
-          "query": [
-            {
-              "key": "limit",
-              "value": "1"
-            },
-            {
-              "key": "onlyActive",
-              "value": "true"
-            },
-            {
-              "key": "offset",
-              "value": "0"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Get Ride",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "if (d.list && d.list.length > 0) {",
-              "    pm.environment.set('driver_ride_id', d.list[0].id);",
-              "    console.log('Ride:', d.list[0].id, 'Status:', d.list[0].status);",
-              "}",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "token",
-            "value": "{{driver2_token}}"
-          }
-        ],
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/ride/list?limit=1&isActive=true",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "ride",
-            "list"
-          ],
-          "query": [
-            {
-              "key": "limit",
-              "value": "1"
-            },
-            {
-              "key": "isActive",
-              "value": "true"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 Start Ride",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); }); console.log('Ride started!');"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver2_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\"rideOtp\": \"{{ride_otp}}\", \"point\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/start",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "ride",
-            "{{driver_ride_id}}",
-            "start"
-          ]
-        }
-      }
-    },
-    {
-      "name": "D2 End Ride",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "// Small delay before ending ride",
-              "const start = Date.now();",
-              "while (Date.now() - start < 1000) { /* busy wait */ }"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); }); console.log('Ride ended!');"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
-          },
-          {
-            "key": "token",
-            "value": "{{driver2_token}}"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\"point\": {\"lat\": {{dest_lat}}, \"lon\": {{dest_lon}}}}"
-        },
-        "url": {
-          "raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/end",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "driver",
-            "ride",
-            "{{driver_ride_id}}",
-            "end"
-          ]
-        }
-      }
-    },
-    {
-      "name": "Get Driver Ride Invoices",
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [
-              "// Wait for invoice generation after ride end",
-              "const start = Date.now();",
-              "while (Date.now() - start < 2000) { /* busy wait */ }"
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "var d = pm.response.json();",
-              "console.log('Driver Ride Invoices - totalItems:', d.totalItems);",
-              "if (d.invoices && d.invoices.length > 0) {",
-              "    d.invoices.forEach(function(inv, i) {",
-              "        console.log('Invoice ' + i + ': number=' + inv.invoiceNumber + ' type=' + inv.invoiceType + ' amount=' + inv.totalAmountPayable);",
-              "    });",
-              "}",
-              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-              "pm.test('Response has invoices array', function () { pm.expect(d.invoices).to.be.an('array'); });",
-              "pm.test('Response has totalItems', function () { pm.expect(d.totalItems).to.be.a('number'); });"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "GET",
-        "header": [
-          {
-            "key": "token",
-            "value": "{{driver_token}}"
-          }
-        ],
-        "url": {
-          "raw": "{{baseURL_namma_P}}/subscription/invoices?invoiceType=%22Ride%22&limit=10&offset=0",
-          "host": [
-            "{{baseURL_namma_P}}"
-          ],
-          "path": [
-            "subscription",
-            "invoices"
-          ],
-          "query": [
-            {
-              "key": "invoiceType",
-              "value": "%22Ride%22"
-            },
-            {
-              "key": "limit",
-              "value": "10"
-            },
-            {
-              "key": "offset",
-              "value": "0"
-            }
-          ]
-        }
-      },
-      "response": []
-    }
-  ],
-  "variable": [
-    {
-      "key": "_test_driver_number",
-      "value": ""
-    },
-    {
-      "key": "_test_rider_number",
-      "value": ""
-    },
-    {
-      "key": "_test_reg_no",
-      "value": ""
-    }
-  ]
+	"info": {
+		"name": "NY Auto Driver Cancellation + Reallocation",
+		"description": "2 drivers: D1 gets ride, cancels -> D2 gets reallocated ride -> completes | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"exec": [
+					"// Auto-skip mock-server requests when envType is not Local.",
+					"// Set envType=Local in Local env files; omit / set to 'Master' otherwise.",
+					"(function () {",
+					"  var envType = pm.environment.get('envType') || 'Local';",
+					"  if (envType === 'Local') return;",
+					"  var raw = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
+					"  if (raw.indexOf('mockServerUrl') !== -1 || raw.indexOf('mock_fcm_url') !== -1) {",
+					"    console.log('[skip] mock-only request on envType=' + envType + ': ' + (pm.info && pm.info.requestName));",
+					"    if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+					"      pm.execution.skipRequest();",
+					"    }",
+					"  }",
+					"})();",
+					"",
+					"if (!pm.collectionVariables.get('_test_driver_number')) {",
+					"    var d1 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+					"    var d2 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+					"    var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+					"    var reg1 = 'KA' + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
+					"    var reg2 = 'KA' + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
+					"    pm.collectionVariables.set('_test_driver_number', d1);",
+					"    pm.collectionVariables.set('_test_driver2_number', d2);",
+					"    pm.collectionVariables.set('_test_rider_number', rNum);",
+					"    pm.collectionVariables.set('_test_reg_no', reg1);",
+					"    pm.collectionVariables.set('_test_reg_no2', reg2);",
+					"    console.log('D1:', d1, 'D2:', d2, 'Rider:', rNum);",
+					"}"
+				],
+				"type": "text/javascript"
+			}
+		}
+	],
+	"item": [
+		{
+			"name": "D1 Auth",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.environment.set('driver_authId', d.authId);",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"// Reset all test-run variables so this run gets fresh drivers/riders.",
+							"// Without this, collection variables persist and D1/D2 reuse the same",
+							"// phone numbers across runs, causing stale ride/booking state conflicts.",
+							"var city = pm.environment.get('dashboard_city') || 'Bangalore';",
+							"var rcPrefixMap = {Bangalore:'KA',Chennai:'TN',Kolkata:'WB',Delhi:'DL',Hyderabad:'TS',Mumbai:'MH',Mysore:'KA'};",
+							"var rcPrefix = rcPrefixMap[city] || 'KA';",
+							"var d1 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+							"var d2 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+							"var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+							"var reg1 = rcPrefix + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
+							"var reg2 = rcPrefix + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
+							"pm.collectionVariables.set('_test_driver_number', d1);",
+							"pm.collectionVariables.set('_test_driver2_number', d2);",
+							"pm.collectionVariables.set('_test_rider_number', rNum);",
+							"pm.collectionVariables.set('_test_reg_no', reg1);",
+							"pm.collectionVariables.set('_test_reg_no2', reg2);",
+							"console.log('Fresh run: D1=' + d1 + ' D2=' + d2 + ' Rider=' + rNum + ' Reg1=' + reg1 + ' (' + city + ')');"
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"mobileNumber\": \"{{_test_driver_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{driver_merchant_id}}\",\n    \"merchantOperatingCity\": \"{{city}}\"\n}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/auth",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"auth"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 OTP",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.environment.set('driver_token', d.token);",
+							"pm.environment.set('driver_id', d.person.id);",
+							"console.log('Driver ID:', d.person.id);",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"otp\": \"{{login_otp}}\",\n    \"deviceToken\": \"test-device\"\n}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/auth/{{driver_authId}}/verify",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"auth",
+						"{{driver_authId}}",
+						"verify"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Add Vehicle",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Vehicle added', function () { pm.response.to.have.status(200); });",
+							"console.log('AddVehicle:', pm.response.text());"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{dashboard_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"registrationNo\": \"{{_test_reg_no}}\",\n  \"vehicleClass\": \"3w\",\n  \"colour\": \"Green\",\n  \"model\": \"AUTO RICKSHAW\",\n  \"make\": \"Bajaj\",\n  \"vehicleCategory\": \"AUTO_CATEGORY\"\n}"
+				},
+				"url": {
+					"raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/addVehicle",
+					"host": [
+						"{{baseURL_BPP_Dashboard_Internal}}"
+					],
+					"path": [
+						"{{dashboard_merchant_id}}",
+						"{{dashboard_city}}",
+						"driver",
+						"{{driver_id}}",
+						"addVehicle"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Enable",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Driver enabled', function () { pm.response.to.have.status(200); });",
+							"console.log('Enable:', pm.response.text());"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{dashboard_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver_id}}/enable",
+					"host": [
+						"{{baseURL_BPP_Dashboard_Internal}}"
+					],
+					"path": [
+						"{{dashboard_merchant_id}}",
+						"{{dashboard_city}}",
+						"driver",
+						"{{driver_id}}",
+						"enable"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Subscribe Plan",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Plan subscribed', function () { pm.expect(pm.response.code).to.be.oneOf([200, 500]); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/plan/18911beb-28ba-456d-8cca-4d019461d2b0/subscribe?serviceName=%22YATRI_SUBSCRIPTION%22",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"plan",
+						"18911beb-28ba-456d-8cca-4d019461d2b0",
+						"subscribe"
+					],
+					"query": [
+						{
+							"key": "serviceName",
+							"value": "%22YATRI_SUBSCRIPTION%22"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Set Location",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					},
+					{
+						"key": "vt",
+						"value": "AUTO_RICKSHAW"
+					},
+					{
+						"key": "dm",
+						"value": "ONLINE"
+					},
+					{
+						"key": "mId",
+						"value": "{{driver_merchant_id}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "[\n    {\n        \"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}},\n        \"ts\": \"{{current_time}}\"\n    }\n]"
+				},
+				"url": {
+					"raw": "{{baseUrl_lts}}/driver/location",
+					"host": [
+						"{{baseUrl_lts}}"
+					],
+					"path": [
+						"driver",
+						"location"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Set Online",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/setActivity?active=true&mode=%22ONLINE%22",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"setActivity"
+					],
+					"query": [
+						{
+							"key": "active",
+							"value": "true"
+						},
+						{
+							"key": "mode",
+							"value": "%22ONLINE%22"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Auth",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.environment.set('driver2_authId', d.authId);",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"mobileNumber\": \"{{_test_driver2_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{driver_merchant_id}}\",\n    \"merchantOperatingCity\": \"{{city}}\"\n}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/auth",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"auth"
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 OTP",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.environment.set('driver2_token', d.token);",
+							"pm.environment.set('driver2_id', d.person.id);",
+							"console.log('Driver2 ID:', d.person.id);",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"otp\": \"{{login_otp}}\",\n    \"deviceToken\": \"test-device\"\n}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/auth/{{driver2_authId}}/verify",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"auth",
+						"{{driver2_authId}}",
+						"verify"
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Add Vehicle",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Vehicle added', function () { pm.response.to.have.status(200); });",
+							"console.log('AddVehicle:', pm.response.text());"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{dashboard_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"registrationNo\": \"{{_test_reg_no2}}\", \"vehicleClass\": \"3w\", \"colour\": \"Green\", \"model\": \"AUTO RICKSHAW\", \"make\": \"Bajaj\", \"vehicleCategory\": \"AUTO_CATEGORY\"}"
+				},
+				"url": {
+					"raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver2_id}}/addVehicle",
+					"host": [
+						"{{baseURL_BPP_Dashboard_Internal}}"
+					],
+					"path": [
+						"{{dashboard_merchant_id}}",
+						"{{dashboard_city}}",
+						"driver",
+						"{{driver2_id}}",
+						"addVehicle"
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Enable",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Driver enabled', function () { pm.response.to.have.status(200); });",
+							"console.log('Enable:', pm.response.text());"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{dashboard_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{driver2_id}}/enable",
+					"host": [
+						"{{baseURL_BPP_Dashboard_Internal}}"
+					],
+					"path": [
+						"{{dashboard_merchant_id}}",
+						"{{dashboard_city}}",
+						"driver",
+						"{{driver2_id}}",
+						"enable"
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Subscribe Plan",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Plan subscribed', function () { pm.expect(pm.response.code).to.be.oneOf([200, 500]); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/plan/18911beb-28ba-456d-8cca-4d019461d2b0/subscribe?serviceName=%22YATRI_SUBSCRIPTION%22",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"plan",
+						"18911beb-28ba-456d-8cca-4d019461d2b0",
+						"subscribe"
+					],
+					"query": [
+						{
+							"key": "serviceName",
+							"value": "%22YATRI_SUBSCRIPTION%22"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Rider Auth",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.environment.set('rider_authId', d.authId);",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{bap_short_id}}\"\n}"
+				},
+				"url": {
+					"raw": "{{baseUrl_app}}/auth",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"auth"
+					]
+				}
+			}
+		},
+		{
+			"name": "Rider OTP",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.environment.set('rider_token', d.token);",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"otp\": \"{{login_otp}}\",\n    \"deviceToken\": \"test-rider\"\n}"
+				},
+				"url": {
+					"raw": "{{baseUrl_app}}/auth/{{rider_authId}}/verify",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"auth",
+						"{{rider_authId}}",
+						"verify"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Location Update",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					},
+					{
+						"key": "vt",
+						"value": "AUTO_RICKSHAW"
+					},
+					{
+						"key": "dm",
+						"value": "ONLINE"
+					},
+					{
+						"key": "mId",
+						"value": "{{driver_merchant_id}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "[\n    {\n        \"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}},\n        \"ts\": \"{{current_time}}\"\n    }\n]"
+				},
+				"url": {
+					"raw": "{{baseUrl_lts}}/driver/location",
+					"host": [
+						"{{baseUrl_lts}}"
+					],
+					"path": [
+						"driver",
+						"location"
+					]
+				}
+			}
+		},
+		{
+			"name": "Ride Search",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"setTimeout(function(){}, 2000);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.environment.set('searchId', d.searchId);",
+							"console.log('Search ID:', d.searchId);",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"// Wait for async beckn search processing across services\nconst _delay = 5000; const _start = Date.now(); while (Date.now() - _start < _delay) {}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"fareProductType\": \"ONE_WAY\", \"contents\": {\"origin\": {\"address\": {\"area\": \"Test Origin\", \"areaCode\": \"000000\", \"city\": \"{{city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}}, \"destination\": {\"address\": {\"area\": \"Test Destination\", \"areaCode\": \"000000\", \"city\": \"{{city}}\", \"country\": \"India\", \"state\": \"{{state}}\"}, \"gps\": {\"lat\": {{dest_lat}}, \"lon\": {{dest_lon}}}}, \"isReallocationEnabled\": true}}"
+				},
+				"url": {
+					"raw": "{{baseUrl_app}}/rideSearch",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideSearch"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Search Results",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"setTimeout(function(){}, 5000);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"if (d.estimates && d.estimates.length > 0) {",
+							"    var want = pm.environment.get('auto_vehicle_variant') || 'AUTO_RICKSHAW';",
+							"    var est = d.estimates.find(e => e.vehicleVariant === want)",
+							"           || d.estimates.find(e => e.vehicleServiceTierType === want)",
+							"           || d.estimates[0];",
+							"    pm.environment.set('estimateId', est.id);",
+							"    console.log('Estimate:', est.id, est.vehicleVariant, est.estimatedFare, '(wanted', want + ')');",
+							"}",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"pm.test('Has estimates', function () { pm.expect(d, 'response body').to.be.an('object'); pm.expect(d.estimates, 'estimates field').to.be.an('array'); pm.expect(d.estimates.length, 'estimate count').to.be.above(0); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl_app}}/rideSearch/{{searchId}}/results",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideSearch",
+						"{{searchId}}",
+						"results"
+					]
+				}
+			}
+		},
+		{
+			"name": "Select Estimate (Auto Assign)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"// Wait for async select processing before next step\nconst _sel_delay = 8000; const _sel_start = Date.now(); while (Date.now() - _sel_start < _sel_delay) {}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"autoAssignEnabled\": true, \"autoAssignEnabledV2\": true}"
+				},
+				"url": {
+					"raw": "{{baseUrl_app}}/estimate/{{estimateId}}/select2",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"estimate",
+						"{{estimateId}}",
+						"select2"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Nearby Ride Requests (Driver)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Wait briefly before checking nearby requests",
+							"const start = Date.now();",
+							"while (Date.now() - start < 1000) { /* busy wait */ }"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"if (d.searchRequestsForDriver && d.searchRequestsForDriver.length > 0) {",
+							"    var req = d.searchRequestsForDriver[0];",
+							"    pm.environment.set('searchTryId', req.searchTryId);",
+							"    console.log('Got search request, searchTryId:', req.searchTryId, 'baseFare:', req.baseFare, 'variant:', req.requestedVehicleVariant);",
+							"} else {",
+							"    console.log('WARNING: No nearby ride requests found for driver. Response:', JSON.stringify(d));",
+							"}",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"pm.test('Has search requests', function () {",
+							"    pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty;",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/nearbyRideRequest",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"nearbyRideRequest"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Accept Ride",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"console.log('Driver accepted ride!');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"searchTryId\": \"{{searchTryId}}\", \"offeredFare\": null, \"response\": \"Accept\"}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/searchRequest/quote/respond",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"searchRequest",
+						"quote",
+						"respond"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Booking (Rider)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Wait for booking to be created after driver acceptance",
+							"const delay = pm.environment.get('booking_wait_ms') || 5000;",
+							"const start = Date.now();",
+							"while (Date.now() - start < delay) { /* busy wait */ }"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"if (d.list && d.list.length > 0) {",
+							"    var booking = d.list[0];",
+							"    pm.environment.set('customer_bookingId', booking.id);",
+							"    var otp = booking.rideOtp;",
+							"    if (!otp && booking.rideList && booking.rideList.length > 0) {",
+							"        otp = booking.rideList[0].rideOtp;",
+							"    }",
+							"    pm.environment.set('ride_otp', otp);",
+							"    console.log('Booking:', booking.id, 'OTP:', otp, 'Status:', booking.status);",
+							"}",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl_app}}/rideBooking/list?limit=1&onlyActive=true&offset=0",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideBooking",
+						"list"
+					],
+					"query": [
+						{
+							"key": "limit",
+							"value": "1"
+						},
+						{
+							"key": "onlyActive",
+							"value": "true"
+						},
+						{
+							"key": "offset",
+							"value": "0"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Get Ride",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"if (d.list && d.list.length > 0) {",
+							"    pm.environment.set('driver_ride_id', d.list[0].id);",
+							"    console.log('Ride:', d.list[0].id, 'Status:', d.list[0].status);",
+							"}",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/ride/list?limit=1&isActive=true",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"ride",
+						"list"
+					],
+					"query": [
+						{
+							"key": "limit",
+							"value": "1"
+						},
+						{
+							"key": "isActive",
+							"value": "true"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Set Location",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					},
+					{
+						"key": "vt",
+						"value": "AUTO_RICKSHAW"
+					},
+					{
+						"key": "dm",
+						"value": "ONLINE"
+					},
+					{
+						"key": "mId",
+						"value": "{{driver_merchant_id}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "[\n    {\n        \"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}},\n        \"ts\": \"{{current_time}}\"\n    }\n]"
+				},
+				"url": {
+					"raw": "{{baseUrl_lts}}/driver/location",
+					"host": [
+						"{{baseUrl_lts}}"
+					],
+					"path": [
+						"driver",
+						"location"
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Set Online",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/setActivity?active=true&mode=%22ONLINE%22",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"setActivity"
+					],
+					"query": [
+						{
+							"key": "active",
+							"value": "true"
+						},
+						{
+							"key": "mode",
+							"value": "%22ONLINE%22"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Location Update",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.globals.set('current_time', new Date().toISOString().replace(/\\.\\d{3}/, ''));"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					},
+					{
+						"key": "vt",
+						"value": "AUTO_RICKSHAW"
+					},
+					{
+						"key": "dm",
+						"value": "ONLINE"
+					},
+					{
+						"key": "mId",
+						"value": "{{driver_merchant_id}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "[\n    {\n        \"pt\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}},\n        \"ts\": \"{{current_time}}\"\n    }\n]"
+				},
+				"url": {
+					"raw": "{{baseUrl_lts}}/driver/location",
+					"host": [
+						"{{baseUrl_lts}}"
+					],
+					"path": [
+						"driver",
+						"location"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Cancel Ride",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const start = Date.now();",
+							"while (Date.now() - start < 1000) {}"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"console.log('D1 cancelled ride!');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"reasonCode\": \"OTHER\", \"additionalInfo\": \"test cancellation\"}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/cancel",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"ride",
+						"{{driver_ride_id}}",
+						"cancel"
+					]
+				}
+			}
+		},
+		{
+			"name": "D1 Set Offline",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/setActivity?active=false&mode=%22OFFLINE%22",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"setActivity"
+					],
+					"query": [
+						{
+							"key": "active",
+							"value": "false"
+						},
+						{
+							"key": "mode",
+							"value": "%22OFFLINE%22"
+						}
+					]
+				}
+			},
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"// Set D1 offline immediately after cancellation so D1 cannot",
+							"// accept the reallocated ride before D2. Without this, both",
+							"// D1 and D2 receive the reallocation request and D1 often wins,",
+							"// causing D2 to get RIDE_REQUEST_ALREADY_ACCEPTED.",
+							"pm.test('Status code is 200', function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "D2 Get Nearby Ride Requests",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"// Wait 5s for the reallocation fork to create the new SearchTry and",
+							"// dispatch a SearchRequestForDriver to D2. Only 1s is not enough \u2014",
+							"// the BPP fork has to create ST2, persist it, and write SRFD to Redis.",
+							"// The test script retries up to 3 times (5s \u00d7 3 = 15s max) so a slow",
+							"// local stack still passes without using the wrong (old/completed) searchTryId.",
+							"const s = Date.now(); while (Date.now() - s < 5000) {}"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"var d = pm.response.json();",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"if (d.searchRequestsForDriver && d.searchRequestsForDriver.length > 0) {",
+							"    var req = d.searchRequestsForDriver[0];",
+							"    pm.environment.set('searchTryId', req.searchTryId);",
+							"    pm.collectionVariables.set('_d2_nearby_retries', 0);",
+							"    console.log('D2 got realloc search request, searchTryId:', req.searchTryId, 'baseFare:', req.baseFare);",
+							"    pm.test('Has search requests', function () {",
+							"        pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty;",
+							"    });",
+							"} else {",
+							"    var retries = parseInt(pm.collectionVariables.get('_d2_nearby_retries') || '0');",
+							"    console.log('WARNING: D2 found no realloc ride requests (attempt ' + (retries + 1) + '/3). Reallocation may not have dispatched yet.');",
+							"    if (retries < 2) {",
+							"        pm.collectionVariables.set('_d2_nearby_retries', retries + 1);",
+							"        pm.execution.setNextRequest('D2 Get Nearby Ride Requests');",
+							"    } else {",
+							"        pm.collectionVariables.set('_d2_nearby_retries', 0);",
+							"        pm.test('Has search requests', function () {",
+							"            pm.expect(d.searchRequestsForDriver).to.be.an('array').that.is.not.empty;",
+							"        });",
+							"    }",
+							"}"
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/nearbyRideRequest",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"nearbyRideRequest"
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Accept Ride",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"console.log('Driver accepted ride!');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"searchTryId\": \"{{searchTryId}}\", \"offeredFare\": null, \"response\": \"Accept\"}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/searchRequest/quote/respond",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"searchRequest",
+						"quote",
+						"respond"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Booking After Reallocation",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Wait for booking to be created after driver acceptance",
+							"const delay = pm.environment.get('booking_wait_ms') || 5000;",
+							"const start = Date.now();",
+							"while (Date.now() - start < delay) { /* busy wait */ }"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"if (d.list && d.list.length > 0) {",
+							"    var booking = d.list[0];",
+							"    pm.environment.set('customer_bookingId', booking.id);",
+							"    var otp = booking.rideOtp;",
+							"    if (!otp && booking.rideList && booking.rideList.length > 0) {",
+							"        otp = booking.rideList[0].rideOtp;",
+							"    }",
+							"    pm.environment.set('ride_otp', otp);",
+							"    console.log('Booking:', booking.id, 'OTP:', otp, 'Status:', booking.status);",
+							"}",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{rider_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl_app}}/rideBooking/list?limit=1&onlyActive=true&offset=0",
+					"host": [
+						"{{baseUrl_app}}"
+					],
+					"path": [
+						"rideBooking",
+						"list"
+					],
+					"query": [
+						{
+							"key": "limit",
+							"value": "1"
+						},
+						{
+							"key": "onlyActive",
+							"value": "true"
+						},
+						{
+							"key": "offset",
+							"value": "0"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Get Ride",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"if (d.list && d.list.length > 0) {",
+							"    pm.environment.set('driver_ride_id', d.list[0].id);",
+							"    console.log('Ride:', d.list[0].id, 'Status:', d.list[0].status);",
+							"}",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/ride/list?limit=1&isActive=true",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"ride",
+						"list"
+					],
+					"query": [
+						{
+							"key": "limit",
+							"value": "1"
+						},
+						{
+							"key": "isActive",
+							"value": "true"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 Start Ride",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); }); console.log('Ride started!');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"rideOtp\": \"{{ride_otp}}\", \"point\": {\"lat\": {{origin_lat}}, \"lon\": {{origin_lon}}}}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/start",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"ride",
+						"{{driver_ride_id}}",
+						"start"
+					]
+				}
+			}
+		},
+		{
+			"name": "D2 End Ride",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Small delay before ending ride",
+							"const start = Date.now();",
+							"while (Date.now() - start < 1000) { /* busy wait */ }"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); }); console.log('Ride ended!');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "token",
+						"value": "{{driver2_token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"point\": {\"lat\": {{dest_lat}}, \"lon\": {{dest_lon}}}}"
+				},
+				"url": {
+					"raw": "{{baseURL_namma_P}}/driver/ride/{{driver_ride_id}}/end",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"driver",
+						"ride",
+						"{{driver_ride_id}}",
+						"end"
+					]
+				}
+			}
+		},
+		{
+			"name": "Get Driver Ride Invoices",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// Wait for invoice generation after ride end",
+							"const start = Date.now();",
+							"while (Date.now() - start < 2000) { /* busy wait */ }"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var d = pm.response.json();",
+							"console.log('Driver Ride Invoices - totalItems:', d.totalItems);",
+							"if (d.invoices && d.invoices.length > 0) {",
+							"    d.invoices.forEach(function(inv, i) {",
+							"        console.log('Invoice ' + i + ': number=' + inv.invoiceNumber + ' type=' + inv.invoiceType + ' amount=' + inv.totalAmountPayable);",
+							"    });",
+							"}",
+							"pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+							"pm.test('Response has invoices array', function () { pm.expect(d.invoices).to.be.an('array'); });",
+							"pm.test('Response has totalItems', function () { pm.expect(d.totalItems).to.be.a('number'); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "token",
+						"value": "{{driver_token}}"
+					}
+				],
+				"url": {
+					"raw": "{{baseURL_namma_P}}/subscription/invoices?invoiceType=%22Ride%22&limit=10&offset=0",
+					"host": [
+						"{{baseURL_namma_P}}"
+					],
+					"path": [
+						"subscription",
+						"invoices"
+					],
+					"query": [
+						{
+							"key": "invoiceType",
+							"value": "%22Ride%22"
+						},
+						{
+							"key": "limit",
+							"value": "10"
+						},
+						{
+							"key": "offset",
+							"value": "0"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "_test_driver_number",
+			"value": ""
+		},
+		{
+			"key": "_test_rider_number",
+			"value": ""
+		},
+		{
+			"key": "_test_reg_no",
+			"value": ""
+		}
+	]
 }

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/03-AutoDriverCancellation.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/03-AutoDriverCancellation.json
@@ -802,8 +802,12 @@
             "exec": [
               "var d = pm.response.json();",
               "if (d.estimates && d.estimates.length > 0) {",
-              "    pm.environment.set('estimateId', d.estimates[0].id);",
-              "    console.log('Estimate:', d.estimates[0].id, d.estimates[0].vehicleVariant, d.estimates[0].estimatedFare);",
+              "    var want = pm.environment.get('auto_vehicle_variant') || 'AUTO_RICKSHAW';",
+              "    var est = d.estimates.find(e => e.vehicleVariant === want)",
+              "           || d.estimates.find(e => e.vehicleServiceTierType === want)",
+              "           || d.estimates[0];",
+              "    pm.environment.set('estimateId', est.id);",
+              "    console.log('Estimate:', est.id, est.vehicleVariant, est.estimatedFare, '(wanted', want + ')');",
               "}",
               "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
               "pm.test('Has estimates', function () { pm.expect(d, 'response body').to.be.an('object'); pm.expect(d.estimates, 'estimates field').to.be.an('array'); pm.expect(d.estimates.length, 'estimate count').to.be.above(0); });"

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/03-AutoDriverCancellation.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/03-AutoDriverCancellation.json
@@ -55,6 +55,31 @@
             ],
             "type": "text/javascript"
           }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// Reset all test-run variables so this run gets fresh drivers/riders.",
+              "// Without this, collection variables persist and D1/D2 reuse the same",
+              "// phone numbers across runs, causing stale ride/booking state conflicts.",
+              "var city = pm.environment.get('dashboard_city') || 'Bangalore';",
+              "var rcPrefixMap = {Bangalore:'KA',Chennai:'TN',Kolkata:'WB',Delhi:'DL',Hyderabad:'TS',Mumbai:'MH',Mysore:'KA'};",
+              "var rcPrefix = rcPrefixMap[city] || 'KA';",
+              "var d1 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+              "var d2 = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+              "var rNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+              "var reg1 = rcPrefix + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
+              "var reg2 = rcPrefix + String(Math.floor(10+Math.random()*89)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String.fromCharCode(65+Math.floor(Math.random()*26)) + String(Math.floor(1000+Math.random()*8999));",
+              "pm.collectionVariables.set('_test_driver_number', d1);",
+              "pm.collectionVariables.set('_test_driver2_number', d2);",
+              "pm.collectionVariables.set('_test_rider_number', rNum);",
+              "pm.collectionVariables.set('_test_reg_no', reg1);",
+              "pm.collectionVariables.set('_test_reg_no2', reg2);",
+              "console.log('Fresh run: D1=' + d1 + ' D2=' + d2 + ' Rider=' + rNum + ' Reg1=' + reg1 + ' (' + city + ')');"
+            ]
+          }
         }
       ],
       "request": {
@@ -1326,6 +1351,63 @@
           ]
         }
       }
+    },
+    {
+      "name": "D1 Set Offline",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{driver_token}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": ""
+        },
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/setActivity?active=false&mode=%22OFFLINE%22",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "setActivity"
+          ],
+          "query": [
+            {
+              "key": "active",
+              "value": "false"
+            },
+            {
+              "key": "mode",
+              "value": "%22OFFLINE%22"
+            }
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// Set D1 offline immediately after cancellation so D1 cannot",
+              "// accept the reallocated ride before D2. Without this, both",
+              "// D1 and D2 receive the reallocation request and D1 often wins,",
+              "// causing D2 to get RIDE_REQUEST_ALREADY_ACCEPTED.",
+              "pm.test('Status code is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "D2 Get Nearby Ride Requests",

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/03-AutoDriverCancellation.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/03-AutoDriverCancellation.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "NY Auto Driver Cancellation + Reallocation",
-    "description": "2 drivers: D1 gets ride, cancels -> D2 gets reallocated ride -> completes",
+    "description": "2 drivers: D1 gets ride, cancels -> D2 gets reallocated ride -> completes | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [
@@ -616,7 +616,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"NAMMA_YATRI\"\n}"
+          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{bap_short_id}}\"\n}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/04-CabRideFlow.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/04-CabRideFlow.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "NY Taxi Ride Flow",
-    "description": "End-to-end taxi/sedan ride: search -> assign -> start -> end",
+    "description": "End-to-end taxi/sedan ride: search -> assign -> start -> end | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [
@@ -440,7 +440,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"NAMMA_YATRI\"\n}"
+          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{bap_short_id}}\"\n}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/05-CabUserCancellation.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/05-CabUserCancellation.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "NY Taxi User Cancellation",
-    "description": "Taxi ride with rider cancellation",
+    "description": "Taxi ride with rider cancellation | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [
@@ -440,7 +440,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"NAMMA_YATRI\"\n}"
+          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{bap_short_id}}\"\n}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/06-CabDriverCancellation.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/06-CabDriverCancellation.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "NY Taxi Driver Cancellation + Reallocation",
-    "description": "2 drivers (SEDAN): D1 gets ride, cancels -> D2 gets reallocated ride -> completes",
+    "description": "2 drivers (SEDAN): D1 gets ride, cancels -> D2 gets reallocated ride -> completes | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [
@@ -616,7 +616,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"NAMMA_YATRI\"\n}"
+          "raw": "{\n    \"mobileNumber\": \"{{_test_rider_number}}\",\n    \"mobileCountryCode\": \"+91\",\n    \"merchantId\": \"{{bap_short_id}}\"\n}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/07-RideNearby.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/07-RideNearby.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "07-RideNearby",
-    "description": "Integration test for GET /{driverId}/nearby.\nSetup: registers 5 drivers at origin_lat/lon + 5 riders who each do a search from the same origin.\nAsserts: nearbyDriverCount >= 4 (other 4 drivers visible to driver1), nearbyCustomerCount >= 5.",
+    "description": "Integration test for GET /{driverId}/nearby.\nSetup: registers 5 drivers at origin_lat/lon + 5 riders who each do a search from the same origin.\nAsserts: nearbyDriverCount >= 4 (other 4 drivers visible to driver1), nearbyCustomerCount >= 5. | Fix: Rider Auth now uses {{bap_short_id}} instead of hardcoded 'NAMMA_YATRI', so Delhi (BHARAT_TAXI) and Kolkata (JATRI_SAATHI) riders authenticate against the correct BAP merchant and the serviceability geofence check uses the right region list.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [
@@ -1774,7 +1774,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"mobileNumber\": \"{{_test_rider1_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"NAMMA_YATRI\"}"
+          "raw": "{\"mobileNumber\": \"{{_test_rider1_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{bap_short_id}}\"}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",
@@ -1850,7 +1850,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"mobileNumber\": \"{{_test_rider2_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"NAMMA_YATRI\"}"
+          "raw": "{\"mobileNumber\": \"{{_test_rider2_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{bap_short_id}}\"}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",
@@ -1926,7 +1926,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"mobileNumber\": \"{{_test_rider3_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"NAMMA_YATRI\"}"
+          "raw": "{\"mobileNumber\": \"{{_test_rider3_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{bap_short_id}}\"}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",
@@ -2002,7 +2002,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"mobileNumber\": \"{{_test_rider4_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"NAMMA_YATRI\"}"
+          "raw": "{\"mobileNumber\": \"{{_test_rider4_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{bap_short_id}}\"}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",
@@ -2078,7 +2078,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"mobileNumber\": \"{{_test_rider5_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"NAMMA_YATRI\"}"
+          "raw": "{\"mobileNumber\": \"{{_test_rider5_number}}\", \"mobileCountryCode\": \"+91\", \"merchantId\": \"{{bap_short_id}}\"}"
         },
         "url": {
           "raw": "{{baseUrl_app}}/auth",

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/12-FleetDashboardFlow.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/12-FleetDashboardFlow.json
@@ -1,0 +1,326 @@
+{
+  "info": {
+    "name": "Fleet Association failedRules Field",
+    "description": "Verify that failedRules field is present in driver and vehicle association list responses. Flow: fleet login → add driver → add vehicle → check association lists.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "exec": [
+          "(function () {",
+          "  var envType = pm.environment.get('envType') || 'Local';",
+          "  if (envType === 'Local') return;",
+          "  var raw = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
+          "  if (raw.indexOf('mockServerUrl') !== -1 || raw.indexOf('mock_fcm_url') !== -1) {",
+          "    if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+          "      pm.execution.skipRequest();",
+          "    }",
+          "  }",
+          "})();",
+          "",
+          "if (!pm.collectionVariables.get('_test_fleet_number')) {",
+          "    var fNum = '9' + Math.floor(100000000 + Math.random() * 899999999);",
+          "    pm.collectionVariables.set('_test_fleet_number', fNum);",
+          "    console.log('Test fleet number:', fNum);",
+          "}",
+          "if (!pm.collectionVariables.get('_test_driver_number')) {",
+          "    var dNum = '8' + Math.floor(100000000 + Math.random() * 899999999);",
+          "    pm.collectionVariables.set('_test_driver_number', dNum);",
+          "    console.log('Test driver number:', dNum);",
+          "}",
+          "if (!pm.collectionVariables.get('_test_vehicle_reg')) {",
+          "    var city = pm.environment.get('dashboard_city') || 'Bangalore';",
+          "    var rcPrefix = {'Bangalore': 'KA', 'Chennai': 'TN', 'Kolkata': 'WB', 'Delhi': 'DL', 'Hyderabad': 'TS', 'Mumbai': 'MH', 'Mysore': 'KA'}[city] || 'KA';",
+          "    var vReg = rcPrefix + '01T' + Math.floor(1000 + Math.random() * 8999);",
+          "    pm.collectionVariables.set('_test_vehicle_reg', vReg);",
+          "    console.log('Test vehicle reg:', vReg);",
+          "}"
+        ],
+        "type": "text/javascript"
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "Fleet Owner Login OTP",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{dashboard_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"mobileNumber\": \"{{_test_fleet_number}}\",\n  \"mobileCountryCode\": \"+91\"\n}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/fleet/v2/login/otp?enabled=true",
+          "host": ["{{baseURL_BPP_Dashboard_Internal}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "fleet", "v2", "login", "otp"],
+          "query": [{ "key": "enabled", "value": "true" }]
+        }
+      }
+    },
+    {
+      "name": "Fleet Owner Verify OTP",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.environment.set('fleet_auth_token', d.authToken);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{dashboard_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"mobileNumber\": \"{{_test_fleet_number}}\",\n  \"mobileCountryCode\": \"+91\",\n  \"otp\": \"{{login_otp}}\"\n}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/fleet/v2/verify/otp",
+          "host": ["{{baseURL_BPP_Dashboard_Internal}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "fleet", "v2", "verify", "otp"]
+        }
+      }
+    },
+    {
+      "name": "Send Joining OTP to Driver",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+              "var d = pm.response.json();",
+              "pm.collectionVariables.set('_driver_auth_id', d.authId);",
+              "console.log('Driver authId:', d.authId, 'attempts:', d.attempts);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{fleet_auth_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"mobileNumber\": \"{{_test_driver_number}}\",\n  \"mobileCountryCode\": \"+91\",\n  \"name\": \"TestDriver\"\n}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/sendJoiningOtp",
+          "host": ["{{baseURL_BPP_Dashboard_Internal}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "sendJoiningOtp"]
+        }
+      }
+    },
+    {
+      "name": "Verify Joining OTP for Driver",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+              "console.log('Driver joined fleet successfully');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{fleet_auth_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"mobileNumber\": \"{{_test_driver_number}}\",\n  \"mobileCountryCode\": \"+91\",\n  \"otp\": \"{{login_otp}}\",\n  \"deviceToken\": \"test-device-token\"\n}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/verifyJoiningOtp?authId={{_driver_auth_id}}",
+          "host": ["{{baseURL_BPP_Dashboard_Internal}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "verifyJoiningOtp"],
+          "query": [{ "key": "authId", "value": "{{_driver_auth_id}}" }]
+        }
+      }
+    },
+    {
+      "name": "Add Vehicle for Driver",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "if (pm.response.code !== 200) { console.log('Add vehicle error:', pm.response.text()); }",
+              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+              "console.log('Vehicle added for driver');"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{fleet_auth_token}}" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"registrationNo\": \"{{_test_vehicle_reg}}\",\n  \"vehicleClass\": \"SUV\",\n  \"colour\": \"White\",\n  \"model\": \"Innova\",\n  \"make\": \"Toyota\",\n  \"vehicleCategory\": \"AUTO_CATEGORY\",\n  \"skipFleetChecks\": true\n}"
+        },
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/{{_test_driver_number}}/fleet/addVehicle",
+          "host": ["{{baseURL_BPP_Dashboard_Internal}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "{{_test_driver_number}}", "fleet", "addVehicle"]
+        }
+      }
+    },
+    {
+      "name": "Get Driver Association List",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+              "",
+              "pm.test('Response has correct structure', function () {",
+              "  var d = pm.response.json();",
+              "  pm.expect(d).to.have.property('fleetOwnerId');",
+              "  pm.expect(d).to.have.property('listItem');",
+              "  pm.expect(d).to.have.property('summary');",
+              "  pm.expect(d.listItem).to.be.an('array');",
+              "});",
+              "",
+              "pm.test('listItem is not empty', function () {",
+              "  var d = pm.response.json();",
+              "  pm.expect(d.listItem.length).to.be.above(0);",
+              "});",
+              "",
+              "pm.test('listItem entries contain failedRules field', function () {",
+              "  var d = pm.response.json();",
+              "  d.listItem.forEach(function (item) {",
+              "    pm.expect(item).to.have.property('failedRules');",
+              "    if (item.failedRules !== null) {",
+              "      pm.expect(item.failedRules).to.be.an('array');",
+              "    }",
+              "  });",
+              "});",
+              "console.log('Driver association items:', pm.response.json().listItem.length);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{fleet_auth_token}}" }
+        ],
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/driverAssociation?Limit=10&Offset=0",
+          "host": ["{{baseURL_BPP_Dashboard_Internal}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "driverAssociation"],
+          "query": [
+            { "key": "Limit", "value": "10" },
+            { "key": "Offset", "value": "0" }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Get Vehicle Association List",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "// Wait for mock-idfy callback (500ms) to create the RC in DB",
+              "var start = new Date().getTime();",
+              "while (new Date().getTime() - start < 2000) { /* busy-wait 2s */ }"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+              "",
+              "pm.test('Response has correct structure', function () {",
+              "  var d = pm.response.json();",
+              "  pm.expect(d).to.have.property('fleetOwnerId');",
+              "  pm.expect(d).to.have.property('listItem');",
+              "  pm.expect(d).to.have.property('summary');",
+              "  pm.expect(d.listItem).to.be.an('array');",
+              "});",
+              "",
+              "pm.test('listItem is not empty', function () {",
+              "  var d = pm.response.json();",
+              "  pm.expect(d.listItem.length).to.be.above(0);",
+              "});",
+              "",
+              "pm.test('listItem entries contain failedRules field', function () {",
+              "  var d = pm.response.json();",
+              "  d.listItem.forEach(function (item) {",
+              "    pm.expect(item).to.have.property('failedRules');",
+              "    if (item.failedRules !== null) {",
+              "      pm.expect(item.failedRules).to.be.an('array');",
+              "    }",
+              "  });",
+              "});",
+              "console.log('Vehicle association items:', pm.response.json().listItem);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "token", "value": "{{fleet_auth_token}}" }
+        ],
+        "url": {
+          "raw": "{{baseURL_BPP_Dashboard_Internal}}/{{dashboard_merchant_id}}/{{dashboard_city}}/driver/fleet/vehicleAssociation?Limit=10&Offset=0",
+          "host": ["{{baseURL_BPP_Dashboard_Internal}}"],
+          "path": ["{{dashboard_merchant_id}}", "{{dashboard_city}}", "driver", "fleet", "vehicleAssociation"],
+          "query": [
+            { "key": "Limit", "value": "10" },
+            { "key": "Offset", "value": "0" }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/Local/Local_BT_Delhi.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/Local/Local_BT_Delhi.postman_environment.json
@@ -52,7 +52,7 @@
     },
     {
       "key": "dashboard_token",
-      "value": "local-admin-token-bangalore-namma-yatri",
+      "value": "local-admin-token-delhi-bharat-taxi",
       "type": "default",
       "enabled": true
     },

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/Local/Local_NY_Chennai.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/Local/Local_NY_Chennai.postman_environment.json
@@ -52,7 +52,7 @@
     },
     {
       "key": "dashboard_token",
-      "value": "local-admin-token-bangalore-namma-yatri",
+      "value": "local-admin-token-chennai-namma-yatri",
       "type": "default",
       "enabled": true
     },

--- a/Backend/dev/integration-tests/collections/RideBookingFlow/Local/Local_YS_Kolkata.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/RideBookingFlow/Local/Local_YS_Kolkata.postman_environment.json
@@ -52,7 +52,7 @@
     },
     {
       "key": "dashboard_token",
-      "value": "local-admin-token-bangalore-namma-yatri",
+      "value": "local-admin-token-kolkata-jatri-saathi",
       "type": "default",
       "enabled": true
     },

--- a/Backend/dev/local-testing-data/provider-dashboard.sql
+++ b/Backend/dev/local-testing-data/provider-dashboard.sql
@@ -3,6 +3,9 @@ INSERT INTO atlas_bpp_dashboard.person (id, first_name, last_name, role_id, emai
 	('3680f4b5-dce4-4d03-aa8c-5405690e87bd', 'juspay_admin', 'juspay_admin', '37947162-3b5d-4ed6-bcac-08841be1534d', '0.1.0|0|LhbMPLXsyXE0tjkVpk2AsylStET+zn3gLufYYvF+mWEGaXojqY71IUsw/gJWIIWzbQTGsY31FlnT3BL8o360B2kngyHgMg9A3Jnj0I4=', '\xef2654345b65cbe5230f3cc47ff26ff73cfd7023e10ac258b4b88bab8221a181', '0.1.0|0|oJOzop+9gdchzwbhz/EyxkSZ7s4z/irFEpsQrsNmSXbKnfe96m+P9xkFqy8/BFU1sGUhgszM1JKsuJNXBQ==', '\x26d21f3ddcce96b1fab220d6aea0b5341d4653e812d4e18d542577acbdeef640', '+91',	'\x8c03a02fbcb46d7f7624063574892f64f19b9871138edfcfeb4f0361362e567f', '2022-09-06 11:25:42.609155+00', '2022-09-06 11:25:42.609155+00')
 ON CONFLICT DO NOTHING;
 
+-- Admin tokens: one per city+merchant because merchantCityAccessCheck requires
+-- the token's operating_city to match the URL city exactly. A single Bangalore
+-- token cannot be used for Chennai/Delhi/Kolkata dashboard API calls.
 INSERT INTO atlas_bpp_dashboard.registration_token (id, token, person_id, merchant_id, operating_city, enabled, created_at)
 SELECT
     'local-admin-token-blr-id-00000000000',
@@ -14,6 +17,45 @@ SELECT
     now()
 FROM atlas_bpp_dashboard.merchant m
 WHERE m.short_id = 'NAMMA_YATRI_PARTNER'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO atlas_bpp_dashboard.registration_token (id, token, person_id, merchant_id, operating_city, enabled, created_at)
+SELECT
+    'local-admin-token-chn-id-00000000000',
+    'local-admin-token-chennai-namma-yatri',
+    '3680f4b5-dce4-4d03-aa8c-5405690e87bd',
+    m.id,
+    'Chennai',
+    true,
+    now()
+FROM atlas_bpp_dashboard.merchant m
+WHERE m.short_id = 'NAMMA_YATRI_PARTNER'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO atlas_bpp_dashboard.registration_token (id, token, person_id, merchant_id, operating_city, enabled, created_at)
+SELECT
+    'local-admin-token-del-id-00000000000',
+    'local-admin-token-delhi-bharat-taxi',
+    '3680f4b5-dce4-4d03-aa8c-5405690e87bd',
+    m.id,
+    'Delhi',
+    true,
+    now()
+FROM atlas_bpp_dashboard.merchant m
+WHERE m.short_id = 'BHARAT_TAXI_PARTNER'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO atlas_bpp_dashboard.registration_token (id, token, person_id, merchant_id, operating_city, enabled, created_at)
+SELECT
+    'local-admin-token-kol-id-00000000000',
+    'local-admin-token-kolkata-jatri-saathi',
+    '3680f4b5-dce4-4d03-aa8c-5405690e87bd',
+    m.id,
+    'Kolkata',
+    true,
+    now()
+FROM atlas_bpp_dashboard.merchant m
+WHERE m.short_id = 'JATRI_SAATHI_PARTNER'
 ON CONFLICT DO NOTHING;
 
 -- unencrypted: email: fleet@dashboard.com, password: fleet

--- a/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
+++ b/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
@@ -16,6 +16,12 @@ export interface PostmanCollection {
 
 export interface PostmanItem {
   name: string;
+  /**
+   * Optional custom grouping label. Not part of the Postman spec — real
+   * Postman/Newman ignore unknown fields, so this is harmless to them. When set,
+   * the dashboard groups consecutive steps sharing the same value into one box.
+   */
+  _group?: string;
   event?: PostmanEvent[];
   request: {
     method: string;
@@ -50,7 +56,7 @@ export interface ParsedStep {
   index: number;
   name: string;
   method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-  service: 'rider' | 'driver' | 'lts' | 'provider-dashboard' | 'rider-dashboard' | 'mock-idfy' | 'mock-server' | 'internal';
+  service: 'rider' | 'driver' | 'lts' | 'provider-dashboard' | 'rider-dashboard' | 'mock-idfy' | 'mock-server' | 'juspay-payment' | 'internal';
   /** URL path with {{var}} placeholders, relative to proxy prefix */
   pathTemplate: string;
   /** Raw URL template before service resolution */
@@ -62,6 +68,8 @@ export interface ParsedStep {
   prereqScript: string | null;
   /** Tag for grouping: driver, rider, or system */
   tag: 'driver' | 'rider' | 'system';
+  /** Explicit group label from the item's `_group` field, or null */
+  group: string | null;
   /** Detected wait/delay in ms from prerequest script */
   delayMs: number;
 }
@@ -71,6 +79,12 @@ export interface ParsedTreeNode {
   title: string;
   tag: 'driver' | 'rider' | 'system';
   stepIds: string[];
+  /**
+   * True when this node was formed by an explicit `_group` field (e.g. "Setup Driver A").
+   * Such a group can mix actors, so the UI shows a per-step actor tag instead of a
+   * single (potentially misleading) tag on the group header.
+   */
+  prefixGroup?: boolean;
 }
 
 // ── Base URL → Service mapping ──
@@ -83,7 +97,15 @@ const URL_VAR_TO_SERVICE: Record<string, { service: ParsedStep['service']; strip
   'baseURL_BPP_Dashboard_Internal': { service: 'provider-dashboard' },
   'dashboard_base_url': { service: 'provider-dashboard' },
   'bap_dashboard_url': { service: 'rider-dashboard' },
+  // baseUrl_dashboard points at the rider-app itself with a /dashboard path prefix
+  // (http://localhost:8013/dashboard), NOT the separate rider-dashboard service on :8017.
+  // Routing it through the rider proxy preserves the /dashboard prefix extracted from the env URL.
+  'baseUrl_dashboard': { service: 'rider' },
+  // baseUrl_driver hits the driver-app directly (e.g. http://localhost:8016).
+  // Collections that need /dashboard paths include it explicitly in the URL template.
+  'baseUrl_driver': { service: 'driver' },
   'mockServerUrl': { service: 'mock-server' },
+  'mock_server_url': { service: 'juspay-payment' },
 };
 
 // ── Parser ──
@@ -161,6 +183,9 @@ function parseItem(item: PostmanItem, index: number, envVars: Record<string, str
   // Tag based on name
   const tag = inferTag(item.name);
 
+  // Explicit grouping label (custom `_group` field), if present
+  const group = item._group?.trim() || null;
+
   const id = `postman-${String(index).padStart(2, '0')}-${sanitize(item.name)}`;
 
   return {
@@ -177,6 +202,7 @@ function parseItem(item: PostmanItem, index: number, envVars: Record<string, str
     testScript,
     prereqScript,
     tag,
+    group,
     delayMs,
   };
 }
@@ -218,10 +244,12 @@ function resolveService(
 
 function extractScript(events: PostmanEvent[] | undefined, listen: 'test' | 'prerequest'): string | null {
   if (!events) return null;
-  const ev = events.find(e => e.listen === listen);
-  if (!ev?.script?.exec) return null;
-  const script = ev.script.exec.join('\n').trim();
-  return script || null;
+  const parts = events
+    .filter(e => e.listen === listen && e.script?.exec)
+    .map(e => e.script!.exec!.join('\n').trim())
+    .filter(s => s.length > 0);
+  if (parts.length === 0) return null;
+  return parts.join('\n');
 }
 
 function detectDelay(script: string | null): number {
@@ -248,29 +276,41 @@ function sanitize(name: string): string {
 
 // ── Auto-grouping into TreeNodes ──
 
+// A step may declare an explicit group via the custom `_group` field on its Postman
+// item (carried through to ParsedStep.group). When set, consecutive steps sharing the
+// same group value form one box titled by that group — regardless of actor tag — so
+// e.g. all "Setup Driver A" steps stay together even though they mix driver/system
+// calls. Steps without `_group` fall back to grouping by actor tag (unchanged
+// behaviour), so collections that don't use the field are completely unaffected.
 function autoGroup(steps: ParsedStep[]): ParsedTreeNode[] {
   const nodes: ParsedTreeNode[] = [];
   let currentNode: ParsedTreeNode | null = null;
+  let currentKey: string | null = null; // 'grp:<label>' or 'tag:<tag>'
 
   for (const step of steps) {
-    // Start new group when tag changes or it's the first step
-    if (!currentNode || currentNode.tag !== step.tag) {
+    const key = step.group ? `grp:${step.group}` : `tag:${step.tag}`;
+    // Start a new group when the grouping key changes (explicit group label or,
+    // lacking one, the actor tag) or it's the first step.
+    if (!currentNode || currentKey !== key) {
       currentNode = {
         id: `node-${nodes.length}`,
-        title: inferNodeTitle(step, nodes.length),
+        title: step.group ?? inferNodeTitle(step, nodes.length),
         tag: step.tag,
         stepIds: [],
+        prefixGroup: step.group !== null,
       };
       nodes.push(currentNode);
+      currentKey = key;
     }
     currentNode.stepIds.push(step.id);
   }
 
-  // Refine node titles based on contained steps
+  // Refine titles of single-step tag-grouped nodes to the step name.
+  // Explicitly-grouped nodes keep their group title even when they hold one step.
   for (const node of nodes) {
     if (node.stepIds.length === 1) {
       const step = steps.find(s => s.id === node.stepIds[0]);
-      if (step) node.title = step.name;
+      if (step && step.group === null) node.title = step.name;
     }
   }
 


### PR DESCRIPTION
 Fixed invalid URL error (step 04) caused by `baseURL_BPP_Driver_Direct` missing from `URL_VAR_TO_SERVICE` in `postman-parser.ts` — the parser fell back to `internal` and concatenated the full `http://localhost:8016/dashboard` URL onto `PROXY_BASE`, producing an axios "Failed to construct URL" error
- Fixed `PERSON_NOT_FOUND` (steps 06–07) by redirecting Send/Verify Fleet Joining OTP from provider-dashboard to BPP direct — the dashboard path called `getFleetOwnerAndRequestorIdMerchantBased` with the admin's dashboard `personId`, which has no matching BPP person record

## Files changed

- `Backend/dev/test-tool/dashboard/src/services/postman-parser.ts` — added `baseURL_BPP_Driver_Direct` and `baseUrl_driver` to `URL_VAR_TO_SERVICE`
- `Backend/dev/integration-tests/collections/FleetManagementFlow/01-DriverNameAndAssociation.json` — steps 06–07 now call BPP direct (`bpp_dashboard_token` + `driver/{id}/fleet/driver/{action}` path) instead of provider-dashboard

## Test plan

- [ ] Run `FleetManagementFlow / Fleet Driver Name & Association` with `Local_NY_Bangalore` env — all 13 steps should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new end-to-end Postman suites for fleet driver name & association, fleet dashboard validation, and NY→Mysore intercity rides.
  * Expanded driver name update scenarios in the fleet flow and improved related assertions.
  * Updated ride booking flows to use the correct merchant context and to select estimates using the configured vehicle variant.

* **Chores**
  * Improved Postman workflow parsing/grouping and service URL resolution for better step handling.
  * Refreshed local environment tokens and added SQL migrations to fix local OTP/fleet verification and Chennai search repeat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->