### PR TITLE
Backend: Ehnc - Added Driver block lift time in driver info handler

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/RideBooking/API/Driver.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/RideBooking/API/Driver.yaml
@@ -297,6 +297,7 @@ types:
     - enabled: Bool
     - blocked: Bool
     - blockedReason: Maybe Text
+    - blockLiftTime: Maybe UTCTime
     - verified: Bool
     - subscribed: Bool
     - canDowngradeToSedan: Bool

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/Dashboard/RideBooking/Endpoints/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/Dashboard/RideBooking/Endpoints/Driver.hs
@@ -92,6 +92,7 @@ data DriverInfoRes = DriverInfoRes
     enabled :: Kernel.Prelude.Bool,
     blocked :: Kernel.Prelude.Bool,
     blockedReason :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    blockLiftTime :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
     verified :: Kernel.Prelude.Bool,
     subscribed :: Kernel.Prelude.Bool,
     canDowngradeToSedan :: Kernel.Prelude.Bool,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/RideBooking/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/RideBooking/Driver.hs
@@ -536,6 +536,7 @@ buildDriverInfoRes QPerson.DriverWithRidesCount {..} mbDriverLicense rcAssociati
         enabled = info.enabled,
         blocked = info.blocked,
         blockedReason = info.blockedReason,
+        blockLiftTime = info.blockExpiryTime,
         verified = info.verified,
         subscribed = info.subscribed,
         onboardingDate = info.lastEnabledOn,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Driver information responses now include an optional `blockLiftTime`, representing the expected time a driver block will be lifted (when available).
  * This new field is exposed consistently through the driver-info API and its corresponding response schema/type definitions, alongside existing block-related timing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->