### PR TITLE
fix: structural GTFS extraction (type-agnostic routes, descriptor.cod…

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnSearch.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnSearch.hs
@@ -773,34 +773,44 @@ gtfsPageInfo req =
           maxPage = (tags >>= SpecUtils.getTag "PAGINATION" "MAX_PAGE_NUMBER") >>= (readMaybe . T.unpack) :: Maybe Int
        in (curPage, maxPage)
 
+gtfsFulfillments :: SpecT.OnSearchReq -> [SpecT.Fulfillment]
+gtfsFulfillments req =
+  let providers = fromMaybe [] (req.onSearchReqMessage >>= (\m -> m.onSearchReqMessageCatalog.catalogProviders))
+   in providers >>= (fromMaybe [] . (.providerFulfillments))
+
 extractGtfsPage :: SpecT.OnSearchReq -> ([API.FRFSGtfsStopAPI], [API.FRFSGtfsRouteAPI], [API.FRFSGtfsRouteStopAPI], [API.FRFSGtfsFareAPI])
 extractGtfsPage req =
   let providers = fromMaybe [] (req.onSearchReqMessage >>= (\m -> m.onSearchReqMessageCatalog.catalogProviders))
-      fulfillments = providers >>= (fromMaybe [] . (.providerFulfillments))
-      stopRows = mapMaybe toStop (fulfillments >>= (fromMaybe [] . (.fulfillmentStops)))
-      routeRows = mapMaybe toRoute fulfillments
-      routeStopRows = concatMap toRouteStops fulfillments
+      routeFulfillments = filter isRouteFulfillment (gtfsFulfillments req)
+      stopRows = mapMaybe toStop (routeFulfillments >>= (fromMaybe [] . (.fulfillmentStops)))
+      routeRows = mapMaybe toRoute routeFulfillments
+      routeStopRows = concatMap toRouteStops routeFulfillments
       fareRows = concatMap toFares providers
    in (stopRows, routeRows, routeStopRows, fareRows)
   where
+    -- A transit route is structurally a fulfillment carrying an ordered list of stops.
+    -- Keying off this rather than network-specific type/tag strings keeps it network-agnostic.
+    isRouteFulfillment f = length (fromMaybe [] f.fulfillmentStops) >= 2
+    stopCodeOf s =
+      case s.stopLocation >>= (.locationDescriptor) >>= (.descriptorCode) of
+        Just c -> Just c
+        Nothing -> s.stopId
+    routeCodeOf f =
+      case SpecUtils.getTag "ROUTE_INFO" "ROUTE_ID" (fromMaybe [] f.fulfillmentTags) of
+        Just rid -> Just $ T.strip rid <> maybe "" ("_" <>) (SpecUtils.getTag "ROUTE_INFO" "ROUTE_DIRECTION" (fromMaybe [] f.fulfillmentTags))
+        Nothing -> f.fulfillmentId
     toStop s = do
-      code <- s.stopId
+      code <- stopCodeOf s
       loc <- s.stopLocation
-      let desc = loc.locationDescriptor
-          (lat, lon) = parseGtfsGps loc.locationGps
-      pure API.FRFSGtfsStopAPI {code = code, name = desc >>= (.descriptorName), lat = lat, lon = lon}
-    routeCodeOf f = do
-      let tags = fromMaybe [] f.fulfillmentTags
-      rid <- SpecUtils.getTag "ROUTE_INFO" "ROUTE_ID" tags
-      pure $ T.strip rid <> maybe "" ("_" <>) (SpecUtils.getTag "ROUTE_INFO" "ROUTE_DIRECTION" tags)
+      let (lat, lon) = parseGtfsGps loc.locationGps
+      pure API.FRFSGtfsStopAPI {code = code, name = loc.locationDescriptor >>= (.descriptorName), lat = lat, lon = lon}
     toRoute f = do
-      let tags = fromMaybe [] f.fulfillmentTags
-      rid <- SpecUtils.getTag "ROUTE_INFO" "ROUTE_ID" tags
       code <- routeCodeOf f
+      let shortName = maybe code T.strip (SpecUtils.getTag "ROUTE_INFO" "ROUTE_ID" (fromMaybe [] f.fulfillmentTags))
       pure
         API.FRFSGtfsRouteAPI
           { code = code,
-            shortName = T.strip rid,
+            shortName = shortName,
             vehicleType = f.fulfillmentVehicle >>= (.vehicleCategory),
             variant = f.fulfillmentVehicle >>= (.vehicleVariant)
           }
@@ -810,7 +820,7 @@ extractGtfsPage req =
         Just code ->
           mapMaybe
             ( \(sq, s) -> do
-                stopCode <- s.stopId
+                stopCode <- stopCodeOf s
                 pure API.FRFSGtfsRouteStopAPI {routeCode = code, stopCode = stopCode, sequenceNum = sq, stopType = s.stopType}
             )
             (zip [1 ..] (fromMaybe [] f.fulfillmentStops))
@@ -835,6 +845,9 @@ storeDiscoveryGtfs ibcId req = do
       key = SFU.frfsGtfsCacheKey ibcId
       pagesKey = SFU.frfsGtfsPagesKey ibcId
       (mbCurPage, mbMaxPage) = gtfsPageInfo req
+      fulfillments = gtfsFulfillments req
+  when (not (null fulfillments) && null routes) $
+    logWarning $ "GTFS extract yielded 0 routes from " <> show (length fulfillments) <> " fulfillments for ibc " <> ibcId <> "; fulfillmentTypes=" <> show (mapMaybe (.fulfillmentType) fulfillments) <> ", stopCounts=" <> show (map (length . fromMaybe [] . (.fulfillmentStops)) fulfillments)
   Hedis.withWaitAndLockRedis (key <> ":merge") gtfsMergeLockTtlSec gtfsMergeLockRetryMs $ do
     mbExisting <- Hedis.safeGet key
     seenPages <- fromMaybe [] <$> Hedis.safeGet pagesKey


### PR DESCRIPTION
…e stops, completeness gate)

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transit stop identification by preferring the descriptor code and falling back to the stop ID when needed.
  * Enhanced GTFS extraction from search responses, including more reliable stop/route mapping.
  * Added a warning when search results include fulfillment data but no routes can be extracted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->