### PR TITLE
Removing .git files for Incremental Build

### DIFF
--- a/Backend/dev/test-tool/local-api/server.py
+++ b/Backend/dev/test-tool/local-api/server.py
@@ -911,6 +911,7 @@ REMOTE_EXCLUDES = [
     "data", "node_modules", "dist-newstyle",
     "dist", ".direnv", "_build", "result", "result-*",
     ".cabal-dir",
+    ".git",
     "Frontend/android-native", "Frontend/ios",
     "Frontend/build", "Frontend/dist",
 ]
@@ -1387,6 +1388,56 @@ def _ssh_argv(user: str, host: str, port: int, identity: str | None, want_tty: b
     return argv
 
 
+def _compute_cache_commit(project_root: str, max_n: int = 30) -> str:
+    def _git(args, timeout=20):
+        return subprocess.run(
+            ["git", "-C", project_root, *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+
+    # 1. best-effort fetch (works offline with stale refs; failures are non-fatal)
+    for fetch_args in (
+        ["fetch", "--quiet", "origin",
+         "refs/tags/minio-pushed/*:refs/tags/minio-pushed/*"],
+        ["fetch", "--quiet", "origin", "main"],
+    ):
+        try:
+            _git(fetch_args, timeout=30)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # 2. merge-base with main (fallback HEAD)
+    base = "HEAD"
+    try:
+        mb = _git(["merge-base", "origin/main", "HEAD"], timeout=15)
+        if mb.returncode == 0 and mb.stdout.strip():
+            base = mb.stdout.strip()
+    except Exception:  # noqa: BLE001
+        pass
+
+    # 3. walk back and return the NEAREST commit carrying a minio-pushed tag —
+    #    the single commit whose build cache cache-restore should pull. CI tags a
+    #    commit once its build is pushed to MinIO. If none of the recent ancestors
+    #    is tagged, return "" and cabal builds from scratch.
+    walk = []
+    try:
+        lg = _git(["log", "--format=%H", "-n", str(max_n), base], timeout=15)
+        if lg.returncode == 0:
+            walk = lg.stdout.split()
+    except Exception:  # noqa: BLE001
+        pass
+
+    for sha in walk:
+        try:
+            r = _git(["rev-parse", "-q", "--verify",
+                      f"refs/tags/minio-pushed/{sha}"], timeout=10)
+            if r.returncode == 0:
+                return sha
+        except Exception:  # noqa: BLE001
+            pass
+    return ""
+
+
 def remote_deploy(body: dict) -> dict:
     host = (body.get("host") or "localhost").strip()
     user = (body.get("user") or "").strip()
@@ -1466,14 +1517,34 @@ def remote_deploy(body: dict) -> dict:
         session["running"] = True
         session["buf"].append(f"[deploy] {' '.join(argv)}")
 
-    # After rsync, init a minimal git repo on the remote so Nix copies only
-    # tracked files (much faster than copying the entire untracked directory)
+    # Compute the single MinIO build-cache commit from the dev's LOCAL git (the
+    # Mac has .git; the devbox no longer does): the nearest minio-pushed-tagged
+    # ancestor. cache-restore on the devbox pulls exactly this commit's cache, or
+    # builds from scratch if it's empty / not in MinIO. Dropped as
+    # Backend/.ci-cache-sha in the post-rsync hook below.
+    cache_commit = _compute_cache_commit(str(PROJECT_ROOT))
+    with session["lock"]:
+        if cache_commit:
+            session["buf"].append(f"[deploy] minio cache commit: {cache_commit}")
+        else:
+            session["buf"].append(
+                "[deploy] no minio-pushed cache commit found — "
+                "cabal will build from scratch"
+            )
+
+    # After rsync, (re)create a minimal 1-commit git repo on the remote so Nix
+    # copies only tracked files (much faster than copying the whole tree). Since
+    # .git is no longer rsynced, `rm -rf .git` also reclaims any stale full-history
+    # .git left by earlier deploys. Then drop the single cache commit for
+    # cache-restore to consume (empty file => build from scratch).
     git_init_cmd = (
         f"cd {shlex.quote(remote_dir)} && "
-        f"git init -q && git add -A && "
+        f"rm -rf .git && git init -q && git add -A && "
         f"GIT_AUTHOR_NAME=deploy GIT_AUTHOR_EMAIL=deploy@deploy "
         f"GIT_COMMITTER_NAME=deploy GIT_COMMITTER_EMAIL=deploy@deploy "
-        f"git commit -q -m deploy --allow-empty 2>/dev/null || true"
+        f"git commit -q -m deploy --allow-empty 2>/dev/null || true; "
+        f"mkdir -p Backend && printf '%s' {shlex.quote(cache_commit)} "
+        f"> Backend/.ci-cache-sha"
     )
     ssh_base = [
         "ssh", "-o", "StrictHostKeyChecking=accept-new",

--- a/Backend/nix/services/nammayatri.nix
+++ b/Backend/nix/services/nammayatri.nix
@@ -619,27 +619,22 @@ in
                   fi
                   echo "cache-restore: connected to MinIO at $MINIO_ENDPOINT"
 
-                  # ── Find nearest ancestor commit that has a cache in MinIO ──
-                  # Walk the user's git history and pick the first commit with a cache.
-                  # If no ancestor matches, skip and let cabal build from scratch.
-                  FOUND_SHA=""
-                  GIT_SHAS=$(git log --format='%H' -n 50 2>/dev/null || true)
-                  if [ -z "$GIT_SHAS" ]; then
-                    echo "cache-restore: no git history found (ensure .git is synced), skipping"
-                    exit 0
-                  fi
-                  for sha in $GIT_SHAS; do
-                    if mc stat "nycache/haskell-cache/cabal-build/$sha/dist-newstyle.tar.zst" >/dev/null 2>&1; then
-                      FOUND_SHA="$sha"
-                      break
-                    fi
-                  done
-
+                  # ── Pick the commit whose dist-newstyle cache to restore ──
+                  # The dev's Mac (which has .git) computes the single nearest
+                  # 'minio-pushed'-tagged commit and drops it in .ci-cache-sha.
+                  # This lets deploys skip .git entirely — no git history here.
+                  # Empty file (no tagged ancestor) or not-in-MinIO => build from
+                  # scratch.
+                  FOUND_SHA=$(tr -d '[:space:]' < .ci-cache-sha 2>/dev/null || true)
                   if [ -z "$FOUND_SHA" ]; then
-                    echo "cache-restore: no cached ancestor commit found in MinIO (checked last 50), skipping"
+                    echo "cache-restore: no minio-pushed cache commit in .ci-cache-sha, building from scratch"
                     exit 0
                   fi
-                  echo "cache-restore: found cache for ancestor commit $FOUND_SHA"
+                  if ! mc stat "nycache/haskell-cache/cabal-build/$FOUND_SHA/dist-newstyle.tar.zst" >/dev/null 2>&1; then
+                    echo "cache-restore: cache commit $FOUND_SHA not in MinIO, building from scratch"
+                    exit 0
+                  fi
+                  echo "cache-restore: found cache for commit $FOUND_SHA"
 
                   # ── Download and extract ──
                   TMPFILE=$(mktemp /tmp/dist-newstyle-XXXXXX.tar.zst)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved remote deployment handling by using a dedicated cache commit marker for build reuse.
  * Added support for restoring build caches from a single, explicitly recorded commit reference.

* **Bug Fixes**
  * Prevented local repository metadata from being uploaded during remote deploys.
  * Ensured remote deployments start from a clean minimal repository state.
  * Fallback behavior now safely builds from scratch when no matching cache is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->