### PR TITLE
[refactor]: Put master redis lock for seat booking in premium buses

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSSeatBooking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSSeatBooking.hs
@@ -86,23 +86,24 @@ holdSeats tripId seatIds fromIdx toIdx holdId ttl seatBitMapTtl = do
           toBS (length seatIds),
           toBS seatBitMapTtl
         ]
-  pSeatKeys <- traverse Redis.buildKey seatKeys
-  pMetaKey <- Redis.buildKey mKey
-  pTimerKey <- Redis.buildKey tKey
-  let allKeys = pSeatKeys ++ [pMetaKey, pTimerKey]
-  res :: Integer <-
-    Redis.runHedis
-      ( RawRedis.eval Lua.holdSeatScript allKeys args ::
-          RawRedis.Redis (Either RawRedis.Reply Integer)
-      )
-  case res of
-    1 -> do
-      logInfo $ "SeatBooking:holdSeats SUCCESS holdId=" <> holdId <> " tripId=" <> tripId
-      void $ Redis.sAdd "active-seat-holds" [ActiveSeatHold tripId holdId]
-      pure True
-    _ -> do
-      logWarning $ "SeatBooking:holdSeats CONFLICT holdId=" <> holdId <> " tripId=" <> tripId <> " seats=" <> show seatIdStrs
-      pure False
+  Redis.runInMasterCloudRedisCell $ do
+    pSeatKeys <- traverse Redis.buildKey seatKeys
+    pMetaKey <- Redis.buildKey mKey
+    pTimerKey <- Redis.buildKey tKey
+    let allKeys = pSeatKeys ++ [pMetaKey, pTimerKey]
+    res :: Integer <-
+      Redis.runHedis
+        ( RawRedis.eval Lua.holdSeatScript allKeys args ::
+            RawRedis.Redis (Either RawRedis.Reply Integer)
+        )
+    case res of
+      1 -> do
+        logInfo $ "SeatBooking:holdSeats SUCCESS holdId=" <> holdId <> " tripId=" <> tripId
+        void $ Redis.sAdd "active-seat-holds" [ActiveSeatHold tripId holdId]
+        pure True
+      _ -> do
+        logWarning $ "SeatBooking:holdSeats CONFLICT holdId=" <> holdId <> " tripId=" <> tripId <> " seats=" <> show seatIdStrs
+        pure False
 
 releaseHold ::
   (MonadFlow m, Redis.HedisFlow m r) =>
@@ -111,36 +112,37 @@ releaseHold ::
   m ()
 releaseHold tripId holdId = do
   logInfo $ "SeatBooking:releaseHold attempting holdId=" <> holdId <> " tripId=" <> tripId
