### PR TITLE
feat: Fleet Engine (ODRD) REST client, config and JWT auth

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -44,6 +44,7 @@ library
       API.Dashboard.Fleet
       API.Dashboard.Fleet.Registration
       API.External.LiveEKD
+      API.FleetEngineToken
       API.IGM
       API.Internal
       API.Internal.Auth
@@ -316,6 +317,7 @@ library
       Domain.Action.UI.File
       Domain.Action.UI.FinanceInvoice
       Domain.Action.UI.FleetDriverAssociation
+      Domain.Action.UI.FleetEngineToken
       Domain.Action.UI.FleetOwnerList
       Domain.Action.UI.FRFSFleetOperator
       Domain.Action.UI.Insurance
@@ -557,6 +559,7 @@ library
       SharedLogic.Finance.SubscriptionPurchase
       SharedLogic.Finance.Wallet
       SharedLogic.Fleet
+      SharedLogic.FleetEngine
       SharedLogic.FleetOperatorStats
       SharedLogic.FleetVehicleStats
       SharedLogic.GoogleMaps

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API.hs
@@ -16,6 +16,7 @@ module API where
 
 import qualified API.Beckn as Beckn
 import qualified API.Dashboard as Dashboard
+import qualified API.FleetEngineToken as FleetEngineToken
 import qualified API.IGM as IGM
 import qualified API.Internal as Internal
 import qualified API.Internal.SyncSearch as InternalSyncSearch
@@ -63,6 +64,7 @@ type DriverOfferAPI =
 type MainAPI =
   UI.API
     -- :<|> Beckn.API -- TODO : Revert after 2.x release
