### PR TITLE
Backend:fix : Go Home Cfg Query miss for City Creation

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
@@ -218,7 +218,6 @@ import qualified Storage.CachedQueries.PlanTranslation as SCQPT
 import qualified Storage.CachedQueries.SubscriptionConfig as CQSC
 import qualified Storage.CachedQueries.VehicleServiceTier as CQVST
 import Storage.ConfigPilot.Config.DocumentVerificationConfig (DocumentVerificationConfigDimensions (..))
-import Storage.ConfigPilot.Config.GoHomeConfig (GoHomeConfigDimensions (..))
 import Storage.ConfigPilot.Config.LeaderBoardConfigs (LeaderBoardConfigsDimensions (..))
 import Storage.ConfigPilot.Config.MerchantServiceUsageConfig (MerchantServiceUsageConfigDimensions (..))
 import Storage.ConfigPilot.Config.PayoutConfig (PayoutConfigDimensions (..))
@@ -3507,12 +3506,12 @@ postMerchantConfigOperatingCityCreate merchantShortId city req = do
 
   -- go home config
   mbGoHomeConfig <-
-    getConfig (GoHomeConfigDimensions {merchantOperatingCityId = newMerchantOperatingCityId.getId}) (Just (Just <$> CGHC.findByMerchantOpCityId newMerchantOperatingCityId Nothing)) >>= \case
-      Just _ -> return Nothing
-      Nothing -> do
-        goHomeConfig <- getConfig (GoHomeConfigDimensions {merchantOperatingCityId = baseOperatingCityId.getId}) (Just (Just <$> CGHC.findByMerchantOpCityId baseOperatingCityId Nothing)) >>= fromMaybeM (InvalidRequest $ "GoHome Config not found for MerchantOperatingCity: " <> baseOperatingCityId.getId)
+    withTryCatch "GoHomeConfig:findByMerchantOpCityId:postMerchantConfigOperatingCityCreate" (CGHC.findByMerchantOpCityId newMerchantOperatingCityId Nothing) >>= \case
+      Left _ -> do
+        goHomeConfig <- CGHC.findByMerchantOpCityId baseOperatingCityId Nothing
         let newGoHomeConfig = buildGoHomeConfig newMerchantId newMerchantOperatingCityId now goHomeConfig
         return $ Just newGoHomeConfig
+      Right _ -> return Nothing
 
   -- leader board configs
   mbLeaderBoardConfig <-
@@ -4330,9 +4329,15 @@ postMerchantConfigOperatingCityWhiteList _ _ req = do
   let whiteListOrgReq = WLO.WhiteListOrg {domain = bppDomain, id = whiteListOrgId, merchantId = Id merchantId, merchantOperatingCityId = Id merchantOperatingCityId, subscriberId = bapSubId, createdAt = now, updatedAt = now}
       valueAddNpReq = VNP.ValueAddNP {enabled = True, subscriberId = bapSubId.getShortId, createdAt = now, updatedAt = now}
       registryMapFallbackReq = RMF.RegistryMapFallback {registryUrl = nyRegistryBaseUrl, subscriberId = bapSubId.getShortId, uniqueId = bapUniqueKeyId}
