### PR TITLE
backend/enhc: Handled prepaid subscription checks in setActivty API

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -269,6 +269,7 @@ import qualified SharedLogic.External.LocationTrackingService.Types as LT
 import SharedLogic.FareCalculator
 import qualified SharedLogic.FareCalculator as FC
 import SharedLogic.FarePolicy
+import SharedLogic.Finance.Prepaid (counterpartyDriver, counterpartyFleetOwner, getPrepaidAvailableBalanceByOwner)
 import qualified SharedLogic.Finance.Wallet as FWallet
 import qualified SharedLogic.Merchant as SMerchant
 import qualified SharedLogic.MessageBuilder as MessageBuilder
@@ -935,6 +936,29 @@ getInformation (personId, merchantId, merchantOpCityId) mbClientId toss tnant' c
   driverGoHomeInfo <- CQDGR.getDriverGoHomeRequestInfo driverId merchantOpCityId Nothing
   makeDriverInformationRes merchantOpCityId driverEntity driverInfo merchant driverReferralCode driverStats driverGoHomeInfo (Just currentDues) (Just manualDues) mbMd5Digest operatorReferral ((.operatorId) <$> doa) inactiveFda activeFda mbFleetInfo
 
+checkPrepaidGoOnlineEligibility ::
+  (MonadFlow m, BeamFlow m r, CacheFlow m r, EsqDBFlow m r) =>
+  Id SP.Person ->
+  TransporterConfig ->
+  Maybe DVC.VehicleCategory ->
+  m ()
+checkPrepaidGoOnlineEligibility personId transporterConfig mbCurrentVehicleCategory = do
+  let isolationEnabled = fromMaybe False transporterConfig.subscriptionConfig.vehicleCategoryScopedPrepaidEnabled
+      mbVehicleCategory = if isolationEnabled then mbCurrentVehicleCategory else Nothing
+  (ownerType, ownerId, counterparty) <-
+    QFDA.findByDriverId (cast personId) True >>= \case
+      Just fleetDriverAssociation -> pure (DSP.FLEET_OWNER, fleetDriverAssociation.fleetOwnerId, counterpartyFleetOwner)
+      Nothing -> pure (DSP.DRIVER, personId.getId, counterpartyDriver)
+  -- Minimum-balance threshold, mirroring the ride-accept check in initializeRide
+  let prepaidThreshold =
+        fromMaybe 0 $ case ownerType of
+          DSP.FLEET_OWNER -> transporterConfig.subscriptionConfig.fleetPrepaidSubscriptionThreshold
+          DSP.DRIVER -> transporterConfig.subscriptionConfig.prepaidSubscriptionThreshold
+  activePurchases <- QSPE.findAllActiveByOwnerAndServiceName ownerId ownerType Plan.PREPAID_SUBSCRIPTION mbVehicleCategory
+  availableBalance <- fromMaybe 0 <$> getPrepaidAvailableBalanceByOwner counterparty ownerId mbVehicleCategory
+  when (null activePurchases || availableBalance <= prepaidThreshold) $
+    throwError (NoActivePrepaidPlan personId.getId)
+
 setActivity ::
   ( MonadFlow m,
     BeamFlow m r,
@@ -960,21 +984,25 @@ setActivity (personId, merchantId, merchantOpCityId) isActive mode = do
         when (isActive || (isJust mode && (mode == Just DriverInfo.SILENT || mode == Just DriverInfo.ONLINE))) $ do
           merchant <- CQM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
           mbVehicle <- QVehicle.findById personId
-          DriverSpecificSubscriptionData {..} <- getDriverSpecificSubscriptionDataWithSubsConfig (personId, merchantId, merchantOpCityId) transporterConfig driverInfo mbVehicle Plan.YATRI_SUBSCRIPTION
-          let commonSubscriptionChecks = not isOnFreeTrial && not transporterConfig.allowDefaultPlanAllocation
-          (planBasedChecks, changeBasedChecks) <- do
-            if isSubscriptionEnabledAtCategoryLevel
-              then do
-                let planBasedChecks' = planMandatoryForCategory && isNothing autoPayStatus && commonSubscriptionChecks && isEnabledForCategory
-                let isSubscriptionEnabledAtCategoryLevelUI = (mbDriverPlan >>= (.isCategoryLevelSubscriptionEnabled)) == Just True
-                let changeBasedChecks' = (isSubscriptionVehicleCategoryChanged || isSubscriptionCityChanged) && commonSubscriptionChecks && isEnabledForCategory && isSubscriptionEnabledAtCategoryLevelUI
-                pure (planBasedChecks', changeBasedChecks')
-              else do
-                let isEnableForVariant = maybe False (`elem` transporterConfig.variantsToEnableForSubscription) (mbVehicle <&> (.variant))
-                let planBasedChecks' = transporterConfig.isPlanMandatory && isNothing autoPayStatus && commonSubscriptionChecks && isEnableForVariant
-                pure (planBasedChecks', False)
-          let isVehicleVariantDisabledForSubscription = maybe False (`elem` fromMaybe [] vehicleVariantsDisabledForSubscription) (mbVehicle <&> (.variant))
-          when ((planBasedChecks || changeBasedChecks) && not isVehicleVariantDisabledForSubscription) $ throwError (NoPlanSelected personId.getId)
+          -- Eligibility check for prepaid drivers:
+          if Plan.PREPAID_SUBSCRIPTION `elem` driverInfo.servicesEnabledForSubscription
+            then checkPrepaidGoOnlineEligibility personId transporterConfig (mbVehicle >>= (.category))
+            else do
+              DriverSpecificSubscriptionData {..} <- getDriverSpecificSubscriptionDataWithSubsConfig (personId, merchantId, merchantOpCityId) transporterConfig driverInfo mbVehicle Plan.YATRI_SUBSCRIPTION
+              let commonSubscriptionChecks = not isOnFreeTrial && not transporterConfig.allowDefaultPlanAllocation
+              (planBasedChecks, changeBasedChecks) <- do
+                if isSubscriptionEnabledAtCategoryLevel
+                  then do
+                    let planBasedChecks' = planMandatoryForCategory && isNothing autoPayStatus && commonSubscriptionChecks && isEnabledForCategory
+                    let isSubscriptionEnabledAtCategoryLevelUI = (mbDriverPlan >>= (.isCategoryLevelSubscriptionEnabled)) == Just True
+                    let changeBasedChecks' = (isSubscriptionVehicleCategoryChanged || isSubscriptionCityChanged) && commonSubscriptionChecks && isEnabledForCategory && isSubscriptionEnabledAtCategoryLevelUI
+                    pure (planBasedChecks', changeBasedChecks')
+                  else do
+                    let isEnableForVariant = maybe False (`elem` transporterConfig.variantsToEnableForSubscription) (mbVehicle <&> (.variant))
+                    let planBasedChecks' = transporterConfig.isPlanMandatory && isNothing autoPayStatus && commonSubscriptionChecks && isEnableForVariant
+                    pure (planBasedChecks', False)
+              let isVehicleVariantDisabledForSubscription = maybe False (`elem` fromMaybe [] vehicleVariantsDisabledForSubscription) (mbVehicle <&> (.variant))
+              when ((planBasedChecks || changeBasedChecks) && not isVehicleVariantDisabledForSubscription) $ throwError (NoPlanSelected personId.getId)
           when merchant.onlinePayment $ do
             driverBankAccount <-
               QFDA.findByDriverId driverId True >>= \case

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
@@ -194,6 +194,7 @@ data DriverError
   = DriverAccountDisabled
   | DriverWithoutVehicle Text
   | NoPlanSelected Text
+  | NoActivePrepaidPlan Text
   | DriverAccountBlocked BlockErrorPayload
   | DriverAccountAlreadyBlocked
   | DriverUnsubscribed
@@ -216,6 +217,7 @@ instance IsBaseError DriverError where
   toMessage DriverAccountDisabled = Just "Driver account has been disabled. He can't go online and receive ride offers in this state."
   toMessage (DriverWithoutVehicle personId) = Just $ "Driver with id = " <> personId <> " has no linked vehicle"
   toMessage (NoPlanSelected personId) = Just $ "Driver with id = " <> personId <> " has not selected any plan"
+  toMessage (NoActivePrepaidPlan personId) = Just $ "Driver with id = " <> personId <> " has no active prepaid subscription with sufficient balance. Please recharge to go online."
   toMessage (DriverAccountBlocked _) = Just "Driver account has been blocked."
   toMessage DriverAccountAlreadyBlocked = Just "Driver account has been already blocked."
   toMessage DriverUnsubscribed = Just "Driver has been unsubscibed from platform. Pay pending amount to subscribe back."
@@ -236,6 +238,7 @@ instance IsHTTPError DriverError where
     DriverAccountDisabled -> "DRIVER_ACCOUNT_DISABLED"
     DriverWithoutVehicle _ -> "DRIVER_WITHOUT_VEHICLE"
     NoPlanSelected _ -> "NO_PLAN_SELECTED"
+    NoActivePrepaidPlan _ -> "NO_ACTIVE_PREPAID_PLAN"
     DriverAccountBlocked _ -> "DRIVER_ACCOUNT_BLOCKED"
     DriverAccountAlreadyBlocked -> "DRIVER_ACCOUNT_ALREADY_BLOCKED"
     DriverUnsubscribed -> "DRIVER_UNSUBSCRIBED"
@@ -254,6 +257,7 @@ instance IsHTTPError DriverError where
     DriverAccountDisabled -> E403
     DriverWithoutVehicle _ -> E400
     NoPlanSelected _ -> E400
+    NoActivePrepaidPlan _ -> E403
     DriverAccountBlocked _ -> E403
     DriverAccountAlreadyBlocked -> E403
     DriverUnsubscribed -> E403


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drivers with prepaid subscription plans now undergo eligibility verification when attempting to go online. The system validates active prepaid purchases and balance requirements. Drivers without valid prepaid plans receive a notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->