### PR TITLE
backend/fix: allow ops/cron end/cancel ride without linked vehicle

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Cancel.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Cancel.hs
@@ -94,7 +94,7 @@ cancel transporterId subscriber reqV2 = withFlowHandlerBecknAPI . ActorInfo.with
         then do
           logError $ "Completed booking cancel request received for ride id : " <> cancelRideReq.bookingId.getId
           mbRide <- QRide.findActiveByRBId booking.id
-          void $ rideSync Nothing mbRide booking merchant
+          void $ rideSync Nothing mbRide booking merchant False
           return Ack
         else do
           fork "cancel received pushing ondc logs" do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Init.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Init.hs
@@ -120,9 +120,11 @@ init transporterId (SignatureAuthResult _ subscriber) reqV2 = withFlowHandlerBec
       exep <- withTryCatch "init:callWithErrorHandling" action
       case exep of
         Left e -> do
+          logError $ "cancelSearchInitLock | Init release (api error) | txn=" <> transactionId
           Redis.unlockRedis (mkCancelSearchInitLockKey transactionId)
           someExceptionToAPIErrorThrow e
         Right a -> do
+          logError $ "cancelSearchInitLock | Init release (api success) | txn=" <> transactionId
           Redis.unlockRedis (mkCancelSearchInitLockKey transactionId)
           pure a
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/ExotelEndRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/ExotelEndRide.hs
@@ -55,7 +55,7 @@ callBasedEndRide callFrom_ callTo_ = withFlowHandlerAPI . ActorInfo.withRequestI
   let callTo = dropFirstZero callTo_
   mobileNumberHash <- getDbHash callFrom
   exophone <- CQExophone.findByEndRidePhone callTo >>= fromMaybeM (ExophoneDoesNotExist callTo)
-  shandle <- EndRide.buildEndRideHandle exophone.merchantId exophone.merchantOperatingCityId Nothing
+  shandle <- EndRide.buildEndRideHandle exophone.merchantId exophone.merchantOperatingCityId Nothing False
   DExotelEndRide.callBasedEndRide shandle exophone.merchantId mobileNumberHash callFrom
   where
     dropFirstZero = T.dropWhile (== '0')

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Ride.hs
@@ -257,7 +257,7 @@ endRide :: (Id SP.Person, Id Merchant.Merchant, Id DMOC.MerchantOperatingCity) -
 endRide (requestorId, merchantId, merchantOpCityId) rideId EndRideReq {..} = withFlowHandlerAPI . ActorInfo.withPersonIdActorInfo requestorId $ do
   requestor <- findPerson requestorId
   let driverReq = RideEnd.DriverEndRideReq {..}
-  shandle <- withTimeAPI "endRide" "buildEndRideHandle" $ RideEnd.buildEndRideHandle merchantId merchantOpCityId (Just rideId)
+  shandle <- withTimeAPI "endRide" "buildEndRideHandle" $ RideEnd.buildEndRideHandle merchantId merchantOpCityId (Just rideId) False
   withTimeAPI "endRide" "driverEndRide" $ RideEnd.driverEndRide shandle rideId driverReq
 
 cancelRide :: (Id SP.Person, Id Merchant.Merchant, Id DMOC.MerchantOperatingCity) -> Id Ride.Ride -> CancelRideReq -> FlowHandler RideCancel.CancelRideResp

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
@@ -324,10 +324,12 @@ cancelSearch ::
 cancelSearch _merchantId searchTry = do
   searchRequest <- QSR.findById searchTry.requestId >>= fromMaybeM (SearchRequestNotFound searchTry.requestId.getId)
   callWithErrorHandling searchRequest.transactionId $ do
-    -- Lock Description: This is a Lock held between Init and Cancel Search, if Init is OnGoing the Booking will be created post the lock release and Cancel Search will fail with `RideRequestAlreadyAccepted`.
+    -- Lock Description: This is a Lock held between Init and Cancel Search, if Init is OnGoing the Booking will be created post the lock release and Cancel Search will fail with `CancelSearchLockNotAcquired`.
     -- Lock Release: Any Exceptions or at end of this function.
