### PR TITLE
backend/chore: bump json-logic-hs (bucket/arrayAt operators)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1777,11 +1777,11 @@
     "json-logic-hs": {
       "flake": false,
       "locked": {
-        "lastModified": 1780415936,
-        "narHash": "sha256-I5UaWmMOdMAjyDv1Tr1wIIi+SwF5FsnrJAoqVIddkgA=",
+        "lastModified": 1781617079,
+        "narHash": "sha256-NXtj+dgXi4KRO13Sa51HL7eWjWGFeNWZ0egDjuxvCH8=",
         "owner": "nammayatri",
         "repo": "json-logic-hs",
-        "rev": "90393a4a87dc252f4f245c3c215acd6e4c4abe90",
+        "rev": "dcdd6a603faf7f8b140728fb3511d7498d6ab03f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What
Bumps the `json-logic-hs` flake input `90393a4` → `dcdd6a6`. **Engine-only change — only `flake.lock` (3 lines).** No application code changes.

## Why
Brings in two new rules-engine operators, `bucket` and `arrayAt`, which let large grid/table configs (e.g. the congestion-charge dynamic logic) be written as compact lookup tables instead of deeply nested if/else chains (~96 KB → ~5 KB, with identical output). Used by upcoming control-center config changes.

Library changes (merged, with full equivalence proof + tests):
- `nammayatri/json-logic-hs#7` — the `bucket`/`arrayAt` operators + equivalence sweep.
- `nammayatri/json-logic-hs#8` — moves a shared `runLogics` helper into `JsonLogic.Runner` so it no longer collides with `Lib.Yudhishthira.Tools.Utils.runLogics` (that collision is why this is the `runner-fix` commit).

## Verified
`cabal build yudhishthira` against this input is green (`-Werror`; `Lib.Yudhishthira.Flow.Dashboard` and all 77 modules compile). narHash independently confirmed.

## ⚠️ Rollout ordering — engine first
This must deploy **before** any dynamic-logic config that uses `bucket`/`arrayAt` is saved in control-center. On an engine without these operators, an unknown operator key is treated as a literal (silently wrong, not an error). So: **deploy this → then swap the congestion config in control-center → verify → ramp.** The config swap is a separate control-center/DB action, not part of this PR.
