### PR TITLE
fix: persist OCR-extracted DL name via cache

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/DocumentRegistration.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/DocumentRegistration.hs
@@ -104,6 +104,7 @@ validateDocument isDashboard (personId, merchantId, merchantOpCityId) ValidateDo
               let dateOfBirth = fmap convertUTCTimetoDate (parseDateTime =<< extractedDL.dateOfBirth)
               let nameOnCard = extractedDL.nameOnCard
               DL.cacheExtractedDl personId documentNumber (show operatingCity.city)
+              DL.cacheExtractedDlName personId nameOnCard
               logDebug $ "DocumentRegistration.validateDocument: Validation completed, returning response with documentNumber=" <> show documentNumber <> ", dateOfBirth=" <> show dateOfBirth
               pure $ (emptyValidateDocumentImageResponse imageId) {documentNumber, dateOfBirth, nameOnCard}
             Nothing ->

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/DriverLicense.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/DriverLicense.hs
@@ -19,6 +19,7 @@ module Domain.Action.UI.DriverOnboarding.DriverLicense
     verifyDL,
     onVerifyDL,
     cacheExtractedDl,
+    cacheExtractedDlName,
     onVerifyDLHandler,
     convertUTCTimetoDate,
   )
@@ -155,7 +156,7 @@ verifyDL verifyBy mbMerchant (personId, merchantId, merchantOpCityId) req@Driver
   checkDLFormat <- isDLNumberFormatValid documentVerificationConfig normalizedDLNumber
   unless checkDLFormat $
     throwError (InvalidRequest "DL number format is not valid")
-  (nameOnTheCard, dateOfBirth) <-
+  (extractedNameOnCard, dateOfBirth) <-
     if isJust nameOnCardFromSdk
       then return (nameOnCardFromSdk, Nothing)
       else
@@ -186,6 +187,11 @@ verifyDL verifyBy mbMerchant (personId, merchantId, merchantOpCityId) req@Driver
                     return (_nameOnCard, extractedDL.dateOfBirth)
                   Nothing -> throwImageError imageId1 ImageExtractionFailed
           else return (Nothing, Nothing)
+  cachedNameOnCard <- getCachedExtractedDlName person.id
+  let nameOnTheCard =
+        case extractedNameOnCard of
+          Just n | not (T.null n) -> Just n
+          _ -> cachedNameOnCard
   decryptedPanNumber <- mapM decrypt driverInfo.panNumber
   decryptedAadhaarNumber <- mapM decrypt driverInfo.aadhaarNumber
   decryptedDlNumber <- mapM decrypt driverInfo.dlNumber
@@ -530,6 +536,19 @@ cacheExtractedDl personId extractedDL operatingCity = do
   let key = dlCacheKey personId
   authTokenCacheExpiry <- getSeconds <$> asks (.authTokenCacheExpiry)
   Redis.setExp key (extractedDL, operatingCity) authTokenCacheExpiry
+
+dlNameCacheKey :: Id Person.Person -> Text
+dlNameCacheKey personId =
+  "providerPlatform:dlNameCacheKey:" <> personId.getId
+
+cacheExtractedDlName :: Id Person.Person -> Maybe Text -> Flow ()
+cacheExtractedDlName personId (Just name) | not (T.null name) = do
+  authTokenCacheExpiry <- getSeconds <$> asks (.authTokenCacheExpiry)
+  Redis.setExp (dlNameCacheKey personId) name authTokenCacheExpiry
+cacheExtractedDlName _ _ = return ()
+
+getCachedExtractedDlName :: Id Person.Person -> Flow (Maybe Text)
+getCachedExtractedDlName personId = Redis.safeGet (dlNameCacheKey personId)
 
 dlNotFoundFallback :: UTCTime -> (Text, Text) -> UTCTime -> VerificationReqRecord -> Person.Person -> Flow AckResponse
 dlNotFoundFallback issueDate (extractedDL, operatingCity) dob verificationReq person = do


### PR DESCRIPTION
Some verification providers (e.g. Morth) never return a driver name, so the DL name can only come from OCR. On the isDLImageValidated fast-path the register flow skips re-extraction and the client may not echo nameOnCard back, so the extracted name was lost and the driver's name never got set.

Cache the OCR-extracted name-on-card at validateDocumentImage time and fall back to it in the DL register flow (after all extraction branches) when the current flow didn't capture a name. Provider-returned names still take precedence via verifiedName <|> nameOnTheCard downstream.


Claude-Session: https://claude.ai/code/session_013ouoeP7gpngUBbhfeTio5u

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver license verification so the “name on card” is preserved more reliably during driver onboarding.
  * When a prior validation already has the name, onboarding now reuses it if the latest scan doesn’t return a usable name.
  * The validation flow now also stores the extracted name (in addition to the document number) to improve consistency across steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->