### PR TITLE
feat: add add GetCity API with nested location and state/language in …

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -820,8 +820,7 @@ data ClearDuesRes = ClearDuesRes
   deriving (Generic, ToJSON, FromJSON, ToSchema)
 
 data GetCityReq = GetCityReq
-  { lat :: Double,
-    lon :: Double,
+  { location :: LatLong,
     merchantId :: Maybe (Id DM.Merchant)
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
@@ -833,6 +832,10 @@ data GetConsentReq = GetConsentReq
 
 data GetCityResp = GetCityResp
   { city :: Maybe Text,
+    state :: Maybe Context.IndianState,
+    language :: Maybe Maps.Language,
+    lat :: Double,
+    lon :: Double,
     status :: APISuccess
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
@@ -2883,22 +2886,31 @@ mkDriverFeeInfoEntity driverFees invoiceStatus transporterConfig serviceName = d
 
 getCity :: GetCityReq -> Flow GetCityResp
 getCity req = do
-  let latLng = LatLong {lat = req.lat, lon = req.lon}
+  let latLng = req.location
+      mkResp mbCity mbState mbLang = GetCityResp {city = mbCity, state = mbState, language = mbLang, lat = req.location.lat, lon = req.location.lon, status = APISuccess.Success}
+      withMOCInfo cityVal mbMId = do
+        mbMoc <- case mbMId of
+          Just mId -> CQMOC.findByMerchantIdAndCity mId cityVal
+          Nothing -> return Nothing
+        return $ mkResp (Just $ show cityVal) ((.state) <$> mbMoc) ((.language) <$> mbMoc)
   case req.merchantId of -- only for backward compatibility, Nothing part to be removed later
     Just mId -> do
       merchant <- CQM.findById mId >>= fromMaybeM (MerchantDoesNotExist mId.getId)
       nearestAndSourceCity <- withTryCatch "getNearestOperatingAndSourceCity:getCity" $ getNearestOperatingAndSourceCity merchant latLng
       case nearestAndSourceCity of
-        Left _ -> return GetCityResp {city = Nothing, status = APISuccess.Success}
-        Right nearestSourceCity -> return GetCityResp {city = Just $ show nearestSourceCity.nearestOperatingCity.city, status = APISuccess.Success}
+        Left _ -> return $ mkResp Nothing Nothing Nothing
+        Right nearestSourceCity -> do
+          let cs = nearestSourceCity.nearestOperatingCity
+          mbMoc <- CQMOC.findByMerchantIdAndCity mId cs.city
+          return $ mkResp (Just $ show cs.city) (Just cs.state) ((.language) <$> mbMoc)
     Nothing -> do
       geometry <- runInReplica $ QGeometry.findGeometriesContainingGps latLng
       case filter (\geom -> geom.city /= Context.City "AnyCity") geometry of
         [] ->
           find (\geom -> geom.city == Context.City "AnyCity") geometry & \case
-            Just anyCityGeom -> return GetCityResp {city = Just $ show anyCityGeom.city, status = APISuccess.Success}
-            Nothing -> return GetCityResp {city = Nothing, status = APISuccess.Success}
-        (g : _) -> return GetCityResp {city = Just $ show g.city, status = APISuccess.Success}
+            Just anyCityGeom -> withMOCInfo anyCityGeom.city Nothing
+            Nothing -> return $ mkResp Nothing Nothing Nothing
+        (g : _) -> withMOCInfo g.city Nothing
 
 data DriverFeeResp = DriverFeeResp
   { createdAt :: UTCTime, -- window start day

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -834,8 +834,7 @@ data GetCityResp = GetCityResp
   { city :: Maybe Text,
     state :: Maybe Context.IndianState,
     language :: Maybe Maps.Language,
-    lat :: Double,
-    lon :: Double,
+    location :: LatLong,
     status :: APISuccess
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
@@ -2887,7 +2886,7 @@ mkDriverFeeInfoEntity driverFees invoiceStatus transporterConfig serviceName = d
 getCity :: GetCityReq -> Flow GetCityResp
 getCity req = do
   let latLng = req.location
-      mkResp mbCity mbState mbLang = GetCityResp {city = mbCity, state = mbState, language = mbLang, lat = req.location.lat, lon = req.location.lon, status = APISuccess.Success}
+      mkResp mbCity mbState mbLang = GetCityResp {city = mbCity, state = mbState, language = mbLang, location = req.location, status = APISuccess.Success}
       withMOCInfo cityVal mbMId = do
         mbMoc <- case mbMId of
           Just mId -> CQMOC.findByMerchantIdAndCity mId cityVal

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -820,7 +820,8 @@ data ClearDuesRes = ClearDuesRes
   deriving (Generic, ToJSON, FromJSON, ToSchema)
 
 data GetCityReq = GetCityReq
-  { location :: LatLong,
+  { lat :: Double,
+    lon :: Double,
     merchantId :: Maybe (Id DM.Merchant)
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
@@ -2885,8 +2886,8 @@ mkDriverFeeInfoEntity driverFees invoiceStatus transporterConfig serviceName = d
 
 getCity :: GetCityReq -> Flow GetCityResp
 getCity req = do
-  let latLng = req.location
-      mkResp mbCity mbState mbLang = GetCityResp {city = mbCity, state = mbState, language = mbLang, location = req.location, status = APISuccess.Success}
+  let latLng = LatLong {lat = req.lat, lon = req.lon}
+      mkResp mbCity mbState mbLang = GetCityResp {city = mbCity, state = mbState, language = mbLang, location = latLng, status = APISuccess.Success}
       withMOCInfo cityVal mbMId = do
         mbMoc <- case mbMId of
           Just mId -> CQMOC.findByMerchantIdAndCity mId cityVal


### PR DESCRIPTION
Description:
Enhanced driver city APIs:
- POST /driver/city: changed request to accept location as nested object `{ "location": { "lat", "lon" } }`
  instead of flat lat/lon fields; added state and language to response
- GET /city/{merchantId}/list: added state and language fields to each city in the response

How did you test it:
Tested manually via Postman:
- POST /ui/driver/city with `{ "location": { "lat": 12.9716, "lon": 77.5946 }, "merchantId": "..." }`
  returned city, state, and language correctly
- GET /ui/city/{merchantId}/list returned city list with state and language for each entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GetCity responses are now enriched with additional location details, including geographic coordinates, plus optional state and language information.

* **API Updates**
  * The GetCity response payload has been expanded to include `state`, `language`, and `location` fields consistently.
  * Backward-compatibility behavior was updated so merchant-based requests may derive state/language from the nearest operating city data, while geometry-based requests focus on city resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->