-    unlessM (Redis.tryLockRedis (mkCancelSearchInitLockKey searchRequest.transactionId) 30) $
-      throwError RideRequestAlreadyAccepted
+    cancelSearchInitLockAcquired <- Redis.tryLockRedis (mkCancelSearchInitLockKey searchRequest.transactionId) 30
+    logError $ "cancelSearchInitLock | cancelSearch acquire | txn=" <> searchRequest.transactionId <> " acquired=" <> show cancelSearchInitLockAcquired
+    unless cancelSearchInitLockAcquired $
+      throwError CancelSearchLockNotAcquired
     when (DTC.isDynamicOfferTrip searchTry.tripCategory) $ do
       mbActiveBooking <- runInMasterDbAndRedis $ QRB.findByTransactionIdAndStatuses searchRequest.transactionId [SRB.NEW, SRB.TRIP_ASSIGNED]
       whenJust mbActiveBooking $ \_ ->
@@ -344,9 +346,11 @@ cancelSearch _merchantId searchTry = do
       exep <- withTryCatch "cancelSearch:callWithErrorHandling" action
       case exep of
         Left e -> do
+          logError $ "cancelSearchInitLock | cancelSearch release (error) | txn=" <> transactionId
           Redis.unlockRedis (mkCancelSearchInitLockKey transactionId)
           someExceptionToAPIErrorThrow e
         Right a -> do
+          logError $ "cancelSearchInitLock | cancelSearch release (success) | txn=" <> transactionId
           Redis.unlockRedis (mkCancelSearchInitLockKey transactionId)
           pure a
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
@@ -397,6 +397,7 @@ validateRequest _merchantId req = do
         -- Lock Description: This is a Lock held between Init and Cancel Search, if Cancel Search is OnGoing then the Driver Quote would be Marked Inactive post the lock release and Init will fail with `QuoteExpired`.
         -- Lock Release: If any errors or Post Init Beckn Action Handler is executed.
         isLockAcquired <- Redis.tryLockRedis (mkCancelSearchInitLockKey searchRequest.transactionId) 30
+        logError $ "cancelSearchInitLock | Init acquire | txn=" <> searchRequest.transactionId <> " acquired=" <> show isLockAcquired
         searchTry <- QST.findById driverQuote.searchTryId >>= fromMaybeM (SearchTryNotFound driverQuote.searchTryId.getId)
         updatedDriverQuote <- runInMasterDbAndRedis $ QDQuote.findById driverQuoteId >>= fromMaybeM (DriverQuoteNotFound driverQuoteId.getId)
         when (updatedDriverQuote.validTill < now || updatedDriverQuote.status == DDQ.Inactive || not isLockAcquired) $
@@ -414,6 +415,7 @@ validateRequest _merchantId req = do
       exep <- withTryCatch "init:validateRequest:callWithErrorHandling" action
       case exep of
         Left e -> do
+          logError $ "cancelSearchInitLock | Init release (validateRequest error) | txn=" <> transactionId
           Redis.unlockRedis (mkCancelSearchInitLockKey transactionId)
           someExceptionToAPIErrorThrow e
         Right a -> pure a

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Booking.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Booking.hs
@@ -145,7 +145,7 @@ postBookingSyncMultiple merchantShortId opCity req = do
                 QBooking.updateStatus bookingId bookingNewStatus
                 whenJust mbCancellationReason QBCR.upsert
               let updBooking = booking{status = bookingNewStatus}
-              void $ SyncRide.rideSync (mbCancellationReason <&> (.source)) (Just ride) updBooking merchant
+              void $ SyncRide.rideSync (mbCancellationReason <&> (.source)) (Just ride) updBooking merchant True
             Nothing -> do
               let mbCancellationReason =
                     if booking.status /= DBooking.CANCELLED
@@ -155,7 +155,7 @@ postBookingSyncMultiple merchantShortId opCity req = do
                 QBooking.updateStatus bookingId DBooking.CANCELLED
                 whenJust mbCancellationReason QBCR.upsert
               let updBooking = booking{status = DBooking.CANCELLED}
-              void $ SyncRide.rideSync (mbCancellationReason <&> (.source)) Nothing updBooking merchant
+              void $ SyncRide.rideSync (mbCancellationReason <&> (.source)) Nothing updBooking merchant True
           pure Common.SuccessItem
     pure $ Common.MultipleBookingSyncRespItem {bookingId = reqItem.bookingId, info}
   logTagInfo "dashboard -> multipleBookingSync: " $ show reqBookingIds

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Ride.hs
@@ -111,7 +111,7 @@ postRideEndMultiple merchantShortId opCity mbRequestorId req = ActorInfo.withDas
   runRequestValidation Common.validateMultipleRideEndReq req
   merchant <- findMerchantByShortId merchantShortId
   merchantOpCityId <- CQMOC.getMerchantOpCityId Nothing merchant (Just opCity)
