### PR TITLE
backend/refactor: move offer banner styling to opaque metadata passthrough

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Offer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Offer.hs
@@ -8,7 +8,6 @@ where
 
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as A
-import qualified Data.Aeson.KeyMap as AKM
 import qualified Data.Text as T
 import Data.Time (utctDay)
 import qualified Domain.SharedLogic.RideDiscount as RD
@@ -64,7 +63,7 @@ data CumulativeOfferRespI = CumulativeOfferRespI
     offerSponsoredBy :: [Text],
     offerIds :: [Text],
     offerListResp :: Payment.OfferListResp,
-    offerStyle :: Maybe OfferThemeConfig
+    metadata :: Maybe A.Value
   }
   deriving (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -273,16 +272,7 @@ mkCumulativeOfferResp merchantOperatingCityId offerListRes legInfos mbFareCtx = 
     else do
       logInfo $ "Running cumulative offer logic with " <> show (length logics) <> " rules"
       result <- LYDL.runLogicsWithDebugLog LYDL.Rider (cast merchantOperatingCityId) LYT.CUMULATIVE_OFFER_POLICY Nothing logics (CumulativeOfferReq offerListRes legInfos)
-      -- offerStyle is cosmetic: if the policy emits a malformed value, drop it
-      -- instead of failing the whole banner parse below.
-      sanitizedResult <- case result.result of
-        A.Object obj
-          | Just styleVal <- AKM.lookup "offerStyle" obj,
-            A.Error styleErr <- (A.fromJSON styleVal :: A.Result (Maybe OfferThemeConfig)) -> do
-            logWarning $ "Failed to parse offerStyle from cumulative offer logic, ignoring it: " <> T.pack styleErr
-            pure $ A.Object (AKM.delete "offerStyle" obj)
-        _ -> pure result.result
-      case A.fromJSON sanitizedResult :: A.Result CumulativeOfferRespI of
+      case A.fromJSON result.result :: A.Result CumulativeOfferRespI of
         A.Success logicResult -> do
           logInfo $ "Cumulative offer logic result: " <> show logicResult
           resp <- mkCumulativeOfferRespFromI logicResult

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/OfferTypes.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/OfferTypes.hs
@@ -1,5 +1,6 @@
 module SharedLogic.OfferTypes where
 
+import qualified Data.Aeson
 import Kernel.Prelude
 import Kernel.Types.Common (HighPrecMoney)
 
@@ -9,27 +10,10 @@ data CumulativeOfferResp = CumulativeOfferResp
     offerSponsoredBy :: [Text],
     offerIds :: [Text],
     offerListResp :: [OfferRespAPIEntity],
-    offerStyle :: Maybe OfferThemeConfig
-  }
-  deriving (Generic, Show)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
-
--- Client falls back to its hardcoded styling for any absent field, so every
--- field stays Maybe and absence must never be treated as an error.
-data OfferStyle = OfferStyle
-  { backgroundColor :: Maybe Text,
-    borderColor :: Maybe Text,
-    iconColor :: Maybe Text,
-    titleColor :: Maybe Text,
-    subtitleColor :: Maybe Text,
-    iconUrl :: Maybe Text
-  }
-  deriving (Generic, Show)
-  deriving anyclass (ToJSON, FromJSON, ToSchema)
-
-data OfferThemeConfig = OfferThemeConfig
-  { light :: Maybe OfferStyle,
-    dark :: Maybe OfferStyle
+    -- Opaque client-owned payload (e.g. offerStyle theming): the backend
+    -- passes it through from CUMULATIVE_OFFER_POLICY untouched so new client
+    -- fields never need a backend change.
+    metadata :: Maybe Data.Aeson.Value
   }
   deriving (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)


### PR DESCRIPTION
## Summary

Follow-up to #15190. Replaces the typed `offerStyle :: Maybe OfferThemeConfig` on `CumulativeOfferResp` with an opaque `metadata :: Maybe Data.Aeson.Value` passthrough, per review feedback: the backend never consumes these values, and a typed schema in the middle meant every new client style field (e.g. borderRadius) required a backend change + release. With `metadata`, new fields are policy JSON + frontend hotpush only.

- `OfferStyle` / `OfferThemeConfig` types deleted; `metadata` flows from the `CUMULATIVE_OFFER_POLICY` output through `CumulativeOfferRespI` → `CumulativeOfferResp` untouched (RecordWildCards).
- The offerStyle sanitize block is deleted too — with an opaque `Value`, any JSON is valid; the client owns lenient decoding with per-field fallbacks (paired FE PR: nammayatri/ny-react-native#6901).
- Contract-safe to swap now: nothing consumes the typed `offerStyle` yet (FE PR unmerged; old apps ignore unknown keys).

Policy payload shape (client contract, documented in the FE):
```json
"metadata": { "offerStyle": { "light": { "backgroundColor": "#FDD440", "...": "..." }, "dark": { "...": "..." } } }
```

## Test plan

- [ ] CI build (change is mechanical: field type swap, single construction site via RecordWildCards, no other references — verified by grep)
- [ ] Verify policy with `metadata` block via NammaTag appDynamicLogic verify on UAT
- [ ] FE pairing: banner renders styled with new contract, default-styled when `metadata` absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved offer metadata handling to support enhanced flexibility in styling and customization. Clients now have greater independence in managing offer presentation configurations without requiring backend changes. System integration has been streamlined while maintaining full compatibility with existing offer management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->