### PR TITLE
backend/enhc:added timebound in coin config update and timebound chec…

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/CoinsConfig.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/CoinsConfig.yaml
@@ -41,6 +41,7 @@ types:
     - active: Bool
     - expirationAt: Maybe Int
     - coins: Int
+    - timeBounds: Maybe TimeBound
     - derive: "'HideSecrets"
   CreateCoinsConfigReq:
     - enum: NewCoinsConfig NewCoinsConfigReq, DuplicateCoinsConfig DuplicateCoinsConfigsReq

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/CoinsConfig.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/CoinsConfig.hs
@@ -71,7 +71,13 @@ data NewCoinsConfigReq = NewCoinsConfigReq
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data UpdateReq = UpdateReq {entriesId :: Kernel.Types.Id.Id Dashboard.Common.CoinsConfig, active :: Kernel.Prelude.Bool, expirationAt :: Kernel.Prelude.Maybe Kernel.Prelude.Int, coins :: Kernel.Prelude.Int}
+data UpdateReq = UpdateReq
+  { entriesId :: Kernel.Types.Id.Id Dashboard.Common.CoinsConfig,
+    active :: Kernel.Prelude.Bool,
+    expirationAt :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    coins :: Kernel.Prelude.Int,
+    timeBounds :: Kernel.Prelude.Maybe Kernel.Types.TimeBound.TimeBound
+  }
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/CoinsConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/CoinsConfig.hs
@@ -6,7 +6,9 @@ module Domain.Action.Dashboard.Management.CoinsConfig
 where
 
 import qualified API.Types.ProviderPlatform.Management.CoinsConfig as Common
+import Data.List (intersect, nub)
 import qualified Data.Text as Text
+import Data.Time.Calendar.WeekDate (toWeekDate)
 import qualified Domain.Types.Coins.CoinsConfig as DTCC
 import qualified Domain.Types.Merchant
 import Domain.Types.Translations (Translations (..))
@@ -28,6 +30,9 @@ import qualified Storage.Queries.Coins.CoinsConfig as QConfig
 import qualified Storage.Queries.Coins.CoinsConfigExtra as QCoinsConfigExtra
 import Storage.Queries.Translations (create)
 import Storage.Queries.TranslationsExtra (isTranslationExist)
+
+incentiveCohortWindowConflictMsg :: Text
+incentiveCohortWindowConflictMsg = "Only 1 incentive cohort window is allowed per day currently."
 
 getCoinsConfigList ::
   ID.ShortId Domain.Types.Merchant.Merchant ->
@@ -72,6 +77,14 @@ putCoinsConfigUpdate ::
 putCoinsConfigUpdate _merchantShortId _opCity req = do
   let findCoinsConfig = QConfig.findById $ ID.cast req.entriesId
   coinsConfig <- findCoinsConfig >>= UC.fromMaybeM (InvalidRequest "Coins config does not exist")
+  let updatedConfig =
+        coinsConfig
+          { DTCC.active = req.active,
+            DTCC.expirationAt = req.expirationAt,
+            DTCC.coins = req.coins,
+            DTCC.timeBounds = req.timeBounds
+          }
+  validateIncentiveCohortTimeBoundWindow updatedConfig (Just coinsConfig.id)
   QConfig.updateCoinEntries req
   clearCache coinsConfig
   pure Success
@@ -102,6 +115,7 @@ postCoinsConfigCreate merchantShortId opCity req = do
       coinsConfig <- findCoinsConfig >>= UC.fromMaybeM (InvalidRequest "Coins config does not exist")
       let duplicatedConfig = coinsConfig {DTCC.id = ID.Id uuid, DTCC.eventFunction = eventFunction}
       pure (duplicatedConfig, eventMessages)
+  validateIncentiveCohortTimeBoundWindow newCoinsConfig Nothing
   QConfig.createCoinEntries newCoinsConfig
   clearCache newCoinsConfig
   processingTranslations newCoinsConfig eventMessageLs
@@ -132,3 +146,90 @@ processingTranslations coinsConfig eventMessageLs = do
               }
     )
     eventMessageLs
