### PR TITLE
feat: return upcoming trips on demand in routeServiceability

### DIFF
--- a/Backend/app/dashboard/Lib/lib-dashboard.cabal
+++ b/Backend/app/dashboard/Lib/lib-dashboard.cabal
@@ -139,13 +139,13 @@ library
     , cereal
     , containers
     , cryptonite
-    , memory
     , dashboard-helper-api
     , dynamic-offer-driver-app
     , esqueleto
     , euler-hs
     , http-types
     , lens
+    , memory
     , mobility-core
     , openapi3
     , passetto-client

--- a/Backend/app/dashboard/rider-dashboard/rider-dashboard.cabal
+++ b/Backend/app/dashboard/rider-dashboard/rider-dashboard.cabal
@@ -32,9 +32,9 @@ library
       API.RiderDashboard.Entity
       API.RiderDashboard.PTEmployee
       API.RiderPlatform
+      App
       Domain.Action.RiderDashboard.Entity
       Domain.Action.RiderDashboard.PTEmployee
-      App
       Domain.Action.RiderPlatform.AppManagement.Customer
       Domain.Action.RiderPlatform.AppManagement.EDCMachine
       Domain.Action.RiderPlatform.AppManagement.EventManagement

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/FrfsTicket.yaml
@@ -317,6 +317,7 @@ types:
   FRFSRouteServiceabilityReq:
     startStopCode: Text
     endStopCode: Text
+    allowUpcomingTrips: Maybe Bool
 
   ActiveRouteRes:
     routeId: Text

--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -353,6 +353,8 @@ types:
     position: LatLong
     serviceSubTypes: "Maybe [ServiceSubType]"
     seatSelectionType: Maybe SeatSelectionType
+    isUpcomingTrip: Maybe Bool
+    previousRouteId: Maybe Text
 
   AlternateRouteDetails:
     routeCode: Text
@@ -392,6 +394,7 @@ types:
     sourceStopCode: Maybe Text
     destinationStopCode: Maybe Text
     vehicleNumber: Maybe Text
+    allowUpcomingTrips: Maybe Bool
     derive: "Show"
 
   AvailableRoute:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/FRFSTicketService.hs
