### PR TITLE
Backend/fix/scheduler flow daily pass status update

### DIFF
--- a/Backend/dev/integration-tests/collections/SchedulerFlow/01-DailyPassStatusUpdate.json
+++ b/Backend/dev/integration-tests/collections/SchedulerFlow/01-DailyPassStatusUpdate.json
@@ -295,7 +295,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"service\": \"juspay\", \"extract\": \"path.2\", \"match\": \"/orders\", \"value\": \"{{_pass_a_order_id}}\", \"response\": {\"status\": \"CHARGED\", \"amount\": 1.0}}"
+          "raw": "{\"service\": \"juspay\", \"extract\": \"path.2\", \"match\": \"/orders\", \"value\": \"{{_pass_a_order_short_id}}\", \"response\": {\"status\": \"CHARGED\", \"amount\": 1.0}}"
         },
         "url": {
           "raw": "{{mockServerUrl}}/mock/override",
@@ -332,13 +332,13 @@
           }
         ],
         "url": {
-          "raw": "{{baseUrl_app}}/payment/{{_pass_a_order_id}}/status",
+          "raw": "{{baseUrl_app}}/payment/{{_pass_a_order_short_id}}/status",
           "host": [
             "{{baseUrl_app}}"
           ],
           "path": [
             "payment",
-            "{{_pass_a_order_id}}",
+            "{{_pass_a_order_short_id}}",
             "status"
           ]
         }
@@ -430,7 +430,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\"service\": \"juspay\", \"extract\": \"path.2\", \"match\": \"/orders\", \"value\": \"{{_pass_b_order_id}}\", \"response\": {\"status\": \"CHARGED\", \"amount\": 1.0}}"
+          "raw": "{\"service\": \"juspay\", \"extract\": \"path.2\", \"match\": \"/orders\", \"value\": \"{{_pass_b_order_short_id}}\", \"response\": {\"status\": \"CHARGED\", \"amount\": 1.0}}"
         },
         "url": {
           "raw": "{{mockServerUrl}}/mock/override",
@@ -467,13 +467,13 @@
           }
         ],
         "url": {
-          "raw": "{{baseUrl_app}}/payment/{{_pass_b_order_id}}/status",
+          "raw": "{{baseUrl_app}}/payment/{{_pass_b_order_short_id}}/status",
           "host": [
             "{{baseUrl_app}}"
           ],
           "path": [
             "payment",
-            "{{_pass_b_order_id}}",
+            "{{_pass_b_order_short_id}}",
             "status"
           ]
         }

--- a/Backend/dev/integration-tests/collections/SchedulerFlow/Local/Local_NY_Bangalore.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/SchedulerFlow/Local/Local_NY_Bangalore.postman_environment.json
@@ -63,6 +63,12 @@
       "enabled": true
     },
     {
+      "key": "mock_fcm_url",
+      "value": "http://localhost:${MOCK_SERVER_PORT:8080}/fcm",
+      "type": "default",
+      "enabled": true
+    },
+    {
       "key": "contextApiUrl",
       "value": "http://localhost:${TEST_CONTEXT_API_PORT:7082}",
       "type": "default",

--- a/Backend/dev/integration-tests/collections/SchedulerFlow/Local/Local_NY_Chennai.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/SchedulerFlow/Local/Local_NY_Chennai.postman_environment.json
@@ -70,7 +70,7 @@
     },
     {
       "key": "mock_fcm_url",
-      "value": "http://localhost:${MOCK_FCM_PORT:4545}",
+      "value": "http://localhost:${MOCK_SERVER_PORT:8080}/fcm",
       "type": "default",
       "enabled": true
     },

--- a/Backend/dev/integration-tests/collections/SchedulerFlow/README.md
+++ b/Backend/dev/integration-tests/collections/SchedulerFlow/README.md
@@ -19,7 +19,7 @@ The full dev stack must be running (`, run-mobility-stack-dev`), including:
 - rider-app-scheduler (8058) — executes jobs
 - rider-producer (9990) — moves jobs from Redis sorted set to stream
 - mock-server (8080) — provides `/mock/sql/select` + `/mock/sql/update` for DB seeding/verification
