### PR TITLE
backend/fix: show offer discount as its own invoice line

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Finance/RidePayment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Finance/RidePayment.hs
@@ -301,7 +301,7 @@ createRidePaymentLedger ::
   HighPrecMoney -> -- cashbackPayoutAmount (amount to pay back to rider, 0 for DISCOUNT)
   HighPrecMoney -> -- rideVatAbsorbedOnDiscount (platform-absorbed VAT on the discount portion)
   m (Either FinanceError RidePaymentLedgerResult)
-createRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platformFee offerDiscountAmount cashbackPayoutAmount _rideVatAbsorbedOnDiscount = do
+createRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platformFee offerDiscountAmount cashbackPayoutAmount rideVatAbsorbedOnDiscount = do
   result <- runFinance ctx $ do
     let (riderSrc, riderDst) =
           if ctx.isOnline
@@ -330,6 +330,7 @@ createRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platformFe
         platformFee
         offerDiscountAmount
         cashbackPayoutAmount
+        rideVatAbsorbedOnDiscount
   case result of
     Left err -> do
       logError $ "Failed to create ride payment ledger: " <> show err
@@ -351,18 +352,6 @@ mkDeductionLineItem :: Text -> LineItemDescription -> HighPrecMoney -> Bool -> M
 mkDeductionLineItem desc descType amt isExt
   | amt > 0 = Just InvoiceLineItem {description = desc, descriptionType = Just descType, quantity = 1, unitPrice = - amt, lineTotal = - amt, isExternalCharge = isExt, groupId = Nothing, itemType = Just Adjustment}
   | otherwise = Nothing
-
--- | Ride-fare invoice line. Discount, when present, is captured in the
---   'RideFarePostDiscount' description so the renderer shows the post-discount
---   fare with a human-readable discount summary (no separate deduction line).
-mkRideFareLineItem :: HighPrecMoney -> Currency -> HighPrecMoney -> Maybe InvoiceLineItem
-mkRideFareLineItem amt currency discountAmount
-  | amt <= 0 = Nothing
-  | discountAmount > 0 =
-    let desc = "Ride Fare Post Discount (" <> show currency <> " " <> show discountAmount <> ")"
-        descType = RideFarePostDiscount currency discountAmount
-     in Just InvoiceLineItem {description = desc, descriptionType = Just descType, quantity = 1, unitPrice = amt, lineTotal = amt, isExternalCharge = False, groupId = Just "g-ride", itemType = Just Fare}
-  | otherwise = Just InvoiceLineItem {description = "Ride Fare", descriptionType = Just RideFare, quantity = 1, unitPrice = amt, lineTotal = amt, isExternalCharge = False, groupId = Just "g-ride", itemType = Just Fare}
 
 -- ---------------------------------------------------------------------------
 -- 1a. Upsert core ride payment ledger on amount change
@@ -497,12 +486,12 @@ upsertCoreRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platfo
 createFullyDiscountedRidePaymentLedger ::
   (BeamFlow.BeamFlow m r, Finance.HasActorInfo m r) =>
   FinanceCtx ->
-  HighPrecMoney -> -- rideFare (original, before discount)
-  HighPrecMoney -> -- gstAmount
+  HighPrecMoney -> -- rideFare (post-discount, from the ledger info — 0 for the fully-discounted portion)
+  HighPrecMoney -> -- gstAmount (post-discount)
   HighPrecMoney -> -- tollFare
   HighPrecMoney -> -- tollVatAmount
   HighPrecMoney -> -- platformFee
-  HighPrecMoney -> -- offerDiscountAmount (should equal rideFare + gstAmount + platformFee)
+  HighPrecMoney -> -- offerDiscountAmount (the full clamped gross discount)
   HighPrecMoney -> -- rideVatAbsorbedOnDiscount (platform-absorbed VAT on the discount portion)
   m (Either FinanceError RidePaymentLedgerResult)
 createFullyDiscountedRidePaymentLedger ctx rideFare gstAmount tollFare tollVatAmount platformFee offerDiscountAmount rideVatAbsorbedOnDiscount = do
@@ -761,33 +750,41 @@ buildRidePaymentInvoiceConfig ::
   HighPrecMoney -> -- tollFare
   HighPrecMoney -> -- tollVatAmount
   HighPrecMoney -> -- platformFee
-  HighPrecMoney -> -- offerDiscountAmount (for ride-fare description suffix)
+  HighPrecMoney -> -- offerDiscountAmount (rendered as its own deduction line)
   HighPrecMoney -> -- cashbackPayoutAmount (rendered as deduction line)
+  HighPrecMoney -> -- rideVatAbsorbedOnDiscount (reconstructs the pre-discount fare/tax)
   InvoiceConfig