+    :<|> FleetEngineToken.API
     :<|> Idfy.IdfyWebhookAPI
     :<|> ( Capture "merchantId" (ShortId DM.Merchant)
              :> Idfy.IdfyWebhookAPI
@@ -119,6 +121,7 @@ mainServer :: AppEnv -> FlowServer MainAPI
 mainServer env =
   UI.handler
     -- :<|> Beckn.handler -- TODO : Revert after 2.x release
+    :<|> FleetEngineToken.handler
     :<|> oldIdfyWebhookHandler
     :<|> idfyWebhookHandler
     :<|> idfyWebhookV2Handler

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/FleetEngineToken.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/FleetEngineToken.hs
@@ -1,0 +1,43 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module API.FleetEngineToken
+  ( API,
+    handler,
+  )
+where
+
+import Domain.Action.UI.FleetEngineToken (FleetEngineDriverTokenRes (..))
+import qualified Domain.Action.UI.FleetEngineToken as DFleetEngineToken
+import qualified Domain.Types.Merchant as Merchant
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Person as Person
+import Environment
+import EulerHS.Prelude
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import Servant
+import Storage.Beam.SystemConfigs ()
+import Tools.Auth
+
+type API =
+  TokenAuth
+    :> "fleetEngine"
+    :> "driverToken"
+    :> Get '[JSON] FleetEngineDriverTokenRes
+
+handler :: FlowServer API
+handler =
+  getFleetEngineDriverToken
+
+getFleetEngineDriverToken ::
+  (Id Person.Person, Id Merchant.Merchant, Id DMOC.MerchantOperatingCity) ->
+  FlowHandler FleetEngineDriverTokenRes
+getFleetEngineDriverToken (personId, merchantId, merchantOpCityId) =
+  withFlowHandlerAPI $ withPersonIdLogTag personId $ DFleetEngineToken.getFleetEngineDriverToken (personId, merchantId, merchantOpCityId)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FleetEngineToken.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FleetEngineToken.hs
@@ -1,0 +1,48 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Domain.Action.UI.FleetEngineToken
+  ( FleetEngineDriverTokenRes (..),
+    getFleetEngineDriverToken,
+  )
+where
+
+import qualified Domain.Types.Merchant as Merchant
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Person as Person
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Error
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import qualified SharedLogic.FleetEngine as FleetEngine
+
+-- | Driver JWT + vehicleId + providerId — all three needed to initialise the Driver SDK on the phone.
+data FleetEngineDriverTokenRes = FleetEngineDriverTokenRes
+  { token :: Text,
+    vehicleId :: Text,
+    providerId :: Text
+  }
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
+getFleetEngineDriverToken ::
+  ( MonadFlow m,
+    EsqDBFlow m r,
+    CacheFlow m r,
+    EncFlow m r,
+    CoreMetrics m,
+    HasRequestId r
+  ) =>
+  (Id Person.Person, Id Merchant.Merchant, Id DMOC.MerchantOperatingCity) ->
+  m FleetEngineDriverTokenRes
+getFleetEngineDriverToken (personId, _, merchantOpCityId) = do
+  (token, vehicleId, providerId) <-
+    FleetEngine.mkDriverToken merchantOpCityId personId
+      >>= fromMaybeM (InternalError "Fleet Engine is not configured for this city")
+  pure FleetEngineDriverTokenRes {..}

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
@@ -14,6 +14,7 @@ import Kernel.External.Call.Interface.Types
 import qualified Kernel.External.ChallanSearch.Interface.Types as ChallanSearchInterface
 import qualified Kernel.External.ChallanSearch.Types as ChallanSearch
 import Kernel.External.Encryption
+import Kernel.External.FleetEngine.Config (FleetEngineCfg)
 import qualified Kernel.External.GSTEInvoice.Interface.Types as GSTEInvoice
 import qualified Kernel.External.GSTEInvoice.Types as GSTEInvoice
 import qualified Kernel.External.IncidentReport.Interface.Types as IncidentReport
@@ -67,6 +68,10 @@ data SAPProvider = Journal
   deriving stock (Eq, Ord, Show, Read, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
+data FleetEngineProvider = GoogleFleetEngine
+  deriving stock (Eq, Ord, Show, Read, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
 data ServiceName
   = MapsService Maps.MapsService
   | SmsService Sms.SmsService
@@ -98,6 +103,7 @@ data ServiceName
   | GSTEInvoiceService GSTEInvoice.GSTEInvoiceService
   | AirportReachargeService Payment.PaymentService
   | ChallanSearchService ChallanSearch.ChallanSearchService
+  | FleetEngineService FleetEngineProvider
   deriving stock (Eq, Ord, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
@@ -134,6 +140,7 @@ instance Show ServiceName where
   show (GSTEInvoiceService s) = "GSTEInvoice_" <> show s
   show (AirportReachargeService s) = "AirportReacharge_" <> show s
   show (ChallanSearchService s) = "ChallanSearch_" <> show s
+  show (FleetEngineService s) = "FleetEngine_" <> show s
 
 instance Read ServiceName where
   readsPrec d' =
@@ -260,6 +267,10 @@ instance Read ServiceName where
                  | r1 <- stripPrefix "ChallanSearch_" r,
                    (v1, r2) <- readsPrec (app_prec + 1) r1
                ]
+            ++ [ (FleetEngineService v1, r2)
+                 | r1 <- stripPrefix "FleetEngine_" r,
+                   (v1, r2) <- readsPrec (app_prec + 1) r1
+               ]
       )
     where
       app_prec = 10
@@ -296,6 +307,7 @@ data ServiceConfigD (s :: UsageSafety)
   | GSTEInvoiceServiceConfig !GSTEInvoice.GSTEInvoiceConfig
   | AirportReachargeServiceConfig !PaymentServiceConfig
   | ChallanSearchServiceConfig !ChallanSearchInterface.ChallanSearchServiceConfig
+  | FleetEngineServiceConfig !FleetEngineCfg
   deriving (Generic, Eq, Show)
 
 type ServiceConfig = ServiceConfigD 'Safe

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
@@ -127,6 +127,7 @@ import qualified Lib.Types.SpecialLocation as SL
 import Network.URI (parseURI, uriQuery)
 import qualified SharedLogic.External.LocationTrackingService.Types as LT
 import qualified SharedLogic.FarePolicy as SFP
+import qualified SharedLogic.FleetEngine as FleetEngine
 import qualified SharedLogic.MerchantPaymentMethod as DMPM
 import qualified SharedLogic.VehicleServiceTier as SVST
 import Storage.Beam.IssueManagement ()
@@ -646,6 +647,7 @@ sendRideStartedUpdateToBAP booking ride tripStartLocation = do
   retryConfig <- asks (.longDurationRetryCfg)
   rideStartedMsgV2 <- ACL.buildOnStatusReqV2 merchant booking rideStartedBuildReq Nothing
   void $ callOnStatusV2 rideStartedMsgV2 retryConfig merchant.id
+  fork "FleetEngine: trip enroute to dropoff on ride started" $ FleetEngine.notifyRideStarted booking ride
 
 sendRideEstimatedEndTimeRangeUpdateToBAP ::
   ( CacheFlow m r,
@@ -762,6 +764,7 @@ sendRideCompletedUpdateToBAP booking ride fareParams paymentMethodInfo paymentUr
   retryConfig <- asks (.longDurationRetryCfg)
   rideCompletedMsgV2 <- ACL.buildOnUpdateMessageV2 merchant booking Nothing rideCompletedBuildReq
   void $ callOnUpdateV2 rideCompletedMsgV2 retryConfig merchant.id
+  fork "FleetEngine: complete trip on ride completed" $ FleetEngine.notifyRideCompleted booking ride
 
 sendBookingCancelledUpdateToBAP ::
   ( EsqDBFlow m r,
@@ -792,6 +795,8 @@ sendBookingCancelledUpdateToBAP booking transporter cancellationSource cancellat
   retryConfig <- asks (.longDurationRetryCfg)
   bookingCancelledMsgV2 <- ACL.buildOnCancelMessageV2 transporter booking.bapCity booking.bapCountry (show Enums.CANCELLED) bookingCancelledBuildReqV2 Nothing
   void $ callOnCancelV2 bookingCancelledMsgV2 retryConfig transporter.id
+  whenJust mbRide $ \cancelledRide ->
+    fork "FleetEngine: cancel trip on booking cancelled" $ FleetEngine.notifyTripCancelled booking.merchantOperatingCityId cancelledRide.id
 
 sendDriverOffer ::
   ( HasFlowEnv m r '["nwAddress" ::: BaseUrl],
@@ -902,6 +907,7 @@ sendDriverArrivalUpdateToBAP booking ride arrivalTime = do
   retryConfig <- asks (.shortDurationRetryCfg)
   driverArrivedMsgV2 <- ACL.buildOnUpdateMessageV2 merchant booking Nothing driverArrivedBuildReq
   void $ callOnUpdateV2 driverArrivedMsgV2 retryConfig merchant.id
+  fork "FleetEngine: arrived at pickup on driver arrival" $ FleetEngine.notifyDriverArrived booking ride
 
 sendPhoneCallRequestUpdateToBAP ::
   ( CacheFlow m r,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FleetEngine.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FleetEngine.hs
@@ -1,0 +1,157 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+-- | Mirrors the BPP ride lifecycle into Google Fleet Engine trips. Best-effort:
+-- a no-op when the city has no Fleet Engine service config, and callers must
+-- 'fork' entry points so failures never disturb the ride flow.
+--
+-- tripId = BPP rideId (1:1); vehicleId = driverId (1:1).
+module SharedLogic.FleetEngine
+  ( mkDriverToken,
+    notifyTripCreated,
+    notifyDriverArrived,
+    notifyRideStarted,
+    notifyRideCompleted,
+    notifyTripCancelled,
+  )
+where
+
+import qualified Data.Text as T
+import qualified Domain.Types.Booking as DRB
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.MerchantServiceConfig as DOSC
+import qualified Domain.Types.Person as DP
+import qualified Domain.Types.Ride as SRide
+import Kernel.External.Encryption (decrypt)
+import qualified Kernel.External.FleetEngine.Auth as FEAuth
+import qualified Kernel.External.FleetEngine.Client as FEClient
+import Kernel.External.FleetEngine.Config (FleetEngineCfg)
+import qualified Kernel.External.FleetEngine.Config as FEConfig
+import qualified Kernel.External.FleetEngine.Types as FETypes
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import qualified Storage.CachedQueries.Merchant.MerchantServiceConfig as QOMSC
+
+type FleetEngineFlow m r =
+  ( MonadFlow m,
+    EsqDBFlow m r,
+    CacheFlow m r,
+    EncFlow m r,
+    CoreMetrics m,
+    HasRequestId r
+  )
+
+getFleetEngineCfg ::
+  (CacheFlow m r, EsqDBFlow m r) =>
+  Id DMOC.MerchantOperatingCity ->
+  m (Maybe FleetEngineCfg)
+getFleetEngineCfg merchantOpCityId = do
+  mbServiceConfig <- QOMSC.findByServiceAndCity (DOSC.FleetEngineService DOSC.GoogleFleetEngine) merchantOpCityId
+  pure $ case mbServiceConfig of
+    Just sc -> case sc.serviceConfig of
+      DOSC.FleetEngineServiceConfig cfg -> Just cfg
+      _ -> Nothing
+    Nothing -> Nothing
+
+-- | Returns 'Nothing' when Fleet Engine is off for the city, or on config/token
+-- errors (logged, not thrown) — callers decide how to surface each case.
+mkDriverToken ::
+  FleetEngineFlow m r =>
+  Id DMOC.MerchantOperatingCity ->
+  Id DP.Person ->
+  m (Maybe (Text, Text, Text))
+mkDriverToken merchantOpCityId driverId = do
+  mbCfg <- getFleetEngineCfg merchantOpCityId
+  case mbCfg of
+    Nothing -> pure Nothing -- feature off for this city
+    Just cfg -> do
+      saText <- decrypt cfg.driverServiceAccountJson
+      case FEAuth.parseServiceAccount saText of
+        Left err -> do
+          logError $ "FleetEngine: invalid driver service account for city " <> merchantOpCityId.getId <> ": " <> T.pack err
+          pure Nothing
+        Right sa -> do
+          let vehicleId = driverId.getId -- Fleet Engine vehicleId is the driverId (driver<->vehicle is 1:1)
+              ttl = fromMaybe FEConfig.defaultDriverTokenTtl cfg.driverTokenTtlSeconds
+          eToken <- liftIO $ FEAuth.mintFleetEngineToken sa (FEAuth.DriverToken vehicleId) ttl
+          case eToken of
+            Left err -> do
+              logError $ "FleetEngine: driver token mint failed for city " <> merchantOpCityId.getId <> ": " <> T.pack err
+              pure Nothing
+            Right token -> pure $ Just (token, vehicleId, cfg.providerId)
+
+-- | Silent skip when Fleet Engine is off; logs (never throws) on config/token errors.
+withFleetEngine ::
+  FleetEngineFlow m r =>
+  Id DMOC.MerchantOperatingCity ->
+  (Text -> Text -> BaseUrl -> m ()) -> -- providerId -> serverToken -> baseUrl
+  m ()
+withFleetEngine merchantOpCityId action = do
+  mbCfg <- getFleetEngineCfg merchantOpCityId
+  case mbCfg of
+    Nothing -> pure () -- feature off for this city
+    Just cfg -> do
+      saText <- decrypt cfg.serverServiceAccountJson
+      case FEAuth.parseServiceAccount saText of
+        Left err -> logError $ "FleetEngine: invalid server service account for city " <> merchantOpCityId.getId <> ": " <> T.pack err
+        Right sa -> do
+          let ttl = fromMaybe FEConfig.defaultServerTokenTtl cfg.serverTokenTtlSeconds
+          eToken <- liftIO $ FEAuth.mintFleetEngineToken sa FEAuth.ServerToken ttl
+          case eToken of
+            Left err -> logError $ "FleetEngine: server token mint failed for city " <> merchantOpCityId.getId <> ": " <> T.pack err
+            Right token -> action cfg.providerId token (fromMaybe FEClient.defaultFleetEngineBaseUrl cfg.fleetEngineUrl)
+
+-- | Ensure the vehicle exists, then create the trip and assign it (NEW -> ENROUTE_TO_PICKUP).
+notifyTripCreated :: FleetEngineFlow m r => DRB.Booking -> SRide.Ride -> m ()
+notifyTripCreated booking ride =
+  withFleetEngine booking.merchantOperatingCityId $ \providerId token baseUrl -> do
+    let tripId = ride.id.getId
+        vehicleId = ride.driverId.getId -- driver<->vehicle is 1:1
+        pickupPoint = Just (FETypes.LatLng booking.fromLocation.lat booking.fromLocation.lon)
+        dropoffPoint = (\loc -> FETypes.LatLng loc.lat loc.lon) <$> booking.toLocation
+    ensureVehicleExists baseUrl providerId token vehicleId
+    FEClient.createTrip baseUrl providerId token tripId (FETypes.mkCreateTripBody FETypes.EXCLUSIVE pickupPoint dropoffPoint Nothing)
+    FEClient.assignVehicleAndStart baseUrl providerId token tripId vehicleId
+
+-- | GET-first: don't overwrite state the Driver SDK may set once mobile integration lands.
+ensureVehicleExists :: FleetEngineFlow m r => BaseUrl -> Text -> Text -> Text -> m ()
+ensureVehicleExists baseUrl providerId token vehicleId = do
+  mbVeh <- FEClient.getVehicle baseUrl providerId token vehicleId
+  when (isNothing mbVeh) $
+    FEClient.createVehicle baseUrl providerId token vehicleId defaultVehicle
+
+-- | Placeholder body — Driver SDK overwrites state and vehicleType at online-time.
+defaultVehicle :: FETypes.Vehicle
+defaultVehicle =
+  FETypes.Vehicle
+    { vehicleState = FETypes.OFFLINE,
+      supportedTripTypes = [FETypes.EXCLUSIVE],
+      maximumCapacity = 4,
+      vehicleType = FETypes.VehicleType {category = FETypes.AUTO}
+    }
+
+notifyTripStatus :: FleetEngineFlow m r => Id DMOC.MerchantOperatingCity -> Id SRide.Ride -> FETypes.TripStatus -> m ()
+notifyTripStatus merchantOpCityId rideId status =
+  withFleetEngine merchantOpCityId $ \providerId token baseUrl -> do
+    logInfo $ "FleetEngine: updateTripStatus provider=" <> providerId <> " tripId=" <> rideId.getId <> " status=" <> show status
+    FEClient.updateTripStatus baseUrl providerId token rideId.getId status
+
+notifyDriverArrived :: FleetEngineFlow m r => DRB.Booking -> SRide.Ride -> m ()
+notifyDriverArrived booking ride = notifyTripStatus booking.merchantOperatingCityId ride.id FETypes.ARRIVED_AT_PICKUP
+
+notifyRideStarted :: FleetEngineFlow m r => DRB.Booking -> SRide.Ride -> m ()
+notifyRideStarted booking ride = notifyTripStatus booking.merchantOperatingCityId ride.id FETypes.ENROUTE_TO_DROPOFF
+
+notifyRideCompleted :: FleetEngineFlow m r => DRB.Booking -> SRide.Ride -> m ()
+notifyRideCompleted booking ride = notifyTripStatus booking.merchantOperatingCityId ride.id FETypes.COMPLETE
+
+notifyTripCancelled :: FleetEngineFlow m r => Id DMOC.MerchantOperatingCity -> Id SRide.Ride -> m ()
+notifyTripCancelled merchantOpCityId rideId = notifyTripStatus merchantOpCityId rideId FETypes.CANCELED

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
@@ -57,6 +57,7 @@ import qualified Lib.Types.SpecialLocation as SL
 import qualified SharedLogic.Analytics as Analytics
 import qualified SharedLogic.CallBAPInternal as CallBAPInternal
 import qualified SharedLogic.DriverPool as DP
+import qualified SharedLogic.FleetEngine as FleetEngine
 import qualified SharedLogic.External.LocationTrackingService.Flow as LF
 import qualified SharedLogic.External.LocationTrackingService.Types as LT
 import qualified SharedLogic.FareCalculator as FC
@@ -199,6 +200,8 @@ initializeRide merchant driver booking mbOtpCode enableFrequentLocationUpdates m
 
   fork "DriverScoreEventHandler OnNewRideAssigned" $
     DS.driverScoreEventHandler booking.merchantOperatingCityId DST.OnNewRideAssigned {merchantId = merchantId, driverId = ride.driverId, currency = ride.currency, distanceUnit = booking.distanceUnit}
+
+  fork "FleetEngine: create trip on ride assigned" $ FleetEngine.notifyTripCreated booking ride
 
   notifyRideRelatedNotificationOnEvent ride now DRN.RIDE_ASSIGNED
   notifyRideRelatedNotificationOnEvent ride now DRN.PICKUP_TIME

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
@@ -144,6 +144,7 @@ getConfigJSON = \case
     Payment.PaytmEDCConfig cfg -> toJSON cfg
   Domain.ChallanSearchServiceConfig challanCfg -> case challanCfg of
     ChallanSearchInterface.SignzyChallanSearch cfg -> toJSON cfg
+  Domain.FleetEngineServiceConfig cfg -> toJSON cfg
 
 getServiceName :: Domain.ServiceConfig -> Domain.ServiceName
 getServiceName = \case
@@ -232,6 +233,7 @@ getServiceName = \case
   Domain.AirportReachargeServiceConfig paymentCfg -> Domain.AirportReachargeService $ getPaymentServiceConfigJson paymentCfg
   Domain.ChallanSearchServiceConfig challanCfg -> case challanCfg of
     ChallanSearchInterface.SignzyChallanSearch _ -> Domain.ChallanSearchService ChallanSearch.Signzy
+  Domain.FleetEngineServiceConfig _ -> Domain.FleetEngineService Domain.GoogleFleetEngine
 
 getPaymentServiceConfigJson :: Payment.PaymentServiceConfig -> Payment.PaymentService
 getPaymentServiceConfigJson = \case
@@ -331,6 +333,7 @@ mkServiceConfig configJSON serviceName = either (\err -> throwError $ InternalEr
   Domain.GSTEInvoiceService GSTEInvoice.CharteredInfo -> Domain.GSTEInvoiceServiceConfig . GSTEInvoice.CharteredInfoEInvoiceConfig <$> eitherValue configJSON
   Domain.AirportReachargeService paymentServiceName -> Domain.AirportReachargeServiceConfig <$> mkPaymentServiceConfig configJSON paymentServiceName
   Domain.ChallanSearchService ChallanSearch.Signzy -> Domain.ChallanSearchServiceConfig . ChallanSearchInterface.SignzyChallanSearch <$> eitherValue configJSON
+  Domain.FleetEngineService Domain.GoogleFleetEngine -> Domain.FleetEngineServiceConfig <$> eitherValue configJSON
 
 eitherValue :: FromJSON a => A.Value -> Either Text a
 eitherValue value = case A.fromJSON value of

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -50,6 +50,7 @@ library
       API.Dashboard
       API.Dashboard.Exotel
       API.Depot
+      API.FleetEngineToken
       API.FRFS
       API.FRFSMetrics
       API.IGM
@@ -292,6 +293,7 @@ library
       Domain.Action.UI.FeedbackForm
       Domain.Action.UI.File
       Domain.Action.UI.FinanceInvoice
+      Domain.Action.UI.FleetEngineToken
       Domain.Action.UI.FollowRide
       Domain.Action.UI.FRFSInternal
       Domain.Action.UI.FRFSTicketService

--- a/Backend/app/rider-platform/rider-app/Main/src/API.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API.hs
@@ -23,6 +23,7 @@ import qualified API.Beckn as Beckn
 import qualified API.Conductor as Conductor
 import qualified API.Dashboard as Dashboard
 import qualified API.Depot as Depot
+import qualified API.FleetEngineToken as FleetEngineToken
 import qualified API.FRFS as FRFS
 import qualified API.FRFSMetrics as FRFSMetrics
 import qualified API.IGM as IGM
@@ -95,6 +96,7 @@ type MainAPI =
     :<|> Conductor.API
     :<|> Depot.API
     :<|> FRFSMetrics.API
+    :<|> FleetEngineToken.API
 
 riderAPI :: Proxy API
 riderAPI = Proxy
@@ -125,6 +127,7 @@ mainServer =
     :<|> Conductor.handler
     :<|> Depot.handler
     :<|> FRFSMetrics.handler
+    :<|> FleetEngineToken.handler
 
 type SwaggerAPI = "swagger" :> Get '[HTML] BS.ByteString
 

--- a/Backend/app/rider-platform/rider-app/Main/src/API/FleetEngineToken.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/FleetEngineToken.hs
@@ -1,0 +1,41 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module API.FleetEngineToken where
+
+import qualified Domain.Action.UI.FleetEngineToken as DFleetEngineToken
+import qualified Domain.Types.Merchant as Merchant
+import qualified Domain.Types.Person as Person
+import qualified Domain.Types.Ride as Ride
+import Environment
+import Kernel.Prelude
+import Kernel.Types.Id
+import Servant
+import Tools.Auth (TokenAuth)
+import Tools.FlowHandling (withFlowHandlerAPIPersonId)
+import Kernel.Types.App (MandatoryQueryParam)
+
+
+type API =
+  TokenAuth
+    :> "fleetEngine"
+    :> "consumerToken"
+    :> MandatoryQueryParam "rideId" (Id Ride.Ride)
+    :> Get '[JSON] DFleetEngineToken.FleetEngineConsumerTokenRes
+
+handler :: FlowServer API
+handler = getFleetEngineConsumerToken
+
+getFleetEngineConsumerToken ::
+  (Id Person.Person, Id Merchant.Merchant) ->
+  Id Ride.Ride ->
+  FlowHandler DFleetEngineToken.FleetEngineConsumerTokenRes
+getFleetEngineConsumerToken (personId, merchantId) rideId =
+  withFlowHandlerAPIPersonId personId $
+    DFleetEngineToken.getFleetEngineConsumerToken (personId, merchantId) rideId

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FleetEngineToken.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FleetEngineToken.hs
@@ -1,0 +1,84 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+-- | Mints a consumer-scoped Fleet Engine JWT so the rider Consumer SDK can
+-- subscribe to a specific trip. tripId = BPP rideId (1:1). Signed with the
+-- city's consumer SA (@roles/fleetengine.consumerSdkUser@).
+module Domain.Action.UI.FleetEngineToken
+  ( FleetEngineConsumerTokenRes (..),
+    getFleetEngineConsumerToken,
+  )
+where
+
+import qualified Data.Text as T
+import qualified Domain.Types.Merchant as Merchant
+import Domain.Types.MerchantOperatingCity (MerchantOperatingCity)
+import qualified Domain.Types.MerchantServiceConfig as DOSC
+import qualified Domain.Types.Person as Person
+import qualified Domain.Types.Ride as Ride
+import Environment
+import Kernel.External.Encryption (decrypt)
+import qualified Kernel.External.FleetEngine.Auth as FEAuth
+import Kernel.External.FleetEngine.Config (FleetEngineCfg)
+import qualified Kernel.External.FleetEngine.Config as FEConfig
+import Kernel.Prelude
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import qualified Storage.CachedQueries.Merchant.MerchantServiceConfig as QOMSC
+import qualified Storage.Queries.Booking as QBooking
+import qualified Storage.Queries.Ride as QRide
+import Tools.Error
+
+data FleetEngineConsumerTokenRes = FleetEngineConsumerTokenRes
+  { token :: Text,
+    tripId :: Text,
+    providerId :: Text,
+    expiresInSeconds :: Integer
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema, Show)
+
+getFleetEngineConsumerToken ::
+  (Id Person.Person, Id Merchant.Merchant) ->
+  Id Ride.Ride ->
+  Flow FleetEngineConsumerTokenRes
+getFleetEngineConsumerToken (personId, _merchantId) rideId = do
+  ride <- QRide.findById rideId >>= fromMaybeM (RideNotFound rideId.getId)
+  booking <- QBooking.findById ride.bookingId >>= fromMaybeM (BookingNotFound ride.bookingId.getId)
+  unless (booking.riderId == personId) $ throwError AccessDenied
+  cfg <- getFleetEngineCfg booking.merchantId booking.merchantOperatingCityId >>= fromMaybeM (InternalError "Fleet Engine not configured")
+  saText <- decrypt cfg.consumerServiceAccountJson
+  sa <- case FEAuth.parseServiceAccount saText of
+    Left err -> throwError $ InternalError ("Fleet Engine: invalid consumer service account: " <> T.pack err)
+    Right sa -> pure sa
+  let tripId = ride.bppRideId.getId
+      ttl = fromMaybe FEConfig.defaultConsumerTokenTtl cfg.consumerTokenTtlSeconds
+  eToken <- liftIO $ FEAuth.mintFleetEngineToken sa (FEAuth.ConsumerToken tripId) ttl
+  token <- case eToken of
+    Left err -> throwError $ InternalError ("Fleet Engine: consumer token mint failed: " <> T.pack err)
+    Right token -> pure token
+  pure
+    FleetEngineConsumerTokenRes
+      { token = token,
+        tripId = tripId,
+        providerId = cfg.providerId,
+        expiresInSeconds = ttl
+      }
+
+getFleetEngineCfg ::
+  (CacheFlow m r, EsqDBFlow m r) =>
+  Id Merchant.Merchant ->
+  Id MerchantOperatingCity ->
+  m (Maybe FleetEngineCfg)
+getFleetEngineCfg merchantId merchantOpCityId = do
+  mbServiceConfig <- QOMSC.findByMerchantOpCityIdAndService merchantId merchantOpCityId (DOSC.FleetEngineService DOSC.GoogleFleetEngine)
+  pure $ case mbServiceConfig of
+    Just sc -> case sc.serviceConfig of
+      DOSC.FleetEngineServiceConfig cfg -> Just cfg
+      _ -> Nothing
+    Nothing -> Nothing

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Extra/MerchantServiceConfig.hs
@@ -8,6 +8,7 @@ import qualified Kernel.External.Call as Call
 import Kernel.External.Call.Interface.Types
 import qualified Kernel.External.EventTracking as EventTracking
 import qualified Kernel.External.EventTracking.Interface.Types as EventTrackingInterface
+import Kernel.External.FleetEngine.Config (FleetEngineCfg)
 import qualified Kernel.External.IncidentReport.Interface.Types as IncidentReport
 import qualified Kernel.External.Insurance.Interface.Types as Insurance
 import qualified Kernel.External.Insurance.Types as Insurance
@@ -32,6 +33,11 @@ import Tools.Beam.UtilsTH
 import Utils.Common.JWT.Config as GW
 
 -- Extra code goes here --
+
+data FleetEngineProvider = GoogleFleetEngine
+  deriving stock (Eq, Ord, Show, Read, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
 data ServiceName
   = MapsService Maps.MapsService
   | SmsService Sms.SmsService
@@ -59,6 +65,7 @@ data ServiceName
   | SOSService SOS.SOSService
   | SettlementService Settlement.SettlementService
   | EventTrackingService EventTracking.EventTrackingService
+  | FleetEngineService FleetEngineProvider
   deriving stock (Eq, Ord, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
@@ -91,6 +98,7 @@ instance Show ServiceName where
   show (SOSService s) = "SOS_" <> show s
   show (SettlementService s) = "Settlement_" <> show s
   show (EventTrackingService s) = "EventTracking_" <> show s
+  show (FleetEngineService s) = "FleetEngine_" <> show s
 
 instance Read ServiceName where
   readsPrec d' =
@@ -201,6 +209,10 @@ instance Read ServiceName where
                  | r1 <- stripPrefix "EventTracking_" r,
                    (v1, r2) <- readsPrec (app_prec + 1) r1
                ]
+            ++ [ (FleetEngineService v1, r2)
+                 | r1 <- stripPrefix "FleetEngine_" r,
+                   (v1, r2) <- readsPrec (app_prec + 1) r1
+               ]
       )
     where
       app_prec = 10
@@ -233,6 +245,7 @@ data ServiceConfigD (s :: UsageSafety)
   | SOSServiceConfig !SOSInterface.SOSServiceConfig
   | SettlementServiceConfig !Settlement.SettlementServiceConfig
   | EventTrackingServiceConfig !EventTrackingInterface.EventTrackingServiceConfig
+  | FleetEngineServiceConfig !FleetEngineCfg
   deriving (Generic, Eq)
 
 type ServiceConfig = ServiceConfigD 'Safe
@@ -272,8 +285,10 @@ instance Show (ServiceConfigD 'Safe) where
   show (SOSServiceConfig cfg) = "SOSServiceConfig " <> show cfg
   show (SettlementServiceConfig cfg) = "SettlementServiceConfig " <> show cfg
   show (EventTrackingServiceConfig cfg) = "EventTrackingServiceConfig " <> show cfg
+  show (FleetEngineServiceConfig cfg) = "FleetEngineServiceConfig " <> show cfg
 
 instance Show (ServiceConfigD 'Unsafe) where
+  show (FleetEngineServiceConfig cfg) = "FleetEngineServiceConfig " <> show cfg
   show (MapsServiceConfig cfg) = "MapsServiceConfig " <> show cfg
   show (SmsServiceConfig cfg) = "SmsServiceConfig " <> show cfg
   show (WhatsappServiceConfig cfg) = "WhatsappServiceConfig " <> show cfg

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MerchantServiceConfig.hs
@@ -214,6 +214,7 @@ getServiceName msc = case msc.serviceConfig of
   SettlementServiceConfig cfg -> SettlementService cfg.settlementService
   EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
     EventTrackingInterface.MoengageConfig _ -> EventTrackingService EventTracking.Moengage
+  FleetEngineServiceConfig _ -> FleetEngineService GoogleFleetEngine
 
 upsertMerchantServiceConfig :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => MerchantServiceConfig -> m ()
 upsertMerchantServiceConfig cfg = do

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/PlaceBasedServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/PlaceBasedServiceConfig.hs
@@ -160,3 +160,4 @@ getServiceNameFromPlaceBasedConfigs msc = case msc.serviceConfig of
   SettlementServiceConfig cfg -> SettlementService cfg.settlementService
   EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
     EventTrackingInterface.MoengageConfig _ -> EventTrackingService EventTracking.Moengage
+  FleetEngineServiceConfig _ -> FleetEngineService GoogleFleetEngine

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/MerchantServiceConfigExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/MerchantServiceConfigExtra.hs
@@ -204,3 +204,4 @@ getServiceNameConfigJSON = \case
   Domain.SettlementServiceConfig cfg -> (Domain.SettlementService cfg.settlementService, toJSON cfg)
   Domain.EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
     EventTrackingInterface.MoengageConfig cfg -> (Domain.EventTrackingService EventTracking.Moengage, toJSON cfg)
+  Domain.FleetEngineServiceConfig cfg -> (Domain.FleetEngineService Domain.GoogleFleetEngine, toJSON cfg)

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Transformers/MerchantServiceConfig.hs
@@ -95,6 +95,7 @@ getServiceConfigFromDomain serviceName configJSON = do
       Just cfg | cfg.settlementService == svc -> Just $ Domain.SettlementServiceConfig cfg
       _ -> Nothing
     Domain.EventTrackingService EventTracking.Moengage -> Domain.EventTrackingServiceConfig . EventTrackingInterface.MoengageConfig <$> valueToMaybe configJSON
+    Domain.FleetEngineService Domain.GoogleFleetEngine -> Domain.FleetEngineServiceConfig <$> valueToMaybe configJSON
 
 mkPaymentServiceConfig :: A.Value -> Payment.PaymentService -> Maybe Payment.PaymentServiceConfig
 mkPaymentServiceConfig configJSON = \case
@@ -190,6 +191,7 @@ getServiceNameConfigJson = \case
   Domain.SettlementServiceConfig cfg -> (Domain.SettlementService cfg.settlementService, toJSON cfg)
   Domain.EventTrackingServiceConfig eventTrackingCfg -> case eventTrackingCfg of
     EventTrackingInterface.MoengageConfig cfg -> (Domain.EventTrackingService EventTracking.Moengage, toJSON cfg)
+  Domain.FleetEngineServiceConfig cfg -> (Domain.FleetEngineService Domain.GoogleFleetEngine, toJSON cfg)
 
 getPaymentServiceConfigJson :: Payment.PaymentServiceConfig -> (Payment.PaymentService, A.Value)
 getPaymentServiceConfigJson = \case

--- a/flake.lock
+++ b/flake.lock
@@ -4004,11 +4004,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1784546064,
-        "narHash": "sha256-JIcDktfX6XfCMvnRnueZEkxilYK6s6YPv37TvBTXG6w=",
+        "lastModified": 1784570397,
+        "narHash": "sha256-+AhQgSUSsaoOOrhACy6sgIs8FlD0625glPGch+xyXFg=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "e080d09d01d2cff10631cd437e53a6b0200abdb8",
+        "rev": "c7c0ee885d0f6d2a1ccd64305571b0f5705e1fe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Backend half of Google **Fleet Engine** (ODRD) journey sharing.

**Trip mirroring (BPP):** `SharedLogic/FleetEngine.hs` mirrors the ride lifecycle into Fleet Engine trips, hooked via `fork` into the existing BPP→BAP fan-out in `SharedLogic/CallBAP.hs`:
- ride assigned → `CreateTrip` (with pickup/dropoff waypoints from the booking) + assign vehicle (NEW → ENROUTE_TO_PICKUP)
- driver arrival / start / complete / cancel → `UpdateTripStatus` ARRIVED_AT_PICKUP / ENROUTE_TO_DROPOFF / COMPLETE / CANCELED

**Token endpoints:**
- BAP rider-app: `GET /fleetEngine/consumerToken?rideId=` (TokenAuth) — verifies ride ownership, mints a consumer JWT scoped to the trip (`tripId = ride.bppRideId`).
- BPP driver-app: `GET /fleetEngine/driverToken` (TokenAuth) — mints a vehicle-scoped driver JWT (via `mkDriverToken`).

**Config:** a new per-`MerchantOperatingCity` `FleetEngineService` `MerchantServiceConfig` variant on **both** apps (hand-written Extra sum-types + all exhaustive transformer/cached-query sites). Absent config ⇒ every path is a silent no-op.

`tripId = bppRideId` (idempotent CreateTrip); `vehicleId` derived from driverId; server/consumer/driver JWTs minted from the city's encrypted service-account JSON.

### Additional Changes

- [x] This PR modifies dhall configs/environment variables — requires a per-city `FleetEngineService` `merchant_service_config` row (encrypted service-account JSON + provider/project id) for enabled cities. No schema change.

> **Cross-repo dependency:** requires `Kernel.External.FleetEngine.*` from **nammayatri/shared-kernel#1381**; the shared-kernel pin must be bumped for CI.

## Motivation and Context

Google's Consumer/Driver SDKs only render journey-sharing ETAs for trips that exist in Fleet Engine with a reporting vehicle. The BPP owns ride-state and driver identity, so it writes the trip lifecycle; the apps need short-lived scoped JWTs, minted here.

## How did you test it?

**Not compiled here** — the authoring sandbox has no `nix`/`cabal`. Hand-written modules mirror `SharedLogic/GoogleMobilityBilling.hs`, the `CallBAP` fork pattern, and the existing `MerchantServiceConfig` variant/transformer pattern; the token endpoints mirror `API/UI/RideRoute.hs` (BPP) / `API/FRFSMetrics.hs` + HotSpot TokenAuth (BAP). Needs `cabal build` after the shared-kernel pin bump. WIP.

## Checklist

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fleet Engine token endpoints for both driver and rider apps.
  * Drivers can now retrieve a short-lived driver token.
  * Riders can now retrieve a short-lived consumer token for their trip.
  * Ride lifecycle updates are now reflected in Fleet Engine, including assignment, arrival, start, completion, and cancellation.

* **Bug Fixes**
  * Added support for storing and reading Fleet Engine service configuration across app flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->