### PR TITLE
backend/enh/Redis-Caching-Layer-For-ConfigPilot

### DIFF
--- a/Backend/lib/config-pilot/src/Lib/ConfigPilot/Config/GetterInternal.hs
+++ b/Backend/lib/config-pilot/src/Lib/ConfigPilot/Config/GetterInternal.hs
@@ -102,15 +102,16 @@ getConfigImpl _dimensions wrappedConfig logicDomain merchantOpCityId = do
 configPilotInMemKey :: ConfigDimensions a => a -> [Text]
 configPilotInMemKey dims = ["ConfigPilot", show (getConfigType dims), dimensionsCacheKey dims]
 
--- | Invalidate the in-mem cache for a config type across all pods.
--- Sets a Redis key that the background cleanup thread reads to clear matching in-mem entries.
+-- | Invalidate both cache layers for a config type across all pods: the in-mem
+-- L1 (shudhi sidecar + Redis cleanup flag) and the Redis L2 hash bucket.
 invalidateConfigInMem :: (MonadFlow m, CacheFlow m r, CoreMetrics m, HasInMemEnv r) => ConfigType -> m ()
 invalidateConfigInMem cfgType = do
   let keyPrefix :: Text = "ConfigPilot:" <> show cfgType
   now <- getCurrentTime
   let val = A.object ["forceCleanupTimestamp" .= timeOfDayFromUTCTime now, "forceCleanupKeyPrefix" .= keyPrefix]
   Hedis.setExp "inmem:force:cleanup:timeofday" val 600
-  IM.refreshInMem keyPrefix -- This one does clear using the shudhi sidecar, above is a fallback for thread running in this project for cleanup after TTL
+  IM.refreshInMem keyPrefix -- L1: clear in-mem across pods via the shudhi sidecar (the Redis flag above is the TTL-based fallback)
+  Hedis.delRedisCacheBucket keyPrefix -- L2: drop the cross-pod Redis hash bucket for this config type in one DEL
   where
     timeOfDayFromUTCTime t =
       let dayTime = utctDayTime t

--- a/Backend/lib/config-pilot/src/Lib/ConfigPilot/Interface/Getter.hs
+++ b/Backend/lib/config-pilot/src/Lib/ConfigPilot/Interface/Getter.hs
@@ -10,6 +10,7 @@ module Lib.ConfigPilot.Interface.Getter
 where
 
 import Kernel.Prelude
+import qualified Kernel.Storage.Hedis as Hedis
 import qualified Kernel.Storage.InMem as IM
 import Kernel.Types.Id
 import Lib.ConfigPilot.Config.GetterInternal (PersonIdKey (..), TxnIdKey (..), configPilotInMemKey, getConfigImpl, invalidateConfigInMem)
@@ -65,14 +66,21 @@ resolveConfigList ::
   Maybe [DimMatcher dims cfg] ->
   m [cfg]
 resolveConfigList dims logicDomain mocId fetch matchers fallback =
-  IM.withInMemCache (configPilotInMemKey dims) 3600 $ do
-    cfgs <- fetch
-    let applyMatchers ms = filter (\c -> all (matchesDim dims c) ms) cfgs
-    let filtered = case (applyMatchers matchers, fallback) of
-          ([], Just fb) -> applyMatchers fb
-          (results, _) -> results
-    let wrappers = map (\c -> LYT.Config {config = c, extraDimensions = Nothing, identifier = 0}) filtered
-    mapM (\w -> getConfigImpl dims w logicDomain mocId) wrappers
+  -- Two-layer cache: per-pod in-mem (L1) wraps a cross-pod Redis hash (L2).
+  -- L2 hash prefix mirrors 'configPilotInMemKey' ("ConfigPilot:<configType>");
+  -- the dimensions form the hash field and 'withRedisCache' appends the cached
+  -- type name. L2 currently relies on its TTL; explicit invalidation is TODO.
+  IM.withInMemCache cacheKey 3600 $
+    Hedis.withRedisCache redisHashPrefix [dimensionsCacheKey dims] 1800 $ do
+      cfgs <- fetch
+      let applyMatchers ms = filter (\c -> all (matchesDim dims c) ms) cfgs
+      let filtered = case (applyMatchers matchers, fallback) of
+            ([], Just fb) -> applyMatchers fb
+            (results, _) -> results
+      let wrappers = map (\c -> LYT.Config {config = c, extraDimensions = Nothing, identifier = 0}) filtered
+      mapM (\w -> getConfigImpl dims w logicDomain mocId) wrappers
   where
+    cacheKey = configPilotInMemKey dims
+    redisHashPrefix = "ConfigPilot:" <> show (getConfigType dims)
     matchesDim dims' c (DimMatcher getDimVal getCfgVal eqFn) =
       maybe True (\dv -> maybe False (eqFn dv) (getCfgVal c)) (getDimVal dims')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config list lookups now use a two-level cache: a faster local in-memory cache backed by a shared Redis hash cache for improved response times and cross-pod consistency.
* **Bug Fixes**
  * Cache invalidation was clarified and strengthened to improve update propagation, including prompt refresh of local cached entries and reliable cleanup of the shared Redis cache for the affected keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->