### PR TITLE
backend/fix/address proof status and upload logic changed

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
@@ -251,6 +251,13 @@ validateImageHandler isDashboard mbUploaderRole mbDocConfigs (personId, _, merch
       when (imageType == DVC.ProfilePhoto) $
         fork "deferred face match on selfie upload" $
           runDeferredFaceMatchOnSelfie person imageEntity.createdAt
+      when (imageType == DVC.LocalResidenceProof) $
+        mapM_
+          ( \staleImg -> do
+              _ <- withTryCatch "S3:delete:staleLocalResidenceProof" $ S3.delete (T.unpack staleImg.s3Path)
+              Query.deleteById staleImg.id
+          )
+          (filter (\staleImg -> staleImg.id /= imageEntity.id) allImages)
       return $ ImageValidateResponse {imageId = imageEntity.id}
   where
     checkErrors id_ _ Nothing = throwImageError id_ ImageValidationFailed

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
@@ -1354,7 +1354,10 @@ getProcessedDriverDocuments role driverId entityImagesInfo docType useHVSdkForDL
       return (status, reason, url, Nothing, mbS3Path, mbImageId, Nothing)
     DVC.LocalResidenceProof -> do
       let (status, reason, url) = checkImageValidity entityImagesInfo DVC.LocalResidenceProof
-      return (status, reason, url, Nothing, mbS3Path, mbImageId, Nothing)
+      mbIdentityInfo <- QDII.findByDriverId driverId
+      let hasAddressDetails =
+            maybe False (\info -> isJust info.address && isJust info.addressDocumentType && isJust info.addressState) mbIdentityInfo
+      return (if hasAddressDetails then status else Just NO_DOC_AVAILABLE, reason, url, Nothing, mbS3Path, mbImageId, Nothing)
     DVC.DriverVehicleNOC -> do
       let (status, reason, url) = checkImageValidity entityImagesInfo DVC.DriverVehicleNOC
       return (status, reason, url, Nothing, mbS3Path, mbImageId, Nothing)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of residence proof uploads by automatically removing older leftover images when a new one is submitted.
  * Updated document status results so residence proof is shown as unavailable when required address details are missing, preventing misleading processing states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->