### PR TITLE
feat(driver-app): add Prometheus counter for driver search-request responses

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -948,6 +948,8 @@ library
       Tools.Metrics
       Tools.Metrics.ARDUBPPMetrics
       Tools.Metrics.ARDUBPPMetrics.Types
+      Tools.Metrics.DriverSearchRequestResponseMetrics
+      Tools.Metrics.DriverSearchRequestResponseMetrics.Types
       Tools.Metrics.SendSearchRequestToDriverMetrics
       Tools.Metrics.SendSearchRequestToDriverMetrics.Types
       Tools.Notifications

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -338,6 +338,7 @@ import qualified Storage.Queries.VendorFee as QVF
 import qualified Tools.Auth as Auth
 import Tools.Error
 import Tools.Event
+import qualified Tools.Metrics as Metrics
 import qualified Tools.Payout as Payout
 import Tools.SMS as Sms hiding (Success)
 import Tools.Verification hiding (ImageType, length)
@@ -1897,6 +1898,7 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
               DTC.QuoteBased _ -> acceptStaticOfferDriverRequest (Just searchTry) driver (fromMaybe searchTry.estimateId sReqFD.estimateId) reqOfferedValue merchant clientId transporterConfig Nothing
             when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False True False False
             QSRD.updateDriverResponse (Just Accept) Inactive req.notificationSource req.renderedAt req.respondedAt sReqFD.id
+            Metrics.incrementDriverResponseCounter (show sReqFD.batchNumber) (show req.response)
             DS.driverScoreEventHandler merchantOpCityId $ buildDriverRespondEventPayload searchTry.id searchTry.requestId driverFCMPulledList
             unless (sReqFD.isForwardRequest) $ Redis.unlockRedis (editDestinationLockKey driverId)
           else do
@@ -1907,6 +1909,7 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
     Reject -> do
       when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False False True False
       QSRD.updateDriverResponse (Just Reject) Inactive req.notificationSource req.renderedAt req.respondedAt sReqFD.id
+      Metrics.incrementDriverResponseCounter (show sReqFD.batchNumber) (show req.response)
       DP.removeSearchReqIdFromMap merchantId driverId searchTry.requestId
       -- Handle queue skip for special zone rides — forked so a slow Redis/LTS hop
       -- can't add latency to the driver-respond hot path.
@@ -1917,6 +1920,7 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
     Pulled -> do
       when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False False False True
       QSRD.updateDriverResponse (Just Pulled) Inactive req.notificationSource req.renderedAt req.respondedAt sReqFD.id
+      Metrics.incrementDriverResponseCounter (show sReqFD.batchNumber) (show req.response)
       throwError UnexpectedResponseValue
   pure Success
   where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Environment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Environment.hs
@@ -248,6 +248,7 @@ data AppEnv = AppEnv
     googleTranslateKey :: Text,
     bppMetrics :: BPPMetricsContainer,
     ssrMetrics :: SendSearchRequestToDriverMetricsContainer,
+    driverSearchRequestResponseMetrics :: DriverSearchRequestResponseMetricsContainer,
     searchRequestExpirationSeconds :: NominalDiffTime,
     searchRequestExpirationSecondsForMultimodal :: NominalDiffTime,
     driverQuoteExpirationSeconds :: NominalDiffTime,
