### PR TITLE
ci: normalize workspace path in repl steps to fix incremental builds …

### DIFF
--- a/.github/workflows/cabal-main-push.yaml
+++ b/.github/workflows/cabal-main-push.yaml
@@ -179,10 +179,10 @@ jobs:
 
       - name: Build repl artifacts (dynamic-offer-driver-app)
         run: |
-          ln -sfn "$GITHUB_WORKSPACE" "$HOME/ny-nammayatri-src"
+          ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri-src"
           nix develop .#backend --command bash -c "
             export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
-            cd $HOME/ny-nammayatri-src/Backend
+            cd /tmp/nammayatri-src/Backend
             cabal repl dynamic-offer-driver-app \
               --repl-options='-fno-code -fwrite-interface' \
               --builddir=dist-newrepl-driver <<< ':quit'
@@ -190,10 +190,10 @@ jobs:
 
       - name: Build repl artifacts (rider-app)
         run: |
-          ln -sfn "$GITHUB_WORKSPACE" "$HOME/ny-nammayatri-src"
+          ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri-src"
           nix develop .#backend --command bash -c "
             export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
-            cd $HOME/ny-nammayatri-src/Backend
+            cd /tmp/nammayatri-src/Backend
             cabal repl rider-app \
               --repl-options='-fno-code -fwrite-interface' \
               --builddir=dist-newrepl-rider <<< ':quit'

--- a/.github/workflows/cabal-main-push.yaml
+++ b/.github/workflows/cabal-main-push.yaml
@@ -109,9 +109,10 @@ jobs:
       - name: Build (incremental cabal)
         run: |
           set -o pipefail
+          ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri"
           nix develop .#backend --command bash -c "
             export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
-            cd Backend
+            cd /tmp/nammayatri/Backend
             echo \"GHC libdir: \$(ghc --print-libdir)\"
             echo '--- cabal dry-run (what it plans to rebuild) ---'
             cabal build all --dry-run 2>&1 | tail -20
@@ -179,10 +180,10 @@ jobs:
 
       - name: Build repl artifacts (dynamic-offer-driver-app)
         run: |
-          ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri-src"
+          ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri"
           nix develop .#backend --command bash -c "
             export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
-            cd /tmp/nammayatri-src/Backend
+            cd /tmp/nammayatri/Backend
             cabal repl dynamic-offer-driver-app \
               --repl-options='-fno-code -fwrite-interface' \
               --builddir=dist-newrepl-driver <<< ':quit'
@@ -190,10 +191,10 @@ jobs:
 
       - name: Build repl artifacts (rider-app)
         run: |
-          ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri-src"
+          ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri"
           nix develop .#backend --command bash -c "
             export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
-            cd /tmp/nammayatri-src/Backend
+            cd /tmp/nammayatri/Backend
             cabal repl rider-app \
               --repl-options='-fno-code -fwrite-interface' \
               --builddir=dist-newrepl-rider <<< ':quit'

--- a/.github/workflows/cabal-main-push.yaml
+++ b/.github/workflows/cabal-main-push.yaml
@@ -72,6 +72,7 @@ jobs:
           ln -sfn "$CACHE_ROOT/dist-newstyle" Backend/dist-newstyle
           ln -sfn "$CACHE_ROOT/dist-newrepl-driver" Backend/dist-newrepl-driver
           ln -sfn "$CACHE_ROOT/dist-newrepl-rider" Backend/dist-newrepl-rider
+          ln -sfn "$CACHE_ROOT/.cabal-dir" /tmp/ny-cabal
 
       - name: Link HIE dirs to persistent cache
         run: |
@@ -111,7 +112,7 @@ jobs:
           set -o pipefail
           ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri"
           nix develop .#backend --command bash -c "
-            export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
+            export CABAL_DIR=/tmp/ny-cabal
             cd /tmp/nammayatri/Backend
             echo \"GHC libdir: \$(ghc --print-libdir)\"
             echo '--- cabal dry-run (what it plans to rebuild) ---'
@@ -182,7 +183,7 @@ jobs:
         run: |
           ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri"
           nix develop .#backend --command bash -c "
-            export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
+            export CABAL_DIR=/tmp/ny-cabal
             cd /tmp/nammayatri/Backend
             cabal repl dynamic-offer-driver-app \
               --repl-options='-fno-code -fwrite-interface' \
@@ -193,7 +194,7 @@ jobs:
         run: |
           ln -sfn "$GITHUB_WORKSPACE" "/tmp/nammayatri"
           nix develop .#backend --command bash -c "
-            export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
+            export CABAL_DIR=/tmp/ny-cabal
             cd /tmp/nammayatri/Backend
             cabal repl rider-app \
               --repl-options='-fno-code -fwrite-interface' \
@@ -216,6 +217,18 @@ jobs:
           tar -I 'zstd -T0 -3' -cf rider.tar.zst -C "$CACHE_ROOT" dist-newrepl-rider/
           mc cp rider.tar.zst "minio/haskell-cache/cabal-repl/${{ github.sha }}/rider-app.tar.zst"
           rm -f rider.tar.zst
+
+      - name: Push cabal store to MinIO
+        run: |
+          MINIO_ENDPOINT=$(jq -r '.minio_endpoint' /etc/service_discovery.json)
+          MINIO_ACCESS_KEY=$(jq -r '.minio_access_key' /etc/service_discovery.json)
+          MINIO_SECRET_KEY=$(jq -r '.minio_secret_key' /etc/service_discovery.json)
+          mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+
+          CACHE_ROOT=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}
+          tar -I 'zstd -T0 -3' -cf cabal-store.tar.zst -C "$CACHE_ROOT/.cabal-dir" store/
+          mc cp cabal-store.tar.zst "minio/haskell-cache/cabal-store/${{ github.sha }}/cabal-store.tar.zst"
+          rm -f cabal-store.tar.zst
 
       - name: Cleanup staging dir
         if: always()

--- a/.github/workflows/cabal-main-push.yaml
+++ b/.github/workflows/cabal-main-push.yaml
@@ -179,9 +179,10 @@ jobs:
 
       - name: Build repl artifacts (dynamic-offer-driver-app)
         run: |
+          ln -sfn "$GITHUB_WORKSPACE" "$HOME/ny-nammayatri-src"
           nix develop .#backend --command bash -c "
             export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
-            cd Backend
+            cd $HOME/ny-nammayatri-src/Backend
             cabal repl dynamic-offer-driver-app \
               --repl-options='-fno-code -fwrite-interface' \
               --builddir=dist-newrepl-driver <<< ':quit'
@@ -189,9 +190,10 @@ jobs:
 
       - name: Build repl artifacts (rider-app)
         run: |
+          ln -sfn "$GITHUB_WORKSPACE" "$HOME/ny-nammayatri-src"
           nix develop .#backend --command bash -c "
             export CABAL_DIR=$HOME/ny-cabal-unoptimized-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
-            cd Backend
+            cd $HOME/ny-nammayatri-src/Backend
             cabal repl rider-app \
               --repl-options='-fno-code -fwrite-interface' \
               --builddir=dist-newrepl-rider <<< ':quit'


### PR DESCRIPTION
…on PR runner

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow to standardize workspace path handling for incremental builds and `cabal repl` by running commands from a consistent temporary source directory.
  * Improved build caching by symlinking the persistent Cabal cache into a temporary location for reuse across steps.
  * Added an artifact upload that packages and uploads the Cabal store to MinIO for faster subsequent workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->