### PR TITLE
backend/fix/added-failed-ids-to-subscription-purchase-api

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/FinanceManagement.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/FinanceManagement.yaml
@@ -190,6 +190,7 @@ types:
     - totalItems: Int
     - summary: Summary
     - subscriptions: [SubscriptionPurchaseListItem]
+    - failedOwnerIds: [Text]
   SubscriptionPurchaseListItem:
     - subscriptionPurchaseId: Maybe Text
     - purchasedAt: Maybe UTCTime

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/FinanceManagement.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/FinanceManagement.hs
@@ -336,7 +336,7 @@ data SubscriptionPurchaseListItem = SubscriptionPurchaseListItem
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data SubscriptionPurchaseListRes = SubscriptionPurchaseListRes {totalItems :: Kernel.Prelude.Int, summary :: Dashboard.Common.Summary, subscriptions :: [SubscriptionPurchaseListItem]}
+data SubscriptionPurchaseListRes = SubscriptionPurchaseListRes {totalItems :: Kernel.Prelude.Int, summary :: Dashboard.Common.Summary, subscriptions :: [SubscriptionPurchaseListItem], failedOwnerIds :: [Kernel.Prelude.Text]}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/FinanceManagement.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/FinanceManagement.hs
@@ -148,16 +148,18 @@ getFinanceManagementSubscriptionPurchaseList merchantShortId opCity mbAmountMax 
             (Just offset)
 
   -- Build response items (use each subscription's serviceName for plan lookup)
-  items <- mapM (\sub -> buildSubscriptionPurchaseItem sub limit offset) subscriptions
+  results <- mapM (\sub -> tryBuildSubscriptionPurchaseItem sub limit offset) subscriptions
 
-  let totalItems = length items
+  let (failedOwnerIds, items) = partitionEithers results
+      totalItems = length items
       summary = Dashboard.Common.Summary {totalCount = totalItems, count = totalItems}
 
   pure $
     API.SubscriptionPurchaseListRes
       { totalItems,
         summary,
-        subscriptions = items
+        subscriptions = items,
+        failedOwnerIds
       }
   where
     parseServiceName :: Text -> Maybe DPlan.ServiceNames
@@ -188,6 +190,15 @@ getFinanceManagementSubscriptionPurchaseList merchantShortId opCity mbAmountMax 
         mbAmountMax
         (Just limit)
         (Just offset)
+
+    tryBuildSubscriptionPurchaseItem :: DSP.SubscriptionPurchase -> Int -> Int -> Flow (Either Text API.SubscriptionPurchaseListItem)
+    tryBuildSubscriptionPurchaseItem subscription limit' offset' = do
+      result <- withTryCatch ("buildSubscriptionPurchaseItem:" <> subscription.ownerId) $ buildSubscriptionPurchaseItem subscription limit' offset'
+      case result of
+        Right item -> pure $ Right item
+        Left err -> do
+          logError $ "Failed to build subscription item for ownerId: " <> subscription.ownerId <> ", error: " <> show err
+          pure $ Left subscription.ownerId
 
     buildSubscriptionPurchaseItem :: DSP.SubscriptionPurchase -> Int -> Int -> Flow API.SubscriptionPurchaseListItem
     buildSubscriptionPurchaseItem subscription _limit _offset = do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Finance management subscription purchase lists now include a new `failedOwnerIds` field indicating which subscription purchase owner IDs could not be processed.
  * When some items fail, the response still returns the successfully built `subscriptions` with accurate `totalItems` and `summary`.
* **Bug Fixes**
  * Improved resilience during subscription purchase list rendering so individual item errors no longer abort the entire response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->