### PR TITLE
rider-app/feat: CUMTA ₹1 BHIM-UPI cumulative offer on standalone FRFS bus quotes (prod hot-push)

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -501,6 +501,7 @@ library
       SharedLogic.NyRegularSubscriptionHasher
       SharedLogic.NySubscription
       SharedLogic.Offer
+      SharedLogic.OfferTypes
       SharedLogic.OTP
       SharedLogic.PassExpiryReminder
       SharedLogic.PassRestore

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/FrfsTicket.yaml
@@ -37,6 +37,7 @@ imports:
   SeatType: Domain.Types.Seat
   Person: Domain.Types.Person
   FleetOperatorTripAction: Domain.Types.FleetOperatorTripAction
+  CumulativeOfferResp: SharedLogic.OfferTypes
 
 module: FRFSTicketService
 types:
@@ -76,6 +77,7 @@ types:
     integratedBppConfigId: Id IntegratedBPPConfig
     categories: [CategoryInfoResponse]
     observingFailures: Maybe Bool
+    offer: Maybe CumulativeOfferResp
 
     derive: "Show"
 

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/FRFSTicketService.hs
@@ -30,6 +30,7 @@ import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
 import qualified Kernel.Types.TimeBound
 import Servant
+import qualified SharedLogic.OfferTypes
 import Tools.Auth
 
 data ActiveRouteRes = ActiveRouteRes {lastScheduleTime :: Data.Text.Text, routeId :: Data.Text.Text}
@@ -157,6 +158,7 @@ data FRFSQuoteAPIRes = FRFSQuoteAPIRes
     eventDiscountAmount :: Data.Maybe.Maybe Kernel.Types.Common.HighPrecMoney,
     integratedBppConfigId :: Kernel.Types.Id.Id Domain.Types.IntegratedBPPConfig.IntegratedBPPConfig,
     observingFailures :: Data.Maybe.Maybe Kernel.Prelude.Bool,
+    offer :: Data.Maybe.Maybe SharedLogic.OfferTypes.CumulativeOfferResp,
     price :: Kernel.Types.Common.HighPrecMoney,
     priceWithCurrency :: Kernel.Types.Common.PriceAPIEntity,
     quantity :: Kernel.Prelude.Int,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -74,6 +74,7 @@ import qualified Kernel.Utils.CalculateDistance as CD
 import Kernel.Utils.Common hiding (mkPrice)
 import Kernel.Utils.SlidingWindowLimiter (checkSlidingWindowLimitWithOptions)
 import qualified Lib.JourneyModule.RouteServiceability as JMRouteServiceability
+import qualified Lib.JourneyModule.Types as JMTypes
 import qualified Lib.JourneyModule.Utils as JMU
 import qualified Lib.JourneyModule.Utils as JourneyUtils
 import qualified Lib.Payment.Domain.Action as DPayment
@@ -90,6 +91,7 @@ import SharedLogic.FRFSStatus
 import SharedLogic.FRFSUtils
 import SharedLogic.FRFSUtils as FRFSUtils
 import qualified SharedLogic.IntegratedBPPConfig as SIBC
+import qualified SharedLogic.Offer as SOffer
 import qualified SharedLogic.PTCircuitBreaker as PTCircuitBreaker
 import qualified SharedLogic.Scheduler.Jobs.FRFSSeatHoldReaper as SeatHold
 import Storage.Beam.Payment ()
@@ -634,7 +636,7 @@ postFrfsSearchHandler (personId, merchantId) merchantOperatingCity integratedBPP
   return $ FRFSSearchAPIRes quotes searchReqId
 
 getFrfsSearchQuote :: (CallExternalBPP.FRFSSearchFlow m r, HasShortDurationRetryCfg r c) => (Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant) -> Kernel.Types.Id.Id Domain.Types.FRFSSearch.FRFSSearch -> m [API.Types.UI.FRFSTicketService.FRFSQuoteAPIRes]
-getFrfsSearchQuote (mbPersonId, _) searchId_ = do
+getFrfsSearchQuote (mbPersonId, merchantId_) searchId_ = do
   personId <- fromMaybeM (InvalidRequest "Invalid person id") mbPersonId
   search <- QFRFSSearch.findById searchId_ >>= fromMaybeM (InvalidRequest "Invalid search id")
   integratedBppConfig <- SIBC.findIntegratedBPPConfigFromEntity search
@@ -676,6 +678,22 @@ getFrfsSearchQuote (mbPersonId, _) searchId_ = do
                in compare (maybe 0 (.amount) mbAdultPrice1) (maybe 0 (.amount) mbAdultPrice2)
           )
           routeFilteredQuotesWithCategories
