### PR TITLE
enh: make lts queries fallback to secondary; treat  prefix as null

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/RiderLocation.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/RiderLocation.hs
@@ -19,7 +19,6 @@ import qualified Kernel.Storage.Hedis as Hedis
 import Kernel.Types.Common
 import Kernel.Types.Id
 import qualified Kernel.Types.Id
-import Kernel.Types.Version (CloudType (..))
 import qualified Kernel.Utils.CalculateDistance
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig)
@@ -51,11 +50,8 @@ postIdentifyNearByBus (_mbPersonId, merchantId) req = do
             _ -> Nothing
       let nearbyBusSearchRadius :: Double = fromMaybe 0.1 riderConfig.nearbyBusSearchRadius
           maxNearbyBuses :: Int = fromMaybe 5 riderConfig.maxNearbyBuses
-      cloudType <- asks (.cloudType)
       busesBS <-
-        mapM (pure . decodeUtf8) =<< case cloudType of
-          Just GCP -> Hedis.runInMasterLTSRedisCell $ Hedis.geoSearch (nearbyBusKey redisPrefix) (Hedis.FromLonLat userPos.lon userPos.lat) (Hedis.ByRadius nearbyBusSearchRadius "km")
-          _ -> CQMMB.withCrossAppRedisNew $ Hedis.geoSearch (nearbyBusKey redisPrefix) (Hedis.FromLonLat userPos.lon userPos.lat) (Hedis.ByRadius nearbyBusSearchRadius "km")
+        mapM (pure . decodeUtf8) =<< Hedis.runInMultiCloudLTSRedisForList (Hedis.geoSearch (nearbyBusKey redisPrefix) (Hedis.FromLonLat userPos.lon userPos.lat) (Hedis.ByRadius nearbyBusSearchRadius "km"))
       logDebug $ "getNearbyBuses: busesBS: " <> show busesBS
       if null busesBS
         then do
@@ -63,9 +59,7 @@ postIdentifyNearByBus (_mbPersonId, merchantId) req = do
           pure []
         else do
           logDebug $ "getNearbyBuses: Fetching bus metadata for " <> show (length busesBS) <> " buses"
-          buses <- case cloudType of
-            Just GCP -> Hedis.runInMasterLTSRedisCell $ Hedis.hmGet (vehicleMetaKey redisPrefix) busesBS
-            _ -> CQMMB.withCrossAppRedisNew $ Hedis.hmGet (vehicleMetaKey redisPrefix) busesBS
+          buses <- Hedis.runInMultiCloudLTSRedisForMaybeList $ Hedis.hmGet (vehicleMetaKey redisPrefix) busesBS
           let validBuses = catMaybes buses
               sortedLimitedBuses = take maxNearbyBuses $ EulerHS.Prelude.sortOn (distanceToUser userPos) validBuses
           pure sortedLimitedBuses
@@ -102,10 +96,10 @@ postIdentifyNearByBus (_mbPersonId, merchantId) req = do
 
     nearbyBusKey :: Maybe Text -> Text
     nearbyBusKey mbRedisPrefix = case mbRedisPrefix of
-      Just prefix -> prefix <> ":bus_locations"
+      Just prefix | prefix /= "" -> prefix <> ":bus_locations"
       _ -> "bus_locations"
 
     vehicleMetaKey :: Maybe Text -> Text
     vehicleMetaKey mbRedisPrefix = case mbRedisPrefix of
-      Just prefix -> prefix <> ":bus_metadata_v2"
+      Just prefix | prefix /= "" -> prefix <> ":bus_metadata_v2"
       _ -> "bus_metadata_v2"

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFSJourneyUtils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFSJourneyUtils.hs
@@ -54,8 +54,8 @@ defaultBusTrackingConfigFRFS =
 
 nearbyBusKeyFRFS :: Maybe Text -> Text
 nearbyBusKeyFRFS mbRedisPrefix = case mbRedisPrefix of
-  Just prefix -> prefix <> ":bus_locations"
-  Nothing -> "bus_locations"
+  Just prefix | prefix /= "" -> prefix <> ":bus_locations"
+  _ -> "bus_locations"
 
 topVehicleCandidatesKeyFRFS :: Text -> Text
 topVehicleCandidatesKeyFRFS journeyLegId = "journeyLegTopVehicleCandidates:" <> journeyLegId
@@ -283,14 +283,11 @@ getVehicleMetadata vehicleNumbers integratedBppConfig = do
         DIBC.ONDC config -> config.redisPrefix
         DIBC.DIRECT config -> config.redisPrefix
         _ -> Nothing