-  QWLO.create whiteListOrgReq
-  SQVNP.create valueAddNpReq
-  QRMF.create registryMapFallbackReq
+  existingWhiteListOrg <- QWLO.findBySubscriberIdDomainMerchantIdAndMerchantOperatingCityId bapSubId bppDomain (Id merchantId) (Id merchantOperatingCityId)
+  when (isNothing existingWhiteListOrg) $ QWLO.create whiteListOrgReq
+  SQVNP.findByPrimaryKey bapSubId.getShortId >>= \case
+    Just existing ->
+      unless existing.enabled $
+        SQVNP.updateByPrimaryKey existing {VNP.enabled = True, VNP.updatedAt = now}
+    Nothing -> SQVNP.create valueAddNpReq
+  existingRegistryMapFallback <- QRMF.findByPrimaryKey bapSubId.getShortId bapUniqueKeyId
+  when (isNothing existingRegistryMapFallback) $ QRMF.create registryMapFallbackReq
   pure $
     Common.WhiteListOperatingCityRes
       { whiteListSuccess = True,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/CachedQueries/GoHomeConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/CachedQueries/GoHomeConfig.hs
@@ -31,9 +31,7 @@ import qualified Kernel.Storage.Hedis as Hedis
 import Kernel.Types.Cac
 import Kernel.Types.CacheFlow (CacheFlow)
 import Kernel.Types.Common
-import Kernel.Types.Error
 import Kernel.Types.Id
-import Kernel.Utils.Error.Throwing
 import Storage.Beam.SystemConfigs ()
 import qualified Storage.Queries.GoHomeConfig as Queries
 
@@ -43,20 +41,22 @@ create = Queries.create
 getGoHomeConfigFromDB :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Id MerchantOperatingCity -> m (Maybe GoHomeConfig)
 getGoHomeConfigFromDB id = do
   Hedis.safeGet (makeGoHomeKey id) >>= \case
-    Just cfg -> return cfg
+    Just cfg -> return (Just cfg)
     Nothing -> do
       expTime <- fromIntegral <$> asks (.cacheConfig.configsExpTime)
-      cfg <- fromMaybeM (InternalError ("Could not find Go-To config corresponding to the stated merchant id" <> show id)) =<< Queries.findByMerchantOpCityId id
-      Hedis.setExp (makeGoHomeKey id) cfg expTime
-      return (Just cfg)
+      Queries.findByMerchantOpCityId id >>= \case
+        Just cfg -> do
+          Hedis.setExp (makeGoHomeKey id) cfg expTime
+          return (Just cfg)
+        Nothing -> return Nothing
 
 getConfigsFromMemory :: (CacheFlow m r, EsqDBFlow m r) => Id MerchantOperatingCity -> m (Maybe GoHomeConfig)
 getConfigsFromMemory id = do
   isExpired <- DTC.updateConfig DTC.LastUpdatedGoHomeConfig
   getConfigFromMemoryCommon (DTC.GoHomeConfig id.getId) isExpired CM.isExperimentsRunning
 
-findByMerchantOpCityId :: (CacheFlow m r, MonadFlow m, EsqDBFlow m r) => Id MerchantOperatingCity -> m GoHomeConfig
-findByMerchantOpCityId id = getGoHomeConfigFromDB id <&> fromJust
+findByMerchantOpCityId :: (CacheFlow m r, MonadFlow m, EsqDBFlow m r) => Id MerchantOperatingCity -> m (Maybe GoHomeConfig)
+findByMerchantOpCityId = getGoHomeConfigFromDB
 
 makeGoHomeKey :: Id MerchantOperatingCity -> Text
 makeGoHomeKey id = "driver-offer:CachedQueries:GoHomeConfig:MerchantOpCityId-" <> id.getId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Merchant.hs
@@ -66,6 +66,7 @@ import qualified Domain.Types.BecknConfig as DBC
 import Domain.Types.BusinessHour
 import qualified Domain.Types.Exophone as DExophone
 import qualified Domain.Types.Geometry as DGEO
+import qualified Domain.Types.HotSpotConfig as DHSC
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantMessage as DMM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
@@ -78,6 +79,7 @@ import Domain.Types.ServiceCategory
 import Domain.Types.ServicePeopleCategory
 import Domain.Types.TicketPlace hiding (Fee (..))
 import Domain.Types.TicketService
+import qualified Domain.Types.ValueAddNP as DValueAddNP
 import qualified Domain.Types.WhiteListOrg as WLO
 import Environment
 import qualified EulerHS.Language as L
@@ -131,6 +133,7 @@ import Storage.Beam.IssueManagement ()
 import Storage.Beam.SchedulerJob ()
 import Storage.Beam.SpecialZone ()
 import qualified Storage.CachedQueries.Exophone as CQExophone
+import qualified Storage.CachedQueries.HotSpotConfig as HSC
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.CachedQueries.Merchant.MerchantMessage as CQMM
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
@@ -146,6 +149,7 @@ import qualified Storage.Queries.BusinessHour as SQBH
 import qualified Storage.Queries.BusinessHourExtra as SQBHE
 import qualified Storage.Queries.Geometry as QGeo
 import qualified Storage.Queries.GeometryGeom as QGEO
+import qualified Storage.Queries.HotSpotConfig as QHSC
 import qualified Storage.Queries.Merchant as QM
 import qualified Storage.Queries.MerchantPushNotification as SQMPN
 import qualified Storage.Queries.MerchantServiceConfig as SQMSC
@@ -155,6 +159,7 @@ import qualified Storage.Queries.ServicePeopleCategory as SQSPC
 import qualified Storage.Queries.ServicePeopleCategoryExtra as SQSPCE
 import qualified Storage.Queries.TicketPlace as SQTP
 import qualified Storage.Queries.TicketService as SQTS
+import qualified Storage.Queries.ValueAddNP as QValueAddNP
 import qualified Storage.Queries.WhiteListOrg as QWLO
 import qualified Toll.Domain.Types.Toll as Toll
 import qualified Toll.Storage.CachedQueries.Toll as CQToll
@@ -523,6 +528,17 @@ postMerchantConfigOperatingCityCreate merchantShortId city req = do
           _ -> return Nothing
       _ -> return Nothing
 
+  -- hot spot config (only for a new merchant, copied from base merchant; keyed by merchant id)
+  mbHotSpotConfig <-
+    case mbNewMerchant of
+      Just _ ->
+        HSC.findConfigByMerchantId newMerchantId >>= \case
+          Just _ -> return Nothing
+          Nothing -> do
+            baseHotSpotConfig <- HSC.findConfigByMerchantId baseRequestedCityMerchant.id
+            return $ (\cfg -> cfg {DHSC.id = Id newMerchantId.getId}) <$> baseHotSpotConfig
+      Nothing -> return Nothing
+
   cityAlreadyCreated <- CQMOC.findByMerchantIdAndCity newMerchantId req.city
   newMerchantOperatingCityId <-
     case cityAlreadyCreated of
@@ -725,6 +741,7 @@ postMerchantConfigOperatingCityCreate merchantShortId city req = do
     ( do
         whenJust mbGeometry $ \geometry -> QGeo.create geometry
         whenJust mbNewMerchant $ \newMerchant -> QM.create newMerchant
+        whenJust mbHotSpotConfig $ \hotSpotConfig -> QHSC.create hotSpotConfig
         whenJust mbNewOperatingCity $ \newOperatingCity -> CQMOC.create newOperatingCity
         whenJust mbMerchantMessages $ \merchantMessages -> mapM_ CQMM.create merchantMessages
         whenJust mbMerchantPaymentMethods $ \mPM -> mapM_ CQMPM.create mPM
@@ -1921,7 +1938,22 @@ postMerchantConfigOperatingCityWhiteList _ _ req = do
             createdAt = now,
             updatedAt = now
           }
-  QWLO.create whiteListOrgReq
+  existingWhiteListOrg <- QWLO.findBySubscriberIdDomainMerchantIdAndMerchantOperatingCityId req.bppSubscriberId bppSubDomain (Id merchantId) (Id merchantOperatingCityId)
+  when (isNothing existingWhiteListOrg) $ QWLO.create whiteListOrgReq
+
+  let bppSubscriberId = req.bppSubscriberId.getShortId
+  QValueAddNP.findByPrimaryKey bppSubscriberId >>= \case
+    Just existing ->
+      unless existing.enabled $
+        QValueAddNP.updateByPrimaryKey existing {DValueAddNP.enabled = True, DValueAddNP.updatedAt = now}
+    Nothing ->
+      QValueAddNP.create
+        DValueAddNP.ValueAddNP
+          { enabled = True,
+            subscriberId = bppSubscriberId,
+            createdAt = now,
+            updatedAt = now
+          }
 
   pure $
     Common.WhiteListOperatingCityRes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home configuration handling by safely returning “not found” when no config exists, rather than failing unexpectedly.
  * Propagates optional configuration results through the flow to avoid runtime crashes.
  * Go-home configuration replication during merchant operating city creation now uses safer fallback behavior.

* **New Features**
  * Merchant operating city creation now conditionally copies HotSpot configuration to the new merchant when available.
  * Whitelisting is now idempotent and upserts Value-Add NP to enabled when not already present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->