### PR TITLE
added udf1 parameter in createOrderReq

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Plan.hs
@@ -1204,7 +1204,8 @@ createPrepaidSubscriptionOrder serviceName driverId merchantId merchantOpCityId 
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = Nothing
           }
   paymentServiceName <- Payment.decidePaymentService subscriptionConfig.paymentServiceName driver.clientSdkVersion driver.merchantOperatingCityId
   (createOrderCall, pseudoClientId) <- Payment.createOrder merchantId merchantOpCityId paymentServiceName (Just driver.id.getId)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/StclMembership.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/StclMembership.hs
@@ -139,7 +139,8 @@ postSubmitApplication (mbDriverId, merchantId, merchantOperatingCityId) req = do
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = Nothing
           }
 
   -- PaymentServiceType for createOrderService (STCL)
@@ -330,7 +331,8 @@ postBuyAdditionalShares (mbDriverId, merchantId, merchantOperatingCityId) req = 
                   basket = Nothing,
                   paymentRules = Nothing,
                   autoRefundPostSuccess = Nothing,
-                  paymentFilter = Nothing
+                  paymentFilter = Nothing,
+                  udf1 = Nothing
                 }
         SharedLogic.Payment.createOrderV2 (driverId, merchantId, merchantOperatingCityId) resumeReq (Just paymentServiceType)
       Nothing -> do
@@ -379,7 +381,8 @@ postBuyAdditionalShares (mbDriverId, merchantId, merchantOperatingCityId) req = 
                   basket = Nothing,
                   paymentRules = Nothing,
                   autoRefundPostSuccess = Nothing,
-                  paymentFilter = Nothing
+                  paymentFilter = Nothing,
+                  udf1 = Nothing
                 }
 
         createOrderResp <- SharedLogic.Payment.createOrderV2 (driverId, merchantId, merchantOperatingCityId) createOrderReq (Just paymentServiceType)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs
@@ -169,7 +169,8 @@ createOrder (driverId, merchantId, opCity) serviceName (driverFees, driverFeesTo
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = Nothing
           }
   let commonMerchantId = cast @DM.Merchant @DPayment.Merchant merchantId
       commonPersonId = cast @DP.Person @DPayment.Person driver.id
@@ -493,7 +494,8 @@ createWalletTopupOrder (driverId, merchantId, mocId) amount mbExistingOrderId = 
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
             webhookUrl = Just nwAddress,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = Nothing
           }
   (createOrderCall, pseudoClientId) <- TPayment.createOrder merchantId mocId paymentServiceName (Just driver.id.getId)
   let commonMerchantId = cast @DM.Merchant @DPayment.Merchant merchantId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/BBPS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/BBPS.hs
@@ -88,6 +88,7 @@ postBbpsCreateOrder (mbPersonId, merchantId) req = do
   isSplitEnabled <- Payment.getIsSplitEnabled merchantId person.merchantOperatingCityId Nothing Payment.BBPS
   splitSettlementDetails <- Payment.mkSplitSettlementDetails isSplitEnabled bbpsAmount [] False False
   staticCustomerId <- SLUtils.getStaticCustomerId person req.mobileNumber
+  udf1 <- SLUtils.getPersonUdf1 person
   nwAddress <- asks (.nwAddress)
   let createOrderReq =
         Payment.CreateOrderReq
@@ -112,7 +113,8 @@ postBbpsCreateOrder (mbPersonId, merchantId) req = do
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = udf1
           }
   let commonMerchantId = Kernel.Types.Id.cast @Merchant.Merchant @DPayment.Merchant person.merchantId
       commonMerchantOperatingCityId = Kernel.Types.Id.cast @MerchantOperatingCity.MerchantOperatingCity @DPayment.MerchantOperatingCity person.merchantOperatingCityId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -381,6 +381,7 @@ buildCreateOrderResp paymentOrder personId merchantOperatingCityId person paymen
   splitSettlementDetails <- Payment.mkSplitSettlementDetails isSplitEnabled_ paymentOrder.amount [] isPercentageSplitEnabled isSingleMode
   staticCustomerId <- SLUtils.getStaticCustomerId person personPhone
   nwAddress <- asks (.nwAddress)