+  let mbReprAdultPrice = listToMaybe sortedQuotesWithCategories >>= \(_, qcs) -> find (\c -> c.category == ADULT) qcs <&> (.price)
+  mbOffer <-
+    if isJust mbJourneyLeg
+      then pure Nothing
+      else case mbReprAdultPrice of
+        Nothing -> pure Nothing
+        Just reprPrice -> do
+          standaloneLeg <- JMTypes.mkStandaloneFrfsMinimalLegInfo search (Just reprPrice)
+          withTryCatch
+            "getFrfsSearchQuote:cumulativeOffer"
+            ( SOffer.offerListCache merchantId_ personId search.merchantOperatingCityId (FRFSUtils.getPaymentType False search.vehicleType) reprPrice Nothing
+                >>= \offersResp -> SOffer.mkCumulativeOfferResp search.merchantOperatingCityId offersResp [standaloneLeg] Nothing
+            )
+            >>= \case
+              Left _ -> pure Nothing
+              Right mbResp -> pure mbResp
   mapM
     ( \(quote, quoteCategories) -> do
         let (routeStations :: Maybe [FRFSRouteStationsAPI], stations :: Maybe [FRFSStationAPI]) =
@@ -700,6 +718,7 @@ getFrfsSearchQuote (mbPersonId, _) searchId_ = do
               integratedBppConfigId = quote.integratedBppConfigId,
               stations = fromMaybe [] stations,
               observingFailures = Just observingFailures,
+              offer = mbOffer,
               ..
             }
     )

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerOrganizationFRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerOrganizationFRFS.hs
@@ -584,6 +584,7 @@ mkQuoteRes (quote, quoteCategories) = do
         eventDiscountAmount = quote.eventDiscountAmount,
         integratedBppConfigId = quote.integratedBppConfigId,
         observingFailures = Nothing,
+        offer = Nothing,
         ..
       }
 

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Types.hs
@@ -3,6 +3,7 @@ module ExternalBPP.CallAPI.Types where
 import Kernel.External.Types (SchedulerFlow, ServiceFlow)
 import Kernel.Prelude
 import Kernel.Sms.Config (SmsConfig)
+import Kernel.Storage.Clickhouse.Config (ClickhouseFlow)
 import Kernel.Storage.Esqueleto.Config
 import Kernel.Storage.Hedis
 import Kernel.Utils.Common
@@ -17,7 +18,8 @@ type FRFSSearchFlow m r =
     EsqDBReplicaFlow m r,
     Metrics.HasBAPMetrics m r,
     CallFRFSBPP.BecknAPICallFlow m r,
-    EncFlow m r
+    EncFlow m r,
+    ClickhouseFlow m r
   )
 
 type FRFSConfirmFlow m r c =

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
@@ -1195,6 +1195,134 @@ castCategoryToMode Spec.METRO = DTrip.Metro
 castCategoryToMode Spec.SUBWAY = DTrip.Subway
 castCategoryToMode Spec.BUS = DTrip.Bus
 