-  shandle <- EHandler.buildEndRideHandle merchant.id merchantOpCityId Nothing
+  shandle <- EHandler.buildEndRideHandle merchant.id merchantOpCityId Nothing True
   logTagInfo "dashboard -> multipleRideEnd : " $ show (req.rides <&> (.rideId))
   respItems <- forM req.rides $ \reqItem -> do
     info <- handle Common.listItemErrHandler $ do
@@ -141,7 +141,7 @@ postRideCancelMultiple merchantShortId opCity req = do
                 additionalInfo = reqItem.additionalInfo,
                 doCancellationRateBasedBlocking = Nothing
               }
-      Success <- CHandler.dashboardCancelRideHandler CHandler.cancelRideHandle merchant.id merchantOpCityId rideId dashboardReq
+      Success <- CHandler.dashboardCancelRideHandler CHandler.cancelRideHandle merchant.id merchantOpCityId rideId dashboardReq True
       pure Common.SuccessItem
     pure $ Common.MultipleRideSyncRespItem {rideId = reqItem.rideId, info}
   pure $ Common.MultipleRideSyncResp {list = respItems}

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Ride.hs
@@ -844,7 +844,7 @@ rideSync merchantShortId opCity reqRideId = do
 
   logTagInfo "dashboard -> syncRide : " $ show rideId <> "; status: " <> show ride.status
 
-  SyncRide.rideSync Nothing (Just ride) booking merchant
+  SyncRide.rideSync Nothing (Just ride) booking merchant True
 
 ---------------------------------------------------------------------
 
@@ -863,7 +863,7 @@ multipleRideSync merchantShortId opCity rideSyncReq = do
       ( \(ride, booking) ->
           mapLeft show
             <$> ( withTryCatch "mkMultipleRideData:multipleRideSync" $
-                    mkMultipleRideData ride.id <$> SyncRide.rideSync Nothing (Just ride) booking merchant
+                    mkMultipleRideData ride.id <$> SyncRide.rideSync Nothing (Just ride) booking merchant True
                 )
       )
       ridesBookingsZip
@@ -946,7 +946,7 @@ bookingWithVehicleNumberAndPhone merchant merchantOpCityId req = do
 endActiveRide :: Id DRide.Ride -> Id DM.Merchant -> Id DMOC.MerchantOperatingCity -> Flow ()
 endActiveRide rideId merchantId merchantOperatingCityId = do
   let dashboardReq = EHandler.DashboardEndRideReq {point = Nothing, merchantId, merchantOperatingCityId, odometer = Nothing}
-  shandle <- EHandler.buildEndRideHandle merchantId merchantOperatingCityId (Just rideId)
+  shandle <- EHandler.buildEndRideHandle merchantId merchantOperatingCityId (Just rideId) False
   void $ EHandler.dashboardEndRide shandle rideId dashboardReq
 
 fareBreakUp :: ShortId DM.Merchant -> Context.City -> Id Common.Ride -> Flow Common.FareBreakUpRes

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/RideBooking/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/RideBooking/Ride.hs
@@ -62,7 +62,7 @@ postRideEnd merchantShortId opCity reqRideId mbRequestorId Common.EndRideReq {po
   let merchantId = merchant.id
   let odometer = (\value -> DRide.OdometerReading Nothing value) <$> odometerReadingValue
   let dashboardReq = EHandler.DashboardEndRideReq {point, merchantId, merchantOperatingCityId, odometer}
-  shandle <- EHandler.buildEndRideHandle merchantId merchantOperatingCityId (Just rideId)
+  shandle <- EHandler.buildEndRideHandle merchantId merchantOperatingCityId (Just rideId) True
   EHandler.dashboardEndRide shandle rideId dashboardReq
 
 getRideCurrentActiveRide :: ShortId DM.Merchant -> Context.City -> Text -> Flow (Id Common.Ride)
@@ -79,7 +79,7 @@ postRideCancel merchantShortId opCity reqRideId mbRequestorId Common.CancelRideR
             additionalInfo,
             doCancellationRateBasedBlocking = Nothing
           }
