### PR TITLE
backend/fix: render pass photo via passPhotoMediaId

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/Pass.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/Pass.yaml
@@ -107,6 +107,7 @@ types:
     deviceMismatch: Bool
     deviceSwitchAllowed: Bool
     profilePicture: Maybe Text
+    passPhotoMediaId: Maybe (Id MediaFile)
     futureRenewals: [PurchasedPassTransactionAPIEntity]
     isPreferredSourceAndDestinationSet: Bool
     derive: "Show"

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/Pass.hs
@@ -115,6 +115,7 @@ data PurchasedPassAPIEntity = PurchasedPassAPIEntity
     lastVerifiedVehicleNumber :: Data.Maybe.Maybe Data.Text.Text,
     passEntity :: PassDetailsAPIEntity,
     passNumber :: Data.Text.Text,
+    passPhotoMediaId :: Data.Maybe.Maybe (Kernel.Types.Id.Id IssueManagement.Domain.Types.MediaFile.MediaFile),
     profilePicture :: Data.Maybe.Maybe Data.Text.Text,
     purchaseDate :: Data.Time.Day,
     startDate :: Data.Time.Day,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -718,10 +718,6 @@ buildPurchasedPassAPIEntity mbLanguage person mbDeviceId today purchasedPass = d
   mbLastVerified <- QPassVerifyTransaction.findLastVerifiedVehicleNumberByPurchasePassId purchasedPass.id
   let lastVerifiedVehicleNumber = fmap fst mbLastVerified
   let isAutoVerified = (mbLastVerified >>= snd) == Just True
-  -- Prefer the uploaded media file (new flow) and resolve it to a URL; fall back to the legacy inline photo.
-  mbMediaUrl <- case purchasedPass.passPhotoMediaId of
-    Just mediaId -> fmap (.url) <$> QMediaFile.findById mediaId
-    Nothing -> pure Nothing
   return $
     PassAPI.PurchasedPassAPIEntity
       { id = purchasedPass.id,
@@ -734,7 +730,8 @@ buildPurchasedPassAPIEntity mbLanguage person mbDeviceId today purchasedPass = d
         startDate = purchasedPass.startDate,
         deviceMismatch,
         deviceSwitchAllowed = purchasedPass.deviceSwitchCount < maxSwitchCount,
-        profilePicture = mbMediaUrl <|> purchasedPass.profilePicture <|> person.profilePicture,
+        profilePicture = purchasedPass.profilePicture <|> person.profilePicture,
+        passPhotoMediaId = purchasedPass.passPhotoMediaId,
         daysToExpire = daysToExpire,
         purchaseDate = DT.utctDay purchasedPass.createdAt,
         expiryDate = purchasedPass.endDate,


### PR DESCRIPTION
PurchasedPassAPIEntity.profilePicture was set to mediaFile.url (.../v2/pass-photo/media?filePath=...) — a route that is never mounted, so the client got a 404 and pass photos never loaded (reinstall, device-switch, list).

Expose passPhotoMediaId on the entity and drop the dead url resolution; the client renders via the existing GET /multimodal/pass/photo/{mediaId} (getMultimodalPassPhoto -> fetchPassPhotoFromS3, owner-checked). profilePicture keeps the legacy inline-photo / person fallback.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purchased pass responses now include an optional photo media reference.

* **Bug Fixes**
  * Improved profile picture handling for purchased passes so the displayed image now follows a simpler, more consistent fallback order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->