### PR TITLE
added gzip decompress support

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnConfirm.hs
@@ -47,7 +47,8 @@ handler = onConfirm
 
 onConfirm :: Maybe (Id DM.Merchant) -> SignatureAuthResult -> ByteString -> FlowHandler Spec.AckResponse
 onConfirm mbMerchantId authResult reqBS = withFlowHandlerAPI $ do
-  req <- case decodeOnConfirmReq reqBS of
+  reqBS' <- Utils.decompressGzipBody reqBS
+  req <- case decodeOnConfirmReq reqBS' of
     Right r -> pure r
     Left err -> throwError (InvalidRequest (toText err))
   mbForwarded <- Forwarding.maybeForwardOnConfirm mbMerchantId authResult req reqBS

--- a/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnInit.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnInit.hs
@@ -45,7 +45,8 @@ handler = onInit
 
 onInit :: Maybe (Id DM.Merchant) -> SignatureAuthResult -> ByteString -> FlowHandler Spec.AckResponse
 onInit mbMerchantId authResult reqBS = withFlowHandlerAPI $ do
-  req <- case decodeOnInitReq reqBS of
+  reqBS' <- Utils.decompressGzipBody reqBS
+  req <- case decodeOnInitReq reqBS' of
     Right r -> pure r
     Left err -> throwError (InvalidRequest (toText err))
   mbForwarded <- Forwarding.maybeForwardOnInit mbMerchantId authResult req reqBS

--- a/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnSearch.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnSearch.hs
@@ -44,7 +44,8 @@ handler = onSearch
 
 onSearch :: Maybe (Id DM.Merchant) -> SignatureAuthResult -> ByteString -> FlowHandler Spec.AckResponse
 onSearch mbMerchantId authResult reqBS = withFlowHandlerAPI $ do
-  req <- case decodeOnSearchReq reqBS of
+  reqBS' <- Utils.decompressGzipBody reqBS
+  req <- case decodeOnSearchReq reqBS' of
     Right r -> pure r
     Left err -> throwError (InvalidRequest (toText err))
   mbForwarded <- Forwarding.maybeForwardOnSearch mbMerchantId authResult req reqBS

--- a/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnSelect.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnSelect.hs
@@ -41,7 +41,8 @@ handler = onSelect
 
 onSelect :: SignatureAuthResult -> ByteString -> FlowHandler Spec.AckResponse
 onSelect _ reqBS = withFlowHandlerAPI $ do
-  req <- case decodeOnSelectReq reqBS of
+  reqBS' <- Utils.decompressGzipBody reqBS
+  req <- case decodeOnSelectReq reqBS' of
     Right r -> pure r
     Left err -> throwError (InvalidRequest (toText err))
   transaction_id <- req.onSelectReqContext.contextTransactionId & fromMaybeM (InvalidRequest "TransactionId not found")

--- a/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/Beckn/FRFS/OnStatus.hs
@@ -40,7 +40,8 @@ handler = onStatus
 
 onStatus :: Maybe (Id DM.Merchant) -> SignatureAuthResult -> ByteString -> FlowHandler Spec.AckResponse
 onStatus mbMerchantId authResult reqBS = withFlowHandlerAPI $ do
-  req <- case decodeOnStatusReq reqBS of
+  reqBS' <- Utils.decompressGzipBody reqBS
+  req <- case decodeOnStatusReq reqBS' of
     Right r -> pure r
     Left err -> throwError (InvalidRequest (toText err))
   mbForwarded <- Forwarding.maybeForwardOnStatus mbMerchantId authResult req reqBS

--- a/Backend/lib/beckn-spec/beckn-spec.cabal
+++ b/Backend/lib/beckn-spec/beckn-spec.cabal
@@ -368,6 +368,7 @@ library
     , wai
     , wai-middleware-prometheus
     , warp
+    , zlib
   default-language: Haskell2010
   if flag(Local)
     ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
@@ -503,4 +504,5 @@ test-suite beckn-spec-test
     , wai
     , wai-middleware-prometheus
     , warp
+    , zlib
   default-language: Haskell2010

--- a/Backend/lib/beckn-spec/package.yaml
+++ b/Backend/lib/beckn-spec/package.yaml
@@ -108,6 +108,7 @@ dependencies:
   - unordered-containers
   - utf8-string
   - geojson
+  - zlib
   - safe-money
   - dhall
   - tasty

--- a/Backend/lib/beckn-spec/src/BecknV2/FRFS/Utils.hs
+++ b/Backend/lib/beckn-spec/src/BecknV2/FRFS/Utils.hs
@@ -3,8 +3,11 @@ module BecknV2.FRFS.Utils where
 import qualified BecknV2.FRFS.Enums as Spec
 import qualified BecknV2.FRFS.Types as Spec hiding (Domain)
 import qualified BecknV2.OnDemand.Enums as BecknSpec
+import qualified Codec.Compression.GZip as GZip
+import qualified Control.Exception as E
 import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time
@@ -14,6 +17,7 @@ import Kernel.Prelude
 import Kernel.Types.Common
 import qualified Kernel.Types.Error as Error
 import Kernel.Utils.Error
+import Kernel.Utils.Logging (logWarning)
 
 tfDescriptor :: Maybe Text -> Maybe Text -> Maybe Spec.Descriptor
 tfDescriptor mCode mName = do
@@ -210,3 +214,15 @@ unescapeQuotedJSON bs =
             Right txt -> Just (TE.encodeUtf8 txt)
             Left _ -> Nothing
     else Nothing
+
+
+decompressGzipBody :: (MonadFlow m) => ByteString -> m ByteString
+decompressGzipBody bs
+  | BS.take 2 bs == BS.pack [0x1f, 0x8b] = do
+    eRes <- liftIO $ E.try @E.SomeException (E.evaluate (BL.toStrict (GZip.decompress (BL.fromStrict bs))))
+    case eRes of
+      Right out -> pure out
+      Left err -> do
+        logWarning $ "FRFS callback: gzip decompression failed (" <> show err <> "); using raw body"
+        pure bs
+  | otherwise = pure bs


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FRFS endpoints now detect and accept gzip-compressed request bodies, improving compatibility with clients that send compressed payloads
  * Requests are automatically decompressed when needed while preserving behavior for uncompressed inputs
  * Decompression failures are handled gracefully (logged) and fall back to the original payload to maintain robustness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->