+  udf1 <- SLUtils.getPersonUdf1 person
   let createOrderReq =
         Payment.CreateOrderReq
           { orderId = paymentOrder.id.getId,
@@ -404,7 +405,8 @@ buildCreateOrderResp paymentOrder personId merchantOperatingCityId person paymen
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = udf1
           }
   mbPaymentOrderValidTill <- Payment.getPaymentOrderValidity (cast paymentOrder.merchantId) merchantOperatingCityId Nothing paymentServiceType
   isMetroTestTransaction <- asks (.isMetroTestTransaction)

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/ParkingBooking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/ParkingBooking.hs
@@ -75,6 +75,7 @@ postMultimodalParkingBook mbApiKey req = do
   customerPhone <- person.mobileNumber & fromMaybeM (PersonFieldNotPresent "mobileNumber") >>= decrypt
   staticCustomerId <- SLUtils.getStaticCustomerId person customerPhone
   nwAddress <- asks (.nwAddress)
+  udf1 <- SLUtils.getPersonUdf1 person
   let createOrderReq =
         Payment.CreateOrderReq
           { orderId = paymentOrderId,
@@ -98,7 +99,8 @@ postMultimodalParkingBook mbApiKey req = do
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = udf1
           }
 
   let commonMerchantId = Kernel.Types.Id.cast @Domain.Types.Merchant.Merchant @DPayment.Merchant person.merchantId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -325,8 +325,10 @@ purchasePassWithPayment isDashboard person pass merchantId personId mbStartDay m
         isSplitEnabled <- TPayment.getIsSplitEnabled merchantId person.merchantOperatingCityId Nothing TPayment.FRFSPassPurchase
         isPercentageSplitEnabled <- TPayment.getIsPercentageSplit merchantId person.merchantOperatingCityId Nothing TPayment.FRFSPassPurchase
         splitSettlementDetails <- TPayment.mkUnaggregatedSplitSettlementDetails isSplitEnabled pass.amount vendorSplitList isPercentageSplitEnabled False
+        basket <- TPayment.mkOfferBasket merchantId person.merchantOperatingCityId Nothing TPayment.FRFSPassPurchase pass.amount 1
         staticCustomerId <- SLUtils.getStaticCustomerId person customerPhone
         nwAddress <- asks (.nwAddress)
+        udf1 <- SLUtils.getPersonUdf1 person
         let createOrderReq =
               Payment.CreateOrderReq
                 { orderId = paymentOrderId.getId,
@@ -347,10 +349,11 @@ purchasePassWithPayment isDashboard person pass merchantId personId mbStartDay m
                   metadataGatewayReferenceId = Nothing,
                   webhookUrl = Just nwAddress,
                   splitSettlementDetails,
-                  basket = Nothing,
+                  basket = Just basket,
                   paymentRules = Nothing,
                   autoRefundPostSuccess = Nothing,
-                  paymentFilter = Nothing
+                  paymentFilter = Nothing,
+                  udf1 = udf1
                 }
 
         let commonMerchantId = Id.cast @DM.Merchant @DPayment.Merchant merchantId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
@@ -140,6 +140,7 @@ createOrder (personId, merchantId) rideId = do
   splitSettlementDetails <- Payment.mkSplitSettlementDetails isSplitEnabled totalFare.amount [] isPercentageSplitEnabled False
   staticCustomerId <- SLUtils.getStaticCustomerId person customerPhone
   nwAddress <- asks (.nwAddress)
+  udf1 <- SLUtils.getPersonUdf1 person
   let createOrderReq =
         Payment.CreateOrderReq
           { orderId = rideId.getId,
@@ -163,7 +164,8 @@ createOrder (personId, merchantId) rideId = do
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = udf1
           }
 
   let commonMerchantId = cast @DM.Merchant @DPayment.Merchant merchantId
@@ -203,6 +205,7 @@ createRideBookingPaymentOrder booking = do
       pure $ Just mapping.terminalId
     Nothing -> pure Nothing
 
+  udf1 <- SLUtils.getPersonUdf1 person
   let createOrderReq =
         Payment.CreateOrderReq
           { orderId = paymentOrderId,
@@ -226,7 +229,8 @@ createRideBookingPaymentOrder booking = do
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = udf1
           }
   let commonMerchantId = cast @DM.Merchant @DPayment.Merchant booking.merchantId
       commonPersonId = cast @DP.Person @DPayment.Person person.id
@@ -876,6 +880,7 @@ postWalletRecharge (personId, merchantId) req = do
                       }
                 }
           }
+  udf1 <- SLUtils.getPersonUdf1 person
   let createOrderReq =
         Payment.CreateOrderReq
           { orderId = paymentOrderId,
@@ -899,7 +904,8 @@ postWalletRecharge (personId, merchantId) req = do
             basket = Nothing,
             paymentRules = Just paymentRules,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = udf1
           }
 
   let commonMerchantId = cast @DM.Merchant @DPayment.Merchant merchantId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TicketService.hs
