### PR TITLE
Backend/fixes: finnishId and TaxiDriverPermit in default documents

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding.hs
@@ -83,7 +83,7 @@ import qualified Tools.Whatsapp as Whatsapp
 import Utils.Common.Cac.KeyNameConstants
 
 defaultDriverDocumentTypes :: [DVC.DocumentType]
-defaultDriverDocumentTypes = [DVC.DriverLicense, DVC.AadhaarCard, DVC.PanCard, DVC.Permissions, DVC.ProfilePhoto, DVC.UploadProfile, DVC.SocialSecurityNumber, DVC.BackgroundVerification, DVC.GSTCertificate, DVC.BusinessLicense, DVC.LocalResidenceProof, DVC.PoliceVerificationCertificate, DVC.DrivingSchoolCertificate, DVC.TrainingForm, DVC.DriverInspectionHub]
+defaultDriverDocumentTypes = [DVC.DriverLicense, DVC.AadhaarCard, DVC.PanCard, DVC.Permissions, DVC.ProfilePhoto, DVC.UploadProfile, DVC.SocialSecurityNumber, DVC.BackgroundVerification, DVC.GSTCertificate, DVC.BusinessLicense, DVC.LocalResidenceProof, DVC.PoliceVerificationCertificate, DVC.DrivingSchoolCertificate, DVC.TrainingForm, DVC.DriverInspectionHub,DVC.FinnishIDResidencePermit,DVC.TaxiDriverPermit]
 
 defaultFleetDocumentTypes :: [DVC.DocumentType]
 defaultFleetDocumentTypes = [DVC.AadhaarCard, DVC.PanCard, DVC.GSTCertificate, DVC.BusinessLicense, DVC.UDYAMCertificate, DVC.TANCertificate, DVC.LDCCertificate]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
@@ -724,6 +724,14 @@ getDriverDocTypes merchantOpCityId allDocVerificationConfigs possibleVehicleCate
                     && isDriverSideDoc config
               )
               driverConfigs
+      let allDriverConfigs =
+            filter
+              ( \config ->
+                  config.vehicleCategory `elem` possibleVehicleCategories
+                    && isDriverSideDoc config
+              )
+              driverConfigs
+          allDriverDocumentTypes = nub (allDriverConfigs <&> (.documentType))
       if onlyMandatoryDocs == Just True
         then do
           let driverDocumentTypes = nub (mandatoryDriverConfigs <&> (.documentType))
@@ -735,7 +743,7 @@ getDriverDocTypes merchantOpCityId allDocVerificationConfigs possibleVehicleCate
               <> "; driverDocumentTypes: "
               <> show driverDocumentTypes
           pure driverDocumentTypes
-        else pure SDO.defaultDriverDocumentTypes
+        else pure $ if null allDriverDocumentTypes then SDO.defaultDriverDocumentTypes else allDriverDocumentTypes
 
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drivers can now use Finnish ID Residence Permit and Taxi Driver Permit as valid identity documents during onboarding.
* **Improvements**
  * Onboarding now better determines which optional document types to show (filtered by vehicle category) and falls back to the default list when no options are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->