### PR TITLE
backend/fix: call multimodal transit if not able to find a route

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Search.hs
@@ -64,7 +64,12 @@ search merchant merchantOperatingCity bapConfig searchReq mbFare routeDetails in
           _ -> callOndcSearch networkHostUrl
     _ -> do
       onSearchReq <- Flow.search merchant merchantOperatingCity integratedBPPConfig bapConfig Nothing Nothing searchReq routeDetails blacklistedServiceTiers blacklistedFareQuoteTypes isSingleMode mbProviderRouteId
-      processOnSearch onSearchReq
+      if null onSearchReq.quotes
+        then do
+          logDebug $ "Quotes are null, calling Multimodal Discovery Search"
+          onSearchReq' <- Flow.multimodalDiscoverySearch merchant merchantOperatingCity integratedBPPConfig bapConfig Nothing Nothing searchReq routeDetails blacklistedServiceTiers blacklistedFareQuoteTypes isSingleMode mbProviderRouteId
+          processOnSearch onSearchReq'
+        else processOnSearch onSearchReq
   where
     processOnSearch :: (FRFSSearchFlow m r, HasShortDurationRetryCfg r c) => DOnSearch.DOnSearch -> m ()
     processOnSearch onSearchReq = do

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Common.hs
@@ -1,6 +1,7 @@
 module ExternalBPP.Flow.Common where
 
 import qualified BecknV2.FRFS.Enums as Spec
+import Control.Applicative ((<|>))
 import Data.List (sortOn)
 import qualified Data.List.NonEmpty as NE
 import Data.Ord (Down (..))
@@ -24,23 +25,41 @@ import Domain.Types.MerchantOperatingCity
 import qualified ExternalBPP.ExternalAPI.CallAPI as CallAPI
 import ExternalBPP.ExternalAPI.Types
 import qualified ExternalBPP.Flow.Fare as Flow
+import Kernel.External.Maps.Google.MapsClient.Types (LatLngV2 (..), LocationV2 (..), WayPointV2 (..))
 import Kernel.External.MasterCloudForward (HasMasterCloudForwarder)
+import qualified Kernel.External.MultiModal.Interface as KMultiModal
+import Kernel.External.MultiModal.Interface.Types as MultiModalTypes
 import Kernel.External.Types (ServiceFlow)
 import Kernel.Prelude
 import qualified Kernel.Storage.Esqueleto.Config as DB
 import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import Lib.ConfigPilot.Interface.Types (getConfig)
 import qualified Lib.JourneyModule.Utils as JMU
 import SharedLogic.FRFSUtils
 import qualified Storage.CachedQueries.FRFSCancellationConfig as CQFRFSCancellationConfig
+import qualified Storage.CachedQueries.Merchant.RiderConfig as CQRC
 import Storage.CachedQueries.OTPRest.OTPRest as OTPRest
+import Storage.ConfigPilot.Config.RiderConfig (RiderConfigDimensions (..))
 import Tools.Error
 import qualified Tools.Metrics.BAPMetrics as Metrics
+import qualified Tools.MultiModal as TMultiModal
 
 search :: (CoreMetrics m, CacheFlow m r, EsqDBFlow m r, DB.EsqDBReplicaFlow m r, EncFlow m r, ServiceFlow m r, HasShortDurationRetryCfg r c, HasMasterCloudForwarder r) => Merchant -> MerchantOperatingCity -> IntegratedBPPConfig -> BecknConfig -> Maybe BaseUrl -> Maybe Text -> DFRFSSearch.FRFSSearch -> [FRFSRouteDetails] -> [Spec.ServiceTierType] -> [DFRFSQuote.FRFSQuoteType] -> Bool -> Maybe Text -> m DOnSearch