-  CHandler.dashboardCancelRideHandler CHandler.cancelRideHandle merchant.id merchantOpCityId rideId dashboardReq
+  CHandler.dashboardCancelRideHandler CHandler.cancelRideHandle merchant.id merchantOpCityId rideId dashboardReq True
 
 postRideBookingWithVehicleNumberAndPhone :: ShortId DM.Merchant -> Context.City -> Maybe Text -> Common.BookingWithVehicleAndPhoneReq -> Flow Common.BookingWithVehicleAndPhoneRes
 postRideBookingWithVehicleNumberAndPhone merchantShortId opCity mbRequestorId req = ActorInfo.withDashboardMbPersonIdActorInfo ((Id @DP.Person) <$> mbRequestorId) $ do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide.hs
@@ -76,7 +76,7 @@ import TransactionLogs.Types
 data ServiceHandle m = ServiceHandle
   { findRideById :: Id DRide.Ride -> m (Maybe DRide.Ride),
     findById :: Id DP.Person -> m (Maybe DP.Person),
-    cancelRide :: Id DRide.Ride -> DRide.RideEndedBy -> DBCR.BookingCancellationReason -> Bool -> Maybe Bool -> m (),
+    cancelRide :: Id DRide.Ride -> DRide.RideEndedBy -> DBCR.BookingCancellationReason -> Bool -> Maybe Bool -> Bool -> m (),
     findBookingByIdInReplica :: Id SRB.Booking -> m (Maybe SRB.Booking),
     pickUpDistance :: SRB.Booking -> LatLong -> LatLong -> m Meters
   }
@@ -161,11 +161,12 @@ dashboardCancelRideHandler ::
   Id DMOC.MerchantOperatingCity ->
   Id DRide.Ride ->
   CancelRideReq ->
+  Bool ->
   Flow APISuccess.APISuccess
-dashboardCancelRideHandler shandle merchantId merchantOpCityId rideId req =
+dashboardCancelRideHandler shandle merchantId merchantOpCityId rideId req allowSnapshotVehicleFallback =
   -- TODO ActorInfo.withDashboardPersonIdActorInfo requestorId $ do
   withLogTag ("merchantId-" <> merchantId.getId) $ do
-    void $ cancelRideImpl shandle (DashboardRequestorId (merchantId, merchantOpCityId)) rideId req False
+    void $ cancelRideImpl shandle (DashboardRequestorId (merchantId, merchantOpCityId)) rideId req False allowSnapshotVehicleFallback
     return APISuccess.Success
 
 cancelRideHandler ::
@@ -175,7 +176,7 @@ cancelRideHandler ::
   CancelRideReq ->
   Flow CancelRideResp
 cancelRideHandler sh requestorId rideId req = withLogTag ("rideId-" <> rideId.getId) do
-  (cancellationCnt, isGoToDisabled) <- cancelRideImpl sh requestorId rideId req False
+  (cancellationCnt, isGoToDisabled) <- cancelRideImpl sh requestorId rideId req False False
   pure $ buildCancelRideResp cancellationCnt isGoToDisabled
   where
     buildCancelRideResp cancelCnt isGoToDisabled =
@@ -203,8 +204,9 @@ cancelRideImpl ::
   Id DRide.Ride ->
   CancelRideReq ->
   Bool ->
+  Bool ->
   m (Maybe Int, Maybe Bool)
-cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = do
+cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation allowSnapshotVehicleFallback = do
   ride <- findRideById rideId >>= fromMaybeM (RideDoesNotExist rideId.getId)
   unless (isValidRide ride) $ throwError $ RideInvalidStatus ("This ride cannot be canceled" <> Text.pack (show ride.status))
   let driverId = ride.driverId
@@ -274,7 +276,7 @@ cancelRideImpl ServiceHandle {..} requestorId rideId req isForceReallocation = d
               CQDGR.deactivateDriverGoHomeRequest booking.merchantOperatingCityId driverId DDGR.SUCCESS driverGoHomeReqInfo (Just False)
         )
         ((,,,) <$> cancellationCnt <*> driverGoHomeRequestId <*> goHomeConfig <*> dghInfo)