@@ -395,6 +396,7 @@ buildAppEnv cfg@AppCfg {searchRequestExpirationSeconds = _searchRequestExpiratio
   let kafkaProducerForART = Just kafkaProducerTools
   bppMetrics <- registerBPPMetricsContainer metricsSearchDurationTimeout
   ssrMetrics <- registerSendSearchRequestToDriverMetricsContainer
+  driverSearchRequestResponseMetrics <- registerDriverSearchRequestResponseMetricsContainer
   coreMetrics <- Metrics.registerCoreMetricsContainer
   kafkaClickhouseEnv <- createConn kafkaClickhouseCfg
   serviceClickhouseEnv <- createConn driverClickhouseCfg

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics.hs
@@ -16,4 +16,5 @@ module Tools.Metrics (module Reexport) where
 
 import Kernel.Tools.Metrics.CoreMetrics as Reexport
 import Tools.Metrics.ARDUBPPMetrics as Reexport
+import Tools.Metrics.DriverSearchRequestResponseMetrics as Reexport
 import Tools.Metrics.SendSearchRequestToDriverMetrics as Reexport

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSearchRequestResponseMetrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSearchRequestResponseMetrics.hs
@@ -1,0 +1,40 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Tools.Metrics.DriverSearchRequestResponseMetrics
+  ( module Tools.Metrics.DriverSearchRequestResponseMetrics,
+    module Reexport,
+  )
+where
+
+import qualified EulerHS.Language as L
+import EulerHS.Prelude
+import GHC.Records.Extra
+import Prometheus as P
+import Tools.Metrics.DriverSearchRequestResponseMetrics.Types as Reexport
+
+-- | Increment the driver-respond counter for a single response to a search request.
+-- Labels emitted: (deployment version, batch number, response type e.g. "Accept"/"Reject"/"Pulled").
+-- Both @batchNumber@ and @response@ are passed pre-rendered as Text by the caller so this
+-- module stays decoupled from domain types.
+incrementDriverResponseCounter :: HasDriverSearchRequestResponseMetrics m r => Text -> Text -> m ()
+incrementDriverResponseCounter batchNumber response = do
+  metricsContainer <- asks (.driverSearchRequestResponseMetrics)
+  version <- asks (.version)
+  incrementDriverResponseCounter' metricsContainer batchNumber response version
+
+incrementDriverResponseCounter' :: L.MonadFlow m => DriverSearchRequestResponseMetricsContainer -> Text -> Text -> DeploymentVersion -> m ()
+incrementDriverResponseCounter' metricsContainer batchNumber response version = do
+  let driverResponseCounter = metricsContainer.driverResponseCounter
+  L.runIO $ P.withLabel driverResponseCounter (version.getDeploymentVersion, batchNumber, response) P.incCounter

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSearchRequestResponseMetrics/Types.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSearchRequestResponseMetrics/Types.hs
@@ -1,0 +1,46 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Tools.Metrics.DriverSearchRequestResponseMetrics.Types
+  ( HasDriverSearchRequestResponseMetrics,
+    DriverSearchRequestResponseMetricsContainer (..),
+    module CoreMetrics,
+    registerDriverSearchRequestResponseMetricsContainer,
+  )
+where
+
+import EulerHS.Prelude
+import Kernel.Tools.Metrics.CoreMetrics as CoreMetrics
+import Kernel.Utils.Common
+import Prometheus as P
+
+type HasDriverSearchRequestResponseMetrics m r =
+  HasFlowEnv m r ["driverSearchRequestResponseMetrics" ::: DriverSearchRequestResponseMetricsContainer, "version" ::: DeploymentVersion]
+
+-- Labels: (version, batch_number, response)
+type DriverResponseCounterMetric = P.Vector P.Label3 P.Counter
+
+newtype DriverSearchRequestResponseMetricsContainer = DriverSearchRequestResponseMetricsContainer
+  { driverResponseCounter :: DriverResponseCounterMetric
+  }
+
+registerDriverSearchRequestResponseMetricsContainer :: IO DriverSearchRequestResponseMetricsContainer
+registerDriverSearchRequestResponseMetricsContainer = do
+  driverResponseCounter <- registerDriverResponseCounter
+  return $ DriverSearchRequestResponseMetricsContainer {..}
+
+registerDriverResponseCounter :: IO DriverResponseCounterMetric
+registerDriverResponseCounter =
+  P.register . P.vector ("version", "batch_number", "response") . P.counter $
+    P.Info "driver_search_request_response_count" "Count of driver responses to a search request, labelled by deployment version, batch number and response type"


### PR DESCRIPTION
## What
Adds a Prometheus counter `driver_search_request_response_count` with labels `(version, batch_number, response)`, incremented in `respondQuote` (`Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs`) whenever a driver Accepts / Rejects / Pulls a search request. This is the respond-side counterpart of the existing send-side counter and mirrors the `Tools.Metrics.SendSearchRequestToDriverMetrics` module pattern.

## Files changed (6, +95)
- NEW `Tools/Metrics/DriverSearchRequestResponseMetrics/Types.hs` — container + `P.Vector P.Label3 P.Counter` registration (`driver_search_request_response_count`).
- NEW `Tools/Metrics/DriverSearchRequestResponseMetrics.hs` — `incrementDriverResponseCounter`.
- `Tools/Metrics.hs` — re-export new module.
- `Environment.hs` — new `AppEnv` field `driverSearchRequestResponseMetrics` + registration in `buildAppEnv`.
- `Domain/Action/UI/Driver.hs` — import + 3 increment call sites (after each `QSRD.updateDriverResponse`).
- `dynamic-offer-driver-app.cabal` — regenerated via hpack to list the 2 new modules.

## Labels
- `version` = backend deployment version (`AppEnv.version.getDeploymentVersion`) — matches send-side counter for clean joins.
- `batch_number` = `sReqFD.batchNumber`.
- `response` = `Accept` / `Reject` / `Pulled`.

## Notes
- Counter increments only after the response is persisted (`updateDriverResponse`), so it reflects responses actually recorded. `P.incCounter` is in-memory, hot-path safe.
- Not compiled in CI sandbox (no prebuilt artifacts); please run `nix develop -c cabal build dynamic-offer-driver-app`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics tracking for driver search responses.
  * Recorded response counts by deployment version, batch number, and response type.
  * Captured driver quote outcomes including accepted, rejected, and pulled responses.
  * Integrated the new metrics into application initialization and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->