### PR TITLE
backend/fix: inspection hub status handling and deadlock correction

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
@@ -353,7 +353,7 @@ postDriverFleetAddVehicleHelper isBulkUpload merchantShortId opCity reqDriverPho
 mapInspectionHubRequestStatusToDashboard :: Maybe DOHR.RequestStatus -> Common.VerificationStatus
 mapInspectionHubRequestStatusToDashboard mbRequestStatus = case mbRequestStatus of
   Just DOHR.APPROVED -> Common.VALID
-  Just DOHR.PENDING -> Common.VALID
+  Just DOHR.PENDING -> Common.PENDING
   Just DOHR.REJECTED -> Common.INVALID
   Nothing -> Common.INVALID
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/VehicleDocs.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/VehicleDocs.hs
@@ -725,7 +725,7 @@ checkInspectionHubRequestCreated requestType mbDriverId mbRegistrationNo = do
 mapInspectionHubRequestStatusToResponseStatus :: Maybe DOHR.RequestStatus -> Maybe ResponseStatus
 mapInspectionHubRequestStatusToResponseStatus mbRequestStatus = case mbRequestStatus of
   Just DOHR.APPROVED -> Just VALID
-  Just DOHR.PENDING -> Just VALID
+  Just DOHR.PENDING -> Just PENDING
   Just DOHR.REJECTED -> Just INVALID
   Nothing -> Just NO_DOC_AVAILABLE
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated inspection-hub request status mapping so pending requests now correctly display as pending instead of valid in the dashboard and vehicle documentation responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->