### PR TITLE
backend/perf/msil: batch before-snapshot read in ledger settlement audit

### DIFF
--- a/Backend/lib/finance-kernel/src/Lib/Finance/Ledger/Service.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Ledger/Service.hs
@@ -693,7 +693,7 @@ markEntriesAsPaidOut ::
 markEntriesAsPaidOut [] _ = pure ()
 markEntriesAsPaidOut entryIds payoutRequestId = do
   actorInfo <- asks (.actorInfo)
-  beforeEntries <- catMaybes <$> mapM QLedger.findById entryIds
+  beforeEntries <- QLedgerExtra.findByIds entryIds
   now <- getCurrentTime
   updateWithKV
     [ Se.Set BeamLE.settlementStatus (Just PAID_OUT),
@@ -717,7 +717,7 @@ markEntriesAsProcessing ::
 markEntriesAsProcessing [] _ = pure ()
 markEntriesAsProcessing entryIds mbSettlementId = do
   actorInfo <- asks (.actorInfo)
-  beforeEntries <- catMaybes <$> mapM QLedger.findById entryIds
+  beforeEntries <- QLedgerExtra.findByIds entryIds
   now <- getCurrentTime
   updateWithKV
     ( [ Se.Set BeamLE.settlementStatus (Just PROCESSING),
@@ -749,7 +749,7 @@ markEntriesAsUnsettled ::
 markEntriesAsUnsettled [] = pure ()
 markEntriesAsUnsettled entryIds = do
   actorInfo <- asks (.actorInfo)
-  beforeEntries <- catMaybes <$> mapM QLedger.findById entryIds
+  beforeEntries <- QLedgerExtra.findByIds entryIds
   now <- getCurrentTime
   updateWithKV
     [ Se.Set BeamLE.settlementStatus (Just UNSETTLED),


### PR DESCRIPTION
Replace per-entry findById (N point reads) with a single QLedgerExtra.findByIds IN-query in markEntriesAsPaidOut/Processing/Unsettled. Behavior unchanged; settlementAuditPairs keys by id.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary
