### PR TITLE
feat: phone-number-hash auth rate limit (two sliding windows) for rider & driver auth

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -1061,6 +1061,10 @@ TransporterConfig:
   fields:
     merchantId: Id Merchant
     merchantOperatingCityId: Id MerchantOperatingCity
+    authPhoneNumberCountThreshold1: Maybe Int
+    authPhoneNumberCountWindow1: Maybe SlidingWindowOptions
+    authPhoneNumberCountThreshold2: Maybe Int
+    authPhoneNumberCountWindow2: Maybe SlidingWindowOptions
     pickupLocThreshold: Meters
     dropLocThreshold: Meters
     editLocTimeThreshold: Seconds
@@ -1653,6 +1657,8 @@ TransporterConfig:
 
   sqlType:
     exotelAppIdMapping: json
+    authPhoneNumberCountWindow1: json
+    authPhoneNumberCountWindow2: json
     pickupLocThreshold: bigint
     dropLocThreshold: bigint
     rideTimeEstimatedThreshold: bigint

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/TransporterConfig.hs
@@ -23,12 +23,17 @@ import Kernel.Prelude
 import qualified Kernel.Types.Beckn.City
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
+import qualified Kernel.Types.SlidingWindowCounters
 import qualified Kernel.Types.Version
 import qualified SharedLogic.BehaviourManagement.IssueBreach
 import qualified Tools.Beam.UtilsTH
 
 data TransporterConfigD (s :: UsageSafety) = TransporterConfig
   { aaEnabledClientSdkVersion :: Kernel.Prelude.Text,
+    authPhoneNumberCountThreshold1 :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    authPhoneNumberCountThreshold2 :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    authPhoneNumberCountWindow1 :: Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions,
+    authPhoneNumberCountWindow2 :: Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions,
     aadhaarImageResizeConfig :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.AadhaarImageResizeConfig,
     aadhaarVerificationRequired :: Kernel.Prelude.Bool,
     acStatusCheckGap :: Kernel.Prelude.Int,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/TransporterConfig.hs
@@ -18,11 +18,16 @@ import qualified Kernel.External.Types
 import Kernel.Prelude
 import qualified Kernel.Prelude
 import qualified Kernel.Types.Beckn.City
+import qualified Kernel.Types.SlidingWindowCounters
 import qualified Kernel.Types.Common
 import Tools.Beam.UtilsTH
 
 data TransporterConfigT f = TransporterConfigT
   { aaEnabledClientSdkVersion :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    authPhoneNumberCountThreshold1 :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int),
+    authPhoneNumberCountThreshold2 :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int),
+    authPhoneNumberCountWindow1 :: B.C f (Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions),
+    authPhoneNumberCountWindow2 :: B.C f (Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions),
     aadhaarImageResizeConfig :: B.C f (Kernel.Prelude.Maybe Data.Aeson.Value),
     aadhaarVerificationRequired :: B.C f Kernel.Prelude.Bool,
     acStatusCheckGap :: B.C f Kernel.Prelude.Int,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/TransporterConfig.hs
