### PR TITLE
backend/fix: store GeoJSON in geometry geom_geo_json on city create

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/src/Dashboard/Common/Merchant.hs
+++ b/Backend/app/dashboard/CommonAPIs/src/Dashboard/Common/Merchant.hs
@@ -675,6 +675,7 @@ newtype CreateMerchantOperatingCityRes = CreateMerchantOperatingCityRes
 
 data CreateMerchantOperatingCityReqT = CreateMerchantOperatingCityReqT
   { geom :: Text,
+    geomGeoJson :: Text,
     city :: Context.City,
     state :: Context.IndianState,
     country :: Context.Country,

--- a/Backend/app/dashboard/provider-dashboard/src/Domain/Action/ProviderPlatform/Management/Merchant.hs
+++ b/Backend/app/dashboard/provider-dashboard/src/Domain/Action/ProviderPlatform/Management/Merchant.hs
@@ -95,6 +95,7 @@ import qualified Kernel.Types.MerchantOperatingCity as KMOC
 import Kernel.Utils.Common
 import Kernel.Utils.Geometry (getGeomFromKML)
 import Kernel.Utils.Validation (runRequestValidation)
+import qualified Lib.GateInfo.Geometry as GGeom
 import Lib.Types.SpecialLocation as SL
 import qualified Lib.Yudhishthira.Tools.DebugLog as DebugLog
 import qualified SharedLogic.Transaction as T
@@ -468,6 +469,7 @@ processMerchantCreateRequest merchantShortId opCity apiTokenInfo canCreateMercha
   -- update entry in dashboard
   baseMerchant <- SQM.findByShortId merchantShortId >>= fromMaybeM (InvalidRequest $ "Merchant not found with shortId " <> show merchantShortId)
   geom <- getGeomFromKML req.file >>= fromMaybeM (InvalidRequest "Cannot convert KML to Geom.")
+  geomGeoJson <- GGeom.getGeoJsonFromKML req.file >>= fromMaybeM (InvalidRequest "Cannot convert KML to GeoJSON.")
   now <- getCurrentTime
   whenJust cityStdCode $ \stdCode -> do
     let (City.City cityText) = req.city
@@ -489,7 +491,7 @@ processMerchantCreateRequest merchantShortId opCity apiTokenInfo canCreateMercha
   whenJust cityStdCode $ \stdCode -> do
     id <- generateGUID
     KQMOC.createIfNotExist $ KMOC.MerchantOperatingCity {id = Id id, city = show req.city, stdCode = Just stdCode}
-  T.withTransactionStoring transaction $ Client.callManagementAPI checkedMerchantId opCity (.merchantDSL.postMerchantConfigOperatingCityCreate) Common.CreateMerchantOperatingCityReqT {geom = T.pack geom, ..}
+  T.withTransactionStoring transaction $ Client.callManagementAPI checkedMerchantId opCity (.merchantDSL.postMerchantConfigOperatingCityCreate) Common.CreateMerchantOperatingCityReqT {geom = T.pack geom, geomGeoJson = geomGeoJson, ..}
   where
     buildMerchant now merchantD baseMerchant =
       DM.Merchant

--- a/Backend/app/dashboard/rider-dashboard/src/Domain/Action/RiderPlatform/Management/Merchant.hs
+++ b/Backend/app/dashboard/rider-dashboard/src/Domain/Action/RiderPlatform/Management/Merchant.hs
@@ -61,6 +61,7 @@ import qualified Kernel.Types.MerchantOperatingCity as KMOC
 import Kernel.Utils.Common
 import Kernel.Utils.Geometry (getGeomFromKML)
 import Kernel.Utils.Validation (runRequestValidation)
+import qualified Lib.GateInfo.Geometry as GGeom
 import qualified Lib.Types.SpecialLocation as SL
 import qualified Lib.Yudhishthira.Tools.DebugLog as DebugLog
 import qualified SharedLogic.Transaction as T
@@ -236,6 +237,7 @@ processMerchantCreateRequest merchantShortId opCity apiTokenInfo canCreateMercha
   -- update entry in dashboard
   baseMerchant <- SQM.findByShortId merchantShortId >>= fromMaybeM (InvalidRequest $ "Merchant not found with shortId " <> show merchantShortId)
   geom <- getGeomFromKML req.file >>= fromMaybeM (InvalidRequest "Cannot convert KML to Geom")
+  geomGeoJson <- GGeom.getGeoJsonFromKML req.file >>= fromMaybeM (InvalidRequest "Cannot convert KML to GeoJSON")
   now <- getCurrentTime
   whenJust cityStdCode $ \stdCode -> do
     let (City.City cityText) = req.city
@@ -257,7 +259,7 @@ processMerchantCreateRequest merchantShortId opCity apiTokenInfo canCreateMercha
   whenJust cityStdCode $ \stdCode -> do
     id <- generateGUID
     KQMOC.createIfNotExist $ KMOC.MerchantOperatingCity {id = Id id, city = show req.city, stdCode = Just stdCode}
-  T.withTransactionStoring transaction $ Client.callManagementAPI checkedMerchantId opCity (.merchantDSL.postMerchantConfigOperatingCityCreate) Common.CreateMerchantOperatingCityReqT {geom = T.pack geom, ..}
+  T.withTransactionStoring transaction $ Client.callManagementAPI checkedMerchantId opCity (.merchantDSL.postMerchantConfigOperatingCityCreate) Common.CreateMerchantOperatingCityReqT {geom = T.pack geom, geomGeoJson = geomGeoJson, ..}
   where
     buildMerchant now merchantD baseMerchant =
       DM.Merchant

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
@@ -3693,7 +3693,7 @@ postMerchantConfigOperatingCityCreate merchantShortId city req = do
             region = show req.city,
             state = req.state,
             city = req.city,
-            geom = Just req.geom
+            geom = Just req.geomGeoJson
           }
 
     buildMerchant merchantId merchantData currentTime DM.Merchant {city = _city, ..} =

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Merchant.hs
@@ -803,7 +803,7 @@ postMerchantConfigOperatingCityCreate merchantShortId city req = do
             region = show req.city,
             state = req.state,
             city = req.city,
-            geom = Just req.geom
+            geom = Just req.geomGeoJson
           }
 
     buildMerchant merchantId merchantData currentTime DM.Merchant {..} = do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Uploaded KML files are now automatically converted to GeoJSON and captured during merchant operating city creation.
  * GeoJSON is stored alongside existing geometry and is now consumed by dashboard and app interfaces for display and mapping.
  * Enhances mapping compatibility, data consistency, and reliability across provider, rider, and dashboard management flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->