### PR TITLE
dynamic-offer-driver-app/fix: allow clearing fareSettlementType back to none

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
@@ -3351,7 +3351,12 @@ postMerchantSpecialLocationUpsert merchantShortId _city mbSpecialLocationId requ
             fetchAllGateFareProduct = mbExistingSpLoc >>= (.fetchAllGateFareProduct),
             supportNumber = request.supportNumber,
             paymentModes = request.paymentModes <|> (mbExistingSpLoc >>= (.paymentModes)) <|> Just SL.defaultPaymentModes,
-            fareSettlementType = request.fareSettlementType <|> (mbExistingSpLoc >>= (.fareSettlementType)),
+            -- Take the request value directly instead of falling back with `<|>` to the
+            -- existing value: `fareSettlementType` is `Maybe FareSettlementType` where
+            -- `Nothing` is the valid "none" selection. With `<|>`, `Nothing` from the
+            -- request would be clobbered by an existing `Just CommissionOnly`, making it
+            -- impossible to clear the setting back to none from the dashboard form.
+            fareSettlementType = request.fareSettlementType,
             ..
           }
 


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Fixes a bug where the special location's **Fare Settlement Type** could not be changed back to "none" from the dashboard. After setting it to `CommissionOnly` (or `FullPayment`), saving with "none" selected had no effect — the old value persisted.

**Root cause:** In `postMerchantSpecialLocationUpsert` (`Domain/Action/Dashboard/Management/Merchant.hs`), the field was merged with the existing value using `<|>`:

```haskell
fareSettlementType = request.fareSettlementType <|> (mbExistingSpLoc >>= (.fareSettlementType))
```

`FareSettlementType` is `CommissionOnly | FullPayment`, and the column is `Maybe FareSettlementType` where `Nothing` **is** the "none" selection. With `<|>`, `Nothing <|> Just CommissionOnly` resolves to `Just CommissionOnly`, so an explicit "none" from the form was clobbered by the stored value. `Nothing` was ambiguously treated as both "not provided" and "clear to none", making it impossible to clear the field.

**Fix:** Take the request value directly for this form-based upsert. On create the existing value is `Nothing` anyway (no behavior change); on update the request value is authoritative, so selecting "none" now clears the field.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context

Reported behavior: set fare settlement type to "commission only", then change it to "none" and save — it stays "commission only". This makes the change stick.

Note: the CSV bulk-upsert path (`SharedLogic/SpecialLocationUpsert.hs`, `mergeSpecialLocationWithExisting`) intentionally keeps the `<|>` merge, since a blank CSV cell is meant to preserve the existing value rather than clear it. Only the interactive form path is changed here.

## How did you test it?

Change is a targeted one-line semantic fix (drop the `<|>` fallback for this field on the form path). Not yet exercised via integration tests in this environment.

## Screenshot of test results

N/A

## Checklist

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN1ntv73mFS8MqYvfmLbzm)_