### PR TITLE
fix: remove driver_id from driver_license upsert to prevent unique constraint violation

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverLicenseExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverLicenseExtra.hs
@@ -26,7 +26,6 @@ upsert a@DriverLicense {..} = do
           Se.Set BeamDL.driverName driverName,
           Se.Set BeamDL.licenseExpiry licenseExpiry,
           Se.Set BeamDL.classOfVehicles classOfVehicles,
-          Se.Set BeamDL.driverId (Kernel.Types.Id.getId driverId),
           Se.Set BeamDL.verificationStatus verificationStatus,
           Se.Set BeamDL.failedRules failedRules,
           Se.Set BeamDL.updatedAt updatedAt


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/1l)

### Root cause
The upsert function in DriverLicenseExtra.hs unconditionally sets driver_id in its UPDATE clause keyed on license_number_hash. When a different row already holds that driver_id, the unique constraint driver_license_unique_driver_id is violated, creating a poison message that blocks the driver drainer.

### Evidence
_see RCA_

### Rollback
Rollback beckn-driver-offer-bpp-production deployment to a commit before 20296bf477d

---
_Draft PR — review and merge manually. Generated by Argus._