### PR TITLE
backend/chore: update shared-kernel flake lock (prodHotPush-BAP)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4004,11 +4004,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1783500251,
-        "narHash": "sha256-DtTYWu1heEKe1+trRHx2QnwEkqZJgo0VoB55j9anht4=",
+        "lastModified": 1783719112,
+        "narHash": "sha256-bWHovGLJRNXeEdm7Pkqx3fV4pXR7cmulVPidDRmZZos=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "3a3788ccef4a1b8165810b1f379238254d7836c7",
+        "rev": "c4ce3c0b3bfb0b9745a36ab461810cddfbb95a9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Bumps `shared-kernel` on the `prodHotPush-BAP` branch to commit [`c4ce3c0`](https://github.com/nammayatri/shared-kernel/commit/c4ce3c0b3bfb0b9745a36ab461810cddfbb95a9c) — merge of [nammayatri/shared-kernel#1413](https://github.com/nammayatri/shared-kernel/pull/1413), *backend: Jusoay Product Offer Zero Amount fix* (cherry-picked from `main` to `prodHotPush-BAP`).
- `flake.lock` only; no source or `flake.nix` changes.

## Test plan
- [ ] `nix flake metadata` shows `shared-kernel: github:nammayatri/shared-kernel/c4ce3c0`
- [ ] `cabal build all` succeeds against the bumped shared-kernel
- [ ] CI pipeline is green