### PR TITLE
enhancement: port build flags and cabal.project changes from main (BAP)

### DIFF
--- a/Backend/app/alchemist/alchemist.cabal
+++ b/Backend/app/alchemist/alchemist.cabal
@@ -84,6 +84,6 @@ executable alchemist-generator-exe
     , yaml
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/alchemist/package.yaml
+++ b/Backend/app/alchemist/package.yaml
@@ -97,6 +97,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/beckn-cli/beckn-cli.cabal
+++ b/Backend/app/beckn-cli/beckn-cli.cabal
@@ -85,7 +85,7 @@ library
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -146,6 +146,6 @@ executable beckn-cli-exe
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/beckn-cli/package.yaml
+++ b/Backend/app/beckn-cli/package.yaml
@@ -93,6 +93,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -120,6 +123,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/dashboard/CommonAPIs/dashboard-helper-api.cabal
+++ b/Backend/app/dashboard/CommonAPIs/dashboard-helper-api.cabal
@@ -252,6 +252,6 @@ library
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/dashboard/CommonAPIs/package.yaml
+++ b/Backend/app/dashboard/CommonAPIs/package.yaml
@@ -116,6 +116,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/dashboard/Lib/lib-dashboard.cabal
+++ b/Backend/app/dashboard/Lib/lib-dashboard.cabal
@@ -163,6 +163,6 @@ library
     , wai
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/dashboard/Lib/package.yaml
+++ b/Backend/app/dashboard/Lib/package.yaml
@@ -131,6 +131,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/dashboard/provider-dashboard/package.yaml
+++ b/Backend/app/dashboard/provider-dashboard/package.yaml
@@ -116,6 +116,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -150,6 +153,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/dashboard/provider-dashboard/provider-dashboard.cabal
+++ b/Backend/app/dashboard/provider-dashboard/provider-dashboard.cabal
@@ -244,7 +244,7 @@ library
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -329,6 +329,6 @@ executable provider-dashboard-exe
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/dashboard/rider-dashboard/package.yaml
+++ b/Backend/app/dashboard/rider-dashboard/package.yaml
@@ -107,6 +107,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -137,6 +140,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/dashboard/rider-dashboard/rider-dashboard.cabal
+++ b/Backend/app/dashboard/rider-dashboard/rider-dashboard.cabal
@@ -197,7 +197,7 @@ library
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -272,6 +272,6 @@ executable rider-dashboard-exe
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/example-service/example-service.cabal
+++ b/Backend/app/example-service/example-service.cabal
@@ -87,7 +87,7 @@ library
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -150,6 +150,6 @@ executable example-service-exe
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/example-service/package.yaml
+++ b/Backend/app/example-service/package.yaml
@@ -96,6 +96,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -120,6 +123,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/kafka-consumers/kafka-consumers.cabal
+++ b/Backend/app/kafka-consumers/kafka-consumers.cabal
@@ -124,7 +124,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -211,6 +211,6 @@ executable kafka-consumers-exe
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/kafka-consumers/package.yaml
+++ b/Backend/app/kafka-consumers/package.yaml
@@ -116,6 +116,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -143,6 +146,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/mocks/fcm/mock-fcm.cabal
+++ b/Backend/app/mocks/fcm/mock-fcm.cabal
@@ -89,7 +89,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -142,6 +142,6 @@ executable mock-fcm-exe
     , record-hasfield
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/mocks/fcm/package.yaml
+++ b/Backend/app/mocks/fcm/package.yaml
@@ -81,6 +81,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -118,6 +121,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/mocks/google/mock-google.cabal
+++ b/Backend/app/mocks/google/mock-google.cabal
@@ -114,7 +114,7 @@ library
     , unordered-containers
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -186,6 +186,6 @@ executable mock-google-exe
     , unordered-containers
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/mocks/google/package.yaml
+++ b/Backend/app/mocks/google/package.yaml
@@ -102,6 +102,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -126,6 +129,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/mocks/idfy/mock-idfy.cabal
+++ b/Backend/app/mocks/idfy/mock-idfy.cabal
@@ -100,7 +100,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -156,6 +156,6 @@ executable mock-idfy-exe
     , record-hasfield
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/mocks/idfy/package.yaml
+++ b/Backend/app/mocks/idfy/package.yaml
@@ -94,6 +94,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -136,6 +139,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/mocks/payment/mock-payment.cabal
+++ b/Backend/app/mocks/payment/mock-payment.cabal
@@ -99,7 +99,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -156,6 +156,6 @@ executable mock-payment-exe
     , record-hasfield
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/mocks/payment/package.yaml
+++ b/Backend/app/mocks/payment/package.yaml
@@ -77,6 +77,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -121,6 +124,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/mocks/public-transport-provider-platform/mock-public-transport-provider-platform.cabal
+++ b/Backend/app/mocks/public-transport-provider-platform/mock-public-transport-provider-platform.cabal
@@ -115,7 +115,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -200,6 +200,6 @@ executable mock-public-transport-provider-platform-exe
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/mocks/public-transport-provider-platform/package.yaml
+++ b/Backend/app/mocks/public-transport-provider-platform/package.yaml
@@ -119,6 +119,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -143,6 +146,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/mocks/rider-platform/mock-rider-platform.cabal
+++ b/Backend/app/mocks/rider-platform/mock-rider-platform.cabal
@@ -84,7 +84,7 @@ library
     , unordered-containers
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -146,6 +146,6 @@ executable mock-rider-platform-exe
     , unordered-containers
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/mocks/rider-platform/package.yaml
+++ b/Backend/app/mocks/rider-platform/package.yaml
@@ -89,6 +89,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -113,6 +116,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/mocks/sms/mock-sms.cabal
+++ b/Backend/app/mocks/sms/mock-sms.cabal
@@ -89,7 +89,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -142,6 +142,6 @@ executable mock-sms-exe
     , record-hasfield
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/mocks/sms/package.yaml
+++ b/Backend/app/mocks/sms/package.yaml
@@ -81,6 +81,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -118,6 +121,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Allocator/driver-offer-allocator.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Allocator/driver-offer-allocator.cabal
@@ -115,7 +115,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -205,6 +205,6 @@ executable driver-offer-allocator-exe
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Allocator/package.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Allocator/package.yaml
@@ -113,6 +113,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -145,6 +148,9 @@ executables:
       - condition: flag(Local)
         then:
           ghc-options:
