### PR TITLE
backend/fix: stripe webhook content type

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API.hs
@@ -40,6 +40,7 @@ import qualified Kernel.External.Payout.Stripe.Webhook as Stripe
 import qualified Kernel.External.Verification.Interface.Idfy as Idfy
 import Kernel.Types.Beckn.Context as Context
 import Kernel.Types.Id
+import Kernel.Types.Servant (RawByteString (..))
 import Kernel.Utils.Common
 import Kernel.Utils.Servant.BasicAuth ()
 import Kernel.Utils.Servant.HTML
@@ -263,7 +264,7 @@ stripePayoutWebhookHandler ::
   Maybe Context.City ->
   Maybe Plan.ServiceNames ->
   Maybe Text ->
-  Stripe.RawByteString ->
+  RawByteString ->
   FlowHandler AckResponse
 stripePayoutWebhookHandler merchantShortId mbOpCity mbServiceName mbSigHeader =
   withFlowHandlerAPI . Payout.stripePayoutWebhookHandler merchantShortId mbOpCity mbServiceName mbSigHeader
@@ -273,7 +274,7 @@ stripeTestPayoutWebhookHandler ::
   Maybe Context.City ->
   Maybe Plan.ServiceNames ->
   Maybe Text ->
-  Stripe.RawByteString ->
+  RawByteString ->
   FlowHandler AckResponse
 stripeTestPayoutWebhookHandler merchantShortId mbOpCity mbServiceName mbSigHeader =
   withFlowHandlerAPI . Payout.stripeTestPayoutWebhookHandler merchantShortId mbOpCity mbServiceName mbSigHeader

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payout.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payout.hs
@@ -45,7 +45,6 @@ import Kernel.Beam.Functions as B (runInReplica)
 import Kernel.External.Encryption (decrypt)
 import qualified Kernel.External.Notification.FCM.Types as FCM
 import qualified Kernel.External.Payment.Stripe.Types.Common as PaymentStripe
-import Kernel.External.Payment.Stripe.Webhook (RawByteString (..))
 import qualified Kernel.External.Payout.Interface as Juspay
 import qualified Kernel.External.Payout.Interface.Events.Types as PayoutEvents
 import qualified Kernel.External.Payout.Interface.Juspay as Juspay
@@ -59,6 +58,7 @@ import Kernel.Streaming.Kafka.Producer.Types (HasKafkaProducer)
 import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Types.Common hiding (id)
 import Kernel.Types.Id
+import Kernel.Types.Servant (RawByteString (..))
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import qualified Lib.Finance.Core.Types as Finance

--- a/Backend/app/rider-platform/rider-app/Main/src/API.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API.hs
@@ -41,6 +41,7 @@ import qualified Kernel.External.Payment.Stripe.Webhook as Stripe
 import qualified Kernel.External.Payout.Juspay.Webhook as JuspayPayout
 import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Types.Id
+import Kernel.Types.Servant (RawByteString (..))
 import Kernel.Utils.Common
 import Kernel.Utils.Servant.BasicAuth ()
 import Kernel.Utils.Servant.HTML
@@ -163,7 +164,7 @@ stripeWebhookHandler ::
   Maybe TPayment.PaymentServiceType ->
   Maybe Text ->
   Maybe Text ->
-  Stripe.RawByteString ->
+  RawByteString ->
   FlowHandler AckResponse
 stripeWebhookHandler merchantShortId mbCity mbServiceType mbPlaceId mbSigHeader =
   withFlowHandlerAPI . ActorInfo.withRequestIdActorInfo . Payment.stripeWebhookHandler merchantShortId mbCity mbServiceType mbPlaceId mbSigHeader
@@ -174,7 +175,7 @@ stripeTestWebhookHandler ::
   Maybe TPayment.PaymentServiceType ->
   Maybe Text ->
   Maybe Text ->
