### PR TITLE
backend/fix: clamp FRFS cancellation charges to [0, baseFare]

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Common.hs
@@ -335,10 +335,24 @@ calculateCancellationCharges merchantOpCityId vehicleCategory baseFare departure
   case mbMatchingTier of
     Nothing -> return (0, baseFare) -- no config → full refund
     Just tier -> do
-      let charges = case tier.cancellationChargeType of
+      let rawCharges = case tier.cancellationChargeType of
             DFRFSCancellationConfig.PERCENTAGE -> baseFare * tier.cancellationChargeValue / 100
             DFRFSCancellationConfig.FLAT -> tier.cancellationChargeValue
-          refund = max 0 (baseFare - charges)
+          charges = min baseFare (max 0 rawCharges)
+          refund = baseFare - charges
+      when (rawCharges /= charges) $
+        logError $
+          "FRFSCancellationConfig misconfigured for tier " <> tier.id.getId
+            <> " (type="
+            <> show tier.cancellationChargeType
+            <> ", value="
+            <> show tier.cancellationChargeValue
+            <> ", baseFare="
+            <> show baseFare
+            <> "): rawCharges="
+            <> show rawCharges
+            <> " clamped to "
+            <> show charges
       return (charges, refund)
   where
     matchesTier mins tier =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cancellation charge calculation to ensure computed charges remain within valid boundaries.
  * Implemented additional validation and error logging for edge cases where charge computations require adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->