+            - -Wno-ambiguous-fields
+            - -Wno-incomplete-uni-patterns
+            - -Wno-incomplete-record-updates
             - -O0
             - -funfolding-use-threshold20
             - -fno-cse

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -1892,7 +1892,7 @@ library
       cac_client
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -2034,6 +2034,6 @@ executable dynamic-offer-driver-app-exe
       cac_client
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/package.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/package.yaml
@@ -168,6 +168,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -207,6 +210,9 @@ executables:
       - condition: flag(Local)
         then:
           ghc-options:
+            - -Wno-ambiguous-fields
+            - -Wno-incomplete-uni-patterns
+            - -Wno-incomplete-record-updates
             - -O0
             - -funfolding-use-threshold20
             - -fno-cse

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/dynamic-offer-driver-drainer.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/dynamic-offer-driver-drainer.cabal
@@ -137,7 +137,7 @@ library
     , warp-tls
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -231,6 +231,6 @@ executable dynamic-offer-driver-drainer-exe
     , warp-tls
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/package.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/package.yaml
@@ -122,6 +122,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -148,6 +151,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/rider-platform/public-transport-rider-platform/Main/package.yaml
+++ b/Backend/app/rider-platform/public-transport-rider-platform/Main/package.yaml
@@ -106,6 +106,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -130,6 +133,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/rider-platform/public-transport-rider-platform/Main/public-transport-rider-platform.cabal
+++ b/Backend/app/rider-platform/public-transport-rider-platform/Main/public-transport-rider-platform.cabal
@@ -212,7 +212,7 @@ library
     , wai
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -290,6 +290,6 @@ executable public-transport-rider-platform-exe
     , wai
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/rider-platform/public-transport-rider-platform/search-consumer/package.yaml
+++ b/Backend/app/rider-platform/public-transport-rider-platform/search-consumer/package.yaml
@@ -95,6 +95,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -119,6 +122,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/rider-platform/public-transport-rider-platform/search-consumer/public-transport-search-consumer.cabal
+++ b/Backend/app/rider-platform/public-transport-rider-platform/search-consumer/public-transport-search-consumer.cabal
@@ -94,7 +94,7 @@ library
     , unordered-containers
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -161,6 +161,6 @@ executable public-transport-search-consumer-exe
     , unordered-containers
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/rider-platform/rider-app-drainer/package.yaml
+++ b/Backend/app/rider-platform/rider-app-drainer/package.yaml
@@ -127,6 +127,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -153,6 +156,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/rider-platform/rider-app-drainer/rider-app-drainer.cabal
+++ b/Backend/app/rider-platform/rider-app-drainer/rider-app-drainer.cabal
@@ -136,7 +136,7 @@ library
     , warp-tls
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -230,6 +230,6 @@ executable rider-app-drainer-exe
     , warp-tls
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/rider-platform/rider-app/Main/package.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/package.yaml
@@ -165,6 +165,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -201,6 +204,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -1713,7 +1713,7 @@ library
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -1851,7 +1851,7 @@ executable rider-app-exe
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 

