### PR TITLE
backend/fix: fix SchedulerFlow DailyPassStatusUpdate integration test

### DIFF
--- a/Backend/dev/integration-tests/collections/SchedulerFlow/01-DailyPassStatusUpdate.json
+++ b/Backend/dev/integration-tests/collections/SchedulerFlow/01-DailyPassStatusUpdate.json
@@ -295,7 +295,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"service\": \"juspay\", \"extract\": \"path.2\", \"match\": \"/orders\", \"value\": \"{{_pass_a_order_id}}\", \"response\": {\"status\": \"CHARGED\", \"amount\": 1.0}}"
+          "raw": "{\"service\": \"juspay\", \"extract\": \"path.2\", \"match\": \"/orders\", \"value\": \"{{_pass_a_order_short_id}}\", \"response\": {\"status\": \"CHARGED\", \"amount\": 1.0}}"
         },
         "url": {
           "raw": "{{mockServerUrl}}/mock/override",
@@ -332,13 +332,13 @@
           }
         ],
         "url": {
-          "raw": "{{baseUrl_app}}/payment/{{_pass_a_order_id}}/status",
+          "raw": "{{baseUrl_app}}/payment/{{_pass_a_order_short_id}}/status",
           "host": [
             "{{baseUrl_app}}"
           ],
           "path": [
             "payment",
-            "{{_pass_a_order_id}}",
+            "{{_pass_a_order_short_id}}",
             "status"
           ]
         }
@@ -430,7 +430,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"service\": \"juspay\", \"extract\": \"path.2\", \"match\": \"/orders\", \"value\": \"{{_pass_b_order_id}}\", \"response\": {\"status\": \"CHARGED\", \"amount\": 1.0}}"
+          "raw": "{\"service\": \"juspay\", \"extract\": \"path.2\", \"match\": \"/orders\", \"value\": \"{{_pass_b_order_short_id}}\", \"response\": {\"status\": \"CHARGED\", \"amount\": 1.0}}"
         },
         "url": {
           "raw": "{{mockServerUrl}}/mock/override",
@@ -467,13 +467,13 @@
           }
         ],
         "url": {
-          "raw": "{{baseUrl_app}}/payment/{{_pass_b_order_id}}/status",
+          "raw": "{{baseUrl_app}}/payment/{{_pass_b_order_short_id}}/status",
           "host": [
             "{{baseUrl_app}}"
           ],
           "path": [
             "payment",
-            "{{_pass_b_order_id}}",
+            "{{_pass_b_order_short_id}}",
             "status"
           ]
         }

--- a/Backend/dev/integration-tests/collections/SchedulerFlow/Local/Local_NY_Bangalore.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/SchedulerFlow/Local/Local_NY_Bangalore.postman_environment.json
@@ -63,6 +63,12 @@
       "enabled": true
     },
     {
+      "key": "mock_fcm_url",
+      "value": "http://localhost:${MOCK_SERVER_PORT:8080}/fcm",
+      "type": "default",
+      "enabled": true
+    },
+    {
       "key": "contextApiUrl",
       "value": "http://localhost:${TEST_CONTEXT_API_PORT:7082}",
       "type": "default",

--- a/Backend/dev/integration-tests/collections/SchedulerFlow/Local/Local_NY_Chennai.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/SchedulerFlow/Local/Local_NY_Chennai.postman_environment.json
@@ -70,7 +70,7 @@
     },
     {
       "key": "mock_fcm_url",
-      "value": "http://localhost:${MOCK_FCM_PORT:4545}",
+      "value": "http://localhost:${MOCK_SERVER_PORT:8080}/fcm",
       "type": "default",
       "enabled": true
     },

--- a/Backend/dev/integration-tests/collections/SchedulerFlow/README.md
+++ b/Backend/dev/integration-tests/collections/SchedulerFlow/README.md
@@ -19,7 +19,7 @@ The full dev stack must be running (`, run-mobility-stack-dev`), including:
 - rider-app-scheduler (8058) — executes jobs
 - rider-producer (9990) — moves jobs from Redis sorted set to stream
 - mock-server (8080) — provides `/mock/sql/select` + `/mock/sql/update` for DB seeding/verification