@@ -214,7 +214,7 @@ data FRFSRouteAPI = FRFSRouteAPI
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data FRFSRouteServiceabilityReq = FRFSRouteServiceabilityReq {endStopCode :: Data.Text.Text, startStopCode :: Data.Text.Text}
+data FRFSRouteServiceabilityReq = FRFSRouteServiceabilityReq {allowUpcomingTrips :: Data.Maybe.Maybe Kernel.Prelude.Bool, endStopCode :: Data.Text.Text, startStopCode :: Data.Text.Text}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -230,9 +230,11 @@ data LegStatus = LegStatus
 data LiveVehicleInfo = LiveVehicleInfo
   { currentTripId :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     eta :: Kernel.Prelude.Maybe [Storage.CachedQueries.Merchant.MultiModalBus.BusStopETA],
+    isUpcomingTrip :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
     locationUTCTimestamp :: Kernel.Prelude.UTCTime,
     number :: Kernel.Prelude.Text,
     position :: Kernel.External.Maps.Types.LatLong,
+    previousRouteId :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     seatSelectionType :: Kernel.Prelude.Maybe Domain.Types.VehicleSeatLayoutMapping.SeatSelectionType,
     serviceSubTypes :: Kernel.Prelude.Maybe [BecknV2.FRFS.Enums.ServiceSubType],
     serviceTierName :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
@@ -352,7 +354,8 @@ data RouteETAResp = RouteETAResp {eta :: Kernel.Prelude.Maybe [Storage.CachedQue
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data RouteServiceabilityReq = RouteServiceabilityReq
-  { destinationStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+  { allowUpcomingTrips :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
+    destinationStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     routeCodes :: Kernel.Prelude.Maybe [RouteCodesWithLeg],
     sourceStopCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     vehicleNumber :: Kernel.Prelude.Maybe Kernel.Prelude.Text

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -1483,7 +1483,7 @@ postFrfsRouteServiceability (mbPersonId, _merchantId) routeId req = do
   routesWithLiveVehicles <-
     catMaybes
       <$> mapConcurrently
-        (\(r, s) -> JMRouteServiceability.buildRouteWithLiveVehicle r s integratedBPPConfig req.startStopCode req.endStopCode frfsTierMap Nothing 5)
+        (\(r, s) -> JMRouteServiceability.buildRouteWithLiveVehicle r s integratedBPPConfig req.startStopCode req.endStopCode frfsTierMap Nothing 5 (fromMaybe False req.allowUpcomingTrips))
         (zip busesForRoutes schedulesForRoutes)
 
   case routesWithLiveVehicles of

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -1961,7 +1961,8 @@ data RouteServiceabilityContext = RouteServiceabilityContext
     merchantOperatingCityId :: Id DMOC.MerchantOperatingCity,
     merchantId :: Id Domain.Types.Merchant.Merchant,
     maxLiveVehiclesPerRoute :: Int,
-    maxAlternateRouteVehicles :: Int
+    maxAlternateRouteVehicles :: Int,
+    allowUpcomingTrips :: Bool
   }
 
 data ResolvedLeg = ResolvedLeg
@@ -1992,7 +1993,8 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) req =
                   merchantOperatingCityId = person.merchantOperatingCityId,
                   merchantId = person.merchantId,
                   maxLiveVehiclesPerRoute = riderConfig.maxLiveVehiclesPerRoute,
-                  maxAlternateRouteVehicles = riderConfig.maxAlternateRouteVehicles
+                  maxAlternateRouteVehicles = riderConfig.maxAlternateRouteVehicles,
+                  allowUpcomingTrips = fromMaybe False req.allowUpcomingTrips
                 }
         let userRequestedCodes = maybe [] (concatMap (.routeCodes)) req.routeCodes
         case req.vehicleNumber of
@@ -2065,6 +2067,11 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) req =
           >>= fromMaybeM (InvalidRequest $ "Route not found with id: " <> routeId)
       routeWithBuses <- CQMMB.getRoutesBuses routeId ctx.integratedBPPConfig
       let maybeBus = find (\b -> b.vehicleNumber == vno) routeWithBuses.buses
+      mbUpcomingBus <-
+        if ctx.allowUpcomingTrips && isNothing maybeBus
+          then find (\b -> b.vehicleNumber == vno) <$> JMRouteServiceability.getFreshUpcomingBuses routeId ctx.integratedBPPConfig (map (.vehicleNumber) routeWithBuses.buses)
+          else pure Nothing
+      let mbResolvedBus = maybeBus <|> mbUpcomingBus
       -- Always fetch schedules from bus-route-schedule API (for tripId)
       busScheduleDetails <- OTPRest.getRouteBusSchedule routeId (Just vno) ctx.integratedBPPConfig
       -- Get vehicle metadata for service tier (shared)
@@ -2113,7 +2120,7 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) req =
                   }
       let allSchedules = map buildScheduleInfo busScheduleDetails
       -- Build live vehicle info if live data exists
-      mbLiveVehicle <- case maybeBus of
+      mbLiveVehicle <- case mbResolvedBus of
         Nothing -> do
           -- No live data on the route hash; fall back to last-known location from the bus_metadata_v2 hash
           mbBusLiveInfo <- JLCF.getBusLiveInfo vno ctx.integratedBPPConfig
@@ -2137,7 +2144,9 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) req =
                       currentTripId = fallbackTripId,
                       serviceSubTypes = mbServiceSubTypes,
                       vehicleTagNumber = mbVehicleTagNumber,
-                      seatSelectionType = seatSelType
+                      seatSelectionType = seatSelType,
+                      isUpcomingTrip = Nothing,
+                      previousRouteId = Nothing
                     }
             _ -> return Nothing
         Just singleBus -> do
@@ -2162,7 +2171,9 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) req =
                       currentTripId = mbCurrentTripId,
                       serviceSubTypes = mbServiceSubTypes,
                       vehicleTagNumber = mbVehicleTagNumber,
-                      seatSelectionType = seatSelType
+                      seatSelectionType = seatSelType,
+                      isUpcomingTrip = singleBus.busData.is_upcoming_trip,
+                      previousRouteId = singleBus.busData.previous_route_id
                     }
       -- Return response with schedules (always) and live vehicle (if available)
       pure $