-  Redis.withLockRedis (holdLockKey tripId holdId) 10 $ do
-    let mKey = metaKey tripId holdId
-        tKey = timerKey tripId holdId
-    mbMeta :: Maybe SeatHoldMeta <- Redis.get mKey
-    case mbMeta of
-      Nothing -> do
-        logInfo $ "SeatBooking:releaseHold no-op (meta not found) holdId=" <> holdId <> " tripId=" <> tripId
-        pure ()
-      Just meta -> do
-        logInfo $ "SeatBooking:releaseHold clearing bits holdId=" <> holdId <> " tripId=" <> tripId <> " seats=" <> show meta.seatIds <> " range=[" <> show meta.fromIdx <> "," <> show meta.toIdx <> ")"
-        let seatIds = meta.seatIds
-            fromIdx = meta.fromIdx
-            toIdx = meta.toIdx
-            seatKeys =
-              map (seatKey tripId . Id) seatIds
-            args =
-              [ toBS fromIdx,
-                toBS toIdx,
-                toBS (length seatIds)
-              ]
-        pSeatKeys <- traverse Redis.buildKey seatKeys
-        void $
-          Redis.runHedis
-            ( RawRedis.eval Lua.clearMultiScript pSeatKeys args ::
-                RawRedis.Redis (Either RawRedis.Reply Integer)
-            )
-        Redis.del mKey
-        Redis.del tKey
-        void $ Redis.srem "active-seat-holds" [ActiveSeatHold tripId holdId]
-        logInfo $ "SeatBooking:releaseHold completed holdId=" <> holdId <> " tripId=" <> tripId
+  Redis.runInMasterCloudRedisCell $
+    Redis.withLockRedis (holdLockKey tripId holdId) 10 $ do
+      let mKey = metaKey tripId holdId
+          tKey = timerKey tripId holdId
+      mbMeta :: Maybe SeatHoldMeta <- Redis.get mKey
+      case mbMeta of
+        Nothing -> do
+          logInfo $ "SeatBooking:releaseHold no-op (meta not found) holdId=" <> holdId <> " tripId=" <> tripId
+          pure ()
+        Just meta -> do
+          logInfo $ "SeatBooking:releaseHold clearing bits holdId=" <> holdId <> " tripId=" <> tripId <> " seats=" <> show meta.seatIds <> " range=[" <> show meta.fromIdx <> "," <> show meta.toIdx <> ")"
+          let seatIds = meta.seatIds
+              fromIdx = meta.fromIdx
+              toIdx = meta.toIdx
+              seatKeys =
+                map (seatKey tripId . Id) seatIds
+              args =
+                [ toBS fromIdx,
+                  toBS toIdx,
+                  toBS (length seatIds)
+                ]
+          pSeatKeys <- traverse Redis.buildKey seatKeys
+          void $
+            Redis.runHedis
+              ( RawRedis.eval Lua.clearMultiScript pSeatKeys args ::
+                  RawRedis.Redis (Either RawRedis.Reply Integer)
+              )
+          Redis.del mKey
+          Redis.del tKey
+          void $ Redis.srem "active-seat-holds" [ActiveSeatHold tripId holdId]
+          logInfo $ "SeatBooking:releaseHold completed holdId=" <> holdId <> " tripId=" <> tripId
 
 confirmBooking ::
   (MonadFlow m, Redis.HedisFlow m r) =>
@@ -149,19 +151,20 @@ confirmBooking ::
   m ()
 confirmBooking tripId holdId = do
   logInfo $ "SeatBooking:confirmBooking attempting holdId=" <> holdId <> " tripId=" <> tripId
-  Redis.withLockRedis (holdLockKey tripId holdId) 10 $ do
-    let mKey = metaKey tripId holdId
-        tKey = timerKey tripId holdId
-    mbMeta :: Maybe SeatHoldMeta <- Redis.get mKey
-    case mbMeta of
-      Nothing -> do
-        logWarning $ "SeatBooking:confirmBooking no-op (meta not found, hold may have expired) holdId=" <> holdId <> " tripId=" <> tripId
-        pure ()
-      Just _ -> do
-        void $ Redis.srem "active-seat-holds" [ActiveSeatHold tripId holdId]
-        Redis.del mKey
-        Redis.del tKey
-        logInfo $ "SeatBooking:confirmBooking completed (bits retained) holdId=" <> holdId <> " tripId=" <> tripId
+  Redis.runInMasterCloudRedisCell $
+    Redis.withLockRedis (holdLockKey tripId holdId) 10 $ do
+      let mKey = metaKey tripId holdId
+          tKey = timerKey tripId holdId
+      mbMeta :: Maybe SeatHoldMeta <- Redis.get mKey
+      case mbMeta of
+        Nothing -> do
+          logWarning $ "SeatBooking:confirmBooking no-op (meta not found, hold may have expired) holdId=" <> holdId <> " tripId=" <> tripId
+          pure ()
+        Just _ -> do
+          void $ Redis.srem "active-seat-holds" [ActiveSeatHold tripId holdId]
+          Redis.del mKey
+          Redis.del tKey
+          logInfo $ "SeatBooking:confirmBooking completed (bits retained) holdId=" <> holdId <> " tripId=" <> tripId
 
 bookingHoldsKey :: Text -> Text
 bookingHoldsKey bookingId = "booking-holds:" <> bookingId
@@ -170,16 +173,17 @@ trackHoldForBooking :: (MonadFlow m, Redis.HedisFlow m r) => Text -> Text -> Int
 trackHoldForBooking bookingId holdId ttl' = do
   logInfo $ "SeatBooking:trackHoldForBooking bookingId=" <> bookingId <> " holdId=" <> holdId
   let k = bookingHoldsKey bookingId