--- a/Backend/app/rider-platform/rider-app/Scheduler/package.yaml
+++ b/Backend/app/rider-platform/rider-app/Scheduler/package.yaml
@@ -113,6 +113,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -143,6 +146,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/rider-platform/rider-app/Scheduler/rider-app-scheduler.cabal
+++ b/Backend/app/rider-platform/rider-app/Scheduler/rider-app-scheduler.cabal
@@ -113,7 +113,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -201,6 +201,6 @@ executable rider-app-scheduler-exe
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/rider-platform/rider-app/search-result-aggregator/package.yaml
+++ b/Backend/app/rider-platform/rider-app/search-result-aggregator/package.yaml
@@ -98,6 +98,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -124,6 +127,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/rider-platform/rider-app/search-result-aggregator/search-result-aggregator.cabal
+++ b/Backend/app/rider-platform/rider-app/search-result-aggregator/search-result-aggregator.cabal
@@ -90,7 +90,7 @@ library
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -156,6 +156,6 @@ executable search-result-aggregator-exe
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/safety-dashboard/package.yaml
+++ b/Backend/app/safety-dashboard/package.yaml
@@ -119,6 +119,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -147,6 +150,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/safety-dashboard/safety-dashboard.cabal
+++ b/Backend/app/safety-dashboard/safety-dashboard.cabal
@@ -169,7 +169,7 @@ library
     , wai
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -254,6 +254,6 @@ executable safety-dashboard-exe
     , wai
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/sdk-event-pipeline/package.yaml
+++ b/Backend/app/sdk-event-pipeline/package.yaml
@@ -101,6 +101,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -126,6 +129,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/sdk-event-pipeline/sdk-event-pipeline.cabal
+++ b/Backend/app/sdk-event-pipeline/sdk-event-pipeline.cabal
@@ -97,7 +97,7 @@ library
     , wai
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -166,6 +166,6 @@ executable sdk-event-pipeline-exe
     , wai
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/special-zone/package.yaml
+++ b/Backend/app/special-zone/package.yaml
@@ -102,6 +102,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -127,6 +130,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/special-zone/special-zone.cabal
+++ b/Backend/app/special-zone/special-zone.cabal
@@ -100,7 +100,7 @@ library
     , uri-encode
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -170,6 +170,6 @@ executable special-zone-exe
     , uri-encode
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/unified-dashboard/package.yaml
+++ b/Backend/app/unified-dashboard/package.yaml
@@ -130,6 +130,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -154,6 +157,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/unified-dashboard/unified-dashboard.cabal
+++ b/Backend/app/unified-dashboard/unified-dashboard.cabal
@@ -210,7 +210,7 @@ library
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -302,6 +302,6 @@ executable unified-dashboard-exe
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/utils/image-api-helper/image-api-helper.cabal
+++ b/Backend/app/utils/image-api-helper/image-api-helper.cabal
@@ -107,7 +107,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -190,6 +190,6 @@ executable image-api-helper-exe
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/app/utils/image-api-helper/package.yaml
+++ b/Backend/app/utils/image-api-helper/package.yaml
@@ -112,6 +112,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -136,6 +139,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/utils/route-extractor/package.yaml
+++ b/Backend/app/utils/route-extractor/package.yaml
@@ -116,6 +116,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -142,6 +145,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/app/utils/route-extractor/route-extractor.cabal
+++ b/Backend/app/utils/route-extractor/route-extractor.cabal
@@ -106,7 +106,7 @@ library
     , xml-conduit
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -189,6 +189,6 @@ executable route-extractor-exe
     , xml-conduit
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/cabal.project
+++ b/Backend/cabal.project
@@ -1,34 +1,18 @@
 packages:
   app/alchemist
   app/provider-platform/dynamic-offer-driver-drainer
