### PR TITLE
Selfie Upload/Re-Upload gate added

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
@@ -219,6 +219,10 @@ validateImageHandler isDashboard mbUploaderRole mbDocConfigs (personId, _, merch
         )
         $ throwError $ DocumentAlreadyValidated (show imageType)
 
+      -- Driver selfie re-upload lock: allowed only while every face-match-bound doc is absent or INVALID.
+      when (imageType == DVC.ProfilePhoto && not isDashboard) $
+        enforceSelfieReuploadPolicy person allImages
+
       imagePath <- createPath personId.getId merchantId.getId imageType fileExtension
       s3Result <-
         withTryCatch "S3:put:uploadImage" $

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding.hs
@@ -1059,10 +1059,13 @@ resolveFaceMatchVerificationStatus person config docImageId mbDocImage mbPlainDo
     _ -> Documents.VALID
 
 -- | On selfie upload, face-match earlier non-SDK doc images: skip while the doc's webhook is pending (the handler resolves it), else run now and promote PENDING->VALID or flip INVALID.
+faceMatchBoundConfigs :: Person.Person -> Flow [ODC.DocumentVerificationConfig]
+faceMatchBoundConfigs person =
+  DL.nubBy (\a b -> a.documentType == b.documentType) . filter (\c -> isJust c.faceMatchSourceDoc && isJust (faceCompareDocTag c.documentType)) <$> CQDVC.findAllByMerchantOpCityId person.merchantOperatingCityId Nothing
+
 runDeferredFaceMatchOnSelfie :: Person.Person -> UTCTime -> Flow ()
 runDeferredFaceMatchOnSelfie person selfieCreatedAt = do
-  -- Config-driven doc list (faceMatchSourceDoc set), intersected with the DL/PAN/Aadhaar hard bound.
-  faceMatchConfigs <- DL.nubBy (\a b -> a.documentType == b.documentType) . filter (\c -> isJust c.faceMatchSourceDoc && isJust (faceCompareDocTag c.documentType)) <$> CQDVC.findAllByMerchantOpCityId person.merchantOperatingCityId Nothing
+  faceMatchConfigs <- faceMatchBoundConfigs person
   forM_ faceMatchConfigs $ \config -> do
     result <- try @_ @SomeException $ matchDeferredDoc config
     case result of
@@ -1105,6 +1108,28 @@ runDeferredFaceMatchOnSelfie person selfieCreatedAt = do
           when (aadhaar.aadhaarFrontImageId == Just docImg.id && aadhaar.verificationStatus == Documents.PENDING) $
             QAadhaarCard.updateVerificationStatus Documents.VALID person.id
       _ -> pure ()
+
+-- | Once a VALID selfie exists, a DRIVER may upload a new one only while every face-match-bound doc (DL/PAN/Aadhaar with faceMatchSourceDoc set) is absent or INVALID.
+enforceSelfieReuploadPolicy :: Person.Person -> [Image.Image] -> Flow ()
+enforceSelfieReuploadPolicy person priorSelfies =
+  when (person.role == Person.DRIVER && any ((== Just Documents.VALID) . (.verificationStatus)) priorSelfies) $ do
+    faceMatchDocTypes <- fmap (.documentType) <$> faceMatchBoundConfigs person
+    docStatuses <- catMaybes <$> mapM lookupDocStatus faceMatchDocTypes
+    let blockingDocs = filter ((/= Documents.INVALID) . snd) docStatuses
+    whenJust (pickBlockingDoc blockingDocs) $ \(docType, status) -> do
+      logInfo $ "Selfie re-upload blocked for driver " <> person.id.getId <> "; non-INVALID face-match docs: " <> show blockingDocs
+      throwError $ SelfieReuploadNotAllowed (show docType) status
+  where
+    lookupDocStatus docType = case docType of
+      ODC.DriverLicense -> fmap (\dl -> (docType, dl.verificationStatus)) <$> DLQuery.findByDriverId person.id
+      ODC.PanCard -> fmap (\pan -> (docType, pan.verificationStatus)) <$> DPQuery.findByDriverId person.id
+      ODC.AadhaarCard -> fmap (\aadhaar -> (docType, aadhaar.verificationStatus)) <$> QAadhaarCard.findByPrimaryKey person.id
+      _ -> pure Nothing
+    -- Highest-severity blocker names the error: VALID > MANUAL_VERIFICATION_REQUIRED > in-flight (PENDING/etc.).
+    pickBlockingDoc docs =
+      DL.find ((== Documents.VALID) . snd) docs
+        <|> DL.find ((== Documents.MANUAL_VERIFICATION_REQUIRED) . snd) docs
+        <|> listToMaybe docs
 
 mkRCIdfyVerificationEntity :: MonadFlow m => Person.Person -> Text -> UTCTime -> DIdfy.ImageExtractionValidation -> EncryptedHashedField 'AsEncrypted Text -> Maybe UTCTime -> Maybe DVC.VehicleCategory -> Maybe Bool -> Maybe Bool -> Maybe Bool -> Id Image.Image -> Maybe Int -> Maybe Text -> m DIdfy.IdfyVerification
 mkRCIdfyVerificationEntity person requestId now imageExtractionValidation encryptedRC dateOfRegistration mbVehicleCategory mbAirConditioned mbOxygen mbVentilator imageId mbRetryCnt mbStatus = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
