### PR TITLE
fix: Association history checks added

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Association/Change.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Association/Change.hs
@@ -2,6 +2,8 @@ module SharedLogic.Association.Change
   ( guardNoLiveRideByDriver,
     guardNoLiveRideByRC,
     guardNoLiveRideInFleet,
+    guardRCNotOwnedByAnotherFleet,
+    guardRCNotActiveWithAnotherDriver,
     withAssociation,
   )
 where
@@ -14,7 +16,9 @@ import Kernel.Types.Id
 import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, throwError)
 import qualified Storage.Queries.DriverRCAssociation as QDriverRC
 import qualified Storage.Queries.FleetDriverAssociation as QFleetDriver
+import qualified Storage.Queries.FleetRCAssociation as QFleetRC
 import qualified Storage.Queries.Ride as QRide
+import Tools.Error
 
 -- Throws if the driver currently has a NEW/UPCOMING/INPROGRESS ride.
 guardNoLiveRideByDriver :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id DP.Person -> m ()
@@ -45,3 +49,33 @@ guardNoLiveRideInFleet fleetOwnerId = do
 -- full association history lives in ClickHouse, not Postgres.
 withAssociation :: Monad m => m () -> m a -> m a
 withAssociation runGuard body = runGuard >> body
+
+-- RC ownership guard, driver side: block a driver from linking an RC that's actively
+-- claimed by a fleet they aren't a member of (e.g. hijacking another fleet's vehicle by
+-- re-verifying its RC number through their own app). Safe for the fleet's own driver:
+-- createFleetRCAssociationIfPossible always creates the fleet_rc_association before this
+-- runs in initiateRCCreation's driver branch, so FleetDriverAssociation membership already
+-- exists by the time a legitimate fleet driver reaches here.
+guardRCNotOwnedByAnotherFleet :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id DP.Person -> Id DVRC.VehicleRegistrationCertificate -> m ()
+guardRCNotOwnedByAnotherFleet driverId rcId = do
+  guardNoLiveRideByRC rcId
+  activeFleetAssocs <- QFleetRC.findAllActiveAssociationByRCId rcId
+  unless (null activeFleetAssocs) $ do
+    membershipChecks <- mapM (\assoc -> isJust <$> QFleetDriver.findByDriverIdAndFleetOwnerId driverId assoc.fleetOwnerId.getId True) activeFleetAssocs
+    unless (or membershipChecks) $ throwError VehicleBelongsToAnotherFleet
+
+-- RC ownership guard, fleet side: a fleet claiming an RC must not silently take over a
+-- vehicle another driver is actively driving (isRcActive=True) -- unconditional block, no
+-- exception. This can't false-positive on the fleet's own active vehicle: the caller
+-- (initiateRCCreation / updateExistingRCFleetOwnerIfEnabled) already self-checks
+-- (isNothing mbFleetAssoc) before calling this helper, and normal flow ordering always
+-- creates the fleet_rc_association before a driver can ever reach isRcActive=True. A driver
+-- who merely linked the RC without activating it isn't a real conflict -- end that stale
+-- link and let the fleet's claim proceed.
+guardRCNotActiveWithAnotherDriver :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id DVRC.VehicleRegistrationCertificate -> m ()
+guardRCNotActiveWithAnotherDriver rcId = do
+  guardNoLiveRideByRC rcId
+  mbActiveDriverAssoc <- QDriverRC.findActiveAssociationByRC rcId True
+  whenJust mbActiveDriverAssoc $ \_ -> throwError RCActiveOnOtherAccount
+  linkedDriverAssocs <- QDriverRC.findAllActiveAssociationByRCId rcId
+  forM_ linkedDriverAssocs $ \assoc -> QDriverRC.endAssociationForRC assoc.driverId rcId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding.hs
@@ -71,6 +71,7 @@ import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig, getOneConfig)
 import qualified SharedLogic.Allocator.Jobs.Overlay.SendOverlay as ACOverlay
 import SharedLogic.Analytics as Analytics
+import qualified SharedLogic.Association.Change as AC
 import SharedLogic.MessageBuilder (addBroadcastMessageToKafka)
 import SharedLogic.VehicleServiceTier
 import qualified Storage.Cac.TransporterConfig as SCTC
@@ -273,6 +274,8 @@ createDriverRCAssociationIfPossible transporterConfig driverId rc = do
       throwError (InvalidRequest "Fleet drivers cannot onboard their own vehicle. Use a fleet vehicle.")
   if canCreateRCAssociation transporterConfig rc
     then do
+      when (transporterConfig.blockDriverOwnRCForFleetDrivers == Just True) $
+        AC.guardRCNotOwnedByAnotherFleet driverId rc.id
       driverRCAssoc <- makeRCAssociation transporterConfig.merchantId transporterConfig.merchantOperatingCityId rc.id defaultAssociationEnd
       DAQuery.create driverRCAssoc
     else do
@@ -309,6 +312,8 @@ createFleetRCAssociationIfPossible ::
 createFleetRCAssociationIfPossible transporterConfig fleetOwnerId rc = do
   if canCreateRCAssociation transporterConfig rc
     then do
+      when (transporterConfig.blockDriverOwnRCForFleetDrivers == Just True) $
+        AC.guardRCNotActiveWithAnotherDriver rc.id
       fleetRCAssoc <- makeFleetRCAssociation transporterConfig.merchantId transporterConfig.merchantOperatingCityId rc.id defaultAssociationEnd
       FRCAssoc.create fleetRCAssoc
     else do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened onboarding protection when linking vehicle registration certificates to drivers and fleets.
  * Prevents creating driver-to-certificate links if the certificate is already owned by an active fleet under another driver account.
  * Prevents creating fleet-to-certificate links when the certificate is already actively linked to a different driver account.
  * If overwriting is enabled, previously active driver links are ended before establishing the new fleet association.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->