### PR TITLE
backend/feat: cross-cloud UI request routing via merchant cloud config

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -122,6 +122,7 @@ library
       API.UI.Whatsapp
       API.UnifiedDashboard
       App
+      App.CrossCloudProxy
       App.Server
       Beckn.ACL.Cancel
       Beckn.ACL.Common

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -17,6 +17,9 @@ imports:
   EntityName: Lib.Payment.Domain.Types.Common
   Integer: Kernel.Prelude
   Version: Kernel.Types.Version
+  CloudType: Kernel.Types.Version
+  showBaseUrl: Kernel.Prelude
+  parseBaseUrl: Kernel.Prelude
   AadhaarVerificationService: Kernel.External.AadhaarVerification.Types
   CallService: Kernel.External.Call
   MapsService: Kernel.External.Maps.Types
@@ -108,6 +111,8 @@ Merchant:
     signingPrivateKey: Maybe Base64
     signatureExpiry: Int
     cipherText: Maybe Base64
+    cloudType: Maybe CloudType
+    cloudBaseUrl: Maybe BaseUrl
   sqlType:
     destinationRestriction: text[]
     originRestriction: text[]
@@ -155,6 +160,7 @@ Merchant:
     registryUrl: Text
     gatewayAndRegistryPriorityList: Maybe [GatewayAndRegistryService]
     mediaFileDocumentLinkExpires: Maybe Seconds
+    cloudBaseUrl: Maybe Text
 
   constraints:
     subscriberId: SecondaryKey
@@ -166,6 +172,7 @@ Merchant:
     destinationRestriction: Kernel.Types.Geofencing.destination|I
     gatewayAndRegistryPriorityList: Kernel.Prelude.Just|I
     mediaFileDocumentLinkExpires: Kernel.Prelude.Just|I
+    cloudBaseUrl: (Kernel.Prelude.fmap showBaseUrl)|I
 
   fromTType:
     geofencingConfig: Kernel.Types.Geofencing.GeofencingConfig originRestriction
@@ -174,6 +181,7 @@ Merchant:
     gatewayAndRegistryPriorityList: fromMaybe [Domain.Types.ONDC, Domain.Types.NY]
       gatewayAndRegistryPriorityList|E
     mediaFileDocumentLinkExpires: Kernel.Prelude.fromMaybe 3600|I
+    cloudBaseUrl: (Kernel.Prelude.maybe (return Kernel.Prelude.Nothing) (Kernel.Prelude.fmap Kernel.Prelude.Just . parseBaseUrl))|MI
 
   queries:
     findById:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -160,6 +160,7 @@ Merchant:
     registryUrl: Text
     gatewayAndRegistryPriorityList: Maybe [GatewayAndRegistryService]
     mediaFileDocumentLinkExpires: Maybe Seconds
+    cloudType: Maybe Text
     cloudBaseUrl: Maybe Text
 
   constraints:
@@ -172,6 +173,7 @@ Merchant:
     destinationRestriction: Kernel.Types.Geofencing.destination|I
     gatewayAndRegistryPriorityList: Kernel.Prelude.Just|I
     mediaFileDocumentLinkExpires: Kernel.Prelude.Just|I
+    cloudType: (Kernel.Prelude.fmap Kernel.Prelude.show)|I
     cloudBaseUrl: (Kernel.Prelude.fmap showBaseUrl)|I
 
   fromTType:
@@ -181,7 +183,8 @@ Merchant:
     gatewayAndRegistryPriorityList: fromMaybe [Domain.Types.ONDC, Domain.Types.NY]
       gatewayAndRegistryPriorityList|E
     mediaFileDocumentLinkExpires: Kernel.Prelude.fromMaybe 3600|I
-    cloudBaseUrl: (Kernel.Prelude.maybe (return Kernel.Prelude.Nothing) (Kernel.Prelude.fmap Kernel.Prelude.Just . parseBaseUrl))|MI
+    cloudType: (Kernel.Prelude.>>= (Kernel.Prelude.readMaybe . Data.Text.unpack))|I
+    cloudBaseUrl: (Kernel.Prelude.pure . (Kernel.Prelude.>>= parseBaseUrl))|MI
 
   queries:
     findById:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/Merchant.hs
@@ -12,6 +12,7 @@ import qualified Kernel.Types.Beckn.Context
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Geofencing
 import qualified Kernel.Types.Id
+import qualified Kernel.Types.Version
 import Kernel.Utils.TH
 import qualified Tools.Beam.UtilsTH
 
@@ -19,6 +20,8 @@ data MerchantD (s :: UsageSafety) = Merchant
   { businessId :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     cipherText :: Kernel.Prelude.Maybe Kernel.Types.Base64.Base64,
     city :: Kernel.Types.Beckn.Context.City,
+    cloudBaseUrl :: Kernel.Prelude.Maybe Kernel.Prelude.BaseUrl,
+    cloudType :: Kernel.Prelude.Maybe Kernel.Types.Version.CloudType,
     country :: Kernel.Types.Beckn.Context.Country,
     createdAt :: Kernel.Prelude.UTCTime,
     description :: Kernel.Prelude.Maybe Kernel.Prelude.Text,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Merchant.hs
@@ -14,12 +14,15 @@ import qualified Kernel.Types.Base64
 import qualified Kernel.Types.Beckn.Context
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Geofencing
+import qualified Kernel.Types.Version
 import Tools.Beam.UtilsTH
 
 data MerchantT f = MerchantT
   { businessId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     cipherText :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Base64.Base64),
     city :: B.C f Kernel.Types.Beckn.Context.City,
+    cloudBaseUrl :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    cloudType :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Version.CloudType),
     country :: B.C f Kernel.Types.Beckn.Context.Country,
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     description :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Merchant.hs
@@ -22,7 +22,7 @@ data MerchantT f = MerchantT
     cipherText :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Base64.Base64),
     city :: B.C f Kernel.Types.Beckn.Context.City,
     cloudBaseUrl :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