-  app/beckn-cli
   app/provider-platform/dynamic-offer-driver-app/Main
   app/provider-platform/dynamic-offer-driver-app/Allocator
   app/rider-platform/rider-app-drainer
   app/rider-platform/rider-app/Main
   app/rider-platform/rider-app/Scheduler
-  app/rider-platform/rider-app/search-result-aggregator
-  app/safety-dashboard
-  app/mocks/sms
-  app/mocks/fcm
   app/dashboard/rider-dashboard
   app/dashboard/provider-dashboard
   app/dashboard/Lib
-  app/unified-dashboard
   app/dashboard/CommonAPIs
-  app/example-service
   app/special-zone
   app/sdk-event-pipeline
-  app/mocks/rider-platform
   app/kafka-consumers
-  app/mocks/idfy
-  app/mocks/payment
-  app/mocks/google
-  app/rider-platform/public-transport-rider-platform/Main
-  app/rider-platform/public-transport-rider-platform/search-consumer
-  app/mocks/public-transport-provider-platform
-  app/utils/route-extractor
-  app/utils/image-api-helper
   lib/passetto-lib
   lib/beckn-spec
   lib/beckn-services
@@ -41,7 +25,6 @@ packages:
   lib/sessionizer-metrics
   lib/yudhishthira
   lib/finance-kernel
-  test
   lib/producer
   lib/utils
   lib/external
@@ -51,7 +34,6 @@ packages:
   lib/consequence-engine
   lib/communication-engine
   lib/behavior-engine
-  hunit-tests
 -- ## 6 parallel jobs by default.
 --
 -- # since we now use "-j4" in "ghc-options" for all packages,

--- a/Backend/default.nix
+++ b/Backend/default.nix
@@ -13,19 +13,10 @@
     let
       # Packages to exclude from CI builds (not needed for production deployment)
       ciExcludedPackages = [
-        "hunit-tests"
-        "beckn-test"
-        "route-extractor"
-        "mock-public-transport-provider-platform"
-        "public-transport-rider-platform"
-        "public-transport-search-consumer"
         "mock-payment"
-        "mock-rider-platform"
         "sdk-event-pipeline"
         "special-zone"
-        "example-service"
         "safety-dashboard"
-        "search-result-aggregator"
         "beckn-cli"
         "alchemist"
         "arion"
@@ -38,19 +29,11 @@
       ];
       # Apps to exclude from CI builds (devour-flake via om ci run)
       ciExcludedApps = [
-        "hunit-tests"
         "beckn-cli-exe"
-        "route-extractor-exe"
-        "mock-public-transport-provider-platform-exe"
-        "public-transport-rider-platform-exe"
-        "public-transport-search-consumer-exe"
         "mock-payment-exe"
-        "mock-rider-platform-exe"
         "sdk-event-pipeline-exe"
         "special-zone-exe"
-        "example-service-exe"
         "safety-dashboard-exe"
-        "search-result-aggregator-exe"
         "trace"
         "alchemist-generator-exe"
       ];
@@ -145,34 +128,18 @@
           alchemist.custom = cacConfig;
           beckn-cli.custom = cacConfig;
           provider-dashboard.custom = cacConfig;
-          example-service.custom = cacConfig;
-          mock-fcm.custom = cacConfig;
-          mock-google.custom = cacConfig;
-          mock-public-transport-provider-platform.custom = cacConfig;
-          mock-rider-platform.custom = cacConfig;
-          mock-sms.custom = cacConfig;
-          mock-payment.custom = cacConfig;
-          public-transport-rider-platform.custom = cacConfig;
-          public-transport-search-consumer.custom = cacConfig;
           rider-app.custom = cacConfig;
-          search-result-aggregator.custom = cacConfig;
           rider-app-drainer.custom = cacConfig;
           special-zone.custom = cacConfig;