-- mock-fcm (4545) — captures push notifications; required by Chennai-only tests that assert on FCM delivery (e.g. `02-PassExpiryReminderMaster.json`, polled via `GET {{mock_fcm_url}}/read/<token>`; `mock_fcm_url` is only set in `Local_NY_Chennai.postman_environment.json`)
+- mock-server (8080) — unified mock server; FCM notifications are mounted at `/fcm` (e.g. `02-PassExpiryReminderMaster.json` polls `GET {{mock_fcm_url}}/read/<token>`; `mock_fcm_url = http://localhost:8080/fcm` in all Local env files)
 - PostgreSQL (5434), Redis cluster (30001-30006)
 
 ## Adding a new scheduler job test

--- a/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
+++ b/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
@@ -103,6 +103,11 @@ const URL_VAR_TO_SERVICE: Record<string, { service: ParsedStep['service']; strip
   'baseUrl_dashboard': { service: 'rider' },
   'mockServerUrl': { service: 'mock-server' },
   'mock_server_url': { service: 'juspay-payment' },
+  // FRFS fleet-operator conductor flow — baseUrl_driver points to driver BPP (port 8016)
+  'baseUrl_driver': { service: 'driver' },
+  // contextApiUrl points at the test-context-api itself (PROXY_BASE), so service='internal'
+  // strips the base and leaves only the path (e.g. /api/db/update) for direct forwarding.
+  'contextApiUrl': { service: 'internal' },
 };
 
 // ── Parser ──

--- a/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
+++ b/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
@@ -108,6 +108,9 @@ const URL_VAR_TO_SERVICE: Record<string, { service: ParsedStep['service']; strip
   // contextApiUrl points at the test-context-api itself (PROXY_BASE), so service='internal'
   // strips the base and leaves only the path (e.g. /api/db/update) for direct forwarding.
   'contextApiUrl': { service: 'internal' },
+  // mock_fcm_url = http://localhost:8080/fcm (FCM is mounted at /fcm on the unified mock server).
+  // Routing via mock-server strips the base and prepends the /fcm path correctly.
+  'mock_fcm_url': { service: 'mock-server' },
 };
 
 // ── Parser ──


### PR DESCRIPTION
Title: backend/fix: fix SchedulerFlow DailyPassStatusUpdate integration test

Body:
Summary

- Fix 1 â PAYMENT_ORDER_NOT_FOUND: Mock override and payment status URL steps were using {{_pass_a/b_order_id}} (Juspay's random internal ID, e.g. mock-short-3f9a2c) instead of {{_pass_a/b_order_short_id}} (the actual PaymentOrder.shortId stored in DB, e.g. P-ABC123). Both "Check Pass A/B Payment" and "Mock Juspay CHARGED" steps are fixed.
- Fix 2 â Invalid URL in "Override Pass B to PreBooked": contextApiUrl was missing from URL_VAR_TO_SERVICE in postman-parser.ts. Without it, the full resolved URL got prepended with PROXY_BASE, producing http://localhost:7082http://localhost:7082/api/db/update â invalid. Adding contextApiUrl â internal makes the parser strip the base, leaving only /api/db/update as the path.

Test plan

- [ ] Run SchedulerFlow / DailyPassStatusUpdate in NY_Bangalore and NY_Chennai
- [ ] Verify "Check Pass A/B Payment" return 200
- [ ] Verify "Override Pass B to PreBooked" returns 200
- [ ] Confirm full suite passes end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Scheduler test collection updated to use short order IDs for payment status checks and mock payment overrides.
* **Chores**
  * Postman URL routing extended to cover driver, internal, and mock-server endpoints; FCM now routed through the unified mock server.
* **Documentation**
  * Scheduler test README updated to reflect unified mock-server FCM location and environment variable usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->