@@ -32,6 +32,10 @@ instance FromTType' Beam.TransporterConfig Domain.Types.TransporterConfig.Transp
       Just
         Domain.Types.TransporterConfig.TransporterConfig
           { aaEnabledClientSdkVersion = fromMaybe Storage.Queries.Transformers.TransporterConfig.fallBackVersionInText aaEnabledClientSdkVersion,
+            authPhoneNumberCountThreshold1 = authPhoneNumberCountThreshold1,
+            authPhoneNumberCountThreshold2 = authPhoneNumberCountThreshold2,
+            authPhoneNumberCountWindow1 = authPhoneNumberCountWindow1,
+            authPhoneNumberCountWindow2 = authPhoneNumberCountWindow2,
             aadhaarImageResizeConfig = (\val -> case Data.Aeson.fromJSON val of Data.Aeson.Success x -> Just x; Data.Aeson.Error _ -> Nothing) =<< aadhaarImageResizeConfig,
             aadhaarVerificationRequired = aadhaarVerificationRequired,
             acStatusCheckGap = acStatusCheckGap,
@@ -338,6 +342,10 @@ instance ToTType' Beam.TransporterConfig Domain.Types.TransporterConfig.Transpor
   toTType' (Domain.Types.TransporterConfig.TransporterConfig {..}) = do
     Beam.TransporterConfigT
       { Beam.aaEnabledClientSdkVersion = Just aaEnabledClientSdkVersion,
+        Beam.authPhoneNumberCountThreshold1 = authPhoneNumberCountThreshold1,
+        Beam.authPhoneNumberCountThreshold2 = authPhoneNumberCountThreshold2,
+        Beam.authPhoneNumberCountWindow1 = authPhoneNumberCountWindow1,
+        Beam.authPhoneNumberCountWindow2 = authPhoneNumberCountWindow2,
         Beam.aadhaarImageResizeConfig = Kernel.Prelude.toJSON <$> aadhaarImageResizeConfig,
         Beam.aadhaarVerificationRequired = aadhaarVerificationRequired,
         Beam.acStatusCheckGap = acStatusCheckGap,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/TransporterConfig.hs
@@ -38,7 +38,11 @@ update :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.Transport
 update (Domain.Types.TransporterConfig.TransporterConfig {..}) = do
   _now <- getCurrentTime
   updateOneWithKV
-    [ Se.Set Beam.pickupLocThreshold pickupLocThreshold,
+    [ Se.Set Beam.authPhoneNumberCountThreshold1 authPhoneNumberCountThreshold1,
+      Se.Set Beam.authPhoneNumberCountThreshold2 authPhoneNumberCountThreshold2,
+      Se.Set Beam.authPhoneNumberCountWindow1 authPhoneNumberCountWindow1,
+      Se.Set Beam.authPhoneNumberCountWindow2 authPhoneNumberCountWindow2,
+      Se.Set Beam.pickupLocThreshold pickupLocThreshold,
       Se.Set Beam.dropLocThreshold dropLocThreshold,
       Se.Set Beam.rideTimeEstimatedThreshold rideTimeEstimatedThreshold,
       Se.Set Beam.defaultPopupDelay defaultPopupDelay,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Registration.hs
@@ -76,6 +76,7 @@ import Kernel.Types.SlidingWindowLimiter
 import Kernel.Types.Version
 import Kernel.Utils.Common
 import qualified Kernel.Utils.Predicates as P
+import qualified Kernel.Utils.SlidingWindowCounters as SWC
 import Kernel.Utils.SlidingWindowLimiter
 import Kernel.Utils.Validation
 import Kernel.Utils.Version
@@ -359,6 +360,15 @@ authWithOtp isDashboard req' mbBundleVersion mbClientVersion mbClientConfigVersi
       SP.GIMS_EMAIL_PASSWORD -> throwError $ InvalidRequest "GIMS_EMAIL_PASSWORD does not use OTP auth"
       SP.GIMS_EMPLOYEE_ID_PASSWORD -> throwError $ InvalidRequest "GIMS_EMPLOYEE_ID_PASSWORD does not use OTP auth"
 
+  -- Phone-number-based auth rate limit (hashed phone, two configurable sliding windows).
+  whenJust ((.hash) <$> person.mobileNumber) $ \mobileNumberHash -> do
+    transporterConfig <-
+      getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = merchantOpCityId.getId}) (Just (SCTC.findByMerchantOpCityId merchantOpCityId Nothing))
+        >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
+    let phoneNumberHashText = Hex.encodeHex (unDbHash mobileNumberHash)
+    mbResetSeconds <- checkAuthLimitExceededByPhone merchantOpCityId.getId phoneNumberHashText transporterConfig
+    whenJust mbResetSeconds $ \resetSeconds -> throwError (HitsLimitError resetSeconds)
+    updateAuthCountersByPhone merchantOpCityId.getId phoneNumberHashText transporterConfig
   checkSlidingWindowLimit (authHitsCountKey person)
   void $ cachePersonOTPChannel person.id otpChannel
   let entityId = getId $ person.id
@@ -954,3 +964,46 @@ signatureAuth req mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVers
   decPerson <- decrypt person
   let personAPIEntity = SP.makePersonAPIEntity decPerson
   return $ AuthRes token.id token.attempts (Just token.token) (Just personAPIEntity)
+
+-- | Redis key for the phone-number-hashed auth sliding-window counter.
+-- The phone number is passed as a hash (never the raw number) so no PII is stored in Redis.
+-- Keyed by merchant-operating-city id for tenant isolation.
+mkPhoneAuthCounterKey :: Text -> Text -> Text -> Text
+mkPhoneAuthCounterKey mocId windowTag phoneNumberHash = "Driver:PhoneAuthCount:" <> phoneNumberHash <> ":" <> mocId <> ":" <> windowTag
+
+-- | Returns @Just resetSeconds@ (the tripped window's length in seconds) when the phone
+-- number has reached a configured sliding-window auth limit; @Nothing@ otherwise.
+-- A window is enforced only when BOTH its threshold and window options are configured.
+checkAuthLimitExceededByPhone ::
+  (CacheFlow m r, MonadFlow m) =>
+  Text ->
+  Text ->
+  TC.TransporterConfig ->
+  m (Maybe Int)
+checkAuthLimitExceededByPhone mocId phoneNumberHash transporterConfig = Redis.withNonCriticalCrossAppRedis $ do
+  r1 <- windowExceeded "W1" transporterConfig.authPhoneNumberCountWindow1 transporterConfig.authPhoneNumberCountThreshold1
+  case r1 of
+    Just _ -> pure r1
+    Nothing -> windowExceeded "W2" transporterConfig.authPhoneNumberCountWindow2 transporterConfig.authPhoneNumberCountThreshold2
+  where
+    windowExceeded windowTag mbWindow mbThreshold =
+      case (mbWindow, mbThreshold) of
+        (Just window, Just threshold) -> do
+          authCount :: Int <- sum . catMaybes <$> SWC.getCurrentWindowValues (mkPhoneAuthCounterKey mocId windowTag phoneNumberHash) window
+          if authCount >= threshold
+            then do
+              logInfo $ "Phone-number auth rate limit hit for driver auth window " <> windowTag <> " with count " <> show authCount
+              pure $ Just (fromIntegral window.period * fromIntegral (SWC.convertPeriodTypeToSeconds window.periodType) :: Int)
+            else pure Nothing
+        _ -> pure Nothing
+
+-- | Increment both configured phone-number auth sliding windows. No-op for an unconfigured window.
+updateAuthCountersByPhone ::
+  (CacheFlow m r, MonadFlow m) =>
+  Text ->
+  Text ->
+  TC.TransporterConfig ->
+  m ()
+updateAuthCountersByPhone mocId phoneNumberHash transporterConfig = Redis.withNonCriticalCrossAppRedis $ do
+  whenJust transporterConfig.authPhoneNumberCountWindow1 $ SWC.incrementWindowCount (mkPhoneAuthCounterKey mocId "W1" phoneNumberHash)
+  whenJust transporterConfig.authPhoneNumberCountWindow2 $ SWC.incrementWindowCount (mkPhoneAuthCounterKey mocId "W2" phoneNumberHash)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Registration.hs
@@ -989,8 +989,8 @@ checkAuthLimitExceededByPhone mocId phoneNumberHash transporterConfig = Redis.wi
     windowExceeded windowTag mbWindow mbThreshold =
       case (mbWindow, mbThreshold) of
         (Just window, Just threshold) -> do
-          authCount :: Int <- sum . catMaybes <$> SWC.getCurrentWindowValues (mkPhoneAuthCounterKey mocId windowTag phoneNumberHash) window
-          if authCount >= threshold
+          authCount <- SWC.getCurrentWindowCount (mkPhoneAuthCounterKey mocId windowTag phoneNumberHash) window
+          if authCount >= fromIntegral threshold
             then do
               logInfo $ "Phone-number auth rate limit hit for driver auth window " <> windowTag <> " with count " <> show authCount
               pure $ Just (fromIntegral window.period * fromIntegral (SWC.convertPeriodTypeToSeconds window.periodType) :: Int)

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/MerchantConfig.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/MerchantConfig.yaml
@@ -21,6 +21,10 @@ MerchantConfig:
     fraudRideCountWindow : Kernel.Types.SlidingWindowCounters.SlidingWindowOptions
     fraudAuthCountThreshold : Maybe Int
     fraudAuthCountWindow : Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions
+    authPhoneNumberCountThreshold1 : Maybe Int
+    authPhoneNumberCountWindow1 : Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions
+    authPhoneNumberCountThreshold2 : Maybe Int
+    authPhoneNumberCountWindow2 : Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions
     createdAt : Maybe UTCTime
     updatedAt : Maybe UTCTime
     enabled : Bool
@@ -44,6 +48,8 @@ MerchantConfig:
     fraudBookingCancelledByDriverCountWindow: json
     fraudSearchCountWindow: json
     fraudAuthCountWindow: json
+    authPhoneNumberCountWindow1: json
+    authPhoneNumberCountWindow2: json
 
   default:
     fraudBookingCancellationCountWindow: |-

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantConfig.hs
@@ -12,7 +12,11 @@ import qualified Kernel.Types.SlidingWindowCounters
 import qualified Tools.Beam.UtilsTH
 
 data MerchantConfig = MerchantConfig
-  { createdAt :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
+  { authPhoneNumberCountThreshold1 :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    authPhoneNumberCountThreshold2 :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    authPhoneNumberCountWindow1 :: Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions,
+    authPhoneNumberCountWindow2 :: Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions,
+    createdAt :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
     enabled :: Kernel.Prelude.Bool,
     fraudAuthCountThreshold :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
     fraudAuthCountWindow :: Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantConfig.hs
@@ -13,7 +13,11 @@ import qualified Kernel.Types.SlidingWindowCounters
 import Tools.Beam.UtilsTH
 
 data MerchantConfigT f = MerchantConfigT
-  { createdAt :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
+  { authPhoneNumberCountThreshold1 :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int)),
+    authPhoneNumberCountThreshold2 :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int)),
+    authPhoneNumberCountWindow1 :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions)),
+    authPhoneNumberCountWindow2 :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions)),
+    createdAt :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
     enabled :: (B.C f Kernel.Prelude.Bool),
     fraudAuthCountThreshold :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int)),
     fraudAuthCountWindow :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.SlidingWindowCounters.SlidingWindowOptions)),

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/MerchantConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/MerchantConfig.hs
@@ -40,7 +40,11 @@ updateByPrimaryKey :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Typ
 updateByPrimaryKey (Domain.Types.MerchantConfig.MerchantConfig {..}) = do
   _now <- getCurrentTime
   updateWithKV
