### PR TITLE
backend/fix: demand for queueStats always 1 fixed

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
@@ -142,11 +142,11 @@ handler merchant req validatedQuote = do
       QRB.updateSpecialZoneOtpCode booking.id otpCode
       updateBookingDetails isNewRider booking riderDetails
       uBooking <- QRB.findById booking.id >>= fromMaybeM (BookingNotFound booking.id.getId)
-      -- Special-zone OTP: customer is committed at this gate (demand fulfilled).
-      -- No driver assigned yet — supply is decremented later when a driver enters the
-      -- OTP and StartRide fires. SETNX-idempotent on bookingId, so safe vs StartRide.
-      fork "specialZoneDemandDecrementOnOtpConfirm" $
-        SpecialZoneDriverDemand.runDemandDecrementForBooking uBooking.id.getId uBooking.pickupGateId (show $ DV.castServiceTierToVariant uBooking.vehicleServiceTier)
+      -- Special-zone OTP: no driver is assigned at Confirm, so demand stays live. It is
+      -- decremented only when a driver actually takes the ride (enters the OTP → StartRide
+      -- fires → completePickupZoneRequestsForDriver) or when the booking is cancelled
+      -- (releasePickupZoneCountersOnCancel). This keeps pendingDemand reflecting unassigned
+      -- demand rather than dropping it the moment the customer confirms.
       mkDConfirmResp Nothing uBooking riderDetails
 
     handleMeterRideFlow isNewRider driver _ booking riderDetails = do
@@ -211,11 +211,10 @@ handler merchant req validatedQuote = do
       searchTry <- initiateDriverSearchBatch driverSearchBatchInput
       QRB.updateSearchTryId booking.id searchTry.id
       uBooking <- QRB.findById booking.id >>= fromMaybeM (BookingNotFound booking.id.getId)
-      -- Static offer Confirm: customer is committed at this gate (demand fulfilled).
-      -- Driver gets matched later via the new search batch; supply tracking happens
-      -- through that flow's StartRide. SETNX-idempotent on bookingId.
-      fork "specialZoneDemandDecrementOnStaticConfirm" $
-        SpecialZoneDriverDemand.runDemandDecrementForBooking uBooking.id.getId uBooking.pickupGateId (show $ DV.castServiceTierToVariant uBooking.vehicleServiceTier)
+      -- Static offer Confirm: no driver is assigned at Confirm (matched later via the new
+      -- search batch), so demand stays live. It is decremented only when that driver takes
+      -- the ride (StartRide → completePickupZoneRequestsForDriver) or when the booking is
+      -- cancelled (releasePickupZoneCountersOnCancel).
       mkDConfirmResp Nothing uBooking riderDetails
 
     updateBookingDetails isNewRider booking riderDetails = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -191,14 +191,15 @@ getSpecialZoneQueueQueueStats merchantShortId opCity gateId = do
   let driverLocMap = Map.fromList $ map (\dl -> (dl.driverId.getId, dl)) driversNearGate
   vehicleStats <- forM cityServiceTiers $ \vst -> do
     let vt = show vst.serviceTierType
+        vtVariant = show (castServiceTierToVariant vst.serviceTierType)
         calloutVars = getCalloutVars vst
         queueResps = mapMaybe (\cv -> Map.lookup cv uniqVariantsQueueMap) calloutVars
         -- Merge queue responses from all callout variants for this tier
         mergedDrivers = concatMap (.drivers) queueResps
         mergedQueueSize = sum $ map (.queueSize) queueResps
     -- Live demand (pending customer searches) and committed supply (drivers notified/accepted)
-    mbDemandCount <- Redis.runInMasterCloudRedisCellWithCrossAppRedis $ Redis.get @Int (SpecialZoneDriverDemand.mkGateSearchDemandKey gateId vt)
-    mbSupplyCount <- Redis.runInMasterCloudRedisCellWithCrossAppRedis $ Redis.get @Int (SpecialZoneDriverDemand.mkGateSearchSupplyKey gateId vt)
+    mbDemandCount <- Redis.runInMasterCloudRedisCellWithCrossAppRedis $ Redis.get @Int (SpecialZoneDriverDemand.mkGateSearchDemandKey gateId vtVariant)
+    mbSupplyCount <- Redis.runInMasterCloudRedisCellWithCrossAppRedis $ Redis.get @Int (SpecialZoneDriverDemand.mkGateSearchSupplyKey gateId vtVariant)
     -- Drivers who accepted the pickup notification and are en-route to the gate
     acceptedRequests <- QSZQR.findAllByGateIdStatusAndVehicleType queueRequestCutoff gateId DSZQR.Accepted vt
     let totalInQueue = mergedQueueSize

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Operator/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Operator/Driver.hs
@@ -82,6 +82,7 @@ import SharedLogic.AnalyticsExtra as AnalyticsExtra
 import qualified SharedLogic.DriverFleetOperatorAssociation as SA
 import qualified SharedLogic.DriverOnboarding as SDO
 import qualified SharedLogic.DriverOnboarding.Status as SStatus