-    cancelRide rideId rideEndedBy rideCancelationReason isForceReallocation req.doCancellationRateBasedBlocking
+    cancelRide rideId rideEndedBy rideCancelationReason isForceReallocation req.doCancellationRateBasedBlocking allowSnapshotVehicleFallback
   pure (cancellationCnt, isGoToDisabled)
   where
     isValidRide ride = ride.status `elem` [DRide.NEW, DRide.UPCOMING]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -109,6 +109,7 @@ import qualified Storage.Queries.FareParameters as QFP
 import qualified Storage.Queries.FleetOwnerInformation as QFOI
 import qualified Storage.Queries.Person as QPerson
 import qualified Storage.Queries.Ride as QRide
+import qualified Storage.Queries.RideDetails as QRideDetails
 import qualified Storage.Queries.RiderDetails as QRiderDetails
 import qualified Storage.Queries.SearchRequest as QSR
 import qualified Storage.Queries.Vehicle as QVeh
@@ -169,8 +170,9 @@ cancelRideImpl ::
   SBCR.BookingCancellationReason ->
   Bool ->
   Maybe Bool ->
+  Bool ->
   m ()
-cancelRideImpl rideId rideEndedBy bookingCReason isForceReallocation doCancellationRateBasedBlocking = do
+cancelRideImpl rideId rideEndedBy bookingCReason isForceReallocation doCancellationRateBasedBlocking allowSnapshotVehicleFallback = do
   isLocked <- Redis.tryLockRedis (buildCancelRideTransactionKey rideId) 15
   if isLocked
     then do
@@ -202,7 +204,15 @@ cancelRideImpl rideId rideEndedBy bookingCReason isForceReallocation doCancellat
             logDebug $ "userNoShowCharges: " <> show userNoShowCharges
             let (userNoShowChargesFee, userNoShowChargesTax, userNoShowChargesLogicVersion, userNoShowOverdueCharge, userNoShowOverdueTax) = userNoShowCharges
             driver <- QPerson.findById ride.driverId >>= fromMaybeM (PersonNotFound ride.driverId.getId)
-            vehicle <- QVeh.findById ride.driverId >>= fromMaybeM (DriverWithoutVehicle ride.driverId.getId)
+            mbVehicle <- QVeh.findById ride.driverId
+            vehicle <- case mbVehicle of
+              Just v -> pure v
+              Nothing
+                | allowSnapshotVehicleFallback -> do
+                  logWarning $ "Vehicle missing for driver " <> ride.driverId.getId <> " on cancelled ride " <> ride.id.getId <> "; using ride_details snapshot (ops cancel)"
+                  rideDetails <- QRideDetails.findById ride.id >>= fromMaybeM (RideNotFound ride.id.getId)
+                  pure $ BP.buildVehicleFromRideDetailsSnapshot booking ride rideDetails
+                | otherwise -> throwError (DriverWithoutVehicle ride.driverId.getId)
             unless (isValidRide ride) $ throwError (InternalError "Ride is not valid for cancellation")
             cancelRideTransaction booking ride bookingCReason merchant rideEndedBy userNoShowChargesFee userNoShowChargesTax userNoShowOverdueCharge userNoShowOverdueTax userNoShowChargesLogicVersion transporterConfig driver
             logTagInfo ("rideId-" <> getId rideId) ("Cancellation reason " <> show bookingCReason.source)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
@@ -193,15 +193,16 @@ buildEndRideHandle ::
   Id DM.Merchant ->
   Id DMOC.MerchantOperatingCity ->
   Maybe (Id DRide.Ride) ->
+  Bool ->
   m (ServiceHandle m)
-buildEndRideHandle merchantId merchantOpCityId rideId = do
+buildEndRideHandle merchantId merchantOpCityId rideId allowSnapshotVehicleFallback = do
   defaultRideInterpolationHandler <- LocUpd.buildRideInterpolationHandler merchantId merchantOpCityId rideId True Nothing
   return $
     ServiceHandle
       { findBookingById = QRB.findById,
         findRideById = QRide.findById,
         getMerchant = MerchantS.findById,
-        notifyCompleteToBAP = CallBAP.sendRideCompletedUpdateToBAP,
+        notifyCompleteToBAP = \b r fp pm pu loc -> CallBAP.sendRideCompletedUpdateToBAP b r fp pm pu loc allowSnapshotVehicleFallback,
         endRideTransaction = RideEndInt.endRideTransaction,
         getFarePolicyByEstOrQuoteId = FarePolicy.getFarePolicyByEstOrQuoteId,
         getFarePolicyOnEndRide = FarePolicy.getFarePolicyOnEndRide,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Payout/SpecialZonePayout.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Payout/SpecialZonePayout.hs
@@ -140,7 +140,7 @@ executeSpecialZonePayout payoutRequest = do
                 odometer = Nothing,
                 driverGpsTurnedOff = Nothing
               }