@@ -2378,7 +2389,7 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) req =
               <$> mapConcurrently
                 ( \(r, s) ->
                     JMU.measureLatency
-                      (JMRouteServiceability.buildRouteWithLiveVehicle r s ctx.integratedBPPConfig rlFromStopCode rlToStopCode frfsTierMap mbSourceLatLong ctx.maxLiveVehiclesPerRoute)
+                      (JMRouteServiceability.buildRouteWithLiveVehicle r s ctx.integratedBPPConfig rlFromStopCode rlToStopCode frfsTierMap mbSourceLatLong ctx.maxLiveVehiclesPerRoute ctx.allowUpcomingTrips)
                       ("enrichResolvedLegs: buildRouteWithLiveVehicle route=" <> r.routeId)
                 )
                 (zip busesForRoutes schedulesForRoutes)

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/RouteServiceability.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/RouteServiceability.hs
@@ -4,7 +4,7 @@ import qualified API.Types.UI.MultimodalConfirm
 import qualified BecknV2.FRFS.Enums
 import Data.List (nub)
 import qualified Data.Map.Strict as Map
-import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
 import qualified Domain.Types.FRFSVehicleServiceTier as DFRFSVehicleServiceTier
 import qualified Domain.Types.IntegratedBPPConfig as DIntegratedBPPConfig
 import qualified Domain.Types.VehicleSeatLayoutMapping as DVSLM
@@ -30,6 +30,22 @@ import qualified Storage.CachedQueries.OTPRest.OTPRest as OTPRest
 import qualified Storage.CachedQueries.VehicleSeatLayoutMappingExtra as CQVehicleSeatLayoutMapping
 import Storage.ConfigPilot.Config.RiderConfig (RiderConfigDimensions (..))
 
+upcomingFreshnessThresholdSec :: Int
+upcomingFreshnessThresholdSec = 300
+
+getFreshUpcomingBuses :: Text -> DIntegratedBPPConfig.IntegratedBPPConfig -> [Text] -> Flow [CQMMB.FullBusData]
+getFreshUpcomingBuses routeId integratedBPPConfig liveVehicleNos = do
+  now <- getCurrentTime
+  let nowSec = floor (utcTimeToPOSIXSeconds now) :: Int
+  upcoming <- CQMMB.getUpcomingRoutesBuses routeId integratedBPPConfig
+  pure $
+    filter
+      ( \b ->
+          (nowSec - b.busData.timestamp) <= upcomingFreshnessThresholdSec
+            && not (b.vehicleNumber `elem` liveVehicleNos)
+      )
+      upcoming.buses
+
 -- | Shared function to build RouteWithLiveVehicle for a single route.
 --   Used by both FRFSTicketService and MultimodalConfirm.
 buildRouteWithLiveVehicle ::
@@ -41,9 +57,15 @@ buildRouteWithLiveVehicle ::
   [(BecknV2.FRFS.Enums.ServiceTierType, DFRFSVehicleServiceTier.FRFSVehicleServiceTier)] ->
   Maybe LatLong ->
   Int ->
+  Bool ->
   Flow (Maybe API.Types.UI.MultimodalConfirm.RouteWithLiveVehicle)
-buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromStopCode toStopCode frfsTierMap mbSourceStopLatLong maxLiveVehicles = do
-  let vehicleNos = nub $ map (.vehicle_no) busScheduleDetails <> map (.vehicleNumber) routeInfo.buses
+buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromStopCode toStopCode frfsTierMap mbSourceStopLatLong maxLiveVehicles allowUpcomingTrips = do
+  upcomingBuses <-
+    if allowUpcomingTrips
+      then getFreshUpcomingBuses routeInfo.routeId integratedBPPConfig (map (.vehicleNumber) routeInfo.buses)
+      else pure []
+  let mergedBuses = routeInfo.buses <> upcomingBuses
+  let vehicleNos = nub $ map (.vehicle_no) busScheduleDetails <> map (.vehicleNumber) mergedBuses
   seatLayoutMappingsByVehicleNo <-
     mapConcurrently
       ( \vehicleNo -> do
@@ -92,7 +114,7 @@ buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromS
       getBusScheduleInfo busScheduleDetails integratedBPPConfig routeInfo.routeId fromStopCode toStopCode frfsTierMap seatLayoutMappingByVehicleNo
   liveVehiclesFork <-
     awaitableFork "getLiveVehicles" $
-      getLiveVehicles routeInfo.buses integratedBPPConfig frfsTierMap mbSourceStopLatLong maxLiveVehicles seatLayoutMappingByVehicleNo activeTripIdByVehicleNo
+      getLiveVehicles mergedBuses integratedBPPConfig frfsTierMap mbSourceStopLatLong maxLiveVehicles seatLayoutMappingByVehicleNo activeTripIdByVehicleNo
   schedules <-
     L.await Nothing schedulesFork >>= \case
       Left err -> throwError $ InternalError $ "getBusScheduleInfo fork failed: " <> show err
@@ -234,7 +256,9 @@ buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromS
                           currentTripId = Map.lookup bus.vehicleNumber activeTripIdByVehicleNo',
                           serviceSubTypes = mbServiceSubTypes,
                           vehicleTagNumber = mbVehicleTagNumber,
-                          seatSelectionType = seatSelType
+                          seatSelectionType = seatSelType,
+                          isUpcomingTrip = bus.busData.is_upcoming_trip,
+                          previousRouteId = bus.busData.previous_route_id
                         }
                   Nothing -> do
                     logError $ "Vehicle info not found for bus: " <> bus.vehicleNumber

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MultiModalBus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/Merchant/MultiModalBus.hs
@@ -8,9 +8,11 @@ module Storage.CachedQueries.Merchant.MultiModalBus
     BusRouteId,
     BusDataWithRoutesInfo (..),
     getRoutesBuses,
