### PR TITLE
backend/chore: bump json-logic-hs to dcdd6a6 (cherry-pick #15257 to prodHotPush-BPP)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1777,11 +1777,11 @@
     "json-logic-hs": {
       "flake": false,
       "locked": {
-        "lastModified": 1780415936,
-        "narHash": "sha256-I5UaWmMOdMAjyDv1Tr1wIIi+SwF5FsnrJAoqVIddkgA=",
+        "lastModified": 1781617079,
+        "narHash": "sha256-NXtj+dgXi4KRO13Sa51HL7eWjWGFeNWZ0egDjuxvCH8=",
         "owner": "nammayatri",
         "repo": "json-logic-hs",
-        "rev": "90393a4a87dc252f4f245c3c215acd6e4c4abe90",
+        "rev": "dcdd6a603faf7f8b140728fb3511d7498d6ab03f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Cherry-picks the `json-logic-hs` bump from #15257 onto `prodHotPush-BPP` so the hotpush carries the `runLogics` namespace fix (bucket / arrayAt operators).

- Pins `json-logic-hs` `90393a4a` → `dcdd6a6` in `flake.lock` (output of nammayatri/json-logic-hs#8)
- Single-file change, 3 lines; already merged to `main` via #15257 (squash commit `203e6be8`)
- `prodHotPush-BPP` diverged from `main` on 2026-05-19, so this needed an explicit cherry-pick

🤖 Generated with [Claude Code](https://claude.com/claude-code)