-          image-api-helper.custom = cacConfig;
-          route-extractor.custom = cacConfig;
           dynamic-offer-driver-app.custom = cacConfig;
           producer.custom = cacConfig;
           dynamic-offer-driver-drainer.custom = cacConfig;
           lib-dashboard.custom = cacConfig;
           kafka-consumers.custom = cacConfig;
           driver-offer-allocator.custom = cacConfig;
-          beckn-test.custom = cacConfig;
           rider-dashboard.custom = cacConfig;
-
-
           namma-dsl.libraryProfiling = false;
           location-updates.check = false;
-          beckn-test.check = false;
           singletons-th.jailbreak = true;
           singletons-base = {
             jailbreak = true;

--- a/Backend/hunit-tests/hunit-tests.cabal
+++ b/Backend/hunit-tests/hunit-tests.cabal
@@ -183,6 +183,6 @@ executable hunit-tests
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/hunit-tests/package.yaml
+++ b/Backend/hunit-tests/package.yaml
@@ -118,6 +118,9 @@ executables:
       - condition: flag(Local)
         then:
           ghc-options:
+            - -Wno-ambiguous-fields
+            - -Wno-incomplete-uni-patterns
+            - -Wno-incomplete-record-updates
             - -O0
             - -funfolding-use-threshold20
             - -fno-cse

--- a/Backend/lib/beckn-services/beckn-services.cabal
+++ b/Backend/lib/beckn-services/beckn-services.cabal
@@ -108,6 +108,6 @@ library
     , uri-encode
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/beckn-services/package.yaml
+++ b/Backend/lib/beckn-services/package.yaml
@@ -114,6 +114,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/beckn-spec/beckn-spec.cabal
+++ b/Backend/lib/beckn-spec/beckn-spec.cabal
@@ -370,7 +370,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 

--- a/Backend/lib/beckn-spec/package.yaml
+++ b/Backend/lib/beckn-spec/package.yaml
@@ -157,6 +157,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/behavior-engine/behavior-engine.cabal
+++ b/Backend/lib/behavior-engine/behavior-engine.cabal
@@ -88,6 +88,6 @@ library
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/behavior-engine/package.yaml
+++ b/Backend/lib/behavior-engine/package.yaml
@@ -80,6 +80,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/behavior-tracker/behavior-tracker.cabal
+++ b/Backend/lib/behavior-tracker/behavior-tracker.cabal
@@ -84,6 +84,6 @@ library
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/behavior-tracker/package.yaml
+++ b/Backend/lib/behavior-tracker/package.yaml
@@ -77,6 +77,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/communication-engine/communication-engine.cabal
+++ b/Backend/lib/communication-engine/communication-engine.cabal
@@ -80,6 +80,6 @@ library
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/communication-engine/package.yaml
+++ b/Backend/lib/communication-engine/package.yaml
@@ -77,6 +77,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/consequence-engine/consequence-engine.cabal
+++ b/Backend/lib/consequence-engine/consequence-engine.cabal
@@ -80,6 +80,6 @@ library
     , time
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/consequence-engine/package.yaml
+++ b/Backend/lib/consequence-engine/package.yaml
@@ -77,6 +77,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/dashcam/dashcam.cabal
+++ b/Backend/lib/dashcam/dashcam.cabal
@@ -102,6 +102,6 @@ library
     , uri-encode
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/dashcam/package.yaml
+++ b/Backend/lib/dashcam/package.yaml
@@ -111,6 +111,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/external/external.cabal
+++ b/Backend/lib/external/external.cabal
@@ -187,6 +187,6 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/external/package.yaml
+++ b/Backend/lib/external/package.yaml
@@ -173,6 +173,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/finance-kernel/finance-kernel.cabal
+++ b/Backend/lib/finance-kernel/finance-kernel.cabal
@@ -179,6 +179,6 @@ library
     , zip-archive
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/finance-kernel/package.yaml
+++ b/Backend/lib/finance-kernel/package.yaml
@@ -95,6 +95,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/gtfs-data-server/gtfs-data-server.cabal
+++ b/Backend/lib/gtfs-data-server/gtfs-data-server.cabal
@@ -95,6 +95,6 @@ library
     , unordered-containers
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/gtfs-data-server/package.yaml
+++ b/Backend/lib/gtfs-data-server/package.yaml
@@ -96,6 +96,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/location-updates/location-updates.cabal
+++ b/Backend/lib/location-updates/location-updates.cabal
@@ -158,7 +158,6 @@ test-suite location-updates-tests
     , lens
     , location-updates
     , mobility-core
-    , mock-google
     , record-dot-preprocessor
     , record-hasfield
     , servant

--- a/Backend/lib/location-updates/location-updates.cabal
+++ b/Backend/lib/location-updates/location-updates.cabal
@@ -90,7 +90,7 @@ library
     , uri-encode
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -174,6 +174,6 @@ test-suite location-updates-tests
     , uri-encode
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/location-updates/package.yaml
+++ b/Backend/lib/location-updates/package.yaml
@@ -100,6 +100,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -139,6 +142,9 @@ tests:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/location-updates/package.yaml
+++ b/Backend/lib/location-updates/package.yaml
@@ -133,7 +133,6 @@ tests:
       - tasty-hspec
       - QuickCheck
       - tasty-quickcheck
-      - mock-google
       - unordered-containers
     ghc-options:
       - -Wall

--- a/Backend/lib/passetto-lib/package.yaml
+++ b/Backend/lib/passetto-lib/package.yaml
@@ -40,6 +40,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -j4
       else:

--- a/Backend/lib/passetto-lib/passetto-lib.cabal
+++ b/Backend/lib/passetto-lib/passetto-lib.cabal
@@ -62,6 +62,6 @@ library
     , vector
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/payment/package.yaml
+++ b/Backend/lib/payment/package.yaml
@@ -115,6 +115,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/payment/payment.cabal
+++ b/Backend/lib/payment/payment.cabal
@@ -177,6 +177,6 @@ library
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/producer/package.yaml
+++ b/Backend/lib/producer/package.yaml
@@ -108,6 +108,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -132,6 +135,9 @@ executables:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/producer/producer.cabal
+++ b/Backend/lib/producer/producer.cabal
@@ -103,7 +103,7 @@ library
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -183,6 +183,6 @@ executable producer-exe
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/scheduler/package.yaml
+++ b/Backend/lib/scheduler/package.yaml
@@ -114,6 +114,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/scheduler/scheduler.cabal
+++ b/Backend/lib/scheduler/scheduler.cabal
@@ -110,6 +110,6 @@ library
     , uuid
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/sessionizer-metrics/package.yaml
+++ b/Backend/lib/sessionizer-metrics/package.yaml
@@ -101,6 +101,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/sessionizer-metrics/sessionizer-metrics.cabal
+++ b/Backend/lib/sessionizer-metrics/sessionizer-metrics.cabal
@@ -94,6 +94,6 @@ library
     , wai-middleware-prometheus
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/shared-services/package.yaml
+++ b/Backend/lib/shared-services/package.yaml
@@ -140,6 +140,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/shared-services/shared-services.cabal
+++ b/Backend/lib/shared-services/shared-services.cabal
@@ -237,6 +237,6 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/special-zone/package.yaml
+++ b/Backend/lib/special-zone/package.yaml
@@ -114,6 +114,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/special-zone/special-zone-a.cabal
+++ b/Backend/lib/special-zone/special-zone-a.cabal
@@ -119,6 +119,6 @@ library
     , vector
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/utils/package.yaml
+++ b/Backend/lib/utils/package.yaml
@@ -6,6 +6,12 @@ author: "nammayatri"
 maintainer: "nammayatri"
 copyright: "2023 Juspay Technologies Private Limited"
 
+flags:
+  Local:
+    description: Enable this flag for faster compile times
+    manual: true
+    default: false
+
 # Metadata used when publishing your package
 # synopsis:            Short description of your package
 # category:            Web
@@ -132,6 +138,23 @@ library:
     - -Widentities
     - -fhide-source-paths
     - -Werror
+  when:
+    - condition: flag(Local)
+      then:
+        ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
+          - -O0
+          - -funfolding-use-threshold20
+          - -fno-cse
+          - -fmax-simplifier-iterations1
+          - -fno-specialise-aggressively
+          - -j4
+      else:
+        ghc-options:
+          - -O2
+          - -j4
   dependencies:
     - mobility-core
     - beckn-spec

--- a/Backend/lib/utils/utils.cabal
+++ b/Backend/lib/utils/utils.cabal
@@ -19,6 +19,11 @@ source-repository head
   type: git
   location: https://github.com/nammayatri/nammayatri
 
+flag Local
+  description: Enable this flag for faster compile times
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Tools.DynamicLogic
@@ -147,3 +152,7 @@ library
     , warp
     , yudhishthira
   default-language: Haskell2010
+  if flag(Local)
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+  else
+    ghc-options: -O2 -j4

--- a/Backend/lib/webhook/package.yaml
+++ b/Backend/lib/webhook/package.yaml
@@ -110,6 +110,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/webhook/webhook.cabal
+++ b/Backend/lib/webhook/webhook.cabal
@@ -106,6 +106,6 @@ library
     , uri-encode
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/lib/yudhishthira/package.yaml
+++ b/Backend/lib/yudhishthira/package.yaml
@@ -150,6 +150,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse

--- a/Backend/lib/yudhishthira/yudhishthira.cabal
+++ b/Backend/lib/yudhishthira/yudhishthira.cabal
@@ -222,7 +222,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 

--- a/Backend/nix/services/nammayatri.nix
+++ b/Backend/nix/services/nammayatri.nix
@@ -162,15 +162,8 @@ in
         "dynamic-offer-driver-drainer-exe"
         "driver-offer-allocator-exe"
         "rider-app-scheduler-exe"
-        "image-api-helper-exe"
-        "mock-fcm-exe"
-        "mock-google-exe"
-        "mock-idfy-exe"
-        "mock-sms-exe"
         "producer-exe"
-        "search-result-aggregator-exe"
         "kafka-consumers-exe"
-        "unified-dashboard-exe"
       ];
 
       # In non-backend profiles (e.g. testDashboard) every haskell process is

