### PR TITLE
Backend/enhc : added city name in servicability api

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Serviceability.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Serviceability.hs
@@ -66,6 +66,7 @@ data PTRestrictedHours = PTRestrictedHours
 data ServiceabilityRes = ServiceabilityRes
   { serviceable :: Bool,
     city :: Maybe Context.City,
+    cityName :: Maybe Text,
     currentCity :: Maybe Context.City,
     specialLocation :: Maybe QSpecialLocation.SpecialLocationFull,
     geoJson :: Maybe Text,
@@ -97,6 +98,8 @@ checkServiceability settingAccessor (personId, merchantId) location shouldUpdate
   case mbNearestOpAndCurrentCity of
     Just (NearestOperatingAndCurrentCity {nearestOperatingCity, currentCity}) -> do
       let city = Just nearestOperatingCity.city
+          (Context.City cityNameText) = nearestOperatingCity.city
+          cityName = Just cityNameText
       specialLocationBody <- QSpecialLocation.findSpecialLocationByLatLongFull location
       let filteredSpecialLocationBody = QSpecialLocation.filterGates specialLocationBody isOrigin
       let mbEnforceFlag = filteredSpecialLocationBody >>= (.enforceTollRoute)
@@ -136,6 +139,7 @@ checkServiceability settingAccessor (personId, merchantId) location shouldUpdate
       return
         ServiceabilityRes
           { city = Nothing,
+            cityName = Nothing,
             currentCity = Nothing,
             serviceable = False,
             specialLocation = Nothing,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service availability responses now display the applicable city name, providing clarity on which city's coverage is being assessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->