### PR TITLE
backend/fix/bot-approval-doc-status-fix-for-driver

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/VehicleDocs.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/VehicleDocs.hs
@@ -18,6 +18,7 @@ import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.OperationHubRequests as DOHR
 import qualified Domain.Types.Person as DP
 import Domain.Types.Plan as Plan
+import qualified Domain.Types.ReviewRequest as DRR
 import qualified Domain.Types.TransporterConfig as DTC
 import qualified Domain.Types.VehicleCategory as DVC
 import qualified Domain.Types.VehicleRegistrationCertificate as RC
@@ -46,6 +47,7 @@ import qualified Storage.Queries.HyperVergeVerification as HVQuery
 import qualified Storage.Queries.IdfyVerification as IVQuery
 import qualified Storage.Queries.Image as IQuery
 import qualified Storage.Queries.OperationHubRequestsExtra as QOHRE
+import qualified Storage.Queries.ReviewRequestExtra as QRRE
 import qualified Storage.Queries.Translations as MTQuery
 import qualified Storage.Queries.Vehicle as QVehicle
 import qualified Storage.Queries.VehicleFitnessCertificate as VFCQuery
@@ -930,14 +932,22 @@ getInspectionHubStatusAndReason requestType mbDriverId mbRegistrationNo = do
 mapApprovedToResponseStatus :: Maybe Bool -> ResponseStatus
 mapApprovedToResponseStatus approved = if approved == Just True then VALID else PENDING
 
--- | BotApproval for a driver / fleet-owner (person-keyed): fleet roles read FleetOwnerInformation, else DriverInformation.
+-- | BotApproval status: @approved@ is the source of truth. Driver approval is two-phase — phase 1 sets @approved = True@
+--   with the ReviewRequest still IN_PROGRESS, phase 2 completes it. So for drivers, @approved == True@ + latest BOT_REVIEW
+--   IN_PROGRESS reports PENDING; every other case follows @approved@. Fleet is single-phase, so the flag alone suffices.
 getBotApprovalStatusForPerson :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => DP.Role -> Id DP.Person -> m (Maybe ResponseStatus)
-getBotApprovalStatusForPerson role personId = do
-  approved <-
-    if SDO.isFleetRole role
-      then (>>= (.approved)) <$> QFOI.findByPrimaryKey personId
-      else (>>= (.approved)) <$> QDI.findById (cast personId)
-  pure . Just $ mapApprovedToResponseStatus approved
+getBotApprovalStatusForPerson role personId =
+  if SDO.isFleetRole role
+    then do
+      approved <- (>>= (.approved)) <$> QFOI.findByPrimaryKey personId
+      pure . Just $ mapApprovedToResponseStatus approved
+    else do
+      approved <- (>>= (.approved)) <$> QDI.findById (cast personId)
+      case mapApprovedToResponseStatus approved of
+        VALID -> do
+          mbReview <- QRRE.findLatestByEntityAndType personId.getId DRR.DRIVER DRR.BOT_REVIEW Nothing
+          pure . Just $ if ((.requestStatus) <$> mbReview) == Just DRR.IN_PROGRESS then PENDING else VALID
+        other -> pure $ Just other
 
 -- | BotApproval for a vehicle (RC-keyed): the RC's own `approved` flag.
 getBotApprovalStatusForVehicle :: Maybe Bool -> ResponseStatus


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Driver approval statuses now reflect active bot reviews.
  * Drivers with an in-progress bot review are shown as **Pending** instead of **Valid**.
  * Fleet approval status behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->