### PR TITLE
feat/provider: add encoded_polyline to frfs/route

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
@@ -19,6 +19,8 @@ import qualified Domain.Types.MerchantOperatingCity
 import qualified Domain.Types.Person
 import Environment (Flow)
 import EulerHS.Prelude hiding (id, unpack)
+import Kernel.External.Maps.Types (LatLong (..))
+import Kernel.External.MultiModal.Utils (decode)
 import Kernel.Prelude (listToMaybe)
 import qualified Kernel.Storage.Hedis as Hedis
 import qualified Kernel.Types.Beckn.Context
@@ -138,7 +140,7 @@ getV2FrfsRoute (_, _merchantId, merchantOpCityId) routeCode mbConfigId mbPlatfor
         totalStops = Just $ length stops,
         stops = Just $ map snd stops,
         timeBounds = Nothing,
-        waypoints = Nothing,
+        waypoints = route.encodedPolyline <&> decode <&> fmap (\point -> LatLong {lat = point.latitude, lon = point.longitude}),
         integratedBppConfigId = getId integratedBPPConfig.id
       }
 

--- a/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
+++ b/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
@@ -52,7 +52,8 @@ data RouteInfoNandi = RouteInfoNandi
     startPoint :: LatLong,
     endPoint :: LatLong,
     stopCount :: Maybe Int,
-    serviceTierType :: Maybe BecknV2.FRFS.Enums.ServiceTierType
+    serviceTierType :: Maybe BecknV2.FRFS.Enums.ServiceTierType,
+    encodedPolyline :: Maybe Text
   }
   deriving (Generic, FromJSON, ToJSON, Show)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route waypoint coordinates are now properly populated in API responses for FRFS routes, enabling accurate route visualization and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->