### PR TITLE
backend/enh: reading region from dhall and falling back to env

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Internal/PickupInstructionHandler.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Internal/PickupInstructionHandler.hs
@@ -76,7 +76,7 @@ handlePickupInstruction ride booking driverIdValue = do
                   S3.S3AwsConf a -> do
                     let bucketName = a.bucketName
                     -- Generate a signed URL with 1 hour expiration (3600 seconds)
-                    result <- withTryCatch "generateDownloadUrl:handlePickupInstruction" $ S3Flow.generateDownloadUrl' bucketName (T.unpack s3Path) 3600
+                    result <- withTryCatch "generateDownloadUrl:handlePickupInstruction" $ S3Flow.generateDownloadUrl' a.region bucketName (T.unpack s3Path) 3600
                     case result of
                       Right signedUrl -> do
                         logInfo "PickupInstructionHandler: Successfully generated signed URL for audio"

--- a/Backend/lib/beckn-services/src/AWS/S3/Flow.hs
+++ b/Backend/lib/beckn-services/src/AWS/S3/Flow.hs
@@ -278,10 +278,23 @@ mockDelete baseDirectory bucketName path =
 getFullPathMock :: String -> Text -> String -> String
 getFullPathMock baseDirectory bucketName path = baseDirectory <> "/" <> cs bucketName <> "/" <> path
 
+mkAwsEnv ::
+  ( MonadFlow m
+  ) =>
+  Text ->
+  m Amazonka.Env
+mkAwsEnv region = do
+  env <- Amazonka.newEnv Amazonka.discover
+  pure $
+    if T.null region
+      then env
+      else env {Amazonka.region = Amazonka.Region' region}
+
 -- | Generate a pre-signed URL for uploading a video
 generateUploadUrl' ::
   ( MonadFlow m
   ) =>
+  Text ->
   Text ->
   String ->
   Seconds ->
@@ -292,6 +305,7 @@ generateUploadUrl' = generateUrl' PUT
 generateDownloadUrl' ::
   ( MonadFlow m
   ) =>
+  Text ->
   Text ->
   String ->
   Seconds ->
@@ -305,11 +319,12 @@ generateUrl' ::
   ) =>
   Method ->
   Text ->
+  Text ->
   String ->
   Seconds ->
   m Text
-generateUrl' method bucketName path expires = withLogTag "S3" $ do
-  env <- Amazonka.newEnv Amazonka.discover
+generateUrl' method region bucketName path expires = withLogTag "S3" $ do
+  env <- mkAwsEnv region
   now <- getCurrentTime
   let bucketName' = Amazonka.BucketName bucketName
       path' = Amazonka.ObjectKey $ T.pack path
@@ -345,10 +360,11 @@ headRequest' ::
   ( MonadFlow m
   ) =>
   Text ->
+  Text ->
   String ->
   m ObjectStatus
-headRequest' bucketName path = withLogTag "S3" $ do
-  env <- Amazonka.newEnv Amazonka.discover
+headRequest' region bucketName path = withLogTag "S3" $ do
+  env <- mkAwsEnv region
   let bucketName' = Amazonka.BucketName bucketName
       path' = Amazonka.ObjectKey $ T.pack path
   res <- liftIO . Amazonka.runResourceT $ Amazonka.send env (Amazonka.newHeadObject bucketName' path')

--- a/Backend/lib/beckn-services/src/AWS/S3/Init.hs
+++ b/Backend/lib/beckn-services/src/AWS/S3/Init.hs
@@ -40,7 +40,7 @@ buildS3Env (S3AwsConf a) = do
       putH = put'' a.bucketName,
       putRawH = putRaw'' a.bucketName,
       deleteH = delete'' a.bucketName,
-      generateUploadUrlH = generateUploadUrl' a.bucketName,
-      generateDownloadUrlH = generateDownloadUrl' a.bucketName,
-      headRequestH = headRequest' a.bucketName
+      generateUploadUrlH = generateUploadUrl' a.region a.bucketName,
+      generateDownloadUrlH = generateDownloadUrl' a.region a.bucketName,
+      headRequestH = headRequest' a.region a.bucketName
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved AWS S3 integration by ensuring the correct AWS region is explicitly specified when generating signed URLs for pickup instructions and related file operations. This enhances reliability across multi-region deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->