### PR TITLE
CRC payload omitNothingFields = True, rqstId append and PAN no fallback

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/CourtRecordCheck.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/CourtRecordCheck.hs
@@ -5,6 +5,7 @@ module Domain.Action.UI.DriverOnboarding.CourtRecordCheck
   )
 where
 
+import Control.Applicative ((<|>))
 import Data.Time (utctDay)
 import qualified Domain.Types.DriverIdentityInfo as DDII
 import qualified Domain.Types.MerchantOperatingCity as DMOC
@@ -20,6 +21,7 @@ import Kernel.Utils.Common
 import qualified SharedLogic.DriverIdentityInfo as DIInfo
 import qualified Storage.Queries.DriverIdentityInfo as QDII
 import qualified Storage.Queries.DriverInformationExtra as QDI
+import qualified Storage.Queries.DriverPanCard as QPanCard
 import qualified Tools.Verification as Verification
 
 runCourtRecordCheck :: Person.Person -> DMOC.MerchantOperatingCity -> Flow ()
@@ -37,9 +39,12 @@ runCourtRecordCheck person merchantOpCity = do
     if isJust (mbIdentityInfo >>= (.courtRecord) >>= (.result))
       then logInfo $ "CourtRecordCheck: court record already present for driver " <> person.id.getId <> ", skipping submit"
       else do
-        mbPanNumber <- mapM decrypt driverInfo.panNumber
+        mbPanCard <- QPanCard.findByDriverId person.id
+        mbPanFromInfo <- mapM decrypt driverInfo.panNumber
+        mbPanFromCard <- mapM (decrypt . (.panCardNumber)) mbPanCard
         let driverName = person.firstName <> maybe "" (" " <>) person.lastName
-            mbDob = utctDay <$> driverInfo.driverDob
+            mbDob = (utctDay <$> driverInfo.driverDob) <|> (utctDay <$> (mbPanCard >>= (.driverDob)))
+            mbPanNumber = mbPanFromInfo <|> mbPanFromCard
             mbAddress = mbIdentityInfo >>= (.address)
             req =
               VI.VerifyCRCReq

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/IdfyWebhook.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/IdfyWebhook.hs
@@ -173,32 +173,38 @@ onVerify (Idfy.VerificationResponse rsp) respDump = do
       logInfo $ "IdfyWebhook.onVerify: CRC result -> storing court record for driverId(group_id)=" <> rsp.group_id
       CourtRecordCheck.onVerifyCRC (Id rsp.group_id) resSrcOp.source_output
       return Ack
-    _ -> do
-      verificationReq <- IVQuery.findByRequestId rsp.request_id >>= fromMaybeM (InternalError $ "Verification request not found for requestId : " <> rsp.request_id)
-      person <- runInReplica $ QP.findById verificationReq.driverId >>= fromMaybeM (PersonDoesNotExist verificationReq.driverId.getId)
-      logInfo $
-        "IdfyWebhook.onVerify: looked up verificationReq requestId=" <> rsp.request_id
-          <> " driverId="
-          <> verificationReq.driverId.getId
-          <> " docType="
-          <> show verificationReq.docType
-          <> " status="
-          <> verificationReq.status
-      IVQuery.updateResponse rsp.status (Just respDump) rsp.request_id
-      let resultStatus = getResultStatus rsp.result
-      logInfo $ "IdfyWebhook.onVerify: parsed resultStatus=" <> show resultStatus
-      if resultStatus == Just "source_down"
-        then do
-          logInfo $ "IdfyWebhook.onVerify: source_down path requestId=" <> rsp.request_id
-          handleIdfySourceDown person scheduleRetryVerificationJob verificationReq
-          return Ack
-        else do
-          mbRemPriorityList <- CQO.getVerificationPriorityList verificationReq.driverId
-          logInfo $ "IdfyWebhook.onVerify: routing to verifyDocument mbRemPriorityList=" <> show mbRemPriorityList
-          ack_ <- maybe (pure Ack) (flip (verifyDocument person verificationReq) mbRemPriorityList) rsp.result
-          logInfo $ "IdfyWebhook.onVerify: completed requestId=" <> rsp.request_id
-          void $ SStatus.processStatusEvent (Just person) Nothing (SStatus.PersonDocChangedEvent verificationReq.driverId)
-          return ack_
+    _
+      | rsp._type == "ind_court_record" -> do
+        -- Failed CRC (no CRCResult) has no idfy_verification row; record on driver_identity_info instead of throwing.
+        logWarning $ "IdfyWebhook.onVerify: CRC callback without result for driverId(group_id)=" <> rsp.group_id <> " status=" <> rsp.status
+        CourtRecordCheck.onVerifyCRCError (Id rsp.group_id) ("Idfy CRC failed: status=" <> rsp.status)
+        return Ack
+      | otherwise -> do
+        verificationReq <- IVQuery.findByRequestId rsp.request_id >>= fromMaybeM (InternalError $ "Verification request not found for requestId=" <> rsp.request_id)
+        person <- runInReplica $ QP.findById verificationReq.driverId >>= fromMaybeM (PersonDoesNotExist verificationReq.driverId.getId)
+        logInfo $
+          "IdfyWebhook.onVerify: looked up verificationReq requestId=" <> rsp.request_id
+            <> " driverId="
+            <> verificationReq.driverId.getId
+            <> " docType="
+            <> show verificationReq.docType
+            <> " status="
+            <> verificationReq.status
+        IVQuery.updateResponse rsp.status (Just respDump) rsp.request_id
+        let resultStatus = getResultStatus rsp.result
+        logInfo $ "IdfyWebhook.onVerify: parsed resultStatus=" <> show resultStatus
+        if resultStatus == Just "source_down"
+          then do
+            logInfo $ "IdfyWebhook.onVerify: source_down path requestId=" <> rsp.request_id
+            handleIdfySourceDown person scheduleRetryVerificationJob verificationReq
+            return Ack
+          else do
+            mbRemPriorityList <- CQO.getVerificationPriorityList verificationReq.driverId
+            logInfo $ "IdfyWebhook.onVerify: routing to verifyDocument mbRemPriorityList=" <> show mbRemPriorityList
+            ack_ <- maybe (pure Ack) (flip (verifyDocument person verificationReq) mbRemPriorityList) rsp.result
+            logInfo $ "IdfyWebhook.onVerify: completed requestId=" <> rsp.request_id
+            void $ SStatus.processStatusEvent (Just person) Nothing (SStatus.PersonDocChangedEvent verificationReq.driverId)
+            return ack_
   where
     getResultStatus :: Maybe Idfy.IdfyResult -> Maybe Text
     getResultStatus mbResult =

--- a/flake.lock
+++ b/flake.lock
@@ -4004,11 +4004,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1782738237,
-        "narHash": "sha256-weeaWfob7kYTuRM4Gp2V1RaC48/jMSNfn1ZmHEv7xn8=",
+        "lastModified": 1782788595,
+        "narHash": "sha256-ew/g1vX1M+ydnPQ1vJ3Z+RY+/t5zzIDzvKc7Ldwz0xw=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "33479ec03726393831008c4857ce0eebd1b0677f",
+        "rev": "ea43a0c42815880c06ecebcc88ba45340a58ac37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
CRC payload omitNothingFields = True, rqstId append and PAN no fallback


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Court record verification now derives PAN and date of birth from the driver’s identity, with a fallback to the driver’s stored PAN-card details when needed.
  * The court-record verification webhook handler is more robust when callback results don’t match the expected verification record, reducing avoidable failures.
  * Failed court-record checks now use a clearer, consistent error-handling flow while still returning the expected acknowledgement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->