--- a/Backend/test/beckn-test.cabal
+++ b/Backend/test/beckn-test.cabal
@@ -148,7 +148,7 @@ library
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4
 
@@ -246,6 +246,6 @@ test-suite beckn-integ-test
     , warp
   default-language: Haskell2010
   if flag(Local)
-    ghc-options: -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
+    ghc-options: -Wno-ambiguous-fields -Wno-incomplete-uni-patterns -Wno-incomplete-record-updates -O0 -funfolding-use-threshold20 -fno-cse -fmax-simplifier-iterations1 -fno-specialise-aggressively -j4
   else
     ghc-options: -O2 -j4

--- a/Backend/test/package.yaml
+++ b/Backend/test/package.yaml
@@ -127,6 +127,9 @@ library:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse
@@ -153,6 +156,9 @@ tests:
     - condition: flag(Local)
       then:
         ghc-options:
+          - -Wno-ambiguous-fields
+          - -Wno-incomplete-uni-patterns
+          - -Wno-incomplete-record-updates
           - -O0
           - -funfolding-use-threshold20
           - -fno-cse


### PR DESCRIPTION
## Summary
Brings the build-flag and `cabal.project` changes from `main` to `prodHotPush-BAP`.

- **package.yaml** — adds `-Wno-ambiguous-fields`, `-Wno-incomplete-uni-patterns`, `-Wno-incomplete-record-updates` under the `Local` flag `ghc-options` block across all backend `package.yaml` files. In `Backend/lib/utils/package.yaml` this also introduces the `flags: Local:` declaration and `when:` switch (matching main). Mirrors PR #15052 (`a43ae67c72` — *enhancement: CI Build*).
- **cabal.project** — drops apps and libs that `main` no longer builds (e.g. `app/beckn-cli`, `app/safety-dashboard`, the mocks, `app/example-service`, `app/unified-dashboard`, public-transport-rider-platform, `app/utils/{route-extractor,image-api-helper}`, `test`, `hunit-tests`). Combines the effects of `a7f8317ec9` (*Deps: remove packages from cabal.project*) and `05a9e31887` (*removed some unwanted cabal*).
- `lib/config-pilot` is intentionally **not** added to `cabal.project`, because the `lib/config-pilot` directory does not exist on this branch yet (its move-to-lib commit `a2710b4c0f` is not in `prodHotPush-BAP`). Adding the entry without the directory would break the build.

## Test plan
- [ ] CI passes
- [ ] Local build (`cabal build all`) succeeds
- [ ] No package referenced by Allocator / Main / Scheduler / drainer that was removed from `cabal.project` is now missing at link time

🤖 Generated with [Claude Code](https://claude.com/claude-code)