-  cloudType <- asks (.cloudType)
-  case cloudType of
-    Just GCP -> Hedis.runInMasterLTSRedisCell $ Hedis.hmGet (vehicleMetaKey redisPrefix) vehicleNumbers
-    _ -> CQMMB.withCrossAppRedisNew $ Hedis.hmGet (vehicleMetaKey redisPrefix) vehicleNumbers
+  Hedis.runInMultiCloudLTSRedisForMaybeList $ Hedis.hmGet (vehicleMetaKey redisPrefix) vehicleNumbers
   where
     vehicleMetaKey :: Maybe Text -> Text
     vehicleMetaKey mbRedisPrefix = case mbRedisPrefix of
-      Just prefix -> prefix <> ":bus_metadata_v2"
+      Just prefix | prefix /= "" -> prefix <> ":bus_metadata_v2"
       _ -> "bus_metadata_v2"
 
 getBusLiveInfo :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, HasFlowEnv m r '["ltsCfg" ::: LT.LocationTrackingeServiceConfig, "cloudType" ::: Maybe CloudType], HasField "ltsHedisEnv" r Redis.HedisEnv, HasField "secondaryLTSHedisEnv" r (Maybe Redis.HedisEnv), HasShortDurationRetryCfg r c, HasKafkaProducer r) => Text -> DIBC.IntegratedBPPConfig -> m (Maybe BusDataWithRoutesInfo)
@@ -303,11 +300,8 @@ getNearbyBusesFRFS userPos' riderConfig integratedBppConfig = do
         DIBC.ONDC config -> config.redisPrefix
         DIBC.DIRECT config -> config.redisPrefix
         _ -> Nothing
-  cloudType <- asks (.cloudType)
   busesBS <-
-    mapM (pure . decodeUtf8) =<< case cloudType of
-      Just GCP -> Hedis.runInMasterLTSRedisCell $ Hedis.geoSearch (nearbyBusKeyFRFS redisPrefix) (Hedis.FromLonLat userPos'.lon userPos'.lat) (Hedis.ByRadius nearbyBusSearchRadius "km")
-      _ -> CQMMB.withCrossAppRedisNew $ Hedis.geoSearch (nearbyBusKeyFRFS redisPrefix) (Hedis.FromLonLat userPos'.lon userPos'.lat) (Hedis.ByRadius nearbyBusSearchRadius "km")
+    mapM (pure . decodeUtf8) =<< Hedis.runInMultiCloudLTSRedisForList (Hedis.geoSearch (nearbyBusKeyFRFS redisPrefix) (Hedis.FromLonLat userPos'.lon userPos'.lat) (Hedis.ByRadius nearbyBusSearchRadius "km"))
   logDebug $ "getNearbyBusesFRFS: busesBS: " <> show busesBS
   buses <-
     if null busesBS

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MultiModalBus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MultiModalBus.hs
@@ -120,8 +120,8 @@ data RouteWithBuses = RouteWithBuses
 -- Create Redis key for a route
 mkRouteKey :: Maybe Text -> Text -> Text
 mkRouteKey mbRedisPrefix routeId = case mbRedisPrefix of
-  Just prefix -> prefix <> ":route:" <> routeId
-  Nothing -> "route:" <> routeId
+  Just prefix | prefix /= "" -> prefix <> ":route:" <> routeId
+  _ -> "route:" <> routeId
 
 -- Get all buses for a single route
 getRoutesBuses :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r, HasField "ltsHedisEnv" r Hedis.HedisEnv, HasField "secondaryLTSHedisEnv" r (Maybe Hedis.HedisEnv), HasField "cloudType" r (Maybe CloudType)) => Text -> DIBC.IntegratedBPPConfig -> m RouteWithBuses
@@ -131,10 +131,7 @@ getRoutesBuses routeId integratedBppConfig = do
         DIBC.DIRECT config -> config.redisPrefix
         _ -> Nothing
   let key = mkRouteKey redisPrefix routeId
-  cloudType <- asks (.cloudType)
-  busDataPairs <- case cloudType of
-    Just GCP -> Hedis.runInMasterLTSRedisCell $ Hedis.hGetAll key
-    _ -> withCrossAppRedisNew $ Hedis.hGetAll key
+  busDataPairs <- Hedis.runInMultiCloudLTSRedisForList $ Hedis.hGetAll key
   let buses = map (uncurry FullBusData) busDataPairs
   return $ RouteWithBuses routeId buses
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized nearby bus searches, vehicle metadata lookups, and route bus reads to consistently use multi-cloud Redis handling for more uniform results.
* **Bug Fixes**
  * Fixed Redis cache-key construction when the Redis prefix is empty (`""`), preventing malformed keys for nearby buses and vehicle metadata.
  * Corrected Redis key formatting for route bus reads when no prefix is provided, ensuring data is retrieved from the right keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->