-  void $ Redis.sAddExp k [holdId] ttl'
+  Redis.runInMasterCloudRedisCell $
+    void $ Redis.sAddExp k [holdId] ttl'
 
 releaseAbandonedHolds :: (MonadFlow m, Redis.HedisFlow m r) => Text -> Text -> Text -> m ()
 releaseAbandonedHolds tripId bookingId successfulHoldId = do
   let k = bookingHoldsKey bookingId
-  allHolds <- Redis.sMembers k
+  allHolds <- Redis.runInMasterCloudRedisCell $ Redis.sMembers k
   let abandonedHolds = filter (/= successfulHoldId) allHolds
   logInfo $ "SeatBooking:releaseAbandonedHolds bookingId=" <> bookingId <> " tripId=" <> tripId <> " successfulHoldId=" <> successfulHoldId <> " abandonedCount=" <> show (length abandonedHolds)
   forM_ abandonedHolds $ \h -> releaseHold tripId h
-  Redis.del k
+  Redis.runInMasterCloudRedisCell $ Redis.del k
 
 releaseConfirmedSeats ::
   (MonadFlow m, Redis.HedisFlow m r) =>
@@ -196,19 +200,20 @@ releaseConfirmedSeats tripId seatIds fromIdx toIdx = do
           toBS toIdx,
           toBS (length seatIds)
         ]
-  pSeatKeys <- traverse Redis.buildKey seatKeys
-  void $
-    Redis.runHedis
-      ( RawRedis.eval Lua.clearMultiScript pSeatKeys args ::
-          RawRedis.Redis (Either RawRedis.Reply Integer)
-      )
+  Redis.runInMasterCloudRedisCell $ do
+    pSeatKeys <- traverse Redis.buildKey seatKeys
+    void $
+      Redis.runHedis
+        ( RawRedis.eval Lua.clearMultiScript pSeatKeys args ::
+            RawRedis.Redis (Either RawRedis.Reply Integer)
+        )
   logInfo $ "SeatBooking:releaseConfirmedSeats completed tripId=" <> tripId
 
 -- | Standard functions (Availability check doesn't need hold hashtags)
 getTripAvailability :: (MonadFlow m, Redis.HedisFlow m r) => Text -> Int -> Int -> [Seat.Seat] -> m [SeatWithStatus]
 getTripAvailability tripId fromIdx toIdx seats = do
   let keys = map (\s -> seatKey tripId s.id) seats
-  bitmaps <- mapM Redis.tryGetFromCluster keys
+  bitmaps <- Redis.runInMasterCloudRedisCell $ mapM Redis.tryGetFromCluster keys
   return $ zipWith (checkSeatStatus fromIdx toIdx) seats bitmaps
 
 checkSeatStatus :: Int -> Int -> Seat.Seat -> Maybe BS.ByteString -> SeatWithStatus

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/FRFSSeatHoldReaper.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/FRFSSeatHoldReaper.hs
@@ -42,7 +42,7 @@ seatHoldReaperImpl ::
   ) =>
   m ()
 seatHoldReaperImpl = do
-  holds <- Hedis.sMembers "active-seat-holds"
+  holds <- Hedis.runInMasterCloudRedisCell $ Hedis.sMembers "active-seat-holds"
   forM_ holds $ \(ActiveSeatHold tripId holdId) ->
     processHold tripId holdId
 
@@ -53,7 +53,7 @@ processHold ::
   m ()
 processHold tripId holdId = do
   let tKey = timerKey tripId holdId
-  timerTtl <- Hedis.ttl tKey
+  timerTtl <- Hedis.runInMasterCloudRedisCell $ Hedis.ttl tKey
   -- TTL == -2 → timer key does not exist (expired)
   when (timerTtl <= -1) $ do
     logInfo $ "SeatHoldReaper:processHold expired holdId=" <> holdId <> " tripId=" <> tripId


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency of the seat-hold and booking lifecycle by routing additional Redis reads/writes and Lua-based seat updates through the primary master-cloud Redis path.
  * Enhanced hold reaping by ensuring active-hold reads and timer TTL checks use the same master-cloud execution flow.
  * Strengthened trip availability retrieval by executing seat-bitmap fetches via the master-cloud Redis path as well.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->