@@ -1394,7 +1394,8 @@ getProcessedDriverDocuments role driverId entityImagesInfo docType useHVSdkForDL
                 mbIdentityInfo <&> \info ->
                   LocalAddressProofMetadata LocalAddressProofDocumentMetadata {state = info.addressState, proofDocumentType = info.addressDocumentType, address = info.address}
               else Nothing
-      return (if hasAddressDetails then status else Just NO_DOC_AVAILABLE, reason, url, Nothing, mbS3Path, mbImageId, Nothing, mbLocalMetadata)
+      let statusWithoutAddress = if isJust mbImageId then Just INVALID else Just NO_DOC_AVAILABLE
+      return (if hasAddressDetails then status else statusWithoutAddress, reason, url, Nothing, mbS3Path, mbImageId, Nothing, mbLocalMetadata)
     DVC.DriverVehicleNOC -> do
       let (status, reason, url) = checkImageValidity entityImagesInfo DVC.DriverVehicleNOC
       return (status, reason, url, Nothing, mbS3Path, mbImageId, Nothing, Nothing)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
@@ -18,6 +18,7 @@ import Data.Aeson (Value (Null), object, (.=))
 import Kernel.External.Types (Language)
 import Kernel.Prelude
 import Kernel.Types.Common (HighPrecMoney)
+import qualified Kernel.Types.Documents as Documents
 import Kernel.Types.Error as Tools.Error hiding (PersonError, SosError, SosIdDoesNotExist)
 import Kernel.Types.Error.BaseError.HTTPError
 import Kernel.Utils.Common (Meters)
@@ -1304,6 +1305,7 @@ data DriverOnboardingError
   | GstInvalid
   | VehicleServiceTierNotFound Text
   | DocumentUnderManualReview Text
+  | SelfieReuploadNotAllowed Text Documents.VerificationStatus
   | DocumentAlreadyValidated Text
   | InvalidWebhookPayload Text Text
   | InvalidReviewStatus Text Text
@@ -1396,6 +1398,12 @@ instance IsBaseError DriverOnboardingError where
     GstInvalid -> Just "Contact Customer Support, GST certificate has been rejected"
     VehicleServiceTierNotFound serviceTier -> Just $ "Service tier config not found for vehicle service tier \"" <> serviceTier <> "\"."
     DocumentUnderManualReview docName -> Just $ "Your " <> docName <> " is under manual review."
