### PR TITLE
backend/fix: remove journey-leg dependency from FRFS payment-success …

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStatus.hs
@@ -191,7 +191,6 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
                   void $ markJourneyPaymentSuccess updatedBooking paymentOrder paymentBooking
                   buildFRFSTicketBookingStatusAPIRes updatedBooking quoteCategories (buildPaymentObject updatedBooking paymentBooking paymentBookingStatus)
                 else do
-                  (mbJourneyId, _) <- getAllJourneyFrfsBookings booking
                   integratedBppConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
                   let fareCachingAllowed = case integratedBppConfig.providerConfig of
                         DIBC.ONDC ondcCfg -> fromMaybe False ondcCfg.fareCachingAllowed
@@ -200,7 +199,7 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
                         if fareCachingAllowed
                           then fromMaybe False booking.ondcOnInitReceived
                           else True
-                  if paymentBookingStatus == FRFSTicketService.SUCCESS && (not isMultiModalBooking || isJust mbJourneyId) && shouldProceedWithConfirm
+                  if paymentBookingStatus == FRFSTicketService.SUCCESS && shouldProceedWithConfirm
                     then do
                       -- Add default TTL of 1 min or the value provided in the config
                       let updatedTTL = addUTCTime (maybe 60 intToNominalDiffTime bapConfig.confirmTTLSec) now


### PR DESCRIPTION
…confirm gate

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment confirmation flow by streamlining the booking confirmation process after successful payment. The system now more reliably proceeds with confirmation without unnecessary intermediate checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->