### PR TITLE
[fix]: Fixed the dhall issue in rider-app for ReconcileRewardInflight

### DIFF
--- a/Backend/dhall-configs/dev/rider-app.dhall
+++ b/Backend/dhall-configs/dev/rider-app.dhall
@@ -296,6 +296,7 @@ let RiderJobType =
       | DailyPassStatusUpdate
       | PassExpiryReminderMaster
       | SettlementReportIngestion
+      | ReconcileRewardInflight
       >
 
 let jobInfoMapx =
@@ -342,6 +343,7 @@ let jobInfoMapx =
       , { mapKey = RiderJobType.DailyPassStatusUpdate, mapValue = True }
       , { mapKey = RiderJobType.PassExpiryReminderMaster, mapValue = True }
       , { mapKey = RiderJobType.SettlementReportIngestion, mapValue = True }
+      , { mapKey = RiderJobType.ReconcileRewardInflight, mapValue = False }
       ]
 
 let cacConfig =
@@ -530,6 +532,7 @@ in  { esqDBCfg
       , remotePath = "/tmp/remote_path"
       }
     , blackListedJobs = [] : List Text
+    , useCachedActiveRidesList = False
     , emailServiceConfig
     , masterCloudProxyConfig =
       { masterUrl = Some "http://localhost:${driverAppInternalPort}"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new rider background processing job: **ReconcileRewardInflight**.
  * Introduced a new configuration flag, **useCachedActiveRidesList** (default: **disabled**), to control whether the active rides list uses cached data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->