-      shandle <- RideEnd.buildEndRideHandle merchantId merchantOpCityId (Just ride.id)
+      shandle <- RideEnd.buildEndRideHandle merchantId merchantOpCityId (Just ride.id) False
       void $ RideEnd.driverEndRide shandle ride.id driverReq
 
   merchantOperatingCity <- CQMOC.findById merchantOpCityId >>= fromMaybeM (MerchantOperatingCityNotFound merchantOpCityId.getId)
@@ -256,7 +256,7 @@ executeOldSpecialZonePayout scheduledPayout = do
                   odometer = Nothing,
                   driverGpsTurnedOff = Nothing
                 }
-        shandle <- RideEnd.buildEndRideHandle mId mocId (Just ride.id)
+        shandle <- RideEnd.buildEndRideHandle mId mocId (Just ride.id) False
         void $ RideEnd.driverEndRide shandle ride.id driverReq
     _ -> pure ()
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/ScheduledRides/ScheduledRideAssignedOnUpdate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/ScheduledRides/ScheduledRideAssignedOnUpdate.hs
@@ -318,7 +318,7 @@ cancelOrReallocate ride cReason isForceReallocation req = do
             additionalInfo = Nothing,
             doCancellationRateBasedBlocking = Nothing
           }
-  (_cancellationCnt, _isGoToDisabled) <- RideCancel.cancelRideImpl RideCancel.cancelRideHandle req ride.id cancelReq isForceReallocation
+  (_cancellationCnt, _isGoToDisabled) <- RideCancel.cancelRideImpl RideCancel.cancelRideHandle req ride.id cancelReq isForceReallocation False
   pure ()
 
 data Result a b = APIFailed | DistanceResp (GetDistanceResp a b)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
@@ -40,6 +40,7 @@ module SharedLogic.CallBAP
     notfyDeliveryImageUploadedToBAP,
     sendChangeServiceTierUpdateToBAP,
     sendAddBaggageUpdateToBAP,
+    buildVehicleFromRideDetailsSnapshot,
   )
 where
 
@@ -92,12 +93,14 @@ import qualified Domain.Types.OnUpdate as DOU
 import qualified Domain.Types.Person as DP
 import qualified Domain.Types.Ride as DRide
 import qualified Domain.Types.Ride as SRide
+import qualified Domain.Types.RideDetails as DRD
 import qualified Domain.Types.SearchRequest as DSR
 import qualified Domain.Types.SearchRequestForDriver as DSRFD
 import qualified Domain.Types.SearchTry as DST
 import qualified Domain.Types.ServiceTierType as DST
 import qualified Domain.Types.Vehicle as DVeh
 import qualified Domain.Types.VehicleServiceTier as DVST
+import qualified Domain.Types.VehicleVariant as Variant
 import qualified EulerHS.Types as Euler
 import qualified IssueManagement.Storage.Queries.MediaFile as MFQuery
 import Kernel.Beam.Functions
@@ -680,6 +683,40 @@ sendRideEstimatedEndTimeRangeUpdateToBAP booking ride = do
   endEstimateTimeRangeMsgV2 <- ACL.buildOnUpdateMessageV2 merchant booking Nothing endEstimateTimeRangeBuildReq
   void $ callOnUpdateV2 endEstimateTimeRangeMsgV2 retryConfig merchant.id
 