+mkStandaloneFrfsMinimalLegInfo :: (MonadFlow m) => FRFSSR.FRFSSearch -> Maybe Price -> m LegInfo
+mkStandaloneFrfsMinimalLegInfo frfsSearch mbFare = do
+  now <- getCurrentTime
+  legId <- generateGUID
+  let mbFareEntity = mkPriceAPIEntity <$> mbFare
+      mkStation stopCode mbName mbPoint mbAddr =
+        FRFSStationAPI
+          { name = fromMaybe "" mbName,
+            code = stopCode,
+            lat = mbPoint <&> (.lat),
+            lon = mbPoint <&> (.lon),
+            address = mbAddr,
+            regionalName = Nothing,
+            hindiName = Nothing,
+            integratedBppConfigId = cast frfsSearch.integratedBppConfigId
+          }
+      originStop = mkStation frfsSearch.fromStationCode frfsSearch.fromStationName frfsSearch.fromStationPoint frfsSearch.fromStationAddress
+      destinationStop = mkStation frfsSearch.toStationCode frfsSearch.toStationName frfsSearch.toStationPoint frfsSearch.toStationAddress
+      legExtraInfo = case frfsSearch.vehicleType of
+        Spec.BUS ->
+          Bus
+            BusLegExtraInfo
+              { originStop = originStop,
+                destinationStop = destinationStop,
+                routeCode = fromMaybe "" frfsSearch.routeCode,
+                bookingId = Nothing,
+                tickets = Nothing,
+                ticketValidity = Nothing,
+                ticketsCreatedAt = Nothing,
+                routeName = Nothing,
+                providerName = Nothing,
+                selectedServiceTier = Nothing,
+                frequency = Nothing,
+                alternateShortNames = [],
+                ticketNo = Nothing,
+                adultTicketQuantity = Just frfsSearch.quantity,
+                childTicketQuantity = Nothing,
+                refund = Nothing,
+                refunds = [],
+                trackingStatus = JMState.InPlan,
+                trackingStatusLastUpdatedAt = now,
+                fleetNo = Nothing,
+                legStartTime = Nothing,
+                legEndTime = Nothing,
+                discounts = Nothing,
+                categories = [],
+                categoryBookingDetails = Nothing,
+                busConductorId = Nothing,
+                busDriverId = Nothing,
+                busTagNumber = Nothing,
+                tripId = Nothing,
+                tripStartTime = Nothing,
+                bookedStopETA = Nothing,
+                driverName = Nothing,
+                driverMobileNumber = Nothing,
+                seatSelectionType = Nothing
+              }
+        Spec.METRO ->
+          Metro
+            MetroLegExtraInfo
+              { routeInfo = [],
+                bookingId = Nothing,
+                tickets = Nothing,
+                ticketValidity = Nothing,
+                ticketsCreatedAt = Nothing,
+                providerName = Nothing,
+                ticketNo = Nothing,
+                adultTicketQuantity = Just frfsSearch.quantity,
+                childTicketQuantity = Nothing,
+                refund = Nothing,
+                refunds = [],
+                categories = [],
+                categoryBookingDetails = Nothing
+              }
+        Spec.SUBWAY ->
+          Subway
+            SubwayLegExtraInfo
+              { routeInfo = [],
+                bookingId = Nothing,
+                tickets = Nothing,
+                ticketValidity = Nothing,
+                ticketsCreatedAt = Nothing,
+                ticketValidityHours = [],
+                providerName = Nothing,
+                providerRouteId = Nothing,
+                deviceId = Nothing,
+                ticketTypeCode = Nothing,
+                selectedServiceTier = Nothing,
+                ticketNo = Nothing,
+                adultTicketQuantity = Just frfsSearch.quantity,
+                childTicketQuantity = Nothing,
+                refund = Nothing,
+                refunds = [],
+                categories = [],
+                categoryBookingDetails = Nothing
+              }
+  pure
+    LegInfo
+      { journeyLegId = legId,
+        skipBooking = False,
+        bookingAllowed = True,
+        pricingId = Nothing,
+        searchId = frfsSearch.id.getId,
+        travelMode = castCategoryToMode frfsSearch.vehicleType,
+        startTime = now,
+        order = 0,
+        status = InPlan,
+        bookingStatus = JMState.Initial JMState.BOOKING_PENDING,
+        estimatedDuration = Nothing,
+        estimatedMinFare = mbFareEntity,
+        estimatedMaxFare = mbFareEntity,
+        estimatedChildFare = Nothing,
+        estimatedTotalFare = Nothing,
+        estimatedDistance = Nothing,
+        legExtraInfo = legExtraInfo,
+        merchantId = frfsSearch.merchantId,
+        merchantOperatingCityId = frfsSearch.merchantOperatingCityId,
+        personId = frfsSearch.riderId,
+        actualDistance = Nothing,
+        totalFare = Nothing,
+        entrance = Nothing,
+        exit = Nothing,
+        validTill = frfsSearch.validTill,
+        hasApplicablePasses = Nothing,
+        observingFailures = Nothing,
+        isCancellable = Nothing
+      }
+
 mkLegInfoFromFrfsSearchRequest :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, HasShortDurationRetryCfg r c) => FRFSSR.FRFSSearch -> DJourneyLeg.JourneyLeg -> [DJourneyLeg.JourneyLeg] -> m LegInfo
 mkLegInfoFromFrfsSearchRequest frfsSearch@FRFSSR.FRFSSearch {..} journeyLeg journeyLegs = do
   let fallbackFare = journeyLeg.estimatedMinFare

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Offer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Offer.hs
@@ -1,6 +1,10 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module SharedLogic.Offer where
+module SharedLogic.Offer
+  ( module SharedLogic.Offer,
+    module Reexport,
+  )
+where
 
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as A
@@ -37,6 +41,7 @@ import qualified Lib.Yudhishthira.Tools.DebugLog as LYDL
 import qualified Lib.Yudhishthira.Tools.Utils as LYTUtils
 import qualified Lib.Yudhishthira.Types as LYT
 import qualified Lib.Yudhishthira.TypesTH as YTH
