### PR TITLE
Enhc: returning live and schedule eta for the routes passing through …

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -432,9 +432,13 @@ types:
     timeStamp: UTCTime
     towerInfo: [TowerInfo]
 
-  StopRouteResp:
-    routeCode: Text
+  RouteETAResp:
     eta: "Maybe [BusStopETA]"
+    isLastStop: Bool
+    isLive: Bool
+
+  PassingRoutes:
+    routeCode: Text
 
 apis:
   - POST:
@@ -786,9 +790,19 @@ apis:
         type: Kernel.Types.APISuccess.APISuccess
 
   - GET:
+      endpoint: /multimodal/route/{routeCode}/eta
+      auth: TokenAuth
+      params:
+        routeCode: Text
+      mandatoryQuery:
+        stopCode: Text
+      response:
+        type: RouteETAResp
+
+  - GET:
       endpoint: /multimodal/stop/{stopCode}/routes
       auth: TokenAuth
       params:
         stopCode: Text
       response:
-        type: "[StopRouteResp]"
+        type: "[PassingRoutes]"

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/MultimodalConfirm.hs
@@ -563,6 +563,19 @@ type API =
            Kernel.Types.APISuccess.APISuccess
       :<|> TokenAuth
       :> "multimodal"
+      :> "route"
+      :> Capture
+           "routeCode"
+           Kernel.Prelude.Text
+      :> "eta"
+      :> MandatoryQueryParam
+           "stopCode"
+           Kernel.Prelude.Text
+      :> Get
+           '[JSON]
+           API.Types.UI.MultimodalConfirm.RouteETAResp
+      :<|> TokenAuth
+      :> "multimodal"
       :> "stop"
       :> Capture
            "stopCode"
@@ -570,11 +583,11 @@ type API =
       :> "routes"
       :> Get
            '[JSON]
-           [API.Types.UI.MultimodalConfirm.StopRouteResp]
+           [API.Types.UI.MultimodalConfirm.PassingRoutes]
   )
 
 handler :: Environment.FlowServer API
-handler = postMultimodalRouteServiceability :<|> postMultimodalInitiate :<|> postMultimodalConfirm :<|> getMultimodalBookingInfo :<|> getMultimodalBookingPaymentStatus :<|> postMultimodalPaymentUpdateOrder :<|> postMultimodalSwitch :<|> postMultimodalJourneyLegSkip :<|> postMultimodalJourneyLegAddSkippedLeg :<|> postMultimodalExtendLeg :<|> postMultimodalExtendLegGetfare :<|> getMultimodalJourneyStatus :<|> postMultimodalJourneyCancel :<|> postMultimodalRiderLocation :<|> postMultimodalOrderSwitchTaxi :<|> postMultimodalOrderSwitchFRFSTier :<|> getMultimodalOrderSimilarJourneyLegs :<|> postMultimodalOrderSwitchJourneyLeg :<|> postMultimodalJourneyFeedback :<|> getMultimodalFeedback :<|> getMultimodalUserPreferences :<|> postMultimodalUserPreferences :<|> postMultimodalTransitOptionsLite :<|> getPublicTransportData :<|> getPublicTransportVehicleData :<|> getMultimodalOrderGetLegTierOptions :<|> postMultimodalOrderSublegSetOnboardedVehicleDetails :<|> postMultimodalOrderSublegSetStatus :<|> postMultimodalOrderSublegSetTrackingStatus :<|> postMultimodalComplete :<|> postMultimodalTicketVerify :<|> postMultimodalOrderSoftCancel :<|> getMultimodalOrderCancelStatus :<|> postMultimodalOrderCancel :<|> postMultimodalOrderChangeStops :<|> postMultimodalRouteAvailability :<|> postMultimodalSwitchRoute :<|> postMultimodalSetRouteName :<|> postMultimodalUpdateBusLocation :<|> postStoreTowerInfo :<|> getMultimodalStopRoutes
+handler = postMultimodalRouteServiceability :<|> postMultimodalInitiate :<|> postMultimodalConfirm :<|> getMultimodalBookingInfo :<|> getMultimodalBookingPaymentStatus :<|> postMultimodalPaymentUpdateOrder :<|> postMultimodalSwitch :<|> postMultimodalJourneyLegSkip :<|> postMultimodalJourneyLegAddSkippedLeg :<|> postMultimodalExtendLeg :<|> postMultimodalExtendLegGetfare :<|> getMultimodalJourneyStatus :<|> postMultimodalJourneyCancel :<|> postMultimodalRiderLocation :<|> postMultimodalOrderSwitchTaxi :<|> postMultimodalOrderSwitchFRFSTier :<|> getMultimodalOrderSimilarJourneyLegs :<|> postMultimodalOrderSwitchJourneyLeg :<|> postMultimodalJourneyFeedback :<|> getMultimodalFeedback :<|> getMultimodalUserPreferences :<|> postMultimodalUserPreferences :<|> postMultimodalTransitOptionsLite :<|> getPublicTransportData :<|> getPublicTransportVehicleData :<|> getMultimodalOrderGetLegTierOptions :<|> postMultimodalOrderSublegSetOnboardedVehicleDetails :<|> postMultimodalOrderSublegSetStatus :<|> postMultimodalOrderSublegSetTrackingStatus :<|> postMultimodalComplete :<|> postMultimodalTicketVerify :<|> postMultimodalOrderSoftCancel :<|> getMultimodalOrderCancelStatus :<|> postMultimodalOrderCancel :<|> postMultimodalOrderChangeStops :<|> postMultimodalRouteAvailability :<|> postMultimodalSwitchRoute :<|> postMultimodalSetRouteName :<|> postMultimodalUpdateBusLocation :<|> postStoreTowerInfo :<|> getMultimodalRouteEta :<|> getMultimodalStopRoutes
 
 postMultimodalRouteServiceability ::
   ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