+    SelfieReuploadNotAllowed docName status ->
+      let reason = case status of
+            Documents.VALID -> "already validated"
+            Documents.MANUAL_VERIFICATION_REQUIRED -> "under manual review"
+            _ -> "under verification"
+       in Just $ "You can't update your selfie because your " <> docName <> " is " <> reason <> ". Please contact support if you need to make changes."
     DocumentAlreadyValidated docName -> Just $ "Your " <> docName <> " is already validated."
     InvalidWebhookPayload svcName errMsg -> Just $ "Unable to parse webhook payload from  " <> svcName <> ". Error: " <> errMsg
     InvalidReviewStatus svcName status -> Just $ "Invalid review status from svc : " <> svcName <> ". Value : " <> status
@@ -1484,6 +1492,7 @@ instance IsHTTPError DriverOnboardingError where
     GstInvalid -> "GST_INVALID"
     VehicleServiceTierNotFound _ -> "VEHICLE_SERVICE_TIER_NOT_FOUND"
     DocumentUnderManualReview _ -> "DOCUMENT_UNDER_MANUAL_REVIEW"
+    SelfieReuploadNotAllowed _ _ -> "SELFIE_REUPLOAD_NOT_ALLOWED"
     DocumentAlreadyValidated _ -> "DOCUMENT_ALREADY_VALIDATED"
     InvalidWebhookPayload _ _ -> "INVALID_WEBHOOK_PAYLOAD"
     InvalidReviewStatus _ _ -> "INVALID_REVIEW_STATUS"
@@ -1570,6 +1579,7 @@ instance IsHTTPError DriverOnboardingError where
     GstInvalid -> E400
     VehicleServiceTierNotFound _ -> E500
     DocumentUnderManualReview _ -> E400
+    SelfieReuploadNotAllowed _ _ -> E400
     DocumentAlreadyValidated _ -> E400
     InvalidWebhookPayload _ _ -> E400
     InvalidReviewStatus _ _ -> E400

--- a/Backend/dev/integration-tests/collections/FaceMatchOnboardingFlow/02-DeferredFaceMatch.json
+++ b/Backend/dev/integration-tests/collections/FaceMatchOnboardingFlow/02-DeferredFaceMatch.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "FaceMatchOnboardingFlow - Deferred",
     "_postman_id": "facematch-deferred-flow",