-search merchant merchantOperatingCity integratedBPPConfig bapConfig mbNetworkHostUrl mbNetworkId searchReq routeDetails blacklistedServiceTiers blacklistedFareQuoteTypes isSingleMode mbProviderRouteId = do
-  quotes <- buildQuotes routeDetails
+search = searchImpl False
+
+-- | Same as 'search', but builds quotes by discovering the transit route
+-- (including interchanges) between the search's stations via the transit
+-- planner, instead of the route-stop mappings. Used as a fallback when
+-- 'search' yields no quotes, e.g. metro journeys that need an interchange
+-- where no single route serves both stations.
+multimodalDiscoverySearch :: (CoreMetrics m, CacheFlow m r, EsqDBFlow m r, DB.EsqDBReplicaFlow m r, EncFlow m r, ServiceFlow m r, HasShortDurationRetryCfg r c, HasMasterCloudForwarder r) => Merchant -> MerchantOperatingCity -> IntegratedBPPConfig -> BecknConfig -> Maybe BaseUrl -> Maybe Text -> DFRFSSearch.FRFSSearch -> [FRFSRouteDetails] -> [Spec.ServiceTierType] -> [DFRFSQuote.FRFSQuoteType] -> Bool -> Maybe Text -> m DOnSearch
+multimodalDiscoverySearch = searchImpl True
+
+searchImpl :: (CoreMetrics m, CacheFlow m r, EsqDBFlow m r, DB.EsqDBReplicaFlow m r, EncFlow m r, ServiceFlow m r, HasShortDurationRetryCfg r c, HasMasterCloudForwarder r) => Bool -> Merchant -> MerchantOperatingCity -> IntegratedBPPConfig -> BecknConfig -> Maybe BaseUrl -> Maybe Text -> DFRFSSearch.FRFSSearch -> [FRFSRouteDetails] -> [Spec.ServiceTierType] -> [DFRFSQuote.FRFSQuoteType] -> Bool -> Maybe Text -> m DOnSearch
+searchImpl useMultimodalDiscovery merchant merchantOperatingCity integratedBPPConfig bapConfig mbNetworkHostUrl mbNetworkId searchReq routeDetails blacklistedServiceTiers blacklistedFareQuoteTypes isSingleMode mbProviderRouteId = do
+  quotes <- bool buildQuotes buildMultimodalDiscoveryQuotes useMultimodalDiscovery routeDetails
   logDebug $ "Route Details Debug: " <> show routeDetails
   validTill <- mapM (\ttl -> addUTCTime (intToNominalDiffTime ttl) <$> getCurrentTime) bapConfig.searchTTLSec
   messageId <- generateGUID
@@ -87,6 +106,77 @@ search merchant merchantOperatingCity integratedBPPConfig bapConfig mbNetworkHos
               )
               routesInfo
           return $ concat quotes
