### PR TITLE
rider-platform/perf: booking-list reads use reader replica

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs
@@ -61,7 +61,6 @@ import Kernel.Types.APISuccess (APISuccess (Success))
 import Kernel.Types.Common
 import Kernel.Types.Flow
 import Kernel.Types.Id
-import Kernel.Types.Version (CloudType (GCP))
 import qualified Kernel.Utils.CalculateDistance as CD
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig)
@@ -300,20 +299,9 @@ bookingListV2ByCustomerLookup merchantId mbLimit mbOffset mbBookingOffset mbJour
           pure person.id
         Nothing -> throwError $ InternalError "No Person Found"
 
-applyMasterDbIfGcp :: Flow a -> Flow a
-applyMasterDbIfGcp computation = do
-  mbCloudType <- asks (.cloudType)
-  case mbCloudType of
-    Just cloudType | cloudType == GCP -> do
-      logInfo "applyMasterDbIfGcp: CloudType is GCP, routing queries to Master DB (AWS)"
-      B.runInMasterDb computation
-    _ -> do
-      logInfo $ "applyMasterDbIfGcp: CloudType is " <> show mbCloudType <> ", using default replica/local DB"
-      computation
-
 bookingListV2 :: (Id Person.Person, Id Merchant.Merchant) -> Maybe Integer -> Maybe Integer -> Maybe Integer -> Maybe Integer -> Maybe Integer -> Maybe Integer -> Maybe Integer -> [SLT.BillingCategory] -> [SLT.RideType] -> [SRB.BookingStatus] -> [DJ.JourneyStatus] -> Maybe Bool -> Maybe SRB.BookingRequestType -> Maybe Bool -> Maybe [Domain.Types.PassType.PassEnum] -> Maybe Bool -> Flow BookingListResV2
-bookingListV2 (personId, merchantId) mbLimit mbOffset mbBookingOffset mbJourneyOffset mbPassOffset mbFromDate' mbToDate' billingCategoryList rideTypeList mbBookingStatusList mbJourneyStatusList mbIsPaymentSuccess mbBookingRequestType mbSendEligiblePassIfAvailable mbPassTypes mbDontNeedFareBreakup = do
-  applyMasterDbIfGcp $ do
+bookingListV2 (personId, merchantId) mbLimit mbOffset mbBookingOffset mbJourneyOffset mbPassOffset mbFromDate' mbToDate' billingCategoryList rideTypeList mbBookingStatusList mbJourneyStatusList mbIsPaymentSuccess mbBookingRequestType mbSendEligiblePassIfAvailable mbPassTypes mbDontNeedFareBreakup =
+  do
     allPasses <- getPassList merchantId personId limitIntMaybe mbInitialPassOffsetInt mbFromDate' mbToDate' mbSendEligiblePassIfAvailable mbPassTypes
     (apiEntity, nextBookingOffset, nextJourneyOffset, nextPassOffset, hasMoreData) <- case mbBookingRequestType of
       Just SRB.BookingRequest -> do
@@ -352,16 +340,15 @@ bookingListV2 (personId, merchantId) mbLimit mbOffset mbBookingOffset mbJourneyO
       _ -> do
         bookingListFork <-
           awaitableFork "bookingListV2->getBookingList" $
-            applyMasterDbIfGcp $ getBookingList (Just personId, merchantId) Nothing False integralLimit mbInitialBookingOffset Nothing Nothing Nothing mbFromDate' mbToDate' mbBookingStatusList Nothing
+            getBookingList (Just personId, merchantId) Nothing False integralLimit mbInitialBookingOffset Nothing Nothing Nothing mbFromDate' mbToDate' mbBookingStatusList Nothing
 
         -- Journeys (NammaTransit) should only be included for PERSONAL billing category and NORMAL ride type
         let shouldIncludeJourneys = shouldIncludeJourneysForFilters billingCategoryList rideTypeList
         journeyListFork <-
           awaitableFork "bookingListV2->getJourneyList" $
-            applyMasterDbIfGcp $
-              if shouldIncludeJourneys
-                then getJourneyList personId integralLimit mbInitialJourneyOffset mbFromDate' mbToDate' mbJourneyStatusList mbIsPaymentSuccess
-                else pure []
+            if shouldIncludeJourneys
+              then getJourneyList personId integralLimit mbInitialJourneyOffset mbFromDate' mbToDate' mbJourneyStatusList mbIsPaymentSuccess
+              else pure []
 
         (rbList, allbookings) <-
           L.await Nothing bookingListFork >>= \case
@@ -425,7 +412,7 @@ bookingListV2 (personId, merchantId) mbLimit mbOffset mbBookingOffset mbJourneyO
           logInfo $ "rbList: test " <> show rbList
         Nothing -> do
           fork "booking list status update" $
-            applyMasterDbIfGcp $ do
+            do
               (rbList_, allbookings_) <- getBookingList (Just personId, merchantId) Nothing False integralLimit mbInitialBookingOffset Nothing Nothing Nothing mbFromDate' mbToDate' mbBookingStatusList Nothing
               checkBookingsForStatus allbookings_
               logInfo $ "rbList: test " <> show rbList_


### PR DESCRIPTION
Remove applyMasterDbIfGcp from bookingListV2. It forced GCP pods to read the booking/journey/pass list from the AWS master (B.runInMasterDb) to avoid AWS->GCP replication lag. With reads now routed to the reader replica via DB config, this override is no longer needed; dropping it lets bookingListV2 use the default replica config and offloads the master. Also removed the now-unused CloudType (GCP) import.

No behaviour change beyond read routing.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Booking lists and ride refreshes now use a more consistent backend path, helping reduce environment-specific inconsistencies and unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->