### PR TITLE
nix/fix: remove Frontend.nix from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -98,7 +98,7 @@
     inputs.common.lib.mkFlake { inherit inputs; } {
       imports = [
         ./Backend/default.nix
-        ./Frontend/default.nix
+        # ./Frontend/default.nix
       ];
     };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project configuration to exclude the frontend component from the default build setup.
  * The backend remains included in the active configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->