### PR TITLE
ci: check minio-pushed git tag instead of mc stat in pr workflows

### DIFF
--- a/.github/workflows/cabal-pr-repl-check-driver.yaml
+++ b/.github/workflows/cabal-pr-repl-check-driver.yaml
@@ -41,30 +41,24 @@ jobs:
           MINIO_SECRET_KEY=$(jq -r '.minio_secret_key' /etc/service_discovery.json)
           mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
 
-      - name: Check repl artifacts exist for merge base
+      - name: Check minio-pushed tag for merge base
         id: artifact-check
         run: |
           MERGE_BASE="${{ steps.merge-base.outputs.sha }}"
+          git fetch origin 'refs/tags/minio-pushed/*:refs/tags/minio-pushed/*' || true
           FOUND_SHA=""
-
           for sha in $(git log --format='%H' -n 10 "$MERGE_BASE"); do
-            echo "Checking artifacts for $sha..."
-            if mc stat "minio/haskell-cache/cabal-repl/$sha/dynamic-offer-driver-app.tar.zst" > /dev/null 2>&1 && \
-               mc stat "minio/haskell-cache/cabal-repl/$sha/repl-support.tar.zst" > /dev/null 2>&1 && \
-               mc stat "minio/haskell-cache/cabal-repl/$sha/cache-root.txt" > /dev/null 2>&1 && \
-               mc stat "minio/haskell-cache/cabal-build/$sha/build-path.txt" > /dev/null 2>&1; then
+            if git rev-parse -q --verify "refs/tags/minio-pushed/$sha" >/dev/null; then
               FOUND_SHA="$sha"
-              echo "Artifacts found for $sha"
+              echo "minio-push verified for $sha"
               break
             fi
-            echo "No artifacts for $sha, trying previous commit..."
           done
-
           if [ -n "$FOUND_SHA" ]; then
             echo "found=true" >> $GITHUB_OUTPUT
             echo "base_sha=$FOUND_SHA" >> $GITHUB_OUTPUT
           else
-            echo "::error::No repl artifacts found in last 10 commits from merge base $MERGE_BASE — cannot run incremental repl check"
+            echo "::error::No minio-pushed tag found in last 10 commits from $MERGE_BASE"
             exit 1
           fi
 

--- a/.github/workflows/cabal-pr-repl-check-rider.yaml
+++ b/.github/workflows/cabal-pr-repl-check-rider.yaml
@@ -41,30 +41,24 @@ jobs:
           MINIO_SECRET_KEY=$(jq -r '.minio_secret_key' /etc/service_discovery.json)
           mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
 
-      - name: Check repl artifacts exist for merge base
+      - name: Check minio-pushed tag for merge base
         id: artifact-check
         run: |
           MERGE_BASE="${{ steps.merge-base.outputs.sha }}"
+          git fetch origin 'refs/tags/minio-pushed/*:refs/tags/minio-pushed/*' || true
           FOUND_SHA=""
-
           for sha in $(git log --format='%H' -n 10 "$MERGE_BASE"); do
-            echo "Checking artifacts for $sha..."
-            if mc stat "minio/haskell-cache/cabal-repl/$sha/rider-app.tar.zst" > /dev/null 2>&1 && \
-               mc stat "minio/haskell-cache/cabal-repl/$sha/repl-support.tar.zst" > /dev/null 2>&1 && \
-               mc stat "minio/haskell-cache/cabal-repl/$sha/cache-root.txt" > /dev/null 2>&1 && \
-               mc stat "minio/haskell-cache/cabal-build/$sha/build-path.txt" > /dev/null 2>&1; then
+            if git rev-parse -q --verify "refs/tags/minio-pushed/$sha" >/dev/null; then
               FOUND_SHA="$sha"
-              echo "Artifacts found for $sha"
+              echo "minio-push verified for $sha"
               break
             fi
-            echo "No artifacts for $sha, trying previous commit..."
           done
-
           if [ -n "$FOUND_SHA" ]; then
             echo "found=true" >> $GITHUB_OUTPUT
             echo "base_sha=$FOUND_SHA" >> $GITHUB_OUTPUT
           else
-            echo "::error::No repl artifacts found in last 10 commits from merge base $MERGE_BASE — cannot run incremental repl check"
+            echo "::error::No minio-pushed tag found in last 10 commits from $MERGE_BASE"
             exit 1
           fi
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI checks to look for a published `minio-pushed` tag when determining the relevant base commit.
  * Improved fallback behavior by scanning recent commits when the exact merge-base tag is unavailable.
  * Updated failure messages to better reflect when no matching tag is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->