### PR TITLE
restricting new purchased pass creation with different device

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -205,7 +205,6 @@ purchasePassWithPayment isDashboard person pass merchantId personId mbStartDay m
         Just DPass.FullSaving -> (Just DPurchasedPass.FullSaving, Nothing)
         Just (DPass.FixedSaving amount) -> (Just DPurchasedPass.FixedSaving, Just amount)
         Just (DPass.PercentageSaving percentage) -> (Just DPurchasedPass.PercentageSaving, Just percentage)
-
   mbSamePassDevice <- QPurchasedPass.findPassByPersonIdAndPassTypeIdAndDeviceId personId merchantId pass.passTypeId deviceId
   -- If there is no pass for the same device, try to find an existing Pending pass to reuse across devices and set it as mbSamePass
   mbSamePass <-
@@ -220,6 +219,19 @@ purchasePassWithPayment isDashboard person pass merchantId personId mbStartDay m
             logInfo $ "Reusing existing purchased pass " <> pendingPass.id.getId <> " and updated deviceId to " <> deviceId
             return $ Just pendingPass
           Nothing -> return Nothing
+
+  -- restricting user from buying new pass in switched device before swtiching..
+  unless isDashboard $ do
+    otherTypePasses <- QPurchasedPass.findAllByPersonIdAndPassTypeIdAndStatus personId merchantId pass.passTypeId [DPurchasedPass.Active, DPurchasedPass.PreBooked]
+    let isOtherActivePass p = maybe True (\samePass -> p.id /= samePass.id) mbSamePass
+    whenJust (listToMaybe (filter isOtherActivePass otherTypePasses)) $ \otherPass -> do
+      passes <- CQPass.findAllByPassTypeIdAndEnabled pass.passTypeId True
+      let maxSwitchCount = case listToMaybe passes >>= (.passConfig) of
+            Just pc -> pc.maxSwitchCount
+            Nothing -> 1
+      if otherPass.deviceSwitchCount < maxSwitchCount
+        then throwError (InvalidRequest "You already have an active or pre-booked pass of this type on another device. Please switch it to this device instead of buying a new pass")
+        else throwError (InvalidRequest "You already have an active or pre-booked pass of this type on another device and the device switch limit has been reached")
 
   passType <- CQPassType.findById pass.passTypeId
   let initialStatus = if pass.amount == 0 then DPurchasedPass.Active else DPurchasedPass.Pending


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent purchasing the same pass type on multiple devices without completing required device switching limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->