-buildRidePaymentInvoiceConfig ctx rideFare gstAmount tollFare tollVatAmount platformFee offerDiscountAmount cashbackPayoutAmount =
-  InvoiceConfig
-    { invoiceType = Ride,
-      issuedToType = DInvType.RIDER,
-      issuedToId = ctx.counterpartyId,
-      issuedToName = ctx.issuedToName,
-      issuedToAddress = ctx.fromLocationAddress,
-      referenceId = Just ctx.referenceId,
-      lineItems =
-        catMaybes
-          [ mkRideFareLineItem (rideFare + platformFee) ctx.currency offerDiscountAmount,
-            mkLineItem "Ride Tax" RideTax gstAmount False Tax (Just "g-ride"),
-            mkLineItem "Toll Fare" TollFare tollFare True Fare (Just "g-toll"),
-            mkLineItem "Toll Tax" TollTax tollVatAmount True Tax (Just "g-toll"),
-            mkDeductionLineItem "Cashback Offer" CashbackOffer cashbackPayoutAmount False
-          ],
-      gstBreakdown = Nothing,
-      isVat = gstAmount > 0 || tollVatAmount > 0,
-      issuedToTaxNo = Nothing,
-      issuedByTaxNo = Nothing,
-      paymentMode = Just $ if ctx.isOnline then "ONLINE" else "CASH",
-      periodStart = Nothing,
-      periodEnd = Nothing
-    }
+buildRidePaymentInvoiceConfig ctx rideFare gstAmount tollFare tollVatAmount platformFee offerDiscountAmount cashbackPayoutAmount rideVatAbsorbedOnDiscount =
+  -- The main table shows the FULL pre-discount fare and its full VAT; the discount is a
+  -- separate negative Adjustment below the total.
+  -- Reconstruction is universal: every caller passes post-discount amounts + the clamped
+  -- gross discount + the VAT absorbed inside it (fully-discounted path included).
+  let preDiscountTax = gstAmount + rideVatAbsorbedOnDiscount
+      preDiscountFareLine = rideFare + platformFee + (offerDiscountAmount - rideVatAbsorbedOnDiscount)
+   in InvoiceConfig
+        { invoiceType = Ride,
+          issuedToType = DInvType.RIDER,
+          issuedToId = ctx.counterpartyId,
+          issuedToName = ctx.issuedToName,
+          issuedToAddress = ctx.fromLocationAddress,
+          referenceId = Just ctx.referenceId,
+          lineItems =
+            catMaybes
+              [ mkLineItem "Ride Fare" RideFare preDiscountFareLine False Fare (Just "g-ride"),
+                mkLineItem "Ride Tax" RideTax preDiscountTax False Tax (Just "g-ride"),
+                mkLineItem "Toll Fare" TollFare tollFare True Fare (Just "g-toll"),
+                mkLineItem "Toll Tax" TollTax tollVatAmount True Tax (Just "g-toll"),
+                mkDeductionLineItem "Discount" OfferDiscount offerDiscountAmount False,
+                mkDeductionLineItem "Cashback Offer" CashbackOffer cashbackPayoutAmount False
+              ],
+          gstBreakdown = Nothing,
+          isVat = preDiscountTax > 0 || tollVatAmount > 0,
+          issuedToTaxNo = Nothing,
+          issuedByTaxNo = Nothing,
+          paymentMode = Just $ if ctx.isOnline then "ONLINE" else "CASH",
+          periodStart = Nothing,
+          periodEnd = Nothing
+        }
 
 -- ---------------------------------------------------------------------------
 -- 3. Void ledger entries when payment intent is cancelled

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Invoice/Interface.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Invoice/Interface.hs
@@ -62,6 +62,7 @@ data LineItemDescription
   | AirportCashRecharge
   | CashbackOffer
   | VatInput
+  | OfferDiscount
   deriving (Eq, Ord, Show, Generic, ToJSON, FromJSON)
 
 -- | groupId is required for Fare/Tax (pairing); Nothing for Adjustment.


### PR DESCRIPTION
The rider ride invoice folded the discount into one post-discount fare line (RideFarePostDiscount description suffix). It now shows the FULL pre-discount fare and its full VAT in the main table, with the gross discount as a separate negative 'Discount' Adjustment below the total. The platform's discount contribution is third-party consideration, so VAT stays on the full fare; invoice totalAmount (= the charged amount) is unchanged because the negative line nets the sum back down. BPP invoices untouched (already correct — the driver receives the full fare).

- buildRidePaymentInvoiceConfig reconstructs pre-discount amounts from the post-discount ledger values + clamped discount + rideVatAbsorbedOnDiscount (which createRidePaymentLedger previously discarded). The reconstruction is universal — all callers, including the fully-discounted path, pass post-discount ledger-info values (that function's doc-comment claimed otherwise and is corrected).
- New OfferDiscount line-item type; mkRideFareLineItem deleted; RideFarePostDiscount stays so historical invoices still render.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ride payment invoices now clearly show offer discounts and cashback as separate deductions.
  * Invoice fare and tax details now accurately reflect VAT absorbed on discounts.
  * Added support for identifying offer-discount line items in invoices.

* **Documentation**
  * Updated fully discounted ride payment terminology to clarify that amounts are calculated post-discount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->