### PR TITLE
feat: return location and currentTripId even when not active on that …

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -112,6 +112,7 @@ import qualified Kernel.Types.Beckn.Context
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import Kernel.Utils.TH
+import qualified Lib.JourneyLeg.Common.FRFSJourneyUtils as JLCF
 import qualified Lib.JourneyLeg.Types as JL
 import Lib.JourneyLeg.Types.Taxi
 import Lib.JourneyModule.Base
@@ -1947,7 +1948,32 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) req =
       let allSchedules = map buildScheduleInfo busScheduleDetails
       -- Build live vehicle info if live data exists
       mbLiveVehicle <- case maybeBus of
-        Nothing -> return Nothing
+        Nothing -> do
+          -- No live data on the route hash; fall back to last-known location from the bus_metadata_v2 hash
+          mbBusLiveInfo <- JLCF.getBusLiveInfo vno ctx.integratedBPPConfig
+          case (mbBusLiveInfo, mbServiceTier) of
+            (Just busLiveInfo, Just serviceTier) -> do
+              mbServiceTypeResp <- OTPRest.getVehicleServiceType ctx.integratedBPPConfig vno Nothing
+              let fallbackTripId = do
+                    serviceTypeResp <- mbServiceTypeResp
+                    waybill <- serviceTypeResp.waybill_id
+                    tNum <- serviceTypeResp.trip_number
+                    return $ JMU.makeTripIdFromWaybillNoAndTripNo waybill tNum
+              return $
+                Just $
+                  API.Types.UI.MultimodalConfirm.LiveVehicleInfo
+                    { eta = Just [],
+                      number = vno,
+                      position = LatLong busLiveInfo.latitude busLiveInfo.longitude,
+                      locationUTCTimestamp = posixSecondsToUTCTime $ fromIntegral busLiveInfo.timestamp,
+                      serviceTierType = serviceTier,
+                      serviceTierName = frfsServiceTierName,
+                      currentTripId = fallbackTripId,
+                      serviceSubTypes = mbServiceSubTypes,
+                      vehicleTagNumber = mbVehicleTagNumber,
+                      seatSelectionType = seatSelType
+                    }
+            _ -> return Nothing
         Just singleBus -> do
           case mbServiceTier of
             Nothing -> do


### PR DESCRIPTION
…routeId from busMetadata and liveRouteInfo

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live vehicle information display for multimodal journeys. When standard vehicle data lookups return no results on single-vehicle routes, the system now implements a fallback mechanism to retrieve live vehicle information using an alternative method. Users will consistently see current vehicle position and timestamp details instead of missing data during trip confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->