@@ -332,6 +332,7 @@ postTicketPlacesBook (mbPersonId, merchantId) placeId req = do
   splitSettlementDetails <- Payment.mkSplitSettlementDetails isSplitEnabled amount.amount (fromMaybe [] vendorSplits) False False
   staticCustomerId <- SLUtils.getStaticCustomerId person personPhone
   nwAddress <- asks (.nwAddress)
+  udf1 <- SLUtils.getPersonUdf1 person
   let createOrderReq =
         Payment.CreateOrderReq
           { orderId = ticketBooking.id.getId,
@@ -355,7 +356,8 @@ postTicketPlacesBook (mbPersonId, merchantId) placeId req = do
             basket = Nothing,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = udf1
           }
   let commonMerchantId = Kernel.Types.Id.cast @Merchant.Merchant @DPayment.Merchant merchantId
       commonPersonId = Kernel.Types.Id.cast @DP.Person @DPayment.Person personId_

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStatus.hs
@@ -379,6 +379,7 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
       splitSettlementDetails <- Payment.mkSplitSettlementDetails isSplitEnabled_ paymentOrder.amount [] isPercentageSplitEnabled isSingleMode
       staticCustomerId <- SLUtils.getStaticCustomerId person personPhone
       nwAddress <- asks (.nwAddress)
+      udf1 <- SLUtils.getPersonUdf1 person
       let createOrderReq =
             Payment.CreateOrderReq
               { orderId = paymentOrder.id.getId,
@@ -402,7 +403,8 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
                 basket = Nothing,
                 paymentRules = Nothing,
                 autoRefundPostSuccess = Nothing,
-                paymentFilter = Nothing
+                paymentFilter = Nothing,
+                udf1 = udf1
               }
       mbPaymentOrderValidTill <- Payment.getPaymentOrderValidity merchantId_ merchantOperatingCityId Nothing (getPaymentType isMultiModalBooking booking.vehicleType)
       isMetroTestTransaction <- asks (.isMetroTestTransaction)

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
@@ -865,6 +865,7 @@ createPaymentOrder bookings merchantOperatingCityId merchantId amount person pay
         _ -> False
   splitSettlementDetails <- Payment.mkUnaggregatedSplitSettlementDetails isSplitEnabled amount vendorSplitArr isPercentageSplitEnabled isSingleMode
   staticCustomerId <- SLUtils.getStaticCustomerId person personPhone
+  udf1 <- SLUtils.getPersonUdf1 person
   let createOrderReq =
         Payment.CreateOrderReq
           { orderId = orderId.getId,
@@ -888,7 +889,8 @@ createPaymentOrder bookings merchantOperatingCityId merchantId amount person pay
             basket = basket,
             paymentRules = Nothing,
             autoRefundPostSuccess = Nothing,
-            paymentFilter = Nothing
+            paymentFilter = Nothing,
+            udf1 = udf1
           }
   let mocId = merchantOperatingCityId
       commonMerchantId = Kernel.Types.Id.cast @Merchant.Merchant @DPayment.Merchant merchantId

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Payment.hs
@@ -877,6 +877,7 @@ makePaymentIntent merchantId merchantOpCityId paymentMode personId mbRideId mbEx
                 basket = Nothing,
                 paymentRules = Nothing,
                 webhookUrl = Just nwAddress,
+                udf1 = Nothing,
                 offerId = req.offerId <&> (.getId),
                 discountAmount = Just req.discountAmount,
                 payoutAmount = Nothing,

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Utils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Utils.hs
@@ -15,6 +15,7 @@
 module SharedLogic.Utils
   ( getStaticCustomerId,
     getPureStaticCustomerId,
+    getPersonUdf1,
   )
 where
 
@@ -22,11 +23,25 @@ import qualified Data.Time as Time
 import qualified Domain.Types.Person as DP
 import EulerHS.Prelude
 import Kernel.Storage.Esqueleto.Config
+import qualified Kernel.Types.Version as Version
 import Kernel.Utils.Common
 import qualified Kernel.Utils.UUID as UUID
 import Lib.ConfigPilot.Interface.Types (getConfig)
 import qualified Storage.CachedQueries.Merchant.RiderConfig as CQRC
 import Storage.ConfigPilot.Config.RiderConfig (RiderConfigDimensions (..))
