### PR TITLE
rider-app/fix: enforce single active EDC machine on update/reactivate

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/AppManagement/EDCMachine.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/AppManagement/EDCMachine.hs
@@ -110,6 +110,13 @@ updateEDCMachine ::
 updateEDCMachine _merchantShortId _opCity mappingId req = do
   mapping <- QEDCMachineMapping.findById mappingId >>= fromMaybeM (InvalidRequest "EDC machine mapping not found")
   now <- getCurrentTime
+  let newTerminalId = fromMaybe mapping.terminalId req.paytmTid
+      isReactivating = req.isActive == Kernel.Prelude.Just True && not mapping.isActive
+  -- Mirror assign: reactivating a mapping must not leave two active mappings
+  -- for the same person or the same terminal.
+  when isReactivating $ do
+    QEDCMachineMappingExtra.deactivateExistingMapping mapping.personId mapping.merchantId mapping.merchantOperatingCityId
+    QEDCMachineMappingExtra.deactivateByTerminalId newTerminalId mapping.merchantId mapping.merchantOperatingCityId
   let updatedMapping =
         mapping
           { DEDCM.machineName = req.machineName <|> mapping.machineName,
@@ -117,7 +124,7 @@ updateEDCMachine _merchantShortId _opCity mappingId req = do
             DEDCM.merchantChannelId = fromMaybe mapping.merchantChannelId req.channelId,
             DEDCM.clientId = fromMaybe mapping.clientId req.clientId,
             DEDCM.merchantKey = fromMaybe mapping.merchantKey req.merchantKey,
-            DEDCM.terminalId = fromMaybe mapping.terminalId req.paytmTid,
+            DEDCM.terminalId = newTerminalId,
             DEDCM.isActive = fromMaybe mapping.isActive req.isActive,
             DEDCM.updatedAt = now
           }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/EDCMachine.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/EDCMachine.hs
@@ -113,6 +113,13 @@ putEdcMachineUpdate (mbRequestorId, _merchantId) mappingId req = do
   _requestorId <- mbRequestorId & fromMaybeM (InvalidRequest "Person not found")
   mapping <- QEDCMachineMapping.findById mappingId >>= fromMaybeM (InvalidRequest "EDC machine mapping not found")
   now <- getCurrentTime
+  let newTerminalId = fromMaybe mapping.terminalId req.paytmTid
+      isReactivating = req.isActive == Kernel.Prelude.Just True && not mapping.isActive
+  -- Mirror assign: reactivating a mapping must not leave two active mappings
+  -- for the same person or the same terminal.
+  when isReactivating $ do
+    QEDCMachineMappingExtra.deactivateExistingMapping mapping.personId mapping.merchantId mapping.merchantOperatingCityId
+    QEDCMachineMappingExtra.deactivateByTerminalId newTerminalId mapping.merchantId mapping.merchantOperatingCityId
   let updatedMapping =
         mapping
           { DEDCM.machineName = req.machineName <|> mapping.machineName,
@@ -120,7 +127,7 @@ putEdcMachineUpdate (mbRequestorId, _merchantId) mappingId req = do
             DEDCM.merchantChannelId = fromMaybe mapping.merchantChannelId req.channelId,
             DEDCM.clientId = fromMaybe mapping.clientId req.clientId,
             DEDCM.merchantKey = fromMaybe mapping.merchantKey req.merchantKey,
-            DEDCM.terminalId = fromMaybe mapping.terminalId req.paytmTid,
+            DEDCM.terminalId = newTerminalId,
             DEDCM.isActive = fromMaybe mapping.isActive req.isActive,
             DEDCM.updatedAt = now
           }


### PR DESCRIPTION
The update handlers set isActive directly without deactivating a person's other active mappings, so reactivating an old machine could leave a person (or a terminal) with more than one active EDC mapping. That breaks the single-active invariant assign relies on and makes the payout lookup (findActiveByPersonIdAndMerchant) pick a machine nondeterministically.

Mirror assign: when an update reactivates a mapping (isActive false->true), first deactivate the person's and the terminal's other active mappings. Applied to both the dashboard (AppManagement) and UI update handlers.


Claude-Session: https://claude.ai/code/session_01YDNkKBuYQA7zHqWd4zBeJf

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved EDC machine reactivation handling.
  - Reactivating a machine now automatically deactivates conflicting active mappings for the same person, merchant, city, or terminal.
  - Prevented duplicate active assignments when changing or reusing terminal IDs.
  - Ensured the selected terminal ID is consistently applied during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->