### PR TITLE
backend/fix: missing ride_duration_fare param in bap fare breakup

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/OnUpdate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/OnUpdate.hs
@@ -126,6 +126,7 @@ mkRideCompletedQuote ride fareParams = do
                      Just (show Enums.CONGESTION_CHARGE),
                      Just (show Enums.WAITING_OR_PICKUP_CHARGES),
                      Just (show Enums.EXTRA_TIME_FARE),
+                     Just (show Enums.RIDE_DURATION_FARE),
                      Just (show Enums.CANCELLATION_CHARGES),
                      Just (show Enums.PET_CHARGES),
                      Just (show Enums.BUSINESS_DISCOUNT),

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Invoice.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Invoice.hs
@@ -43,6 +43,7 @@ getInvoice (mbPersonId, merchantId) from to = do
                   ("EXTRA_TIME_FARE", "Extra Time Fare"),
                   ("FIXED_GOVERNMENT_RATE", "Fixed Government Fare"),
                   ("NIGHT_SHIFT_CHARGE", "Night Shift Charge"),
+                  ("RIDE_DURATION_FARE", "Ride duration Fare"),
                   ("PLATFORM_FEE", "Platform Fee"),
                   ("CGST", "CGST"),
                   ("SGST", "SGST"),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
