### PR TITLE
backend/enh/logs-for-rewards

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Rewards/Consumer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Rewards/Consumer.hs
@@ -97,6 +97,15 @@ evaluateRewardsForRider ::
 evaluateRewardsForRider riderId moCityId completedAt = do
   context <- Ctx.readRiderContext riderId
   activeCampaigns <- QRCmpE.findAllActiveInCityAtTime moCityId completedAt
+  logInfo $
+    "rewards.eval.start riderId="
+      <> riderId.getId
+      <> " moCityId="
+      <> moCityId.getId
+      <> " activeCampaignCount="
+      <> show (length activeCampaigns)
+      <> " context="
+      <> encodeToText context
   foldM_
     ( \pushesSoFar campaign -> do
         cohorts <- QRC.findAllByCampaign campaign.id
@@ -104,6 +113,16 @@ evaluateRewardsForRider riderId moCityId completedAt = do
         let existingNonReclaimed = [u.cohortId | u <- existing, u.status /= DRU.Reclaimed]
         matched <- Eval.evaluateCohorts context cohorts
         let toUnlock = filter (`notElem` existingNonReclaimed) matched
+        when (not (null cohorts)) $
+          logInfo $
+            "rewards.eval.campaign riderId="
+              <> riderId.getId
+              <> " campaignId="
+              <> campaign.id.getId
+              <> " matchedCohortIds="
+              <> show (map (.getId) matched)
+              <> " toUnlockCohortIds="
+              <> show (map (.getId) toUnlock)
         foldM
           ( \sentSoFar cohortId -> do
               cohort <-
@@ -112,7 +131,17 @@ evaluateRewardsForRider riderId moCityId completedAt = do
                   _ -> throwError $ InternalError "Consumer: matched cohort not in cohorts list"
               mCode <- Coupon.claimCoupon campaign cohort riderId
               case mCode of
-                Nothing -> pure sentSoFar
+                Nothing -> do
+                  logInfo $
+                    "rewards.claim.empty riderId="
+                      <> riderId.getId
+                      <> " campaignId="
+                      <> campaign.id.getId
+                      <> " cohortId="
+                      <> cohortId.getId
+                      <> " couponSource="
+                      <> show campaign.couponSourceType
+                  pure sentSoFar
                 Just code -> do
                   now <- getCurrentTime
                   uid <- generateGUID
@@ -149,6 +178,13 @@ evaluateRewardsForRider riderId moCityId completedAt = do
                           pure (sentSoFar + 1)
                         else pure sentSoFar
                     else do
+                      logInfo $
+                        "rewards.unlock.skipped.duplicate riderId="
+                          <> riderId.getId
+                          <> " campaignId="
+                          <> campaign.id.getId
+                          <> " cohortId="
+                          <> cohortId.getId
                       when (campaign.couponSourceType == DRCmp.Pool) $ do
                         Pool.pushBackToPool campaign.id cohort.id code
                         Pool.removeFromInflight campaign.id cohort.id code

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Rewards/Producer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Rewards/Producer.hs
@@ -57,32 +57,42 @@ publishRewardEvalRequested ::
 publishRewardEvalRequested rid moCityId completedAt = do
   mConfig <- CQRC.findByMerchantOperatingCityId moCityId
   let enabled = maybe False (.enableRewardsManagement) mConfig
-  when enabled $ do
-    eventId <- generateGUID
-    let event =
-          RewardEvalRequested
-            { eventId,
-              riderId = rid,
-              merchantOperatingCityId = moCityId,
-              completedAt
-            }
-    result <-
-      try @_ @SomeException $
-        produceMessage (rewardEvalTopic, Just (TE.encodeUtf8 rid.getId)) event
-    case result of
-      Right _ ->
-        logInfo $
-          "rewards.publish.success eventId="
-            <> eventId.getId
-            <> " riderId="
-            <> rid.getId
-      Left e ->
-        logError $
-          "rewards.publish.failed eventId="
-            <> eventId.getId
-            <> " riderId="
-            <> rid.getId
-            <> " moCityId="
-            <> moCityId.getId
-            <> " err="
-            <> show e
+  if enabled
+    then do
+      eventId <- generateGUID
+      let event =
+            RewardEvalRequested
+              { eventId,
+                riderId = rid,
+                merchantOperatingCityId = moCityId,
+                completedAt
+              }
+      result <-
+        try @_ @SomeException $
+          produceMessage (rewardEvalTopic, Just (TE.encodeUtf8 rid.getId)) event
+      case result of
+        Right _ ->
+          logInfo $
+            "rewards.publish.success eventId="
+              <> eventId.getId
+              <> " riderId="
+              <> rid.getId
+              <> " moCityId="
+              <> moCityId.getId
+        Left e ->
+          logError $
+            "rewards.publish.failed eventId="
+              <> eventId.getId
+              <> " riderId="
+              <> rid.getId
+              <> " moCityId="
+              <> moCityId.getId
+              <> " err="
+              <> show e
+    else
+      logInfo $
+        "rewards.publish.skipped riderId="
+          <> rid.getId
+          <> " moCityId="
+          <> moCityId.getId
+          <> " reason=enable_rewards_management_false"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward processing visibility with clearer logs when evaluations start, campaigns are checked, or a reward cannot be applied.
  * Added clearer handling for skipped reward unlocks and empty coupon claims, reducing silent failures.
  * When rewards management is turned off, reward publishing is now explicitly skipped and logged with the relevant rider and city context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->