### PR TITLE
feat: consume with redisPrefix for DIRECT IBC

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/RiderLocation.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/RiderLocation.hs
@@ -46,6 +46,7 @@ postIdentifyNearByBus (_mbPersonId, merchantId) req = do
       integratedBPPConfig <- SIBC.findIntegratedBPPConfig Nothing merchantOperatingCityId Enums.BUS DIBC.MULTIMODAL
       let redisPrefix = case integratedBPPConfig.providerConfig of
             DIBC.ONDC config -> config.redisPrefix
+            DIBC.DIRECT config -> config.redisPrefix
             _ -> Nothing
       let nearbyBusSearchRadius :: Double = fromMaybe 0.1 riderConfig.nearbyBusSearchRadius
           maxNearbyBuses :: Int = fromMaybe 5 riderConfig.maxNearbyBuses

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/IntegratedBPPConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/IntegratedBPPConfig.hs
@@ -30,7 +30,8 @@ instance Show EBIXConfig where
 
 data DIRECTConfig = DIRECTConfig
   { cipherKey :: Base64,
-    qrRefreshTtl :: Maybe Seconds
+    qrRefreshTtl :: Maybe Seconds,
+    redisPrefix :: Maybe Text
   }
   deriving stock (Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFSJourneyUtils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFSJourneyUtils.hs
@@ -280,6 +280,7 @@ getVehicleMetadata :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, H
 getVehicleMetadata vehicleNumbers integratedBppConfig = do
   let redisPrefix = case integratedBppConfig.providerConfig of
         DIBC.ONDC config -> config.redisPrefix
+        DIBC.DIRECT config -> config.redisPrefix
         _ -> Nothing
   cloudType <- asks (.cloudType)
   case cloudType of
@@ -299,6 +300,7 @@ getNearbyBusesFRFS userPos' riderConfig integratedBppConfig = do
   let nearbyBusSearchRadius :: Double = fromMaybe 0.5 riderConfig.nearbyBusSearchRadius
   let redisPrefix = case integratedBppConfig.providerConfig of
         DIBC.ONDC config -> config.redisPrefix
+        DIBC.DIRECT config -> config.redisPrefix
         _ -> Nothing
   cloudType <- asks (.cloudType)
   busesBS <-

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MultiModalBus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MultiModalBus.hs
@@ -128,6 +128,7 @@ getRoutesBuses :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r, HasField "ltsHedis
 getRoutesBuses routeId integratedBppConfig = do
   let redisPrefix = case integratedBppConfig.providerConfig of
         DIBC.ONDC config -> config.redisPrefix
+        DIBC.DIRECT config -> config.redisPrefix
         _ -> Nothing
   let key = mkRouteKey redisPrefix routeId
   cloudType <- asks (.cloudType)
@@ -144,6 +145,7 @@ hasLiveVehicles :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r, HasField "ltsHedi
 hasLiveVehicles routeId integratedBppConfig = do
   let redisPrefix = case integratedBppConfig.providerConfig of
         DIBC.ONDC config -> config.redisPrefix
+        DIBC.DIRECT config -> config.redisPrefix
         _ -> Nothing
   let key = mkRouteKey redisPrefix routeId
   cloudType <- asks (.cloudType)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for DIRECT provider configuration with Redis prefix customization, enabling improved bus availability caching and search performance for direct provider integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->