+
+    -- Multimodal discovery path: quote a single transit journey (no fixed
+    -- route) by discovering the actual legs from the transit planner. Covers
+    -- interchange journeys where no single route serves both stations.
+    buildMultimodalDiscoveryQuotes = \case
+      [FRFSRouteDetails {routeCode = Nothing, startStationCode, endStationCode}] -> mkInterchangeQuote startStationCode endStationCode
+      _ -> return []
+
+    -- Discover the interchange legs from the transit planner and quote them as
+    -- a multi-leg journey through the regular quote path. Enabled only for
+    -- providers whose fare depends solely on origin and destination (CMRL), so
+    -- the fare is correct irrespective of the discovered legs.
+    mkInterchangeQuote startStationCode endStationCode = do
+      routesInfoResult <- withTryCatch "discoverInterchangeRoutesInfo" (discoverInterchangeRoutesInfo startStationCode endStationCode)
+      case routesInfoResult of
+        Left err -> do
+          logError $ "Failed to discover interchange routes between stations: " <> startStationCode <> " and " <> endStationCode <> ", error: " <> show err
+          return []
+        Right routesInfo -> mkQuote Nothing searchReq.vehicleType routesInfo
+
+    -- Asks the transit planner (OTP) for a transit journey between the two
+    -- stations, restricted to the search's vehicle mode, and maps each leg of
+    -- the best route to a RouteStopInfo.
+    discoverInterchangeRoutesInfo startStationCode endStationCode = do
+      fromStation <- OTPRest.getStationByGtfsIdAndStopCode startStationCode integratedBPPConfig >>= fromMaybeM (StationNotFound startStationCode)
+      toStation <- OTPRest.getStationByGtfsIdAndStopCode endStationCode integratedBPPConfig >>= fromMaybeM (StationNotFound endStationCode)
+      fromLat <- fromStation.lat & fromMaybeM (InternalError $ "Latitude not found for station: " <> fromStation.code)
+      fromLon <- fromStation.lon & fromMaybeM (InternalError $ "Longitude not found for station: " <> fromStation.code)
+      toLat <- toStation.lat & fromMaybeM (InternalError $ "Latitude not found for station: " <> toStation.code)
+      toLon <- toStation.lon & fromMaybeM (InternalError $ "Longitude not found for station: " <> toStation.code)
+      riderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = merchantOperatingCity.id.getId}) (Just (CQRC.findByMerchantOperatingCityId merchantOperatingCity.id)) >>= fromMaybeM (RiderConfigNotFound merchantOperatingCity.id.getId)
+      transitServiceReq <- TMultiModal.getTransitServiceReq merchant.id merchantOperatingCity.id
+      now <- getCurrentTime
+      let expectedMode = case searchReq.vehicleType of
+            Spec.METRO -> MultiModalTypes.MetroRail
+            Spec.SUBWAY -> MultiModalTypes.Subway
+            Spec.BUS -> MultiModalTypes.Bus
+          transitRoutesReq =
+            GetTransitRoutesReq
+              { origin = WayPointV2 {location = LocationV2 {latLng = LatLngV2 {latitude = fromLat, longitude = fromLon}}},
+                destination = WayPointV2 {location = LocationV2 {latLng = LatLngV2 {latitude = toLat, longitude = toLon}}},
+                arrivalTime = Nothing,
+                departureTime = Just now,
+                mode = Nothing,
+                transitPreferences = Nothing,
+                transportModes = Nothing,
+                minimumWalkDistance = riderConfig.minimumWalkDistance,
+                permissibleModes = [expectedMode],
+                maxAllowedPublicTransportLegs = riderConfig.maxAllowedPublicTransportLegs,
+                sortingType = MultiModalTypes.Fastest,
+                walkSpeed = Nothing
+              }
+      otpResponse <- KMultiModal.getTransitRoutes Nothing transitServiceReq transitRoutesReq >>= fromMaybeM (InternalError $ "No transit routes found between stations: " <> fromStation.code <> " and " <> toStation.code)
+      transitRoute <-
+        find (\route -> any (\leg -> leg.mode == expectedMode) route.legs && all (\leg -> leg.mode == expectedMode || leg.mode == MultiModalTypes.Walk) route.legs) otpResponse.routes
+          & fromMaybeM (InternalError $ "No suitable transit route found between stations: " <> fromStation.code <> " and " <> toStation.code)
+      let legsRouteDetails = sortOn (.subLegOrder) $ concatMap (.routeDetails) (filter (\leg -> leg.mode == expectedMode) transitRoute.legs)
+      forM legsRouteDetails $ \legRouteDetail -> do
+        routeCode <- (legRouteDetail.gtfsId <&> gtfsIdtoDomainCode) & fromMaybeM (InternalError "Route gtfsId not found in transit leg")
+        legStartStopCode <- ((legRouteDetail.fromStopDetails >>= (.stopCode)) <|> ((legRouteDetail.fromStopDetails >>= (.gtfsId)) <&> gtfsIdtoDomainCode)) & fromMaybeM (InternalError "From stop code not found in transit leg")
+        legEndStopCode <- ((legRouteDetail.toStopDetails >>= (.stopCode)) <|> ((legRouteDetail.toStopDetails >>= (.gtfsId)) <&> gtfsIdtoDomainCode)) & fromMaybeM (InternalError "To stop code not found in transit leg")
+        route <- OTPRest.getRouteByRouteId integratedBPPConfig routeCode >>= fromMaybeM (RouteNotFound routeCode)
+        return $
+          RouteStopInfo
+            { route,
+              totalStops = Nothing,
+              stops = Nothing,
+              startStopCode = legStartStopCode,
+              endStopCode = legEndStopCode,
+              travelTime = nominalDiffTimeToSeconds <$> (diffUTCTime <$> legRouteDetail.toArrivalTime <*> legRouteDetail.fromDepartureTime)
+            }
 
     buildMultipleNonTransitRouteQuotes routesDetails = do
       case routesDetails of


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now supports an additional discovery path for interchange journeys when no fixed route is available.
  * Results can now be generated from transit-planning data for eligible trips, improving coverage for multi-leg journeys.

* **Bug Fixes**
  * Search now falls back to an alternate discovery flow when no quotes are returned, instead of stopping with empty results.
  * Transit legs are filtered and ordered more reliably before quotes are assembled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->