-- mock-fcm (4545) — captures push notifications; required by Chennai-only tests that assert on FCM delivery (e.g. `02-PassExpiryReminderMaster.json`, polled via `GET {{mock_fcm_url}}/read/<token>`; `mock_fcm_url` is only set in `Local_NY_Chennai.postman_environment.json`)
+- mock-server (8080) — unified mock server; FCM notifications are mounted at `/fcm` (e.g. `02-PassExpiryReminderMaster.json` polls `GET {{mock_fcm_url}}/read/<token>`; `mock_fcm_url = http://localhost:8080/fcm` in all Local env files)
 - PostgreSQL (5434), Redis cluster (30001-30006)
 
 ## Adding a new scheduler job test

--- a/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
+++ b/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
@@ -133,6 +133,11 @@ const URL_VAR_TO_SERVICE: Record<string, { service: ParsedStep['service']; strip
   'baseUrl_dashboard': { service: 'rider' },
   'mockServerUrl': { service: 'mock-server' },
   'mock_server_url': { service: 'juspay-payment' },
+  // FRFS fleet-operator conductor flow — baseUrl_driver points to driver BPP (port 8016)
+  'baseUrl_driver': { service: 'driver' },
+  // contextApiUrl points at the test-context-api itself (PROXY_BASE), so service='internal'
+  // strips the base and leaves only the path (e.g. /api/db/update) for direct forwarding.
+  'contextApiUrl': { service: 'internal' },
 };
 
 // ── Parser ──

--- a/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
+++ b/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
@@ -133,8 +133,6 @@ const URL_VAR_TO_SERVICE: Record<string, { service: ParsedStep['service']; strip
   'baseUrl_dashboard': { service: 'rider' },
   'mockServerUrl': { service: 'mock-server' },
   'mock_server_url': { service: 'juspay-payment' },
-  // FRFS fleet-operator conductor flow — baseUrl_driver points to driver BPP (port 8016)
-  'baseUrl_driver': { service: 'driver' },
   // contextApiUrl points at the test-context-api itself (PROXY_BASE), so service='internal'
   // strips the base and leaves only the path (e.g. /api/db/update) for direct forwarding.
   'contextApiUrl': { service: 'internal' },

--- a/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
+++ b/Backend/dev/test-tool/dashboard/src/services/postman-parser.ts
@@ -138,6 +138,9 @@ const URL_VAR_TO_SERVICE: Record<string, { service: ParsedStep['service']; strip
   // contextApiUrl points at the test-context-api itself (PROXY_BASE), so service='internal'
   // strips the base and leaves only the path (e.g. /api/db/update) for direct forwarding.
   'contextApiUrl': { service: 'internal' },
+  // mock_fcm_url = http://localhost:8080/fcm (FCM is mounted at /fcm on the unified mock server).
+  // Routing via mock-server strips the base and prepends the /fcm path correctly.
+  'mock_fcm_url': { service: 'mock-server' },
 };
 
 // ── Parser ──


### PR DESCRIPTION
backend/fix: SchedulerFlow integration test fixes (DailyPassStatusUpdate + PassExpiryReminderMaster)

Description:
## Summary

- **Suite 1 — DailyPassStatusUpdate**: Fixed PAYMENT_ORDER_NOT_FOUND error — steps were using `order_id` but the flow stores `order_short_id`
- **Suite 2 — PassExpiryReminderMaster**: Fixed FCM polling failures — `mock_fcm_url` was pointing to the removed Haskell mock-fcm on port 4545; updated Chennai + Bangalore env files to use unified mock server at `http://localhost:8080/fcm`; added `mock_fcm_url` to `URL_VAR_TO_SERVICE` in postman-parser.ts

## Root Cause (Suite 2)
The standalone mock-fcm-exe (port 4545) was replaced by the unified Python mock server (port 8080/fcm), but env files were never updated. Backend wrote FCM to port 8080, test polled port 4545 → always empty.

## Test plan
- [ ] Run SchedulerFlow/01-DailyPassStatusUpdate with Local NY Chennai/Bangalore
- [ ] Run SchedulerFlow/02-PassExpiryReminderMaster with Local NY Chennai/Bangalore — FCM poll finds notification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test configurations for payment order ID handling and Firebase Cloud Messaging mock service endpoints.

* **Chores**
  * Standardized mock server configuration across local environments to use unified port settings.
  * Updated test documentation and service mapping configurations for mock server dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->