+    getUpcomingRoutesBuses,
     getBusesForRoutes,
     hasLiveVehicles,
     mkRouteKey,
+    mkUpcomingRouteKey,
     withCrossAppRedisNew,
     utcToIST,
   )
@@ -82,7 +84,9 @@ data BusData = BusData
     eta_data :: Maybe [BusStopETA],
     route_id :: Text,
     route_state :: Maybe RouteState,
-    route_number :: Maybe Text
+    route_number :: Maybe Text,
+    is_upcoming_trip :: Maybe Bool,
+    previous_route_id :: Maybe Text
   }
   deriving (Generic, Show, Eq, FromJSON, ToJSON)
 
@@ -123,6 +127,11 @@ mkRouteKey mbRedisPrefix routeId = case mbRedisPrefix of
   Just prefix | prefix /= "" -> prefix <> ":route:" <> routeId
   _ -> "route:" <> routeId
 
+mkUpcomingRouteKey :: Maybe Text -> Text -> Text
+mkUpcomingRouteKey mbRedisPrefix routeId = case mbRedisPrefix of
+  Just prefix | prefix /= "" -> prefix <> ":route:upcoming:" <> routeId
+  _ -> "route:upcoming:" <> routeId
+
 -- Get all buses for a single route
 getRoutesBuses :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r, HasField "ltsHedisEnv" r Hedis.HedisEnv, HasField "secondaryLTSHedisEnv" r (Maybe Hedis.HedisEnv), HasField "cloudType" r (Maybe CloudType)) => Text -> DIBC.IntegratedBPPConfig -> m RouteWithBuses
 getRoutesBuses routeId integratedBppConfig = do
@@ -131,6 +140,17 @@ getRoutesBuses routeId integratedBppConfig = do
         DIBC.DIRECT config -> config.redisPrefix
         _ -> Nothing
   let key = mkRouteKey redisPrefix routeId
+  busDataPairs <- Hedis.runInMultiCloudLTSRedisForList $ Hedis.hGetAll key
+  let buses = map (uncurry FullBusData) busDataPairs
+  return $ RouteWithBuses routeId buses
+
+getUpcomingRoutesBuses :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r, HasField "ltsHedisEnv" r Hedis.HedisEnv, HasField "secondaryLTSHedisEnv" r (Maybe Hedis.HedisEnv), HasField "cloudType" r (Maybe CloudType)) => Text -> DIBC.IntegratedBPPConfig -> m RouteWithBuses
+getUpcomingRoutesBuses routeId integratedBppConfig = do
+  let redisPrefix = case integratedBppConfig.providerConfig of
+        DIBC.ONDC config -> config.redisPrefix
+        DIBC.DIRECT config -> config.redisPrefix
+        _ -> Nothing
+  let key = mkUpcomingRouteKey redisPrefix routeId
   busDataPairs <- Hedis.runInMultiCloudLTSRedisForList $ Hedis.hGetAll key
   let buses = map (uncurry FullBusData) busDataPairs
   return $ RouteWithBuses routeId buses


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for including upcoming buses in route-serviceability searches.
  * Upcoming-trip details now indicate whether a vehicle is upcoming and include its previous route when available.
  * Multimodal and FRFS route requests can now opt in to upcoming-trip results.
  * Upcoming vehicles are considered when no suitable live vehicle is available, subject to freshness limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->