+import SharedLogic.OfferTypes as Reexport
 import qualified SharedLogic.Utils as SLUtils
 import Storage.Beam.Payment ()
 import Storage.ConfigPilot.Config.RiderConfig (RiderDimensions (..))
@@ -56,16 +61,6 @@ data CumulativeOfferRespI = CumulativeOfferRespI
     offerSponsoredBy :: [Text],
     offerIds :: [Text],
     offerListResp :: Payment.OfferListResp
-  }
-  deriving (Generic, Show)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
-
-data CumulativeOfferResp = CumulativeOfferResp
-  { offerTitle :: Text,
-    offerDescription :: Text,
-    offerSponsoredBy :: [Text],
-    offerIds :: [Text],
-    offerListResp :: [OfferRespAPIEntity]
   }
   deriving (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -97,23 +92,6 @@ data OffersFraudChecksResp = OffersFraudChecksResp
   }
   deriving (Generic, Show)
   deriving anyclass (FromJSON, ToJSON)
-
-data OfferRespAPIEntity = OfferRespAPIEntity
-  { offerId :: Text,
-    offerTitle :: Maybe Text,
-    offerDescription :: Maybe Text,
-    offerTnc :: Maybe Text,
-    offerSponsoredBy :: Maybe Text,
-    offerCode :: Text,
-    autoApply :: Bool,
-    isHidden :: Bool,
-    amountSaved :: HighPrecMoney,
-    postOfferAmount :: HighPrecMoney,
-    estimatedAmountSaved :: HighPrecMoney,
-    estimatedPostOfferAmount :: HighPrecMoney
-  }
-  deriving (Generic, Show)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data OffersRespAPIEntity = OffersRespAPIEntity
   { offers :: [OfferRespAPIEntity],

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/OfferTypes.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/OfferTypes.hs
@@ -1,0 +1,31 @@
+module SharedLogic.OfferTypes where
+
+import Kernel.Prelude
+import Kernel.Types.Common (HighPrecMoney)
+
+data CumulativeOfferResp = CumulativeOfferResp
+  { offerTitle :: Text,
+    offerDescription :: Text,
+    offerSponsoredBy :: [Text],
+    offerIds :: [Text],
+    offerListResp :: [OfferRespAPIEntity]
+  }
+  deriving (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+data OfferRespAPIEntity = OfferRespAPIEntity
+  { offerId :: Text,
+    offerTitle :: Maybe Text,
+    offerDescription :: Maybe Text,
+    offerTnc :: Maybe Text,
+    offerSponsoredBy :: Maybe Text,
+    offerCode :: Text,
+    autoApply :: Bool,
+    isHidden :: Bool,
+    amountSaved :: HighPrecMoney,
+    postOfferAmount :: HighPrecMoney,
+    estimatedAmountSaved :: HighPrecMoney,
+    estimatedPostOfferAmount :: HighPrecMoney
+  }
+  deriving (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)


### PR DESCRIPTION
Backport of the FRFS standalone-bus cumulative-offer feature onto the prod hot-push branch, **squashed into one commit**.

Squashed from:
- #15081 `1384a5b6` — `offer :: Maybe CumulativeOfferResp` on `FRFSQuoteAPIRes`, populated for standalone (non-multimodal) FRFS quotes in `getFrfsSearchQuote` via `offerListCache` + `mkCumulativeOfferResp` (wrapped in `withTryCatch` so dynamic-logic failures degrade the offer to `Nothing`, never failing the quote). Offer response types split into a `SharedLogic.OfferTypes` leaf to break the import cycle.
- #15105 `a8c1fde1` — synthesise a minimal transit leg (`mkStandaloneFrfsMinimalLegInfo`) so the `CUMULATIVE_OFFER_POLICY` `transitLegs` filter matches on the standalone path.
- `dab20f53` — populate the synthetic leg's `adultTicketQuantity` (= `search.quantity`) and per-ticket `estimatedMin/MaxFare` so the policy can gate on ticket count / fare.

### Backport notes (please review)
- This branch is **217 commits behind `main`**. The unrelated `serviceTierType` / `routeCode` / `serviceTierName` `FRFSQuoteAPIRes` fields (added on `main` during that gap) were **intentionally not pulled in** — they're absent here. The yaml, generated type, and construction site (`..` + `offer = mbOffer`) are all consistent with only `offer` added.
- **Not yet build-verified locally** (local toolchain had a stale external-dep interface). Relying on CI to compile-verify.

9 files, +194 / −30.