-    "description": "DEFERRED face match via Aadhaar (synchronous -> AadhaarCard record reaches VALID without the async webhook). FLAT structure. Seed: face_match_source_doc='ProfilePhoto' on AadhaarCard. Deferred runs in a fork after selfie upload, so status checks wait ~2.5s.\n  G Aadhaar VALID -> NON-matching selfie -> AadhaarCard INVALID (deferred FAIL)\n  H Aadhaar VALID -> MATCHING selfie -> AadhaarCard stays VALID (deferred PASS)\n\nPENDING-until-face-match model: sync Aadhaar (and non-strict flows) write PENDING when no selfie exists yet; the deferred run on selfie upload promotes PENDING->VALID on a match or flips INVALID on a mismatch. For strict PAN/DL with the 3P webhook still in flight (this harness never fires webhooks), the deferred run does NOTHING - the webhook handler resolves the face match itself on a positive verdict.",
+    "description": "DEFERRED face match via Aadhaar (synchronous -> AadhaarCard record reaches VALID without the async webhook). FLAT structure. Seed: face_match_source_doc='ProfilePhoto' on AadhaarCard. Deferred runs in a fork after selfie upload, so status checks wait ~2.5s.\n  G Aadhaar VALID -> NON-matching selfie -> AadhaarCard INVALID (deferred FAIL)\n  H Aadhaar VALID -> MATCHING selfie -> AadhaarCard stays VALID (deferred PASS)\n\nPENDING-until-face-match model: sync Aadhaar (and non-strict flows) write PENDING when no selfie exists yet; the deferred run on selfie upload promotes PENDING->VALID on a match or flips INVALID on a mismatch. For strict PAN/DL with the 3P webhook still in flight (this harness never fires webhooks), the deferred run does NOTHING - the webhook handler resolves the face match itself on a positive verdict.\n\nSELFIE RE-UPLOAD GATE (enforceSelfieReuploadPolicy): once a DRIVER has a VALID selfie, a new ProfilePhoto upload is allowed ONLY while every face-match-bound doc (DL/PAN/Aadhaar with faceMatchSourceDoc set) is absent or INVALID. Error is state-specific on the strongest blocking doc: VALID->DOCUMENT_ALREADY_VALIDATED (H), MANUAL_VERIFICATION_REQUIRED->DOCUMENT_UNDER_MANUAL_REVIEW, PENDING/other->DOCUMENT_UNDER_VERIFICATION. Covered here: VALID block (H) and INVALID recovery-allow (M last step). MVR/PENDING routing is not API-reproducible in this harness (no doc can hold MVR/PENDING alongside a VALID selfie without a live async webhook) -> verified via manual DB-flip probe; legacy cities (no faceMatchSourceDoc) are a no-op.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [
@@ -617,6 +617,48 @@
       ]
     },
     {
+      "name": "H: Upload 2nd selfie (blocked - Aadhaar VALID)",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{token_H}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/register/validateImage",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "register",
+            "validateImage"
+          ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"image\": \"{{_test_png}}\",\n  \"imageType\": \"ProfilePhoto\",\n  \"validationStatus\": \"AUTO_APPROVED\",\n  \"workflowTransactionId\": \"{{$guid}}\"\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('selfie re-upload blocked while a face-match doc is not INVALID',()=>pm.response.to.have.status(400)); var b={}; try{b=pm.response.json()}catch(e){}; pm.test('VALID doc -> DOCUMENT_ALREADY_VALIDATED',()=>pm.expect(b.errorCode||'','body '+JSON.stringify(b)).to.eql('DOCUMENT_ALREADY_VALIDATED'));"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "name": "M: Auth (sendOTP)",
       "request": {
         "method": "POST",
@@ -1018,6 +1060,48 @@
           "script": {
             "exec": [
               "pm.test('status ok',()=>pm.response.to.have.status(200)); var doc=(pm.response.json().driverDocuments||[]).find(d=>d.documentType==='PanCard')||{}; pm.test('sticky INVALID: a later matching selfie never rescues; recovery is via re-upload',()=>pm.expect(['INVALID','FAILED'],'doc '+JSON.stringify(doc)).to.include(doc.verificationStatus));"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "M: Re-upload selfie after PAN INVALID (recovery -> allowed)",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "token",
+            "value": "{{token_M}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseURL_namma_P}}/driver/register/validateImage",
+          "host": [
+            "{{baseURL_namma_P}}"
+          ],
+          "path": [
+            "driver",
+            "register",
+            "validateImage"
+          ]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"image\": \"{{_test_png}}\",\n  \"imageType\": \"ProfilePhoto\",\n  \"validationStatus\": \"AUTO_APPROVED\",\n  \"workflowTransactionId\": \"facematch-M-recovery\"\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('selfie re-upload allowed once every face-match doc is INVALID (recovery path)',()=>pm.response.to.have.status(200)); pm.test('imageId returned',()=>pm.expect((pm.response.json()||{}).imageId,'body '+JSON.stringify(pm.response.json())).to.be.a('string'));"
             ]
           }
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Selfie re-upload gate: once a driver has a VALID selfie, block new selfie uploads while any mandate doc (DL/PAN/Aadhaar) is still VALID/PENDING/MVR — only allowed once all such docs are INVALID or absent (fresh upload). Returns a state-specific error (DOCUMENT_ALREADY_VALIDATED / DOCUMENT_UNDER_MANUAL_REVIEW / DOCUMENT_UNDER_VERIFICATION). Driver-app selfie uploads only; no-op for fleet/dashboard/legacy cities.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selfie re-upload protection during driver onboarding, restricting Profile Photo re-uploads when a prior selfie is already in an active/terminal verification state (non-dashboard flow).
  * Added clearer handling in the deferred face-match flow to ensure the same policy is applied consistently.

* **Bug Fixes**
  * Re-upload requests now return the correct 400-level response and error code when submission isn’t allowed.
  * Updated local residence proof status behavior when address details are missing but an image exists.

* **Tests**
  * Expanded integration coverage for allowed vs rejected selfie re-uploads in the deferred face-match scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->