+import qualified SharedLogic.DriverOnboarding.VehicleDocs as VDocs
 import qualified SharedLogic.FleetOperatorStats as FleetOpStats
 import SharedLogic.MediaFileDocument (finalizeInspectionMedia)
 import SharedLogic.Merchant (findMerchantByShortId)
@@ -1145,6 +1146,8 @@ postDriverSubmitReviewRequest merchantShortId opCity requestorId req = do
             DVC.VehicleRegistrationCertificate -> do
               mbDoc <- QVRC.findByPrimaryKey rcId
               forM_ mbDoc $ \doc -> QVRC.updateByPrimaryKey doc {DVRC.verificationStatus = Documents.INVALID}
+            DVC.VehicleInspectionForm ->
+              IQuery.updateVerificationStatusByRcIdAndImageTypes Documents.INVALID rcId VDocs.vehicleDocsByRcIdList
             DVC.InspectionHub -> do
               mbRc <- QVRC.findByPrimaryKey rcId
               forM_ mbRc $ \rc -> do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboardingV2.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboardingV2.hs
@@ -1438,8 +1438,7 @@ rcVerifyStatus caller mbRegistrationNo mbRcId = do
     when (passedCityId /= merchantOpCityId) $
       throwError (InvalidRequest $ "RC belongs to city: " <> show merchantOperatingCity.city)
   transporterConfig <- getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = merchantOpCityId.getId}) (Just (SCTC.findByMerchantOpCityId merchantOpCityId Nothing)) >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  -- This RC's mandatory vehicle docs with per-doc statuses (keyed on the RC).
-  (vehicleDocItem, configs) <- SStatus.fetchVehicleDocStatusesForRC rc merchantOperatingCity transporterConfig ENGLISH registrationNo (Just True)
+  (vehicleDocItem, configs) <- SStatus.fetchVehicleDocStatusesForRC rc merchantOperatingCity transporterConfig ENGLISH registrationNo Nothing
   let allValid = SStatus.checkAllVehicleDocsValidForFetchedDocs configs vehicleDocItem
   -- Persist verified only under enableBotFlow (matches existing config behaviour).
   when (transporterConfig.enableBotFlow == Just True) $ do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/ImageExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/ImageExtra.hs
@@ -20,6 +20,7 @@ module Storage.Queries.ImageExtra
     filterImageByEntityIdAndImageTypeAndVerificationStatus,
     filterRecentLatestByEntityIdAndImageType,
     filterRecentByPersonRCAndImageType,
+    updateVerificationStatusByRcIdAndImageTypes,
   )
 where
 
@@ -172,6 +173,24 @@ updateVerificationStatusByIdAndType verificationStatus (Kernel.Types.Id.Id id) i
     [ Se.And
         [ Se.Is BeamI.id $ Se.Eq id,
           Se.Is BeamI.imageType $ Se.Eq imageType
+        ]
+    ]
+
+-- Bulk-set verificationStatus for all images of an RC matching any of the given types, in one call.
+-- Used e.g. to invalidate every vehicle inspection photo when the aggregate VehicleInspectionForm is rejected.
+updateVerificationStatusByRcIdAndImageTypes ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  Documents.VerificationStatus ->
+  Id DReg.VehicleRegistrationCertificate ->
+  [DocumentType] ->
+  m ()
+updateVerificationStatusByRcIdAndImageTypes verificationStatus rcId imageTypes = do
+  now <- getCurrentTime
+  updateWithKV
+    [Se.Set BeamI.verificationStatus (Just verificationStatus), Se.Set BeamI.updatedAt now]
+    [ Se.And
+        [ Se.Is BeamI.rcId $ Se.Eq (Just rcId.getId),
+          Se.Is BeamI.imageType $ Se.In imageTypes
         ]
     ]
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
SpecialZone demand always 1 - Fixed


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Demand counters are no longer reduced immediately when confirming special-zone OTP or static offers; they now update later when the ride actually starts or when the booking is cancelled.
  * Special-zone queue statistics now attribute pending demand and committed supply using the correct vehicle-type variant for clearer dashboard visibility.
  * Driver onboarding verification updates are more consistent: invalid document types are handled in bulk, and RC verify-status fetching logic is corrected to ensure accurate “verified” outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->