-    cloudType :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Version.CloudType),
+    cloudType :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     country :: B.C f Kernel.Types.Beckn.Context.Country,
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     description :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/Merchant.hs
@@ -48,6 +48,8 @@ updateByPrimaryKey (Domain.Types.Merchant.Merchant {..}) = do
     [ Se.Set Beam.businessId businessId,
       Se.Set Beam.cipherText cipherText,
       Se.Set Beam.city city,
+      Se.Set Beam.cloudBaseUrl (Kernel.Prelude.fmap showBaseUrl cloudBaseUrl),
+      Se.Set Beam.cloudType cloudType,
       Se.Set Beam.country country,
       Se.Set Beam.description description,
       Se.Set Beam.enabled enabled,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/Merchant.hs
@@ -49,7 +49,7 @@ updateByPrimaryKey (Domain.Types.Merchant.Merchant {..}) = do
       Se.Set Beam.cipherText cipherText,
       Se.Set Beam.city city,
       Se.Set Beam.cloudBaseUrl (Kernel.Prelude.fmap showBaseUrl cloudBaseUrl),
-      Se.Set Beam.cloudType cloudType,
+      Se.Set Beam.cloudType (Kernel.Prelude.fmap Kernel.Prelude.show cloudType),
       Se.Set Beam.country country,
       Se.Set Beam.description description,
       Se.Set Beam.enabled enabled,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/Merchant.hs
@@ -17,6 +17,7 @@ import qualified Storage.Beam.Merchant as Beam
 
 instance FromTType' Beam.Merchant Domain.Types.Merchant.Merchant where
   fromTType' (Beam.MerchantT {..}) = do
+    cloudBaseUrl' <- Kernel.Prelude.maybe (return Kernel.Prelude.Nothing) (Kernel.Prelude.fmap Kernel.Prelude.Just . parseBaseUrl) cloudBaseUrl
     registryUrl' <- Kernel.Prelude.parseBaseUrl registryUrl
     pure $
       Just
@@ -24,6 +25,8 @@ instance FromTType' Beam.Merchant Domain.Types.Merchant.Merchant where
           { businessId = businessId,
             cipherText = cipherText,
             city = city,
+            cloudBaseUrl = cloudBaseUrl',
+            cloudType = cloudType,
             country = country,
             createdAt = createdAt,
             description = description,
@@ -67,6 +70,8 @@ instance ToTType' Beam.Merchant Domain.Types.Merchant.Merchant where
       { Beam.businessId = businessId,
         Beam.cipherText = cipherText,
         Beam.city = city,
+        Beam.cloudBaseUrl = Kernel.Prelude.fmap showBaseUrl cloudBaseUrl,
+        Beam.cloudType = cloudType,
         Beam.country = country,
         Beam.createdAt = createdAt,
         Beam.description = description,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/Merchant.hs
@@ -3,6 +3,7 @@
 
 module Storage.Queries.OrphanInstances.Merchant where
 
+import qualified Data.Text
 import qualified Domain.Types
 import qualified Domain.Types.Merchant
 import Kernel.Beam.Functions
@@ -17,7 +18,7 @@ import qualified Storage.Beam.Merchant as Beam
 
 instance FromTType' Beam.Merchant Domain.Types.Merchant.Merchant where
   fromTType' (Beam.MerchantT {..}) = do
-    cloudBaseUrl' <- Kernel.Prelude.maybe (return Kernel.Prelude.Nothing) (Kernel.Prelude.fmap Kernel.Prelude.Just . parseBaseUrl) cloudBaseUrl
+    cloudBaseUrl' <- (Kernel.Prelude.pure . (Kernel.Prelude.>>= parseBaseUrl)) cloudBaseUrl
     registryUrl' <- Kernel.Prelude.parseBaseUrl registryUrl
     pure $
       Just
@@ -26,7 +27,7 @@ instance FromTType' Beam.Merchant Domain.Types.Merchant.Merchant where
             cipherText = cipherText,
             city = city,
             cloudBaseUrl = cloudBaseUrl',
-            cloudType = cloudType,
+            cloudType = (Kernel.Prelude.>>= (Kernel.Prelude.readMaybe . Data.Text.unpack)) cloudType,
             country = country,
             createdAt = createdAt,
             description = description,
@@ -71,7 +72,7 @@ instance ToTType' Beam.Merchant Domain.Types.Merchant.Merchant where
         Beam.cipherText = cipherText,
         Beam.city = city,
         Beam.cloudBaseUrl = Kernel.Prelude.fmap showBaseUrl cloudBaseUrl,
-        Beam.cloudType = cloudType,
+        Beam.cloudType = (Kernel.Prelude.fmap Kernel.Prelude.show) cloudType,
         Beam.country = country,
         Beam.createdAt = createdAt,
         Beam.description = description,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI.hs
@@ -15,6 +15,7 @@
 module API.UI
   ( API,
     handler,
+    uiApiPrefix,
   )
 where
 
@@ -89,15 +90,23 @@ import qualified API.UI.Route as Route
 import qualified API.UI.Sos as Sos
 import qualified API.UI.Transporter as Transporter
 import qualified API.UI.Whatsapp as Whatsapp
+import qualified Data.Text as T
 import Environment
+import GHC.TypeLits (symbolVal)
 import Kernel.Prelude
 import Kernel.Utils.Servant.Server (healthCheck)
 import Servant
 
 type HealthCheckAPI = Get '[JSON] Text
 
+--for multi-cloud proxy
+type UIAPIPrefix = "ui"
+
+uiApiPrefix :: Text
+uiApiPrefix = T.pack $ symbolVal (Proxy @UIAPIPrefix)
+
 type API =
-  "ui"
+  UIAPIPrefix
     :> ( HealthCheckAPI
            :<|> Merchant.API
            :<|> MerchantDocument.API

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App.hs
@@ -55,6 +55,7 @@ import Kernel.Utils.Dhall hiding (maybe)
 import qualified Kernel.Utils.FlowLogging as L
 import Kernel.Utils.Servant.SignatureAuth (addAuthManagersToFlowRt, prepareAuthManagers)
 import Network.HTTP.Client as Http
+import qualified Network.HTTP.Client.TLS as HttpTLS
 import Network.HTTP.Types (status408)
 import Network.Wai
 import Network.Wai.Handler.Warp
@@ -160,7 +161,8 @@ runDynamicOfferDriverApp' appCfg = do
         logInfo ("Runtime created. Starting server at port " <> show (appCfg.port))
         pure flowRt'
     let timeoutMiddleware = UE.timeoutEvent flowRt appEnv (responseLBS status408 [] "") appCfg.incomingAPIResponseTimeout
-    runSettings settings $ timeoutMiddleware (App.run (App.EnvR flowRt' appEnv))
+    proxyManager <- HttpTLS.newTlsManager
+    runSettings settings $ timeoutMiddleware (App.run proxyManager (App.EnvR flowRt' appEnv))
 
 convertToHashMap :: Map.Map String Http.ManagerSettings -> HashMap.HashMap Text Http.ManagerSettings
 convertToHashMap = HashMap.fromList . map convert . Map.toList

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App/CrossCloudProxy.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App/CrossCloudProxy.hs
@@ -1,0 +1,50 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module App.CrossCloudProxy (crossCloudProxy) where
+
+import qualified API.UI as UI
+import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Person as DP
+import Environment
+import Kernel.Prelude
+import qualified Kernel.Storage.Hedis as Redis
+import qualified Kernel.Storage.InMem as IM
+import Kernel.Types.Id
+import Kernel.Types.Version (CloudType (..))
+import qualified Network.HTTP.Client as Http
+import qualified Network.Wai as Wai
+import qualified Storage.CachedQueries.Merchant as CQM
+import qualified Storage.Queries.RegistrationToken as QRT
+import Tools.Auth (authTokenCacheKey, merchantIdFallback)
+import qualified "utils" Utils.Common.CrossCloudProxy as CCP
+
+crossCloudProxy :: Http.Manager -> Env -> Wai.Middleware
+crossCloudProxy manager env =
+  case env.appEnv.cloudType of
+    Just podCloud | podCloud /= UNAVAILABLE -> CCP.crossCloudProxyMiddleware env.flowRuntime env.appEnv podCloud [UI.uiApiPrefix] manager resolveOwner
+    _ -> identity
+
+resolveOwner :: Text -> Flow (Maybe (CloudType, BaseUrl))
+resolveOwner token = do
+  mbAuthCached :: Maybe (Id DP.Person, Id DM.Merchant, Id DMOC.MerchantOperatingCity) <- Redis.safeGet (authTokenCacheKey token)
+  mbMerchantId <- case mbAuthCached of
+    Just (_, merchantId, _) -> pure (Just merchantId)
+    Nothing -> fmap (merchantIdFallback . Id @DM.Merchant . (.merchantId)) <$> QRT.findByToken token
+  case mbMerchantId of
+    Nothing -> pure Nothing
+    Just merchantId -> IM.withInMemCache ["crossCloudProxy:merchantCloud", merchantId.getId] 60 $ do
+      mbMerchant :: Maybe DM.Merchant <- CQM.findById merchantId
+      pure $ mbMerchant >>= \merchant -> (,) <$> merchant.cloudType <*> merchant.cloudBaseUrl

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App/Server.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App/Server.hs
@@ -15,6 +15,7 @@
 module App.Server where
 
 import API
+import App.CrossCloudProxy (crossCloudProxy)
 import Environment
 import EulerHS.Prelude
 import Kernel.Tools.Metrics.Init
@@ -22,12 +23,14 @@ import Kernel.Types.Flow
 import Kernel.Utils.App
 import Kernel.Utils.Monitoring.Prometheus.Servant ()
 import qualified Kernel.Utils.Servant.Server as BU
+import qualified Network.HTTP.Client as Http
 import Servant
 import Tools.Auth
 
-run :: Env -> Application
-run = withModifiedEnv' driverOfferAPI $ \modifiedEnv ->
+run :: Http.Manager -> Env -> Application
+run proxyManager = withModifiedEnv' driverOfferAPI $ \modifiedEnv ->
   BU.run driverOfferAPI (driverOfferServer modifiedEnv.appEnv) context modifiedEnv
+    & crossCloudProxy proxyManager modifiedEnv
     & logRequestAndResponse' modifiedEnv
     -- & logBecknRequest modifiedEnv
     & addServantInfo modifiedEnv.appEnv.version driverOfferAPI

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -117,6 +117,7 @@ library
       API.UI.Whatsapp
       API.UnifiedDashboard
       App
+      App.CrossCloudProxy
       App.Server
       Beckn.ACL.Cancel
       Beckn.ACL.Common

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
@@ -120,6 +120,7 @@ Merchant:
     arrivingPickupThreshold: HighPrecDistance
     gatewayAndRegistryPriorityList: Maybe [GatewayAndRegistryService]
     stuckRideAutoCancellationBuffer: Maybe Seconds
+    cloudType: Maybe Text
     cloudBaseUrl: Maybe Text
 
   toTType:
@@ -141,6 +142,7 @@ Merchant:
     arrivedPickupThresholdValue: (Just $ Kernel.Utils.Common.distanceToHighPrecDistance ((.unit) editPickupDistanceThreshold) arrivedPickupThreshold)|E
     arrivingPickupThreshold: (Kernel.Utils.Common.distanceToHighPrecDistance ((.unit) editPickupDistanceThreshold) arrivingPickupThreshold)|E
     gatewayAndRegistryPriorityList: Kernel.Prelude.Just|I
+    cloudType: (Kernel.Prelude.fmap Kernel.Prelude.show)|I
     cloudBaseUrl: (Kernel.Prelude.fmap Kernel.Prelude.showBaseUrl)|I
 
   fromTType:
@@ -157,7 +159,8 @@ Merchant:
     driverDistanceThresholdFromPickup: Kernel.Utils.Common.mkDistanceWithDefault distanceUnit driverDistanceThresholdFromPickupValue driverDistanceThresholdFromPickup|E
     driverOnTheWayNotifyExpiry: (fromMaybe 3600 driverOnTheWayNotifyExpiry)|E
     gatewayAndRegistryPriorityList: fromMaybe [Domain.Types.ONDC, Domain.Types.NY] gatewayAndRegistryPriorityList|E
-    cloudBaseUrl: (Kernel.Prelude.maybe (return Kernel.Prelude.Nothing) (Kernel.Prelude.fmap Kernel.Prelude.Just . Kernel.Prelude.parseBaseUrl))|MI
+    cloudType: (Kernel.Prelude.>>= (Kernel.Prelude.readMaybe . Data.Text.unpack))|I
+    cloudBaseUrl: (Kernel.Prelude.pure . (Kernel.Prelude.>>= Kernel.Prelude.parseBaseUrl))|MI
 
   sqlType:
     editPickupDistanceThreshold: double precision

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
@@ -37,6 +37,7 @@ imports:
   InsuranceService: Kernel.External.Insurance.Types
   EventTrackingService: Kernel.External.EventTracking
   Currency: Kernel.Utils.Common
+  CloudType: Kernel.Types.Version
 
 Merchant:
   derives: "Generic,Show,'UsageSafety"
@@ -86,6 +87,8 @@ Merchant:
     onlinePayment: Bool
     gatewayAndRegistryPriorityList: "[GatewayAndRegistryService]"
     stuckRideAutoCancellationBuffer: Maybe Seconds
+    cloudType: Maybe CloudType
+    cloudBaseUrl: Maybe BaseUrl
 
   excludedFields:
     - merchantId
@@ -117,6 +120,7 @@ Merchant:
     arrivingPickupThreshold: HighPrecDistance
     gatewayAndRegistryPriorityList: Maybe [GatewayAndRegistryService]
     stuckRideAutoCancellationBuffer: Maybe Seconds
+    cloudBaseUrl: Maybe Text
 
   toTType:
     city: defaultCity|E
@@ -137,6 +141,7 @@ Merchant:
     arrivedPickupThresholdValue: (Just $ Kernel.Utils.Common.distanceToHighPrecDistance ((.unit) editPickupDistanceThreshold) arrivedPickupThreshold)|E
     arrivingPickupThreshold: (Kernel.Utils.Common.distanceToHighPrecDistance ((.unit) editPickupDistanceThreshold) arrivingPickupThreshold)|E
     gatewayAndRegistryPriorityList: Kernel.Prelude.Just|I
+    cloudBaseUrl: (Kernel.Prelude.fmap Kernel.Prelude.showBaseUrl)|I
 
   fromTType:
     defaultCity: city|E
@@ -152,6 +157,7 @@ Merchant:
     driverDistanceThresholdFromPickup: Kernel.Utils.Common.mkDistanceWithDefault distanceUnit driverDistanceThresholdFromPickupValue driverDistanceThresholdFromPickup|E
     driverOnTheWayNotifyExpiry: (fromMaybe 3600 driverOnTheWayNotifyExpiry)|E
     gatewayAndRegistryPriorityList: fromMaybe [Domain.Types.ONDC, Domain.Types.NY] gatewayAndRegistryPriorityList|E
+    cloudBaseUrl: (Kernel.Prelude.maybe (return Kernel.Prelude.Nothing) (Kernel.Prelude.fmap Kernel.Prelude.Just . Kernel.Prelude.parseBaseUrl))|MI
 
   sqlType:
     editPickupDistanceThreshold: double precision

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/Merchant.hs
@@ -13,6 +13,7 @@ import qualified Kernel.Types.Common
 import qualified Kernel.Types.Geofencing
 import qualified Kernel.Types.Id
 import qualified Kernel.Types.Registry
+import qualified Kernel.Types.Version
 import qualified Tools.Beam.UtilsTH
 
 data MerchantD (s :: UsageSafety) = Merchant
@@ -23,6 +24,8 @@ data MerchantD (s :: UsageSafety) = Merchant
     bapId :: Kernel.Prelude.Text,
     bapUniqueKeyId :: Kernel.Prelude.Text,
     cipherText :: Kernel.Prelude.Maybe Kernel.Types.Base64.Base64,
+    cloudBaseUrl :: Kernel.Prelude.Maybe Kernel.Types.Common.BaseUrl,
+    cloudType :: Kernel.Prelude.Maybe Kernel.Types.Version.CloudType,
     country :: Kernel.Types.Beckn.Context.Country,
     createdAt :: Kernel.Prelude.UTCTime,
     defaultCity :: Kernel.Types.Beckn.Context.City,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/Merchant.hs
@@ -13,6 +13,7 @@ import qualified Kernel.Types.Base64
 import qualified Kernel.Types.Beckn.Context
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Geofencing
+import qualified Kernel.Types.Version
 import Tools.Beam.UtilsTH
 
 data MerchantT f = MerchantT
@@ -24,6 +25,8 @@ data MerchantT f = MerchantT
     bapId :: B.C f Kernel.Prelude.Text,
     bapUniqueKeyId :: B.C f Kernel.Prelude.Text,
     cipherText :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Base64.Base64),
+    cloudBaseUrl :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    cloudType :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Version.CloudType),
     country :: B.C f Kernel.Types.Beckn.Context.Country,
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     city :: B.C f Kernel.Types.Beckn.Context.City,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/Merchant.hs
@@ -26,7 +26,7 @@ data MerchantT f = MerchantT
     bapUniqueKeyId :: B.C f Kernel.Prelude.Text,
     cipherText :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Base64.Base64),
     cloudBaseUrl :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
-    cloudType :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Version.CloudType),
+    cloudType :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     country :: B.C f Kernel.Types.Beckn.Context.Country,
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     city :: B.C f Kernel.Types.Beckn.Context.City,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/Merchant.hs
@@ -19,6 +19,7 @@ import Storage.Queries.Transformers.Merchant
 
 instance FromTType' Beam.Merchant Domain.Types.Merchant.Merchant where
   fromTType' (Beam.MerchantT {..}) = do
+    cloudBaseUrl' <- Kernel.Prelude.maybe (return Kernel.Prelude.Nothing) (Kernel.Prelude.fmap Kernel.Prelude.Just . Kernel.Prelude.parseBaseUrl) cloudBaseUrl
     driverOfferBaseUrl' <- Kernel.Prelude.parseBaseUrl driverOfferBaseUrl
     gatewayUrl' <- Kernel.Prelude.parseBaseUrl gatewayUrl
     registryUrl' <- Kernel.Prelude.parseBaseUrl registryUrl
@@ -32,6 +33,8 @@ instance FromTType' Beam.Merchant Domain.Types.Merchant.Merchant where
             bapId = bapId,
             bapUniqueKeyId = bapUniqueKeyId,
             cipherText = cipherText,
+            cloudBaseUrl = cloudBaseUrl',
+            cloudType = cloudType,
             country = country,
             createdAt = createdAt,
             defaultCity = city,
@@ -82,6 +85,8 @@ instance ToTType' Beam.Merchant Domain.Types.Merchant.Merchant where
         Beam.bapId = bapId,
         Beam.bapUniqueKeyId = bapUniqueKeyId,
         Beam.cipherText = cipherText,
+        Beam.cloudBaseUrl = Kernel.Prelude.fmap Kernel.Prelude.showBaseUrl cloudBaseUrl,
+        Beam.cloudType = cloudType,
         Beam.country = country,
         Beam.createdAt = createdAt,
         Beam.city = defaultCity,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/Merchant.hs
@@ -3,6 +3,7 @@
 
 module Storage.Queries.OrphanInstances.Merchant where
 
+import qualified Data.Text
 import qualified Domain.Types
 import qualified Domain.Types.Merchant
 import Kernel.Beam.Functions
@@ -19,7 +20,7 @@ import Storage.Queries.Transformers.Merchant
 
 instance FromTType' Beam.Merchant Domain.Types.Merchant.Merchant where
   fromTType' (Beam.MerchantT {..}) = do
-    cloudBaseUrl' <- Kernel.Prelude.maybe (return Kernel.Prelude.Nothing) (Kernel.Prelude.fmap Kernel.Prelude.Just . Kernel.Prelude.parseBaseUrl) cloudBaseUrl
+    cloudBaseUrl' <- (Kernel.Prelude.pure . (Kernel.Prelude.>>= Kernel.Prelude.parseBaseUrl)) cloudBaseUrl
     driverOfferBaseUrl' <- Kernel.Prelude.parseBaseUrl driverOfferBaseUrl
     gatewayUrl' <- Kernel.Prelude.parseBaseUrl gatewayUrl
     registryUrl' <- Kernel.Prelude.parseBaseUrl registryUrl
@@ -34,7 +35,7 @@ instance FromTType' Beam.Merchant Domain.Types.Merchant.Merchant where
             bapUniqueKeyId = bapUniqueKeyId,
             cipherText = cipherText,
             cloudBaseUrl = cloudBaseUrl',
-            cloudType = cloudType,
+            cloudType = (Kernel.Prelude.>>= (Kernel.Prelude.readMaybe . Data.Text.unpack)) cloudType,
             country = country,
             createdAt = createdAt,
             defaultCity = city,
@@ -86,7 +87,7 @@ instance ToTType' Beam.Merchant Domain.Types.Merchant.Merchant where
         Beam.bapUniqueKeyId = bapUniqueKeyId,
         Beam.cipherText = cipherText,
         Beam.cloudBaseUrl = Kernel.Prelude.fmap Kernel.Prelude.showBaseUrl cloudBaseUrl,
-        Beam.cloudType = cloudType,
+        Beam.cloudType = (Kernel.Prelude.fmap Kernel.Prelude.show) cloudType,
         Beam.country = country,
         Beam.createdAt = createdAt,
         Beam.city = defaultCity,

--- a/Backend/app/rider-platform/rider-app/Main/src/API/UI.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/UI.hs
@@ -1,6 +1,7 @@
 module API.UI
   ( API,
     handler,
+    uiApiPrefix,
   )
 where
 
@@ -82,13 +83,21 @@ import qualified API.UI.Serviceability as Serviceability
 import qualified API.UI.Sos as Sos
 import qualified API.UI.Support as Support
 import qualified API.UI.Whatsapp as Whatsapp
+import qualified Data.Text as T
 import Environment
 import EulerHS.Prelude
+import GHC.TypeLits (symbolVal)
 import Kernel.Utils.Servant.Server (healthCheck)
 import Servant
 
+-- for multi-cloud proxy
+type UIAPIPrefix = "v2"
+
+uiApiPrefix :: Text
+uiApiPrefix = T.pack $ symbolVal (Proxy @UIAPIPrefix)
+
 type API =
-  "v2"
+  UIAPIPrefix
     :> ( Get '[JSON] Text
            :<|> Registration.API
            :<|> Profile.API

--- a/Backend/app/rider-platform/rider-app/Main/src/App.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/App.hs
@@ -46,6 +46,7 @@ import Kernel.Utils.Common
 import Kernel.Utils.Dhall (readDhallConfigDefault)
 import qualified Kernel.Utils.FlowLogging as L
 import Kernel.Utils.Servant.SignatureAuth
+import qualified Network.HTTP.Client.TLS as HttpTLS
 import Network.HTTP.Types (status408)
 import Network.Wai
 import Network.Wai.Handler.Warp
@@ -152,4 +153,5 @@ runRiderApp' appCfg = do
         logInfo ("Runtime created. Starting server at port " <> show (appCfg.port))
         pure flowRt'
     let timeoutMiddleware = UE.timeoutEvent flowRt appEnv (responseLBS status408 [] "") appCfg.incomingAPIResponseTimeout
-    runSettings settings $ timeoutMiddleware (App.run (App.EnvR flowRt' appEnv))
+    proxyManager <- HttpTLS.newTlsManager
+    runSettings settings $ timeoutMiddleware (App.run proxyManager (App.EnvR flowRt' appEnv))

--- a/Backend/app/rider-platform/rider-app/Main/src/App/CrossCloudProxy.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/App/CrossCloudProxy.hs
@@ -1,0 +1,49 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module App.CrossCloudProxy (crossCloudProxy) where
+
+import qualified API.UI as UI
+import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.Person as DP
+import Environment
+import Kernel.Prelude
+import qualified Kernel.Storage.Hedis as Redis
+import qualified Kernel.Storage.InMem as IM
+import Kernel.Types.Id
+import Kernel.Types.Version (CloudType (..))
+import qualified Network.HTTP.Client as Http
+import qualified Network.Wai as Wai
+import qualified Storage.CachedQueries.Merchant as CQM
+import qualified Storage.Queries.RegistrationToken as QRT
+import Tools.Auth (authTokenCacheKey, merchantIdFallback)
+import qualified "utils" Utils.Common.CrossCloudProxy as CCP
+
+crossCloudProxy :: Http.Manager -> Env -> Wai.Middleware
+crossCloudProxy manager env =
+  case env.appEnv.cloudType of
+    Just podCloud | podCloud /= UNAVAILABLE -> CCP.crossCloudProxyMiddleware env.flowRuntime env.appEnv podCloud [UI.uiApiPrefix] manager resolveOwner
+    _ -> identity
+
+resolveOwner :: Text -> Flow (Maybe (CloudType, BaseUrl))
+resolveOwner token = do
+  mbAuthCached :: Maybe (Id DP.Person, Id DM.Merchant) <- Redis.safeGet (authTokenCacheKey token)
+  mbMerchantId <- case mbAuthCached of
+    Just (_, merchantId) -> pure (Just merchantId)
+    Nothing -> fmap (merchantIdFallback . Id @DM.Merchant . (.merchantId)) <$> QRT.findByToken token
+  case mbMerchantId of
+    Nothing -> pure Nothing
+    Just merchantId -> IM.withInMemCache ["crossCloudProxy:merchantCloud", merchantId.getId] 60 $ do
+      mbMerchant :: Maybe DM.Merchant <- CQM.findById merchantId
+      pure $ mbMerchant >>= \merchant -> (,) <$> merchant.cloudType <*> merchant.cloudBaseUrl

--- a/Backend/app/rider-platform/rider-app/Main/src/App/Server.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/App/Server.hs
@@ -15,6 +15,7 @@
 module App.Server where
 
 import API
+import App.CrossCloudProxy (crossCloudProxy)
 -- import Beckn.Core (logBecknRequest)
 import Environment
 import EulerHS.Prelude
@@ -22,13 +23,15 @@ import Kernel.Tools.Metrics.Init
 import Kernel.Types.Flow
 import Kernel.Utils.App
 import qualified Kernel.Utils.Servant.Server as BU
+import qualified Network.HTTP.Client as Http
 import Servant
 import Tools.Auth
 
-run :: Env -> Application
-run = withModifiedEnv' riderAPI $ \modifiedEnv ->
+run :: Http.Manager -> Env -> Application
+run proxyManager = withModifiedEnv' riderAPI $ \modifiedEnv ->
   -- withLocalModifications modifiedEnv' riderAPI (\modifiedEnv ->
   BU.run riderAPI API.handler context modifiedEnv
+    & crossCloudProxy proxyManager modifiedEnv
     & logRequestAndResponse' modifiedEnv
     -- & logBecknRequest modifiedEnv
     & addServantInfo modifiedEnv.appEnv.version riderAPI

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/merchant.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/merchant.sql
@@ -88,3 +88,9 @@ ALTER TABLE atlas_driver_offer_bpp.merchant ADD COLUMN vat_number text ;
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.merchant ADD COLUMN business_id text ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.merchant ADD COLUMN cloud_type text ;
+ALTER TABLE atlas_driver_offer_bpp.merchant ADD COLUMN cloud_base_url text ;

--- a/Backend/dev/migrations-read-only/rider-app/merchant.sql
+++ b/Backend/dev/migrations-read-only/rider-app/merchant.sql
@@ -113,3 +113,14 @@ ALTER TABLE atlas_app.merchant ADD COLUMN signing_private_key text ;
 
 ------- SQL updates -------
 
+
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.merchant ADD COLUMN cloud_type text ;
+ALTER TABLE atlas_app.merchant ADD COLUMN cloud_base_url text ;
+
+
+------- SQL updates -------
+

--- a/Backend/lib/utils/src/Utils/Common/CrossCloudProxy.hs
+++ b/Backend/lib/utils/src/Utils/Common/CrossCloudProxy.hs
@@ -11,8 +11,6 @@
 
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
--- requestBody record update is the only way to re-attach a buffered body on this wai version
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Utils.Common.CrossCloudProxy
   ( crossCloudProxyMiddleware,
@@ -20,11 +18,11 @@ module Utils.Common.CrossCloudProxy
   )
 where
 
+import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
-import Data.IORef (atomicModifyIORef, newIORef)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Encoding.Error as TE
 import qualified EulerHS.Runtime as R
 import Kernel.Prelude hiding (app)
 import Kernel.Types.Flow
@@ -34,14 +32,15 @@ import Kernel.Utils.IOLogging (HasLog)
 import qualified Network.HTTP.Client as Http
 import qualified Network.HTTP.Types as HttpTypes
 import qualified Network.Wai as Wai
-import Network.Wai.Internal (Request (..))
 
 forwardedFromHeader :: HttpTypes.HeaderName
 forwardedFromHeader = "x-ny-forwarded-from"
 
 -- | Forwards a UI request landing on the wrong cloud to the cloud owning the
--- person's merchant operating city and relays the response back. Fail-open:
--- any error in resolution or forwarding serves the request locally.
+-- person's merchant operating city and relays the response back verbatim.
+-- Resolution errors fail open (request served locally); once the forward is
+-- attempted there is no local fallback — a failed forward responds 502, so a
+-- non-idempotent operation can never execute on both clouds.
 crossCloudProxyMiddleware ::
   HasLog env =>
   R.FlowRuntime ->
@@ -59,7 +58,7 @@ crossCloudProxyMiddleware flowRt appEnv podCloud uiPrefixes manager resolveOwner
       Nothing -> app req respond
       Just token -> do
         mbTarget <-
-          runFlowR flowRt appEnv (withLogTag "CrossCloudProxy" $ resolveOwner (TE.decodeUtf8 token))
+          runFlowR flowRt appEnv (withLogTag "CrossCloudProxy" $ resolveOwner (TE.decodeUtf8With TE.lenientDecode token))
             `catch` \(SomeException _) -> pure Nothing
         case mbTarget of
           Just (ownerCloud, ownerUrl)
@@ -99,17 +98,18 @@ crossCloudProxyMiddleware flowRt appEnv podCloud uiPrefixes manager resolveOwner
           respond $ Wai.responseLBS (Http.responseStatus resp) respHeaders (Http.responseBody resp)
         Left err -> do
           runFlowR flowRt appEnv . withLogTag "CrossCloudProxy" $
-            logError $ "Forward to " <> show ownerCloud <> " failed, serving locally: " <> show err
-          replayableReq <- replayBody reqBody
-          app replayableReq respond
-
-    replayBody reqBody = do
-      chunksRef <- newIORef (BSL.toChunks reqBody)
-      let readChunk =
-            atomicModifyIORef chunksRef $ \case
-              [] -> ([], BS.empty)
-              (c : cs) -> (cs, c)
-      pure req {requestBody = readChunk}
+            logError $ "Forward to " <> show ownerCloud <> " failed, responding 502: " <> show err
+          respond $
+            Wai.responseLBS
+              HttpTypes.badGateway502
+              [("content-type", "application/json")]
+              ( A.encode $
+                  A.object
+                    [ "errorCode" A..= ("CROSS_CLOUD_FORWARD_FAILURE" :: Text),
+                      "errorMessage" A..= (show err :: Text),
+                      "errorPayload" A..= A.Null
+                    ]
+              )
 
     requestHopHeaders :: [HttpTypes.HeaderName]
     requestHopHeaders = ["host", "content-length", "transfer-encoding", "connection", "accept-encoding", "expect"]

--- a/Backend/lib/utils/src/Utils/Common/CrossCloudProxy.hs
+++ b/Backend/lib/utils/src/Utils/Common/CrossCloudProxy.hs
@@ -1,0 +1,118 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+-- requestBody record update is the only way to re-attach a buffered body on this wai version
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+module Utils.Common.CrossCloudProxy
+  ( crossCloudProxyMiddleware,
+    forwardedFromHeader,
+  )
+where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.IORef (atomicModifyIORef, newIORef)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified EulerHS.Runtime as R
+import Kernel.Prelude hiding (app)
+import Kernel.Types.Flow
+import Kernel.Types.Version (CloudType (..))
+import Kernel.Utils.Common
+import Kernel.Utils.IOLogging (HasLog)
+import qualified Network.HTTP.Client as Http
+import qualified Network.HTTP.Types as HttpTypes
+import qualified Network.Wai as Wai
+import Network.Wai.Internal (Request (..))
+
+forwardedFromHeader :: HttpTypes.HeaderName
+forwardedFromHeader = "x-ny-forwarded-from"
+
+-- | Forwards a UI request landing on the wrong cloud to the cloud owning the
+-- person's merchant operating city and relays the response back. Fail-open:
+-- any error in resolution or forwarding serves the request locally.
+crossCloudProxyMiddleware ::
+  HasLog env =>
+  R.FlowRuntime ->
+  env ->
+  CloudType ->
+  [Text] ->
+  Http.Manager ->
+  (Text -> FlowR env (Maybe (CloudType, BaseUrl))) ->
+  Wai.Middleware
+crossCloudProxyMiddleware flowRt appEnv podCloud uiPrefixes manager resolveOwner app req respond
+  | not isEligiblePath = app req respond
+  | isJust (lookup forwardedFromHeader (Wai.requestHeaders req)) = app req respond
+  | otherwise =
+    case lookup "token" (Wai.requestHeaders req) of
+      Nothing -> app req respond
+      Just token -> do
+        mbTarget <-
+          runFlowR flowRt appEnv (withLogTag "CrossCloudProxy" $ resolveOwner (TE.decodeUtf8 token))
+            `catch` \(SomeException _) -> pure Nothing
+        case mbTarget of
+          Just (ownerCloud, ownerUrl)
+            | ownerCloud /= podCloud && ownerCloud /= UNAVAILABLE ->
+              forward ownerCloud ownerUrl
+          _ -> app req respond
+  where
+    isEligiblePath = case Wai.pathInfo req of
+      (firstSegment : _) -> firstSegment `elem` uiPrefixes
+      [] -> False
+
+    forward ownerCloud ownerUrl = do
+      reqBody <- Wai.strictRequestBody req
+      result <- try @_ @SomeException $ do
+        baseReq <- Http.parseRequest (T.unpack $ showBaseUrl ownerUrl)
+        let basePath = if "/" `BS.isSuffixOf` Http.path baseReq then BS.init (Http.path baseReq) else Http.path baseReq
+            fullPath = basePath <> Wai.rawPathInfo req
+            fwdHeaders =
+              filter (\(h, _) -> h `notElem` requestHopHeaders) (Wai.requestHeaders req)
+                <> [(forwardedFromHeader, TE.encodeUtf8 . T.pack $ show podCloud)]
+            fwdReq =
+              baseReq
+                { Http.method = Wai.requestMethod req,
+                  Http.path = fullPath,
+                  Http.queryString = Wai.rawQueryString req,
+                  Http.requestHeaders = fwdHeaders,
+                  Http.requestBody = Http.RequestBodyLBS reqBody,
+                  Http.redirectCount = 0,
+                  Http.responseTimeout = Http.responseTimeoutMicro 60000000
+                }
+        Http.httpLbs fwdReq manager
+      case result of
+        Right resp -> do
+          runFlowR flowRt appEnv . withLogTag "CrossCloudProxy" $
+            logInfo $ "Forwarded " <> TE.decodeUtf8 (Wai.rawPathInfo req) <> " from " <> show podCloud <> " to " <> show ownerCloud <> ", status: " <> show (HttpTypes.statusCode $ Http.responseStatus resp)
+          let respHeaders = filter (\(h, _) -> h `notElem` responseHopHeaders) (Http.responseHeaders resp)
+          respond $ Wai.responseLBS (Http.responseStatus resp) respHeaders (Http.responseBody resp)
+        Left err -> do
+          runFlowR flowRt appEnv . withLogTag "CrossCloudProxy" $
+            logError $ "Forward to " <> show ownerCloud <> " failed, serving locally: " <> show err
+          replayableReq <- replayBody reqBody
+          app replayableReq respond
+
+    replayBody reqBody = do
+      chunksRef <- newIORef (BSL.toChunks reqBody)
+      let readChunk =
+            atomicModifyIORef chunksRef $ \case
+              [] -> ([], BS.empty)
+              (c : cs) -> (cs, c)
+      pure req {requestBody = readChunk}
+
+    requestHopHeaders :: [HttpTypes.HeaderName]
+    requestHopHeaders = ["host", "content-length", "transfer-encoding", "connection", "accept-encoding", "expect"]
+
+    responseHopHeaders :: [HttpTypes.HeaderName]
+    responseHopHeaders = ["content-length", "transfer-encoding", "connection", "content-encoding"]

--- a/Backend/lib/utils/utils.cabal
+++ b/Backend/lib/utils/utils.cabal
@@ -34,6 +34,7 @@ library
       Utils.Common.Cac.UtilsConstants
       Utils.Common.Cac.UtilsTH
       Utils.Common.CacUtils
+      Utils.Common.CrossCloudProxy
       Utils.Common.Events
       Utils.Common.JWT.Config
       Utils.Common.JWT.TransitClaim


### PR DESCRIPTION
## Problem

We run two clouds (AWS + GCP) serving the same BAP/BPP apps. Clients are routed cloud-side, but a request can still land on the wrong cloud (stale client config, missed update). Today such requests are served by whichever cloud they hit; we want them served by the cloud that owns the request's merchant.

## Solution

A WAI middleware (backend safety net) that transparently forwards wrong-cloud **UI API** requests to the owning cloud and relays the response. The client sees nothing.

### Routing data
Two new **nullable** columns on `merchant` (both schemas):
- `cloud_type` — which cloud this merchant is enabled on (`AWS`/`GCP`)
- `cloud_base_url` — public base URL of this app's deployment on that cloud (path prefix included, e.g. `https://api.<domain>/dobpp`)

`NULL` (current state of every row) ⇒ middleware does nothing. **The feature is fully inert until a merchant row is explicitly configured.**

### Per-request flow (UI routes only)
1. Gate: first path segment ∈ UI tree (`v2` rider / `ui` driver, derived from the new `UIAPIPrefix` type-level constant — same symbol that mounts the Servant UI tree, so route and check cannot drift) **and** `token` header present **and** no `x-ny-forwarded-from` header.
2. Token → merchantId via the existing auth-token Redis cache (read-only; same key + `merchantIdFallback` auth uses). KV regtoken fallback on miss. No auth-cache format change.
3. merchantId → (cloudType, cloudBaseUrl) via in-mem cache (`withInMemCache`, 60s TTL; merchant-cardinality only, no token data in memory).
4. `fromMaybe podCloud merchant.cloudType /= podCloud` (pod cloud from existing `CLOUD_TYPE` env) and URL present ⇒ forward whole request (method/path/query/headers/body), relay response verbatim. Hop-by-hop headers stripped both ways; shared TLS manager; 60s timeout; no redirects.

### Safety properties
- **Loop guard**: forwarded requests carry `x-ny-forwarded-from`; a request bearing it is never forwarded again — config disagreement between clouds costs at most one extra hop, never a loop.
- **Fail-open**: any Redis/KV/config/forward error ⇒ serve locally (buffered body replayed to the local app).
- **Scope**: Beckn, internal, dashboard, webhook, partner-org traffic is structurally untouchable (path gate + token-header gate).
- **Advisory only**: real auth still runs on whichever cloud serves; stale routing data cannot create an auth bypass.
- Middleware sits inside `logRequestAndResponse'`, so forwarded requests appear in request logs; each forward also emits a log line (path, fromCloud → toCloud, status).

## Rollout
1. Deploy (no-op: columns NULL everywhere).
2. Set `cloud_type` + `cloud_base_url` for a merchant; DB replication propagates to both clouds.
3. Monitor `Forwarded` log lines — sustained volume for a merchant means client-side routing config should be fixed.

## Testing
- `cabal build rider-app dynamic-offer-driver-app` green (with `-Werror`).
- Verified against prod edge behavior: public URLs carry path prefixes (`/dobpp`, `/pilot/app`) which the gateway strips before pods — incoming prefix check matches what pods see; outgoing URL join handles prefixed `cloud_base_url` (and trailing slashes).
- Local end-to-end test (forward to a mock second cloud, loop-guard, fail-open) in progress; will update this PR with results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-cloud proxying: automatic routing of UI requests to the merchant’s configured cloud when applicable
  * Merchants can set optional cloud type and base URL for multi-cloud deployments

* **Infrastructure**
  * Server now uses a TLS-enabled HTTP manager for secure inter-cloud calls
  * Database migrations and storage updated to persist merchant cloud configuration settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->