### PR TITLE
backend: fix: use quote station in case multimodal provider

### DIFF
--- a/.github/workflows/cabal-pr-repl-check-driver.yaml
+++ b/.github/workflows/cabal-pr-repl-check-driver.yaml
@@ -5,6 +5,20 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - "main"
+    paths:
+      # Driver app sources
+      - "Backend/app/provider-platform/**"
+      # Shared libraries + dashboard CommonAPIs that the driver repl pulls in
+      - "Backend/lib/**"
+      - "Backend/app/dashboard/CommonAPIs/**"
+      # Cabal / nix build inputs that affect compilation
+      - "Backend/cabal.project"
+      - "Backend/default.nix"
+      - "Backend/nix/**"
+      - "flake.nix"
+      - "flake.lock"
+      # This workflow itself
+      - ".github/workflows/cabal-pr-repl-check-driver.yaml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cabal-pr-repl-check-rider.yaml
+++ b/.github/workflows/cabal-pr-repl-check-rider.yaml
@@ -5,6 +5,20 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - "main"
+    paths:
+      # Rider app sources
+      - "Backend/app/rider-platform/**"
+      # Shared libraries + dashboard CommonAPIs that the rider repl pulls in
+      - "Backend/lib/**"
+      - "Backend/app/dashboard/CommonAPIs/**"
+      # Cabal / nix build inputs that affect compilation
+      - "Backend/cabal.project"
+      - "Backend/default.nix"
+      - "Backend/nix/**"
+      - "flake.nix"
+      - "flake.lock"
+      # This workflow itself
+      - ".github/workflows/cabal-pr-repl-check-rider.yaml"
   workflow_dispatch:
 
 concurrency:

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -721,7 +721,7 @@ getFrfsSearchQuote (mbPersonId, merchantId_) searchId_ = do
         -- Interchange (line-change) points, derived at response time only (storage is unchanged).
         -- buildStations marks segment boundary stops as TRANSIT; dedupe by code, preserving order.
         let interchangeStations :: Maybe [FRFSStationAPI] =
-              (\sts -> nubBy (\a b -> a.code == b.code) (filter (\s -> s.stationType == Just TRANSIT) sts)) <$> stations
+              (\sts -> nubBy (\a b -> a.code == b.code) (filter (\s -> s.stationType == Just TRANSIT) sts)) <$> (stations <|> decodeFromText quote.stationsJson)
         let fareParameters = FRFSUtils.mkFareParameters (FRFSUtils.mkCategoryPriceItemFromQuoteCategories quoteCategories)
             categories = map mkCategoryInfoResponse quoteCategories
         singleAdultTicketPrice <- (find (\category -> category.categoryType == ADULT) fareParameters.priceItems <&> (.unitPrice)) & fromMaybeM (InternalError "Adult Ticket Unit Price not found.")


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interchange station information in FRFS quote responses by adding a fallback to re-derive station data when the previously computed value is unavailable.
  * Transit interchange stations are now more reliably filtered and deduplicated.  
* **Chores**
  * Updated Cabal PR Repl Check workflows to run only when relevant Rider/backend and shared build inputs change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->