### PR TITLE
backend/fix: bot stale review request list fixes

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Operator/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Operator/Driver.hs
@@ -975,6 +975,7 @@ postDriverSubmitReviewRequest merchantShortId opCity requestorId req = do
       API.Types.ProviderPlatform.Operator.Driver.DRIVER -> do
         let driverId = Kernel.Types.Id.Id reqId
         driverInfo <- QDI.findByPrimaryKey driverId >>= fromMaybeM (PersonNotFound reqId)
+        unless driverInfo.verified $ throwError (InvalidRequest "Driver is not verified")
         if isDocReqEmpty
           then do
             -- Two-phase: phase 1 durably commits `approved`; phase 2 (approved == True) does the fast
@@ -985,8 +986,8 @@ postDriverSubmitReviewRequest merchantShortId opCity requestorId req = do
                   transporterConfig <- findByMerchantOpCityId merchantOpCity.id Nothing >>= fromMaybeM (TransporterConfigNotFound merchantOpCity.id.getId)
                   -- Throws (naming the offending docs) if any BotApproval dependency doc isn't VALID.
                   SStatus.botApproveAndReconcile merchantOpCity person transporterConfig
+                  QDI.updateByPrimaryKey driverInfo {DDI.enabled = True}
                   pure (DRR.COMPLETED, Nothing, Nothing)
-            unless driverInfo.verified $ throwError (InvalidRequest "Driver is not verified")
             if driverInfo.approved == Just True
               then runReconcile
               else do
@@ -1000,6 +1001,7 @@ postDriverSubmitReviewRequest merchantShortId opCity requestorId req = do
       API.Types.ProviderPlatform.Operator.Driver.FLEET_OWNER -> do
         let fleetOwnerId = Kernel.Types.Id.Id reqId
         fleetOwnerInfo <- QFOI.findByPrimaryKey fleetOwnerId >>= fromMaybeM (PersonNotFound reqId)
+        unless fleetOwnerInfo.verified $ throwError (InvalidRequest "Fleet Owner is not verified")
         if isDocReqEmpty
           then do
             -- Sync dependency-docs check; the heavy fleet recompute (sets `enabled` + cascades) is forked.
@@ -1007,6 +1009,7 @@ postDriverSubmitReviewRequest merchantShortId opCity requestorId req = do
             transporterConfig <- findByMerchantOpCityId merchantOpCity.id Nothing >>= fromMaybeM (TransporterConfigNotFound merchantOpCity.id.getId)
             -- Throws (naming the offending docs) if any BotApproval dependency doc isn't VALID.
             SStatus.botApproveAndReconcile merchantOpCity fleetPerson transporterConfig
+            QFOI.updateByPrimaryKey fleetOwnerInfo {DFOI.enabled = True}
             pure (DRR.COMPLETED, Nothing, Nothing)
           else do
             applyDocRejections req.entityType reqId validatedDocs
@@ -1016,9 +1019,9 @@ postDriverSubmitReviewRequest merchantShortId opCity requestorId req = do
       API.Types.ProviderPlatform.Operator.Driver.VEHICLE -> do
         let rcId = Kernel.Types.Id.Id reqId
         rcInfo <- QVRC.findByPrimaryKey rcId >>= fromMaybeM (VehicleNotFound reqId)
+        when (rcInfo.verified /= Just True) $ throwError (InvalidRequest "RC is not verified")
         if isDocReqEmpty
           then do
-            when (rcInfo.verified /= Just True) $ throwError (InvalidRequest "RC is not verified")
             unless (rcInfo.approved == Just True) $ QVRC.updateByPrimaryKey rcInfo {DVRC.approved = Just True}
             pure (DRR.COMPLETED, rcInfo.unencryptedCertificateNumber, Nothing)
           else do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the driver and fleet-owner approval workflow so verification is validated earlier and applies consistently across document-empty and non-empty scenarios.
  * Ensured accounts are marked enabled at the correct point after successful reconciliation, including when submitted documents are empty.
  * Updated vehicle/RC verification handling so it’s enforced for both completion (approval) and rejection outcomes, improving consistency across both paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->