+buildVehicleFromRideDetailsSnapshot :: DRB.Booking -> SRide.Ride -> DRD.RideDetails -> DVeh.Vehicle
+buildVehicleFromRideDetailsSnapshot booking ride rideDetails =
+  DVeh.Vehicle
+    { driverId = ride.driverId,
+      merchantId = booking.providerId,
+      merchantOperatingCityId = Just booking.merchantOperatingCityId,
+      registrationNo = rideDetails.vehicleNumber,
+      color = fromMaybe "" rideDetails.vehicleColor,
+      model = fromMaybe "" rideDetails.vehicleModel,
+      vehicleClass = fromMaybe "" rideDetails.vehicleClass,
+      variant = fromMaybe (Variant.castServiceTierToVariant booking.vehicleServiceTier) rideDetails.vehicleVariant,
+      capacity = ride.vehicleServiceTierSeatingCapacity,
+      selectedServiceTiers = [booking.vehicleServiceTier],
+      airConditioned = Nothing,
+      category = Nothing,
+      downgradeReason = Nothing,
+      energyType = Nothing,
+      luggageCapacity = Nothing,
+      mYManufacturing = Nothing,
+      make = Nothing,
+      oxygen = Nothing,
+      registrationCategory = Nothing,
+      ruleBasedUpgradeTiers = Nothing,
+      size = Nothing,
+      vehicleImageId = Nothing,
+      vehicleName = Nothing,
+      vehicleRating = Nothing,
+      vehicleRatingRemark = Nothing,
+      vehicleTags = Nothing,
+      ventilator = Nothing,
+      createdAt = ride.createdAt,
+      updatedAt = ride.updatedAt
+    }
+
 sendRideCompletedUpdateToBAP ::
   ( CacheFlow m r,
     EsqDBFlow m r,
@@ -697,15 +734,24 @@ sendRideCompletedUpdateToBAP ::
   Maybe DMPM.PaymentMethodInfo ->
   Maybe Text ->
   Maybe Maps.LatLong ->
+  Bool ->
   m ()
-sendRideCompletedUpdateToBAP booking ride fareParams paymentMethodInfo paymentUrl tripEndLocation = do
+sendRideCompletedUpdateToBAP booking ride fareParams paymentMethodInfo paymentUrl tripEndLocation allowSnapshotVehicleFallback = do
   isValueAddNP <- CValueAddNP.isValueAddNP booking.bapId
   merchant <-
     CQM.findById booking.providerId
       >>= fromMaybeM (MerchantNotFound booking.providerId.getId)
   driver <- QPerson.findById ride.driverId >>= fromMaybeM (PersonNotFound ride.driverId.getId)
   driverStats <- QDriverStats.findById ride.driverId >>= fromMaybeM DriverInfoNotFound
-  vehicle <- QVeh.findById ride.driverId >>= fromMaybeM (DriverWithoutVehicle ride.driverId.getId)
+  mbVehicle <- QVeh.findById ride.driverId
+  vehicle <- case mbVehicle of
+    Just v -> pure v
+    Nothing
+      | allowSnapshotVehicleFallback -> do
+        logWarning $ "Vehicle missing for driver " <> ride.driverId.getId <> " on completed ride " <> ride.id.getId <> "; using ride_details snapshot (ops/cron sync)"
+        rideDetails <- runInReplica $ QRideDetails.findById ride.id >>= fromMaybeM (RideNotFound ride.id.getId)
+        pure $ buildVehicleFromRideDetailsSnapshot booking ride rideDetails
+      | otherwise -> throwError (DriverWithoutVehicle ride.driverId.getId)
   bppConfig <- QBC.findByMerchantIdDomainAndVehicle merchant.id "MOBILITY" (Utils.mapServiceTierToCategory booking.vehicleServiceTier) >>= fromMaybeM (InternalError "Beckn Config not found")
   riderDetails <- maybe (return Nothing) (runInReplica . QRD.findById) booking.riderId
   riderPhone <- fmap (fmap (.mobileNumber)) (traverse decrypt riderDetails)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SyncRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SyncRide.hs
@@ -58,15 +58,15 @@ import qualified Storage.Queries.RiderDetails as QRD
 import qualified Storage.Queries.Vehicle as QVeh
 import Tools.Error
 
-rideSync :: Maybe DBCR.CancellationSource -> Maybe DRide.Ride -> DB.Booking -> DM.Merchant -> Flow Common.RideSyncRes
-rideSync mbCancellationSource (Just ride) booking merchant =
+rideSync :: Maybe DBCR.CancellationSource -> Maybe DRide.Ride -> DB.Booking -> DM.Merchant -> Bool -> Flow Common.RideSyncRes
+rideSync mbCancellationSource (Just ride) booking merchant allowSnapshotVehicleFallback =
   case ride.status of
     DRide.UPCOMING -> syncUpcomingRide ride booking
     DRide.NEW -> syncNewRide ride booking
     DRide.INPROGRESS -> syncInProgressRide ride booking
-    DRide.COMPLETED -> syncCompletedRide ride booking
+    DRide.COMPLETED -> syncCompletedRide ride booking allowSnapshotVehicleFallback
     DRide.CANCELLED -> syncCancelledRide mbCancellationSource (Just ride) booking merchant
-rideSync mbCancellationSource Nothing booking merchant =
+rideSync mbCancellationSource Nothing booking merchant _allowSnapshotVehicleFallback =
   syncCancelledRide mbCancellationSource Nothing booking merchant
 
 --UPCOMING --
@@ -161,11 +161,11 @@ data RideCompletedInfo = RideCompletedInfo
     paymentUrl :: Maybe Text
   }
 