-    [ Se.Set Beam.enabled enabled,
+    [ Se.Set Beam.authPhoneNumberCountThreshold1 authPhoneNumberCountThreshold1,
+      Se.Set Beam.authPhoneNumberCountThreshold2 authPhoneNumberCountThreshold2,
+      Se.Set Beam.authPhoneNumberCountWindow1 authPhoneNumberCountWindow1,
+      Se.Set Beam.authPhoneNumberCountWindow2 authPhoneNumberCountWindow2,
+      Se.Set Beam.enabled enabled,
       Se.Set Beam.fraudAuthCountThreshold fraudAuthCountThreshold,
       Se.Set Beam.fraudAuthCountWindow fraudAuthCountWindow,
       Se.Set Beam.fraudBookingCancellationCountThreshold fraudBookingCancellationCountThreshold,
@@ -63,7 +67,11 @@ instance FromTType' Beam.MerchantConfig Domain.Types.MerchantConfig.MerchantConf
     pure $
       Just
         Domain.Types.MerchantConfig.MerchantConfig
-          { createdAt = createdAt,
+          { authPhoneNumberCountThreshold1 = authPhoneNumberCountThreshold1,
+            authPhoneNumberCountThreshold2 = authPhoneNumberCountThreshold2,
+            authPhoneNumberCountWindow1 = authPhoneNumberCountWindow1,
+            authPhoneNumberCountWindow2 = authPhoneNumberCountWindow2,
+            createdAt = createdAt,
             enabled = enabled,
             fraudAuthCountThreshold = fraudAuthCountThreshold,
             fraudAuthCountWindow = fraudAuthCountWindow,
@@ -85,7 +93,11 @@ instance FromTType' Beam.MerchantConfig Domain.Types.MerchantConfig.MerchantConf
 instance ToTType' Beam.MerchantConfig Domain.Types.MerchantConfig.MerchantConfig where
   toTType' (Domain.Types.MerchantConfig.MerchantConfig {..}) = do
     Beam.MerchantConfigT
-      { Beam.createdAt = createdAt,
+      { Beam.authPhoneNumberCountThreshold1 = authPhoneNumberCountThreshold1,
+        Beam.authPhoneNumberCountThreshold2 = authPhoneNumberCountThreshold2,
+        Beam.authPhoneNumberCountWindow1 = authPhoneNumberCountWindow1,
+        Beam.authPhoneNumberCountWindow2 = authPhoneNumberCountWindow2,
+        Beam.createdAt = createdAt,
         Beam.enabled = enabled,
         Beam.fraudAuthCountThreshold = fraudAuthCountThreshold,
         Beam.fraudAuthCountWindow = fraudAuthCountWindow,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
@@ -77,7 +77,7 @@ import Email.Types (EmailServiceConfig)
 import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (id)
 import Kernel.Beam.Functions as B
-import Kernel.External.Encryption (decrypt, encrypt, getDbHash)
+import Kernel.External.Encryption (decrypt, encrypt, getDbHash, unDbHash)
 import qualified Kernel.External.Maps as Maps
 import qualified Kernel.External.Types as Language
 import Kernel.External.Whatsapp.Interface.Types as Whatsapp
@@ -94,6 +94,7 @@ import qualified Kernel.Types.Common as BC
 import Kernel.Types.Id
 import Kernel.Types.Predicate
 import Kernel.Types.SlidingWindowLimiter (APIRateLimitOptions)
+import qualified Text.Hex as Hex
 import Kernel.Types.Version
 import Kernel.Utils.App (lookupCloudType)
 import Kernel.Utils.Common
@@ -370,6 +371,12 @@ auth req' mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDe
         whenJust mbMerchantConfigId $ \mcId ->
           SMC.blockCustomerByIP clientIP (Just mcId) riderConfig.blockedUntilInMins
 
+  -- Phone-number-based auth rate limit (hashed phone, two configurable sliding windows).
+  whenJust ((.hash) <$> person.mobileNumber) $ \mobileNumberHash -> do
+    let phoneNumberHashText = Hex.encodeHex (unDbHash mobileNumberHash)
+    mbResetSeconds <- SMC.checkAuthLimitExceededByPhone merchantConfigs phoneNumberHashText
+    whenJust mbResetSeconds $ \resetSeconds -> throwError (HitsLimitError resetSeconds)
+    SMC.updateCustomerAuthCountersByPhone phoneNumberHashText merchantConfigs
   checkSlidingWindowLimit (authHitsCountKey person)
   smsCfg <- asks (.smsCfg)
   let entityId = getId $ person.id

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
@@ -77,7 +77,7 @@ import Email.Types (EmailServiceConfig)
 import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (id)
 import Kernel.Beam.Functions as B
-import Kernel.External.Encryption (decrypt, encrypt, getDbHash, unDbHash)
+import Kernel.External.Encryption (decrypt, encrypt, getDbHash)
 import qualified Kernel.External.Maps as Maps
 import qualified Kernel.External.Types as Language
 import Kernel.External.Whatsapp.Interface.Types as Whatsapp
@@ -94,7 +94,6 @@ import qualified Kernel.Types.Common as BC
 import Kernel.Types.Id
 import Kernel.Types.Predicate
 import Kernel.Types.SlidingWindowLimiter (APIRateLimitOptions)
-import qualified Text.Hex as Hex
 import Kernel.Types.Version
 import Kernel.Utils.App (lookupCloudType)
 import Kernel.Utils.Common
@@ -372,11 +371,15 @@ auth req' mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDe
           SMC.blockCustomerByIP clientIP (Just mcId) riderConfig.blockedUntilInMins
 
   -- Phone-number-based auth rate limit (hashed phone, two configurable sliding windows).
-  whenJust ((.hash) <$> person.mobileNumber) $ \mobileNumberHash -> do
-    let phoneNumberHashText = Hex.encodeHex (unDbHash mobileNumberHash)
-    mbResetSeconds <- SMC.checkAuthLimitExceededByPhone merchantConfigs phoneNumberHashText
-    whenJust mbResetSeconds $ \resetSeconds -> throwError (HitsLimitError resetSeconds)
-    SMC.updateCustomerAuthCountersByPhone phoneNumberHashText merchantConfigs
+  whenJust ((.hash) <$> person.mobileNumber) $ \mobileNumberHash ->
+    -- DbHash's ToJSON instance hex-encodes it, so this yields a stable non-PII Text
+    -- key without a direct Text.Hex dependency (same idiom as the OTP counters below).
+    case A.toJSON mobileNumberHash of
+      A.String phoneNumberHashText -> do
+        mbResetSeconds <- SMC.checkAuthLimitExceededByPhone merchantConfigs phoneNumberHashText
+        whenJust mbResetSeconds $ \resetSeconds -> throwError (HitsLimitError resetSeconds)
+        SMC.updateCustomerAuthCountersByPhone phoneNumberHashText merchantConfigs
+      _ -> pure ()
   checkSlidingWindowLimit (authHitsCountKey person)
   smsCfg <- asks (.smsCfg)
   let entityId = getId $ person.id

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MerchantConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MerchantConfig.hs
@@ -28,6 +28,8 @@ module SharedLogic.MerchantConfig
     blockCustomerByIP,
     updateCustomerAuthCountersByIP,
     isIPBlocked,
+    updateCustomerAuthCountersByPhone,
+    checkAuthLimitExceededByPhone,
   )
 where
 
@@ -236,3 +238,40 @@ isIPBlocked clientIP = Redis.withNonCriticalCrossAppRedis $ do
       let blockKey = "Customer:IPBlocked:" <> clientIP
       blockResult <- Redis.get blockKey
       return $ isJust (blockResult :: Maybe Text)
+
+-- | Redis key for the phone-number-hashed auth sliding-window counter.
+-- The phone number is passed as a hash (never the raw number) so no PII is stored in Redis.
+mkPhoneAuthCounterKey :: Text -> Text -> Text -> Text
+mkPhoneAuthCounterKey ind windowTag phoneNumberHash = "Customer:PhoneAuthCount:" <> phoneNumberHash <> ":" <> ind <> ":" <> windowTag
+
+-- | Increment both configured phone-number auth sliding windows for every merchant config.
+-- No-op for a window that is not configured (Nothing).
+updateCustomerAuthCountersByPhone :: (CacheFlow m r, MonadFlow m) => Text -> [DMC.MerchantConfig] -> m ()
+updateCustomerAuthCountersByPhone phoneNumberHash merchantConfigs = Redis.withNonCriticalCrossAppRedis $
+  forM_ merchantConfigs $ \mc -> do
+    whenJust mc.authPhoneNumberCountWindow1 $ SWC.incrementWindowCount (mkPhoneAuthCounterKey mc.id.getId "W1" phoneNumberHash)
+    whenJust mc.authPhoneNumberCountWindow2 $ SWC.incrementWindowCount (mkPhoneAuthCounterKey mc.id.getId "W2" phoneNumberHash)
+
+-- | Returns @Just resetSeconds@ (the tripped window's length in seconds) when the phone
+-- number has already reached a configured sliding-window auth limit; @Nothing@ otherwise.
+-- A window is enforced only when BOTH its threshold and window options are configured.
+checkAuthLimitExceededByPhone :: (CacheFlow m r, MonadFlow m) => [DMC.MerchantConfig] -> Text -> m (Maybe Int)
+checkAuthLimitExceededByPhone merchantConfigs phoneNumberHash = Redis.withNonCriticalCrossAppRedis $ do
+  results <-
+    forM merchantConfigs $ \mc -> do
+      r1 <- windowExceeded mc.id.getId "W1" mc.authPhoneNumberCountWindow1 mc.authPhoneNumberCountThreshold1
+      case r1 of
+        Just _ -> pure r1
+        Nothing -> windowExceeded mc.id.getId "W2" mc.authPhoneNumberCountWindow2 mc.authPhoneNumberCountThreshold2
+  pure $ listToMaybe (catMaybes results)
+  where
+    windowExceeded ind windowTag mbWindow mbThreshold =
+      case (mbWindow, mbThreshold) of
+        (Just window, Just threshold) -> do
+          authCount :: Int <- sum . catMaybes <$> SWC.getCurrentWindowValues (mkPhoneAuthCounterKey ind windowTag phoneNumberHash) window
+          if authCount >= threshold
+            then do
+              logInfo $ "Phone-number auth rate limit hit for window " <> windowTag <> " with count " <> show authCount
+              pure $ Just (fromIntegral window.period * fromIntegral (SWC.convertPeriodTypeToSeconds window.periodType) :: Int)
+            else pure Nothing
+        _ -> pure Nothing

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MerchantConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MerchantConfig.hs
@@ -268,8 +268,8 @@ checkAuthLimitExceededByPhone merchantConfigs phoneNumberHash = Redis.withNonCri
     windowExceeded ind windowTag mbWindow mbThreshold =
       case (mbWindow, mbThreshold) of
         (Just window, Just threshold) -> do
-          authCount :: Int <- sum . catMaybes <$> SWC.getCurrentWindowValues (mkPhoneAuthCounterKey ind windowTag phoneNumberHash) window
-          if authCount >= threshold
+          authCount <- SWC.getCurrentWindowCount (mkPhoneAuthCounterKey ind windowTag phoneNumberHash) window
+          if authCount >= fromIntegral threshold
             then do
               logInfo $ "Phone-number auth rate limit hit for window " <> windowTag <> " with count " <> show authCount
               pure $ Just (fromIntegral window.period * fromIntegral (SWC.convertPeriodTypeToSeconds window.periodType) :: Int)

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/transporter_config.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/transporter_config.sql
@@ -983,3 +983,9 @@ ALTER TABLE atlas_driver_offer_bpp.transporter_config ADD COLUMN enable_document
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.transporter_config ADD COLUMN enable_pull_pending_doc_verification boolean ;
+
+-- phone-number auth sliding-window rate limit (two independent windows) --
+ALTER TABLE atlas_driver_offer_bpp.transporter_config ADD COLUMN auth_phone_number_count_threshold1 integer;
+ALTER TABLE atlas_driver_offer_bpp.transporter_config ADD COLUMN auth_phone_number_count_window1 json;
+ALTER TABLE atlas_driver_offer_bpp.transporter_config ADD COLUMN auth_phone_number_count_threshold2 integer;
+ALTER TABLE atlas_driver_offer_bpp.transporter_config ADD COLUMN auth_phone_number_count_window2 json;

--- a/Backend/dev/migrations-read-only/rider-app/merchant_config.sql
+++ b/Backend/dev/migrations-read-only/rider-app/merchant_config.sql
@@ -22,3 +22,9 @@ ALTER TABLE atlas_app.merchant_config ADD PRIMARY KEY ( id);
 
 ALTER TABLE atlas_app.merchant_config ADD COLUMN fraud_auth_count_window json  default '{"period":20, "periodType":"Minutes"}';
 ALTER TABLE atlas_app.merchant_config ADD COLUMN fraud_auth_count_threshold integer  default 8;
+
+-- phone-number auth sliding-window rate limit (two independent windows) --
+ALTER TABLE atlas_app.merchant_config ADD COLUMN auth_phone_number_count_threshold1 integer;
+ALTER TABLE atlas_app.merchant_config ADD COLUMN auth_phone_number_count_window1 json;
+ALTER TABLE atlas_app.merchant_config ADD COLUMN auth_phone_number_count_threshold2 integer;
+ALTER TABLE atlas_app.merchant_config ADD COLUMN auth_phone_number_count_window2 json;


### PR DESCRIPTION
---
## Phone-number-based auth rate limit (two sliding windows) — rider & driver

Adds a sliding-window rate limit on the OTP/auth API keyed by a **hashed phone number**, modelled on the existing IP-based auth rate limit. A given phone number cannot call auth more than a configured number of times within a configured window. Two independent windows (W1, W2) are supported, each with its own threshold + `SlidingWindowOptions`, backed by two separate sliding-window counters.

### Config (same tables as the IP-based limit)
Four new **optional** fields added to each config (all `Maybe`, so the feature is off unless configured):
- Rider — `MerchantConfig`: `authPhoneNumberCountThreshold1` / `authPhoneNumberCountWindow1` / `authPhoneNumberCountThreshold2` / `authPhoneNumberCountWindow2`
- Driver — `TransporterConfig`: same four fields.

### Redis keys
- Rider: `Customer:PhoneAuthCount:<phoneHash>:<merchantConfigId>:<W1|W2>`
- Driver: `Driver:PhoneAuthCount:<phoneHash>:<merchantOperatingCityId>:<W1|W2>`

`<phoneHash>` is the hex encoding of the stored `DbHash` of the mobile number — **no raw phone number is ever logged or used in a key** (logs reference only the window tag + count).

### Flow
On auth: check W1 then W2 via `SWC.getCurrentWindowCount`; if either is at/over its threshold, throw `HitsLimitError` (E429) with the window's reset-seconds; otherwise increment both configured windows via `SWC.incrementWindowCount`. Runs before the existing IP-based `checkSlidingWindowLimit`. Driver side applies to the `authWithOtp` path.

### Commits
1. `feat`: phone-number-hash auth rate limit (two sliding windows) for rider & driver auth.
2. `refactor`: use `SWC.getCurrentWindowCount` (returns `m Integer`, reads the quick-access count cache kept in sync by `incrementWindowCount`) instead of `sum . catMaybes <$> getCurrentWindowValues`, in both rider & driver.
3. `fix`: rider-app has no `hex-text` in build-depends, so `import Text.Hex` failed (hidden package). Reuse the rider file's existing `DbHash -> hex Text` idiom (`ToJSON DbHash` → `A.String`, same as the OTP counter keys) and drop the unused `Text.Hex` + `unDbHash` imports. Driver is unaffected (already depends on hex-text via pre-existing usage).

### Before merge
Run NammaDSL `run-generator` for both rider & driver apps to normalise the hand-edited `src-read-only/*` files and the migration SQL, then compile. (Not built in-sandbox — nix build is too heavy there.)

### Files
Driver: `Merchant.yaml`, `Domain/Types/TransporterConfig.hs`, `Storage/Beam/TransporterConfig.hs`, `Storage/Queries/OrphanInstances/TransporterConfig.hs`, `Storage/Queries/TransporterConfig.hs`, `Domain/Action/UI/Registration.hs`.
Rider: `MerchantConfig.yaml`, `Domain/Types/MerchantConfig.hs`, `Storage/Beam/MerchantConfig.hs`, `Storage/Queries/MerchantConfig.hs`, `Domain/Action/UI/Registration.hs`, `SharedLogic/MerchantConfig.hs`.
Migrations: `transporter_config.sql`, `merchant_config.sql`.