### PR TITLE
Backend/enhance: Removed duplicate calls in setActivity

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -942,23 +942,34 @@ checkPrepaidGoOnlineEligibility ::
   (MonadFlow m, BeamFlow m r, CacheFlow m r, EsqDBFlow m r) =>
   Id SP.Person ->
   TransporterConfig ->
+  DSP.SubscriptionOwnerType ->
+  Text ->
   Maybe DVC.VehicleCategory ->
   m ()
-checkPrepaidGoOnlineEligibility personId transporterConfig mbCurrentVehicleCategory = do
+checkPrepaidGoOnlineEligibility personId transporterConfig ownerType ownerId mbCurrentVehicleCategory = do
   let isolationEnabled = fromMaybe False transporterConfig.subscriptionConfig.vehicleCategoryScopedPrepaidEnabled
       mbVehicleCategory = if isolationEnabled then mbCurrentVehicleCategory else Nothing
-  (ownerType, ownerId, counterparty) <-
-    QFDA.findByDriverId (cast personId) True >>= \case
-      Just fleetDriverAssociation -> pure (DSP.FLEET_OWNER, fleetDriverAssociation.fleetOwnerId, counterpartyFleetOwner)
-      Nothing -> pure (DSP.DRIVER, personId.getId, counterpartyDriver)
-  -- Minimum-balance threshold, mirroring the ride-accept check in initializeRide
-  let prepaidThreshold =
+      counterparty = case ownerType of
+        DSP.FLEET_OWNER -> counterpartyFleetOwner
+        DSP.DRIVER -> counterpartyDriver
+      -- Minimum-balance threshold, mirroring the ride-accept check in initializeRide.
+      prepaidThreshold =
         fromMaybe 0 $ case ownerType of
           DSP.FLEET_OWNER -> transporterConfig.subscriptionConfig.fleetPrepaidSubscriptionThreshold
           DSP.DRIVER -> transporterConfig.subscriptionConfig.prepaidSubscriptionThreshold
-  activePurchases <- QSPE.findAllActiveByOwnerAndServiceName ownerId ownerType Plan.PREPAID_SUBSCRIPTION mbVehicleCategory
+  mbActivePurchase <- QSPE.findLatestActiveByOwnerAndServiceName (\_ -> pure ()) ownerId ownerType Plan.PREPAID_SUBSCRIPTION mbVehicleCategory
   availableBalance <- fromMaybe 0 <$> getPrepaidAvailableBalanceByOwner counterparty ownerId mbVehicleCategory
-  when (null activePurchases || availableBalance <= prepaidThreshold) $
+  logInfo $
+    "checkPrepaidGoOnlineEligibility driverId=" <> personId.getId
+      <> " vehicleCategory="
+      <> show mbVehicleCategory
+      <> " hasActivePlan="
+      <> show (isJust mbActivePurchase)
+      <> " availableBalance="
+      <> show availableBalance
+      <> " threshold="
+      <> show prepaidThreshold
+  when (isNothing mbActivePurchase || availableBalance <= prepaidThreshold) $
     throwError (NoActivePrepaidPlan personId.getId)
 
 setActivity ::
@@ -986,9 +997,13 @@ setActivity (personId, merchantId, merchantOpCityId) isActive mode = do
         when (isActive || (isJust mode && (mode == Just DriverInfo.SILENT || mode == Just DriverInfo.ONLINE))) $ do
           merchant <- CQM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
           mbVehicle <- QVehicle.findById personId
+          mbFleetAssociation <- QFDA.findByDriverId driverId True
+          let (ownerType, ownerId) = case mbFleetAssociation of
+                Just fda -> (DSP.FLEET_OWNER, fda.fleetOwnerId)
+                Nothing -> (DSP.DRIVER, personId.getId)
           -- Eligibility check for prepaid drivers:
           if Plan.PREPAID_SUBSCRIPTION `elem` driverInfo.servicesEnabledForSubscription
-            then checkPrepaidGoOnlineEligibility personId transporterConfig (mbVehicle >>= (.category))
+            then checkPrepaidGoOnlineEligibility personId transporterConfig ownerType ownerId (mbVehicle >>= (.category))
             else do
               DriverSpecificSubscriptionData {..} <- getDriverSpecificSubscriptionDataWithSubsConfig (personId, merchantId, merchantOpCityId) transporterConfig driverInfo mbVehicle Plan.YATRI_SUBSCRIPTION
               let commonSubscriptionChecks = not isOnFreeTrial && not transporterConfig.allowDefaultPlanAllocation
@@ -1007,7 +1022,7 @@ setActivity (personId, merchantId, merchantOpCityId) isActive mode = do
               when ((planBasedChecks || changeBasedChecks) && not isVehicleVariantDisabledForSubscription) $ throwError (NoPlanSelected personId.getId)
           when merchant.onlinePayment $ do
             driverBankAccount <-
-              QFDA.findByDriverId driverId True >>= \case
+              case mbFleetAssociation of
                 Just fleetDriverAssociation -> QDBA.findByPrimaryKey (Id @SP.Person fleetDriverAssociation.fleetOwnerId) >>= fromMaybeM (DriverBankAccountNotFound driverId.getId)
                 Nothing -> QDBA.findByPrimaryKey driverId >>= fromMaybeM (DriverBankAccountNotFound driverId.getId)
             unless driverBankAccount.chargesEnabled $ throwError (DriverChargesDisabled driverId.getId)
@@ -1018,8 +1033,7 @@ setActivity (personId, merchantId, merchantOpCityId) isActive mode = do
           when (transporterConfig.enableBotFlow == Just True) $ do
             unless (isJust mbVehicle) $
               throwError $ InvalidRequest "Cannot go online: no active vehicle linked"
-            mbFleetAssoc <- QFDA.findByDriverId driverId True
-            case mbFleetAssoc of
+            case mbFleetAssociation of
               Just fda -> do
                 fleetOwnerInfo <- QFOI.findByPrimaryKey (Id fda.fleetOwnerId) >>= fromMaybeM (PersonNotFound fda.fleetOwnerId)
                 unless fleetOwnerInfo.enabled $


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the go-online eligibility evaluation for prepaid purchases using the driver’s current ownership context and vehicle category.
  * More reliably blocks go-online when no latest active prepaid plan exists or when the available prepaid balance is at/below the required threshold.
  * Corrected payment configuration validation to use the appropriate associated account, reducing activation failures during subscription go-online flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->