+
+-- | Timebound uniqueness for incentive cohort configs (same city/vehicle/trip):
+-- * DriverIncentiveCohortRidesCompleted N — conflict only with the exact same
+--   eventFunction (same threshold N) sharing a weekday.
+-- * DriverIncentiveCohortMetrics _ — conflict with any other Metrics config
+--   sharing a weekday (thresholds ignored; only one Metrics window per day).
+validateIncentiveCohortTimeBoundWindow ::
+  DTCC.CoinsConfig ->
+  Maybe (ID.Id DTCC.CoinsConfig) ->
+  Environment.Flow ()
+validateIncentiveCohortTimeBoundWindow candidate mbExcludeId = do
+  case (candidate.active, nonUnboundedTimeBound candidate.timeBounds) of
+    (True, Just candidateTb) ->
+      case incentiveCohortConflictKind candidate.eventFunction of
+        Nothing -> pure ()
+        Just conflictKind -> do
+          existing <-
+            QCoinsConfigExtra.findActiveConfigsByCityVehicleTrip
+              (ID.Id candidate.merchantOptCityId)
+              candidate.vehicleCategory
+              candidate.tripCategoryType
+          let conflicting =
+                filter
+                  ( \cc ->
+                      maybe True (cc.id /=) mbExcludeId
+                        && matchesIncentiveCohortConflict conflictKind candidate.eventFunction cc.eventFunction
+                        && maybe False (incentiveCohortDaysOverlap candidateTb) (nonUnboundedTimeBound cc.timeBounds)
+                  )
+                  existing
+          unless (null conflicting) $
+            UC.throwError (InvalidRequest incentiveCohortWindowConflictMsg)
+    _ -> pure ()
+
+data IncentiveCohortConflictKind
+  = ExactEventFunction
+  | AnyDriverIncentiveCohortMetrics
+
+incentiveCohortConflictKind :: DCT.DriverCoinsFunctionType -> Maybe IncentiveCohortConflictKind
+incentiveCohortConflictKind = \case
+  DCT.DriverIncentiveCohortRidesCompleted _ -> Just ExactEventFunction
+  DCT.DriverIncentiveCohortMetrics _ -> Just AnyDriverIncentiveCohortMetrics
+  _ -> Nothing
+
+matchesIncentiveCohortConflict ::
+  IncentiveCohortConflictKind ->
+  DCT.DriverCoinsFunctionType ->
+  DCT.DriverCoinsFunctionType ->
+  Bool
+matchesIncentiveCohortConflict ExactEventFunction candidateEf otherEf = otherEf == candidateEf
+matchesIncentiveCohortConflict AnyDriverIncentiveCohortMetrics _ otherEf =
+  case otherEf of
+    DCT.DriverIncentiveCohortMetrics _ -> True
+    _ -> False
+
+nonUnboundedTimeBound :: Maybe TB.TimeBound -> Maybe TB.TimeBound
+nonUnboundedTimeBound = \case
+  Just tb | tb /= TB.Unbounded -> Just tb
+  _ -> Nothing
+
+-- | Conflict if both timebounds occupy any of the same weekdays (Mon=1 .. Sun=7).
+incentiveCohortDaysOverlap :: TB.TimeBound -> TB.TimeBound -> Bool
+incentiveCohortDaysOverlap tb1 tb2 =
+  not . null $ intersect (occupiedWeekDays tb1) (occupiedWeekDays tb2)
+
+occupiedWeekDays :: TB.TimeBound -> [Int]
+occupiedWeekDays = \case
+  TB.Unbounded -> []
+  TB.BoundedByWeekday peaks -> nub $ weekDaysWithPeaks peaks
+  TB.BoundedByDay days ->
+    nub
+      [ dow
+        | (day, peaks) <- days,
+          not (null peaks),
+          let (_, _, dow) = toWeekDate day
+      ]
+
+weekDaysWithPeaks :: TB.BoundedPeaks -> [Int]
+weekDaysWithPeaks peaks =
+  concat
+    [ [1 | not (null peaks.monday)],
+      [2 | not (null peaks.tuesday)],
+      [3 | not (null peaks.wednesday)],
+      [4 | not (null peaks.thursday)],
+      [5 | not (null peaks.friday)],
+      [6 | not (null peaks.saturday)],
+      [7 | not (null peaks.sunday)]
+    ]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Coins/CoinsConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Coins/CoinsConfig.hs
@@ -63,7 +63,8 @@ updateCoinEntries UpdateReq {..} =
   updateWithKV
     [ Se.Set BeamDC.active active,
       Se.Set BeamDC.expirationAt expirationAt,
-      Se.Set BeamDC.coins coins
+      Se.Set BeamDC.coins coins,
+      Se.Set BeamDC.timeBounds timeBounds
     ]
     [Se.Is BeamDC.id $ Se.Eq $ getId entriesId]
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Coins/CoinsConfigExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Coins/CoinsConfigExtra.hs
@@ -7,6 +7,7 @@ import Kernel.Beam.Functions
 import Kernel.Prelude
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import qualified Lib.DriverCoins.Types as DCT
 import qualified Sequelize as Se
 import qualified Storage.Beam.Coins.CoinsConfig as BeamDC
 import Storage.Queries.Coins.CoinsConfig ()
@@ -29,3 +30,21 @@ findAllByMerchantOptCityIdWithLimitOffset (Id merchantOptCityId) mbEventName mbV
     (Se.Asc BeamDC.id)
     limit
     offset
+
+-- | Active EndRide coin configs for city + vehicle + trip category (used by incentive cohort window checks).
+findActiveConfigsByCityVehicleTrip ::
+  (MonadFlow m, CacheFlow m r, EsqDBFlow m r) =>
+  Id DMOC.MerchantOperatingCity ->
+  Maybe DTV.VehicleCategory ->
+  Maybe DCT.TripCategoryType ->
+  m [CoinsConfig]
+findActiveConfigsByCityVehicleTrip (Id merchantOptCityId) mbVehicleCategory mbTripCategoryType =
+  findAllWithKV
+    [ Se.And $
+        [ Se.Is BeamDC.merchantOptCityId $ Se.Eq merchantOptCityId,
+          Se.Is BeamDC.active $ Se.Eq True,
+          Se.Is BeamDC.eventName $ Se.Eq "EndRide"
+        ]
+          <> [Se.Is BeamDC.vehicleCategory $ Se.Eq mbVehicleCategory]
+          <> [Se.Is BeamDC.tripCategoryType $ Se.Eq mbTripCategoryType]
+    ]

--- a/Backend/dev/rest-client/dynamic-offer-driver-app/coinsConfig.http
+++ b/Backend/dev/rest-client/dynamic-offer-driver-app/coinsConfig.http
@@ -81,5 +81,6 @@ token: {{juspay_admin}}
   "entriesId": "dbced2a0-d486-4778-8f59-877f8092d8d2",
   "active": true,
   "coins": 15,
-  "expirationAt": 8886000
+  "expirationAt": 8886000,
+  "timeBounds": null
 }


### PR DESCRIPTION
…ks in apis

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional time-bound settings to coins configuration updates.
  * Added filtering for active configurations by city, vehicle category, and trip category.

* **Bug Fixes**
  * Coins configuration updates now correctly save time-bound settings.
  * Prevented overlapping time bounds for applicable incentive-cohort configurations during creation and updates.
  * Updated example API requests to support the new time-bound field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->