### PR TITLE
feat(scheduler,producer): add Redis + looper-thread healthcheck API

### DIFF
--- a/Backend/lib/producer/package.yaml
+++ b/Backend/lib/producer/package.yaml
@@ -89,6 +89,10 @@ dependencies:
   - rider-app
   - yudhishthira
   - unordered-containers
+  - warp
+  - wai
+  - http-types
+  - unliftio
 
 ghc-options:
   - -Wall

--- a/Backend/lib/producer/producer.cabal
+++ b/Backend/lib/producer/producer.cabal
@@ -82,6 +82,7 @@ library
     , esqueleto
     , euler-hs
     , hedis
+    , http-types
     , mobility-core
     , monad-control
     , persistent
@@ -98,8 +99,11 @@ library
     , template-haskell
     , text
     , time
+    , unliftio
     , unordered-containers
     , uuid
+    , wai
+    , warp
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)
@@ -161,6 +165,7 @@ executable producer-exe
     , esqueleto
     , euler-hs
     , hedis
+    , http-types
     , mobility-core
     , monad-control
     , persistent
@@ -178,8 +183,11 @@ executable producer-exe
     , template-haskell
     , text
     , time
+    , unliftio
     , unordered-containers
     , uuid
+    , wai
+    , warp
     , yudhishthira
   default-language: Haskell2010
   if flag(Local)

--- a/Backend/lib/producer/src/App.hs
+++ b/Backend/lib/producer/src/App.hs
@@ -16,6 +16,7 @@
 module App (startProducer) where
 
 import Data.Function hiding (id)
+import qualified Database.Redis as Redis
 import Debug.Trace as T
 import Environment
 import EulerHS.Interpreters (runFlow)
@@ -33,13 +34,23 @@ import qualified Kernel.Utils.Common as KUC
 import Kernel.Utils.Dhall (readDhallConfigDefault)
 import qualified Kernel.Utils.FlowLogging as L
 import Kernel.Utils.Time ()
+import Network.HTTP.Types (status200, status503)
+import Network.Wai (Application, responseLBS)
+import qualified Network.Wai.Handler.Warp as Warp
 import qualified Producer.Flow as PF
 import System.Environment (lookupEnv)
+import qualified UnliftIO.Async as Async
 
 getDhallName :: ProducerType -> String
 getDhallName = \case
   Driver -> "producer"
   Rider -> "rider-producer"
+
+-- | Default port for the producer health-check HTTP server. Overridable via
+-- the @PRODUCER_HEALTHCHECK_PORT@ environment variable so no dhall/config
+-- schema change is required (keeps existing deployments backward compatible).
+defaultHealthCheckPort :: Int
+defaultHealthCheckPort = 8080
 
 startProducer :: IO ()
 startProducer = do
@@ -69,5 +80,32 @@ startProducerWithEnv flowRt appCfg appEnv producerType = do
         >> L.setOption KVCM.KVMetricCfg appEnv.coreMetrics.kvRedisMetricsContainer
     )
   let producers = map (\_ -> PF.runProducer) [1 .. appCfg.producersPerPod]
