### PR TITLE
backend/chore: update shared-kernel flake lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4004,11 +4004,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1783681396,
-        "narHash": "sha256-//LrTkJgOtC35a1nOiVsCfU7U7VCCZxmkfXCzBvNklA=",
+        "lastModified": 1783689038,
+        "narHash": "sha256-ja1lJy8AICuf0l4WAWD1Epa4URCbsyWZwx8FpfDHVPc=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "66d12d48b45e7c82708259ee54c6586672914d94",
+        "rev": "6e9863db341ae9e5a21abf536d45a857712d33c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates the `shared-kernel` flake input to commit [`6e9863d`](https://github.com/nammayatri/shared-kernel/commit/6e9863db341ae9e5a21abf536d45a857712d33c5) — *backend: Jusoay Product Offer Zero Amount fix*.
- `flake.lock` only; no source or `flake.nix` changes.

## Test plan
- [ ] `nix flake metadata` shows `shared-kernel: github:nammayatri/shared-kernel/6e9863d`
- [ ] `cabal build all` succeeds against the bumped shared-kernel
- [ ] CI pipeline is green