-syncCompletedRide :: DRide.Ride -> DB.Booking -> Flow Common.RideSyncRes
-syncCompletedRide ride booking = do
+syncCompletedRide :: DRide.Ride -> DB.Booking -> Bool -> Flow Common.RideSyncRes
+syncCompletedRide ride booking allowSnapshotVehicleFallback = do
   RideCompletedInfo {..} <- fetchRideCompletedInfo ride booking
   handle (errHandler (Just ride.status) booking.status "ride completed") $
-    CallBAP.sendRideCompletedUpdateToBAP booking ride fareParams paymentMethodInfo paymentUrl Nothing
+    CallBAP.sendRideCompletedUpdateToBAP booking ride fareParams paymentMethodInfo paymentUrl Nothing allowSnapshotVehicleFallback
   pure $ Common.RideSyncRes Common.RIDE_COMPLETED "Success. Sent ride completed update to bap"
 
 fetchRideCompletedInfo :: DRide.Ride -> DB.Booking -> Flow RideCompletedInfo

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
@@ -387,6 +387,7 @@ data DriverQuoteError
   | DriverQuoteExpired
   | NoSearchRequestForDriver
   | RideRequestAlreadyAccepted
+  | CancelSearchLockNotAcquired
   | RideRequestAlreadyAcceptedOrCancelled Text
   | DriverAlreadyQuoted Text
   | QuoteAlreadyRejected
@@ -407,6 +408,7 @@ instance IsBaseError DriverQuoteError where
   toMessage DriverQuoteExpired = Just "Driver quote expired"
   toMessage NoSearchRequestForDriver = Just "No search request for this driver"
   toMessage RideRequestAlreadyAccepted = Just "Ride request already accepted by other driver"
+  toMessage CancelSearchLockNotAcquired = Just "Cancel search could not acquire the init/cancel lock; an init or another cancel is in progress."
   toMessage (RideRequestAlreadyAcceptedOrCancelled srfd) = Just $ "Ride request already accepted by other driver or cancelled:-" <> show srfd
   toMessage (DriverAlreadyQuoted stId) = Just $ "Driver already quoted for stId:-" <> show stId
   toMessage QuoteAlreadyRejected = Just "Quote Already Rejected"
@@ -425,6 +427,7 @@ instance IsHTTPError DriverQuoteError where
     DriverQuoteExpired -> "QUOTE_EXPIRED"
     NoSearchRequestForDriver -> "NO_SEARCH_REQUEST_FOR_DRIVER"
     RideRequestAlreadyAccepted -> "RIDE_REQUEST_ALREADY_ACCEPTED"
+    CancelSearchLockNotAcquired -> "CANCEL_SEARCH_LOCK_NOT_ACQUIRED"
     RideRequestAlreadyAcceptedOrCancelled _ -> "RIDE_REQUEST_ALREADY_ACCEPTED_OR_CANCELLED"
     DriverAlreadyQuoted _ -> "DRIVER_ALREADY_QUOTED"
     QuoteAlreadyRejected -> "QUOTE_ALREADY_REJECTED"
@@ -442,6 +445,7 @@ instance IsHTTPError DriverQuoteError where
     DriverQuoteExpired -> E400
     NoSearchRequestForDriver -> E400
     RideRequestAlreadyAccepted -> E400
+    CancelSearchLockNotAcquired -> E400
     RideRequestAlreadyAcceptedOrCancelled _ -> E409
     DriverAlreadyQuoted _ -> E409
     QuoteAlreadyRejected -> E400


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ride completion and cancellation flows can now fall back to ride-details snapshots when current vehicle details are missing, improving downstream update reliability.
* **Bug Fixes**
  * Cancel/init flows now surface a dedicated error when the cancel-search lock can’t be acquired.
  * Added clearer logging around lock acquisition and lock release during cancel/init processing.
* **Improvements**
  * Updated single-ride and multi-ride sync/cancellation/ride-end handling to support the revised completion/cancellation update rules across the flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->