-  runFlowR flowRt appEnv $ do
-    loopGracefully $ bool producers ([PF.runReviver producerType] <> producers) appEnv.runReviver
+  let looperFlows = bool producers ([PF.runReviver producerType] <> producers) appEnv.runReviver
+  healthCheckPort <- fromMaybe defaultHealthCheckPort . (>>= readMaybe) <$> lookupEnv "PRODUCER_HEALTHCHECK_PORT"
+  -- Run the producer looper(s) in the background and expose a health-check
+  -- HTTP server on the foreground thread. The server reports 200 only when the
+  -- looper thread is alive AND Redis is reachable, otherwise 503.
+  Async.withAsync (runFlowR flowRt appEnv $ loopGracefully looperFlows) $ \looperThread ->
+    Warp.run healthCheckPort (healthCheckApp appEnv looperThread)
+
+-- | WAI application backing the producer health-check endpoint. Responds on any
+-- path so it works as a Kubernetes liveness/readiness probe target.
+healthCheckApp :: AppEnv -> Async.Async () -> Application
+healthCheckApp appEnv looperThread _req respond = do
+  mLooperResult <- Async.poll looperThread
+  redisOk <- checkRedisConnectivity appEnv
+  case (mLooperResult, redisOk) of
+    -- 'poll' returns Nothing while the looper async is still running.
+    (Nothing, True) ->
+      respond $ responseLBS status200 [("Content-Type", "text/plain")] "App is up"
+    _ ->
+      respond $ responseLBS status503 [("Content-Type", "text/plain")] "Producer unhealthy"
+
+-- | Verify Redis connectivity with a PING -> PONG round-trip. Any exception or
+-- non-PONG reply is treated as unhealthy.
+checkRedisConnectivity :: AppEnv -> IO Bool
+checkRedisConnectivity appEnv = do
+  eRes <- try $ Redis.runRedis appEnv.hedisClusterEnv.hedisConnection Redis.ping
+  pure $ case (eRes :: Either SomeException (Either Redis.Reply Redis.Status)) of
+    Right (Right Redis.Pong) -> True
+    _ -> False

--- a/Backend/lib/scheduler/package.yaml
+++ b/Backend/lib/scheduler/package.yaml
@@ -69,6 +69,7 @@ dependencies:
   - time
   - aeson
   - euler-hs
+  - hedis
   - exceptions
   - containers
   - transformers

--- a/Backend/lib/scheduler/scheduler.cabal
+++ b/Backend/lib/scheduler/scheduler.cabal
@@ -91,6 +91,7 @@ library
     , containers
     , euler-hs
     , exceptions
+    , hedis
     , mobility-core
     , postgresql-simple
     , prometheus-client

--- a/Backend/lib/scheduler/src/Lib/Scheduler/App.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/App.hs
@@ -17,11 +17,14 @@ module Lib.Scheduler.App
   )
 where
 
+import qualified Control.Monad.Catch as C
+import qualified Database.Redis as Redis
 import Kernel.Beam.Lib.UtilsTH
 import Kernel.Prelude hiding (mask, throwIO)
 import Kernel.Randomizer
 import Kernel.Storage.Beam.SystemConfigs
 import Kernel.Storage.Esqueleto.Config (prepareEsqDBEnv)
+import qualified Kernel.Storage.Hedis as Hedis
 import Kernel.Storage.Hedis (connectHedis, connectHedisCluster)
 import qualified Kernel.Storage.InMem as IM
 import Kernel.Streaming.Kafka.Producer.Types
@@ -31,7 +34,7 @@ import Kernel.Types.CacheFlow
 import Kernel.Types.Common (Seconds (..))
 import qualified Kernel.Types.MonadGuid as G
 import Kernel.Utils.App
-import Kernel.Utils.Common (threadDelaySec)
+import Kernel.Utils.Common (logError, threadDelaySec)
 import Kernel.Utils.IOLogging (prepareLoggerEnv)
 import Kernel.Utils.Servant.Server
 import Kernel.Utils.Shutdown
@@ -39,7 +42,7 @@ import Lib.Scheduler.Environment
 import Lib.Scheduler.Handler (SchedulerHandle, handler)
 import Lib.Scheduler.Metrics
 import Lib.Scheduler.Types (JobProcessor)
-import Servant (Context (EmptyContext))
+import Servant (Context (EmptyContext), ServerError (..), err503)
 import System.Exit
 import UnliftIO
 
@@ -97,13 +100,42 @@ runSchedulerService s@SchedulerConfig {..} jobInfoMap kvConfigUpdateFrequency ma
     runServerGeneric
       schedulerEnv
       (Proxy @HealthCheckAPI)
-      (pure "App is up")
+      (schedulerHealthCheck schedulerAction)
       identity
       identity
       EmptyContext
       (const identity)
       (\_ -> cancel schedulerAction)
       (runSchedulerM s)
