### PR TITLE
backend: apply special zone service tier names

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboardingV2.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboardingV2.hs
@@ -64,6 +64,7 @@ import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig, getOneConfig)
 import qualified Lib.Finance.Storage.Queries.IndirectTaxTransaction as QIndirectTax
 import qualified Lib.Finance.Storage.Queries.Invoice as QFinanceInvoice
+import qualified Lib.Queries.SpecialLocation as QSpecialLocation
 import SharedLogic.DriverOnboarding
 import qualified SharedLogic.DriverOnboarding as SDO
 import SharedLogic.DriverOnboarding.Digilocker
@@ -75,6 +76,7 @@ import SharedLogic.DriverOnboarding.Digilocker
   )
 import qualified SharedLogic.DriverOnboarding.Digilocker as DigilockerLockerShared
 import qualified SharedLogic.DriverOnboarding.Status as SStatus
+import qualified SharedLogic.External.LocationTrackingService.Flow as LTSFlow
 import SharedLogic.FareCalculator
 import SharedLogic.FarePolicy
 import qualified SharedLogic.Merchant as SMerchant
@@ -411,7 +413,14 @@ getDriverVehicleServiceTiers (mbPersonId, _, merchantOpCityId) = do
   person <- runInReplica $ PersonQuery.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
   driverInfo <- runInReplica $ QDI.findById personId >>= fromMaybeM DriverInfoNotFound
   vehicle <- runInReplica $ QVehicle.findById personId >>= fromMaybeM (VehicleDoesNotExist personId.getId)
-  cityVehicleServiceTiers <- CQVST.findAllByMerchantOpCityId merchantOpCityId Nothing
+  baseCityVehicleServiceTiers <- CQVST.findAllByMerchantOpCityId merchantOpCityId Nothing
+  -- Resolve driver location only when special-zone tier names are configured;
+  -- otherwise this endpoint should avoid an extra LTS call on every preferences refresh.
+  mbSpecialLocationId <-
+    if any (isJust . (.specialZone)) baseCityVehicleServiceTiers
+      then getDriverCurrentSpecialLocationId personId
+      else pure Nothing
+  let cityVehicleServiceTiers = map (CQVST.applySpecialZoneName mbSpecialLocationId) baseCityVehicleServiceTiers
   let personLanguage = fromMaybe ENGLISH person.language
 
   driverVehicleServiceTierTypes <- fetchVehicleTierForDriverWithUsageRestriction False (Just driverInfo) (Just vehicle) Nothing (Just cityVehicleServiceTiers) personId merchantOpCityId
@@ -482,6 +491,19 @@ getDriverVehicleServiceTiers (mbPersonId, _, merchantOpCityId) = do
         enableForAirport = driverInfo.enableForAirport,
         airConditioned = mbAirConditioned
       }
+  where
+    getDriverCurrentSpecialLocationId personId' =
+      ( (listToMaybe <$> LTSFlow.driversLocation [personId'])
+          >>= maybe
+            (pure Nothing)
+            ( \loc ->
+                fmap (.id.getId)
+                  <$> QSpecialLocation.findPickupSpecialLocationByLatLong LatLong {lat = loc.lat, lon = loc.lon}
+            )
+      )
+        `C.catchAll` \err -> do
+          logWarning $ "Unable to resolve special location for driver " <> personId'.getId <> ": " <> show err
+          pure Nothing
 
 postDriverUpdateServiceTiers ::
   ( ( Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved driver onboarding tier lookup to support special-zone pricing names when available.
  * Added automatic location-based matching so eligible drivers can see zone-specific service tier labels.

* **Bug Fixes**
  * Added safe fallback behavior when location lookup fails, so standard tier information still loads without interruption.
  * Reduced the impact of location-service errors by logging issues and continuing gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->