### PR TITLE
fix: dont allow cancellation if no matching cancel config found

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Common.hs
@@ -332,9 +332,11 @@ calculateCancellationCharges merchantOpCityId vehicleCategory baseFare departure
   let minutesBefore = floor (diffUTCTime departureTime now / 60) :: Int
       sortedConfigs = sortOn (Down . (.minMinutesBeforeDeparture)) configs
       mbMatchingTier = find (matchesTier minutesBefore) sortedConfigs
-  case mbMatchingTier of
-    Nothing -> return (0, baseFare) -- no config → full refund
-    Just tier -> do
+  case (configs, mbMatchingTier) of
+    -- No cancellation config for this city/vehicle: feature not opted-in here, keep legacy full-refund behaviour.
+    ([], _) -> return (0, baseFare)
+    -- Inside a configured (allowed) window: apply that tier's charge and refund the remainder.
+    (_, Just tier) -> do
       let rawCharges = case tier.cancellationChargeType of
             DFRFSCancellationConfig.PERCENTAGE -> baseFare * tier.cancellationChargeValue / 100
             DFRFSCancellationConfig.FLAT -> tier.cancellationChargeValue
@@ -354,6 +356,8 @@ calculateCancellationCharges merchantOpCityId vehicleCategory baseFare departure
             <> " clamped to "
             <> show charges
       return (charges, refund)
+    -- Configured, but the current time is outside every allowed window: cancellation is not permitted.
+    (_, Nothing) -> throwError CancellationNotSupported
   where
     matchesTier mins tier =
       mins >= tier.minMinutesBeforeDeparture


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellation charges now distinguish between cases with no cancellation rules and cases where rules exist but the current time falls outside all permitted windows.
  * When no cancellation configuration is provided, riders now receive a full refund with no cancellation charge.
  * When cancellation is configured but not allowed at the moment, the cancellation outcome is no longer treated as a full refund and is handled as unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->