### PR TITLE
[fix]: Secondary Partial Index for Tables

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Invoice.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Invoice.yaml
@@ -50,7 +50,7 @@ Invoice:
     driverFeeId: SecondaryKey
     driverId: "!SecondaryKey" # forcing to be a secondary key
     invoiceShortId: SecondaryKey
-    invoiceStatus: "!SecondaryKeyPartial invoiceStatus:ACTIVE_INVOICE" # partial secondary key for findAllByStatusWithLimit
+    invoiceStatus: "!SecondaryKeyPartial invoiceStatus:ACTIVE_INVOICE"
 
   fromTType:
     merchantOperatingCityId: Storage.Queries.Transformers.Invoice.getMerchantOperatingCityId merchantOperatingCityId driverFeeId id|EM

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Notification.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Notification.yaml
@@ -34,7 +34,7 @@ Notification:
     id: PrimaryKey
     shortId: SecondaryKey
     driverFeeId: "!SecondaryKey"
-    status: "!SecondaryKeyPartial status:NOTIFICATION_CREATED,status:PENDING" # partial secondary key for findAllByStatusWithLimit
+    status: "!SecondaryKeyPartial status:NOTIFICATION_CREATED,status:PENDING"
 
   beamType:
     merchantOperatingCityId: Maybe Text

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Invoice.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Invoice.hs
@@ -39,6 +39,6 @@ instance B.Table InvoiceT where
 
 type Invoice = InvoiceT Identity
 
-$(enableKVPGWithPartialIndex ''InvoiceT ['id] [['driverFeeId], ['driverId], ['invoiceShortId], ['invoiceStatus]] [SKeyPartial [('invoiceStatus, "ACTIVE_INVOICE")]])
+$(enableKVPGWithPartialIndex ''InvoiceT ['id] [['driverFeeId], ['driverId], ['invoiceShortId]] [SKeyPartial [('invoiceStatus, "ACTIVE_INVOICE")]])
 
 $(mkTableInstances ''InvoiceT "invoice")

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Notification.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/Notification.hs
@@ -42,6 +42,6 @@ instance B.Table NotificationT where
 
 type Notification = NotificationT Identity
 
-$(enableKVPGWithPartialIndex ''NotificationT ['id] [['driverFeeId], ['shortId], ['status]] [SKeyPartial [('status, "NOTIFICATION_CREATED"), ('status, "PENDING")]])
+$(enableKVPGWithPartialIndex ''NotificationT ['id] [['driverFeeId], ['shortId]] [SKeyPartial [('status, "NOTIFICATION_CREATED"), ('status, "PENDING")]])
 
 $(mkTableInstances ''NotificationT "notification")

--- a/flake.lock
+++ b/flake.lock
@@ -1971,11 +1971,11 @@
         "common": "common_2"
       },
       "locked": {
-        "lastModified": 1783886187,
-        "narHash": "sha256-2YmTrNr6HF93tc3zrUhf0U5ehXfwpa59BJuEQy935z4=",
+        "lastModified": 1784030205,
+        "narHash": "sha256-jYJ0rNfOBCYYKXvOlUedXS0c29zQgB2hCD/WVvW8yKY=",
         "owner": "nammayatri",
         "repo": "namma-dsl",
-        "rev": "d2111294c11fb6f448b5fdd7e64568eabebee43f",
+        "rev": "f49195311a6ad94dcdcf9f0b01c398d6b92688bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved database indexing for active invoices and relevant notifications.
  * Lookups filtered by invoice status or notification status should be more efficient.
  * Preserved existing status filters and data behavior while streamlining index usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->