+
+-- | udf1 (user defined field 1) sent in the Juspay session/createOrder request.
+-- Resolves to the customer's device id based on the client OS:
+--   iOS     -> person.deviceId
+--   Android -> person.androidId
+-- Returns Nothing when the device/OS is unknown.
+getPersonUdf1 :: Applicative m => DP.Person -> m (Maybe Text)
+getPersonUdf1 person =
+  pure $ case person.clientDevice of
+    Just device -> case device.deviceType of
+      Version.IOS -> person.deviceId
+      Version.ANDROID -> person.androidId
+    Nothing -> Nothing
 
 -- | Pure version of static customer ID generation.
 -- Generates the ID deterministically from phone and merchantId without any config lookups.

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Payment.hs
@@ -49,6 +49,7 @@ module Tools.Payment
     roundToTwoDecimalPlaces,
     fetchGatewayReferenceId,
     fetchOfferSKUConfig,
+    mkOfferBasket,
     extractSplitSettlementDetailsAmount,
     getPaymentOrderValidity,
     offerList,
@@ -844,6 +845,21 @@ fetchOfferSKUConfig merchantId merchantOperatingCityId mbPlaceId paymentServiceT
       RideHailing -> DMSC.PaymentService Payment.Juspay
       OnlineRideHailing -> DMSC.PaymentService Payment.Stripe
       STCL -> DMSC.MembershipPaymentService Payment.Juspay
+
+mkOfferBasket ::
+  (MonadTime m, MonadFlow m, CacheFlow m r, EsqDBFlow m r) =>
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
+  Maybe (Id TicketPlace) ->
+  PaymentServiceType ->
+  HighPrecMoney ->
+  Int ->
+  m [Payment.Basket]
+mkOfferBasket merchantId merchantOperatingCityId mbPlaceId paymentServiceType amount quantity = do
+  mbOfferSKUProductId <- fetchOfferSKUConfig merchantId merchantOperatingCityId mbPlaceId paymentServiceType
+  pure $ case mbOfferSKUProductId of
+    Just offerSKUProductId -> [Payment.Basket {Payment.id = offerSKUProductId, Payment.unitPrice = amount, Payment.quantity = quantity}]
+    Nothing -> [Payment.Basket {Payment.id = "no_basket", Payment.unitPrice = 0, Payment.quantity = quantity}]
 
 loadLoyaltyProgramMap ::
   (CacheFlow m r, EsqDBFlow m r, MonadFlow m) =>

--- a/Backend/lib/payment/src/Lib/Payment/Domain/Action.hs
+++ b/Backend/lib/payment/src/Lib/Payment/Domain/Action.hs
@@ -332,6 +332,7 @@ data CreatePaymentServiceReq = CreatePaymentServiceReq
     basket :: Maybe [Payment.Basket],
     paymentRules :: Maybe Payment.PaymentRules,
     webhookUrl :: Maybe BaseUrl,
+    udf1 :: Maybe Text,
     -- Offer-specific
     offerId :: Maybe Text,
     discountAmount :: Maybe HighPrecMoney,
@@ -506,7 +507,8 @@ createPaymentService merchantId mbMerchantOpCityId personId mbExistingOrderId mb
                 paymentRules = req.paymentRules,
                 autoRefundPostSuccess = Nothing,
                 webhookUrl = req.webhookUrl,
-                paymentFilter = Nothing
+                paymentFilter = Nothing,
+                udf1 = req.udf1
               }
       resp <- createPaymentCall paymentReq
       now <- getCurrentTime

--- a/Backend/lib/payment/src/Lib/Payment/Payout/Registration.hs
+++ b/Backend/lib/payment/src/Lib/Payment/Payout/Registration.hs
@@ -121,7 +121,8 @@ initiateRegistration merchantId mbMerchantOpCityId personId createOrderCall cust
                             enable = True
                           }
                       ]
-                  }
+                  },
+            udf1 = Nothing
           }
 
   logInfo $ "Initiating payout registration for person " <> personId.getId <> " | orderId: " <> orderId <> " | amount: " <> show registrationAmount

--- a/flake.lock
+++ b/flake.lock
@@ -4004,11 +4004,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1782111139,
-        "narHash": "sha256-hNzhv+/MYHSyQw9px7A8aqpoz9y12v5dDfEM7B0So3Q=",
+        "lastModified": 1782133899,
+        "narHash": "sha256-SZX32BN2GmVDnLHgT+21D6TV6+qe1+g4hiWQO8aZrUs=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "aa93850634a6e97415c5bd4c7369d0c3e0cfe86d",
+        "rev": "de762eec4f9f99e71bdeaa2484915bd76e730871",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment order and payment service creation now consistently supports an optional device identifier metadata field (`udf1`) across ride bookings, subscriptions, passes, parking reservations, ticket bookings, BBPS, and wallet top-ups—populated from the rider’s device when available, otherwise left unset.
* **Chores**
  * Minor formatting/indentation adjustment in the UPI payment filter options for the registration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->