-  Stripe.RawByteString ->
+  RawByteString ->
   FlowHandler AckResponse
 stripeTestWebhookHandler merchantShortId mbCity mbServiceType mbPlaceId mbSigHeader =
   withFlowHandlerAPI . ActorInfo.withRequestIdActorInfo . Payment.stripeTestWebhookHandler merchantShortId mbCity mbServiceType mbPlaceId mbSigHeader

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
@@ -72,7 +72,6 @@ import qualified Kernel.External.Payment.Interface.Juspay as Juspay
 import qualified Kernel.External.Payment.Interface.Stripe as Stripe
 import qualified Kernel.External.Payment.Interface.Types as Payment
 import qualified Kernel.External.Payment.Stripe.Types.Common as Stripe
-import Kernel.External.Payment.Stripe.Webhook (RawByteString (..))
 import qualified Kernel.External.Payment.Types as Payment
 import qualified Kernel.External.Wallet as Wallet
 import Kernel.Prelude hiding (head)
@@ -82,6 +81,7 @@ import Kernel.Streaming.Kafka.Producer.Types (HasKafkaProducer)
 import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Types.Common hiding (id)
 import Kernel.Types.Id
+import Kernel.Types.Servant (RawByteString (..))
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import qualified Lib.JourneyModule.Utils as JMU

--- a/Backend/dev/rest-client/dynamic-offer-driver-app/payout.http
+++ b/Backend/dev/rest-client/dynamic-offer-driver-app/payout.http
@@ -1,0 +1,25 @@
+@driver-offer-bpp-host = http://localhost:8016
+
+@merchantShortId = BRIDGE_FINLAND_PARTNER
+@city = Helsinki
+@serviceName = %22PREPAID_SUBSCRIPTION%22
+
+###
+
+# @name stripePayoutWebhook
+# Stripe Connect payout webhook (payout.paid).
+# PREPAID_SUBSCRIPTION + Helsinki -> RidePayout_Stripe config.
+# serviceName is parsed as JSON (mkHttpInstancesForEnum), so use quoted value: "PREPAID_SUBSCRIPTION"
+# Success: {"message":{"ack":{"status":"ACK"}}}
+#
+# Stripe-Signature: set webhookEndpointSecret in RidePayout_Stripe config_json,
+# then sign the raw body (must stay single-line):
+#   TS=$(date +%s)
+#   BODY='{"id":"evt_test_payout_paid_001",...}'  # exact body below
+#   SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$WHSEC" | awk '{print $2}')
+#
+POST {{driver-offer-bpp-host}}/{{merchantShortId}}/service/stripe/payout?city={{city}}&serviceName={{serviceName}}
+Stripe-Signature: t=1,v1=0000000000000000000000000000000000000000000000000000000000000000
+Content-Type: application/json
+
+{"id":"evt_test_payout_paid_001","object":"event","api_version":"2024-04-10","created":1752662400,"data":{"object":{"object":"payout","id":"po_test_001","amount":1000,"currency":"eur","status":"paid","type":"card","method":"standard","created":1752662400,"metadata":{"order_id":"test-payout-order-001"}}},"livemode":false,"pending_webhooks":1,"request":{"id":null,"idempotency_key":null},"type":"payout.paid"}

--- a/flake.lock
+++ b/flake.lock
@@ -4004,11 +4004,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1784199474,
-        "narHash": "sha256-VWmATRq5WxcIMUiuByJPzdP6nVUmPycfI4zHPSWR3EQ=",
+        "lastModified": 1784204115,
+        "narHash": "sha256-2G+A8crISvgaahzNG7dLM2MPbBpOnTUiAfdxoU0e8gc=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "941c5502232c33b29f65d64e574679e821bef912",
+        "rev": "1b20e76138a129597a0f50d19c8f9bd207cf7196",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?

<img width="1315" height="434" alt="Screenshot from 2026-07-16 14-22-25" src="https://github.com/user-attachments/assets/09039bbc-56d1-4d66-a539-3f200d4866a7" />

There is E500 because of local data lack, but content type is correct

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a ready-to-use HTTP request script for testing Stripe payout webhooks, including example query parameters, a sample `payout.paid` payload, and the expected `Stripe-Signature` header format.

* **Bug Fixes**
  * Improved consistency in webhook payload handling across the driver and rider backends by aligning the webhook handler payload type used for Stripe payout/payment events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->