@@ -984,11 +997,21 @@ postStoreTowerInfo ::
   )
 postStoreTowerInfo a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.MultimodalConfirm.postStoreTowerInfo (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a2) a1
 
+getMultimodalRouteEta ::
+  ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
+      Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
+    ) ->
+    Kernel.Prelude.Text ->
+    Kernel.Prelude.Text ->
+    Environment.FlowHandler API.Types.UI.MultimodalConfirm.RouteETAResp
+  )
+getMultimodalRouteEta a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.MultimodalConfirm.getMultimodalRouteEta (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a3) a2 a1
+
 getMultimodalStopRoutes ::
   ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
       Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
     ) ->
     Kernel.Prelude.Text ->
-    Environment.FlowHandler [API.Types.UI.MultimodalConfirm.StopRouteResp]
+    Environment.FlowHandler [API.Types.UI.MultimodalConfirm.PassingRoutes]
   )
 getMultimodalStopRoutes a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.MultimodalConfirm.getMultimodalStopRoutes (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a2) a1

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -282,6 +282,10 @@ data OnboardedVehicleDetailsReq = OnboardedVehicleDetailsReq {vehicleNumber :: K
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
+data PassingRoutes = PassingRoutes {routeCode :: Kernel.Prelude.Text}
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data PaymentFareUpdate = PaymentFareUpdate
   { category :: Domain.Types.FRFSQuoteCategoryType.FRFSQuoteCategoryType,
     journeyLegOrder :: Kernel.Prelude.Int,
@@ -339,6 +343,10 @@ data RouteCodesWithLeg = RouteCodesWithLeg {legOrder :: Kernel.Prelude.Int, rout
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
+data RouteETAResp = RouteETAResp {eta :: Kernel.Prelude.Maybe [Storage.CachedQueries.Merchant.MultiModalBus.BusStopETA], isLastStop :: Kernel.Prelude.Bool, isLive :: Kernel.Prelude.Bool}
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data RouteServiceabilityReq = RouteServiceabilityReq
   { destinationStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     routeCodes :: Kernel.Prelude.Maybe [RouteCodesWithLeg],
@@ -390,10 +398,6 @@ data SingleQRReq = SingleQRReq {provider :: Lib.JourneyModule.Types.Provider, ti
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data StationAPIEntity = StationAPIEntity {stopCode :: Kernel.Prelude.Text}
-  deriving stock (Generic)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
-
-data StopRouteResp = StopRouteResp {eta :: Kernel.Prelude.Maybe [Storage.CachedQueries.Merchant.MultiModalBus.BusStopETA], routeCode :: Kernel.Prelude.Text}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -43,6 +43,7 @@ module Domain.Action.UI.MultimodalConfirm
     postMultimodalUpdateBusLocation,
     postStoreTowerInfo,
     getMultimodalStopRoutes,
+    getMultimodalRouteEta,
   )
 where
 
@@ -94,6 +95,7 @@ import qualified Domain.Types.SearchRequest as DSR
 import qualified Domain.Types.Station as DStation
 import Domain.Utils (castTravelModeToVehicleCategory, mapConcurrently)
 import Environment
+import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (all, any, catMaybes, concatMap, elem, find, forM_, groupBy, id, length, map, mapM_, null, readMaybe, sum, toList, whenJust)
 import qualified ExternalBPP.CallAPI as CallExternalBPP
 import qualified ExternalBPP.ExternalAPI.CallAPI as DirectExternalBPP
@@ -2847,13 +2849,76 @@ getMultimodalStopRoutes ::
     Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
   ) ->
   Kernel.Prelude.Text ->
-  Environment.Flow [ApiTypes.StopRouteResp]
+  Environment.Flow [ApiTypes.PassingRoutes]
 getMultimodalStopRoutes (mbPersonId, _merchantId) stopCode = do
   personId <- mbPersonId & fromMaybeM (InvalidRequest "Person not found")
   person <- QP.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
   integratedBPPConfig <-
-    fromMaybeM (InvalidRequest "Integrated BPP config not found")
-      =<< listToMaybe <$> SIBC.findAllIntegratedBPPConfig person.merchantOperatingCityId Enums.BUS DIBC.MULTIMODAL
+    fromMaybeM (InvalidRequest "Integrated BPP config not found") . listToMaybe
+      =<< SIBC.findAllIntegratedBPPConfig person.merchantOperatingCityId Enums.BUS DIBC.MULTIMODAL
   mappings <- OTPRest.getRouteStopMappingByStopCode stopCode integratedBPPConfig
   let routeCodes = nub (map (.routeCode) mappings)
-  pure $ map (\rc -> ApiTypes.StopRouteResp {routeCode = rc, eta = Nothing}) routeCodes
+  pure $ map (\routeCode -> ApiTypes.PassingRoutes {routeCode = routeCode}) routeCodes
+
+getMultimodalRouteEta ::
+  ( Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person),
+    Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
+  ) ->
+  Kernel.Prelude.Text ->
+  Kernel.Prelude.Text ->
+  Environment.Flow ApiTypes.RouteETAResp
+getMultimodalRouteEta (mbPersonId, _merchantId) routeCode stopCode = do
+  personId <- mbPersonId & fromMaybeM (InvalidRequest "Person not found")
+  person <- QP.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
+  integratedBPPConfig <-
+    fromMaybeM (InvalidRequest "Integrated BPP config not found") . listToMaybe
+      =<< SIBC.findAllIntegratedBPPConfig person.merchantOperatingCityId Enums.BUS DIBC.MULTIMODAL
+  liveEtasFork <-
+    awaitableFork "getMultimodalRouteEta->liveEtas" $ do
+      busesForRoutes <- CQMMB.getBusesForRoutes [routeCode] integratedBPPConfig
+      pure
+        [ etaEntry
+          | routeWithBuses <- busesForRoutes,
+            bus <- routeWithBuses.buses,
+            etaEntry <- fromMaybe [] bus.busData.eta_data,
+            etaEntry.stopCode == stopCode
+        ]
+  scheduleEtasFork <-
+    awaitableFork "getMultimodalRouteEta->scheduleEtas" $ do
+      schedules <- OTPRest.getRouteBusSchedule routeCode Nothing integratedBPPConfig
+      pure
+        [ etaEntry
+          | scheduleDetail <- schedules,
+            etaEntry <- scheduleDetail.eta,
+            etaEntry.stopCode == stopCode
+        ]
+  liveEtas <-
+    L.await Nothing liveEtasFork >>= \case
+      Left err -> do
+        logError $ "getMultimodalRouteEta live ETA fetch failed: " <> show err
+        pure []
+      Right result -> pure result
+  scheduleEtas <-
+    L.await Nothing scheduleEtasFork >>= \case
+      Left err -> do
+        logError $ "getMultimodalRouteEta schedule ETA fetch failed: " <> show err
+        pure []
+      Right result -> pure result
+  let (etas, isLive) =
+        if not (null liveEtas)
+          then (liveEtas, True)
+          else (scheduleEtas, False)
+  if null etas
+    then pure $ ApiTypes.RouteETAResp {eta = Nothing, isLastStop = False, isLive = False}
+    else do
+      enrichedEtas <- mapM (JMRouteServiceability.enrichBusStopETA integratedBPPConfig) etas
+      routeMappings <- OTPRest.getRouteStopMappingByRouteCode routeCode integratedBPPConfig
+      let isLastStop = case sortOn (Down . (.sequenceNum)) routeMappings of
+            (lastStopMapping : _) -> lastStopMapping.stopCode == stopCode
+            [] -> False
+      pure $
+        ApiTypes.RouteETAResp
+          { eta = Just enrichedEtas,
+            isLastStop = isLastStop,
+            isLive = isLive
+          }


### PR DESCRIPTION
…the stop

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New per-route ETA endpoint to fetch ETA details for a specific route at a stop.
  * ETA responses now include live vs scheduled indicator and an is-last-stop flag.
  * Stop listings now return a concise list of passing route codes.
  * ETAs prefer live data when available and fall back to scheduled data otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->