+
+-- | Health check for the scheduler/allocator service.
+--
+-- Verifies two liveness properties and only then returns HTTP 200:
+--   1. The scheduler looper thread is still running (i.e. it has not
+--      crashed or exited). @poll@ returns 'Nothing' while the async is
+--      still running and @Just@ once it has finished (normally or with an
+--      exception).
+--   2. Redis is reachable (a @PING@ round-trips to @PONG@).
+--
+-- On any failure it throws @err503@ so the endpoint reports the service as
+-- unhealthy (5xx) instead of a misleading 200.
+schedulerHealthCheck :: Async () -> SchedulerM Text
+schedulerHealthCheck schedulerAction = do
+  -- (1) Looper thread liveness.
+  mLooperResult <- poll schedulerAction
+  whenJust mLooperResult $ \looperResult -> do
+    logError $ "SCHEDULER_HEALTHCHECK_FAILED: looper thread is not running, result: " <> show looperResult
+    C.throwM err503 {errBody = "Scheduler looper thread is not running"}
+  -- (2) Redis connectivity.
+  eRedis <- Kernel.Prelude.try $ Hedis.withCrossAppRedis $ Hedis.runHedis Redis.ping
+  case eRedis of
+    Right Redis.Pong -> pure "App is up"
+    Right otherStatus -> do
+      logError $ "SCHEDULER_HEALTHCHECK_FAILED: unexpected redis ping response: " <> show otherStatus
+      C.throwM err503 {errBody = "Scheduler redis connectivity check failed"}
+    Left (e :: SomeException) -> do
+      logError $ "SCHEDULER_HEALTHCHECK_FAILED: redis ping failed: " <> show e
+      C.throwM err503 {errBody = "Scheduler redis connectivity check failed"}
 
 -- TODO: explore what is going on here
 -- To which thread do signals come?


### PR DESCRIPTION
## What

Adds a healthcheck to the driver **allocator**, the rider-app **scheduler**, and the **producer** services. Each endpoint returns HTTP **200** only when (a) Redis is reachable (PING→PONG) and (b) the worker/looper thread is still running; otherwise **503**.

## Changes

- **Scheduler / Allocator** (`Backend/lib/scheduler/src/Lib/Scheduler/App.hs`): replaces the static `pure "App is up"` `HealthCheckAPI` handler (shared by both the driver allocator and the rider-app scheduler via `runSchedulerService`) with `schedulerHealthCheck`, which polls the looper `Async` for liveness and pings Redis via `withCrossAppRedis $ runHedis Redis.ping`, throwing `err503` on failure. Adds the `hedis` dependency.
- **Producer** (`Backend/lib/producer/src/App.hs`): adds a lightweight Warp health server. The looper(s) now run in the background via `Async.withAsync`; the foreground serves the health endpoint. Port comes from the `PRODUCER_HEALTHCHECK_PORT` env var (default `8080`) — **no dhall/config schema change**, so existing deployments stay backward compatible. Adds `warp`/`wai`/`http-types`/`unliftio` dependencies.

## Behavior notes

- Producer crash semantics change (intentional): a looper crash no longer exits the process; the healthcheck reports 503 so a Kubernetes liveness probe drives the restart. Wire the probe to the new port.
- `err503` propagation verified: `runServerGeneric`'s natural transformation catches `ServerError` and re-emits via `throwError`, yielding a real 503 (not 500).

## Before merge

- `.cabal` files are generated from `package.yaml` via hpack; hpack was unavailable in the build sandbox, so the cabals were edited by hand to match. Run `hpack` in `Backend/lib/scheduler` and `Backend/lib/producer` to confirm parity.
- Not compiled in the sandbox (no cabal/ghc available) — please run a full `cabal build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health-check endpoints for the producer and scheduler services.
  * Health checks now verify both service liveness and Redis connectivity.
  * Added configurable producer health-check port, defaulting to 8080.

* **Bug Fixes**
  * Health checks return a service-unavailable response when the service process or Redis connection is unhealthy.
  * Improved failure reporting for Redis connectivity and unexpected health-check errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->