### PR TITLE
rider-app/feat: per-vehicle Moengage ride events and user onboarded event

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
@@ -938,19 +938,25 @@ rideCompletedReqHandler ValidatedRideCompletedReq {..} = do
           Just distance -> updRide.chargeableDistance >= Just distance && not person.hasTakenValidRide
           Nothing -> True
   riderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = booking.merchantOperatingCityId.getId}) (Just (CQRC.findByMerchantOperatingCityId booking.merchantOperatingCityId)) >>= fromMaybeM (RiderConfigNotFound booking.merchantOperatingCityId.getId)
+  let vehicleCat = Utils.mapServiceTierToCategory booking.vehicleServiceTierType
   fork "update first ride info" $ do
-    mbPersonFirstRideInfo <- QCP.findByPersonIdAndVehicleCategory booking.riderId $ Just (Utils.mapServiceTierToCategory booking.vehicleServiceTierType)
-    case mbPersonFirstRideInfo of
+    mbPersonFirstRideInfo <- QCP.findByPersonIdAndVehicleCategory booking.riderId $ Just vehicleCat
+    -- Per-category count incl. this ride; reuses the cached count (O(N) query only on cache miss).
+    catRideCount <- case mbPersonFirstRideInfo of
       Just personFirstRideInfo -> do
-        QCP.updateHasTakenValidRideCount (personFirstRideInfo.rideCount + 1) booking.riderId $ Just (Utils.mapServiceTierToCategory booking.vehicleServiceTierType)
+        let newCount = personFirstRideInfo.rideCount + 1
+        QCP.updateHasTakenValidRideCount newCount booking.riderId $ Just vehicleCat
+        pure newCount
       Nothing -> do
-        totalCount <- B.runInReplica $ QRB.findCountByRideIdStatusAndVehicleServiceTierType booking.riderId BT.COMPLETED (Utils.getListOfServiceTireTypes $ Utils.mapServiceTierToCategory booking.vehicleServiceTierType)
-        personClientInfo <- buildPersonClientInfo booking.riderId booking.clientId booking.merchantOperatingCityId booking.merchantId (Utils.mapServiceTierToCategory booking.vehicleServiceTierType) (totalCount + 1)
+        totalCount <- B.runInReplica $ QRB.findCountByRideIdStatusAndVehicleServiceTierType booking.riderId BT.COMPLETED (Utils.getListOfServiceTireTypes vehicleCat)
+        personClientInfo <- buildPersonClientInfo booking.riderId booking.clientId booking.merchantOperatingCityId booking.merchantId vehicleCat (totalCount + 1)
         QCP.create personClientInfo
         when (totalCount == 0) $ do
-          Notify.notifyFirstRideEvent booking.riderId (Utils.mapServiceTierToCategory booking.vehicleServiceTierType) booking.tripCategory
+          Notify.notifyFirstRideEvent booking.riderId vehicleCat booking.tripCategory
           fork ("processing referral payouts for ride: " <> ride.id.getId) $ do
             customerReferralPayout ride totalFare.currency isValidRide riderConfig person booking.merchantId booking.merchantOperatingCityId
+        pure (totalCount + 1)
+    ET.trackVehicleRideCompletedEvents booking.merchantId booking.merchantOperatingCityId booking.riderId vehicleCat catRideCount totalFare.amount
 
   when (not person.hasTakenValidRide && fromMaybe 0 person.totalRidesCount == 0) $
     fork "event_tracking: first_ride_completed" $
@@ -1088,7 +1094,7 @@ rideCompletedReqHandler ValidatedRideCompletedReq {..} = do
   triggerBookingCompletedEvent BookingEventData {booking = booking{status = DRB.COMPLETED}}
   whenJust person.totalRidesCount $ \rideCount ->
     fork "event_tracking: ride_completed" $
-      ET.trackEvent booking.merchantId booking.merchantOperatingCityId (ET.RideCompleted (getId booking.riderId) (rideCount + 1))
+      ET.trackEvent booking.merchantId booking.merchantOperatingCityId (ET.RideCompleted (getId booking.riderId) (rideCount + 1) totalFare.amount)
   when shouldUpdateRideComplete $ void $ QP.updateHasTakenValidRide booking.riderId
   otherParties <- Notify.getAllOtherRelatedPartyPersons booking
   unless (booking.status == DRB.COMPLETED) $

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
@@ -131,6 +131,7 @@ import qualified Storage.Queries.PersonStats as QPS
 import qualified Storage.Queries.RegistrationToken as RegistrationToken
 import Tools.Auth (authTokenCacheKey, decryptAES128)
 import Tools.Error
+import qualified Tools.EventTracking as ET
 import qualified Tools.MultiModal as MM
 import qualified Tools.Notifications as Notify
 import Tools.SignatureResponseBody (SignatureResponseConfig (..), SignedResponse, wrapWithSignature)
@@ -1044,6 +1045,8 @@ createPerson req identifierType notificationToken mbBundleVersion mbClientVersio
   Person.create person
   QPS.create createPersonStats
   addNammaTags person (Y.LoginTagData {id = person.id, gender = req.gender, clientSdkVersion = mbClientVersion, clientBundleVersion = mbBundleVersion, clientReactNativeVersion = mbRnVersion, clientConfigVersion = mbClientConfigVersion, clientDevice = mbDevice})
+  fork "event_tracking: user_onboarded" $
+    ET.trackEvent merchant.id merchantOperatingCityId (ET.UserOnboarded person.id.getId (show identifierType) (show currentCity))
   fork "update emergency contact id" $
     whenJust req.mobileNumber $ \mobileNumber -> updatePersonIdForEmergencyContacts person.id mobileNumber merchant.id
   pure person

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/EventTracking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/EventTracking.hs
@@ -3,13 +3,16 @@
 module Tools.EventTracking
   ( TrackingEvent (..),
     trackEvent,
+    trackVehicleRideCompletedEvents,
   )
 where
 
+import qualified BecknV2.OnDemand.Enums as BecknEnums
 import Data.Aeson (object, (.=))
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.MerchantServiceConfig as DMSC
+import qualified Domain.Types.Person as DP
 import qualified Kernel.External.EventTracking as EventTracking
 import Kernel.Prelude
 import Kernel.Types.Id
@@ -22,10 +25,14 @@ import Storage.ConfigPilot.Config.MerchantServiceUsageConfig (MerchantServiceUsa
 
 data TrackingEvent
   = FirstRideCompleted Text
-  | RideCompleted Text Int
+  | RideCompleted Text Int HighPrecMoney -- riderId, overallRideCount, fare
   | DriverAssigned Text
   | UserSearched Text Double Double (Maybe Double) (Maybe Double)
   | UserRequestedQuotes Text Int
+  | UserOnboarded Text Text Text -- riderId, signupMethod, city
+  | VehicleRideCompleted Text Text Int HighPrecMoney -- riderId, categorySlug (cab|auto|bike), catRideCount, fare
+  | VehicleFirstRideCompleted Text Text HighPrecMoney -- riderId, categorySlug, fare
+  | VehicleFifthRideCompleted Text Text HighPrecMoney -- riderId, categorySlug, fare
 
 trackEvent ::
   (EncFlow m r, EsqDBFlow m r, CacheFlow m r) =>
@@ -87,8 +94,8 @@ eventToAction :: TrackingEvent -> (Text, Text, Value)
 eventToAction = \case
   FirstRideCompleted riderId ->
     (riderId, "ny_user_first_ride_completed", object [])
-  RideCompleted riderId rideCount ->
-    (riderId, "ny_rider_ride_completed", object ["ride_count" .= rideCount])
+  RideCompleted riderId rideCount fare ->
+    (riderId, "ny_rider_ride_completed", object ["ride_count" .= rideCount, "fare" .= fare])
   DriverAssigned riderId ->
     (riderId, "driver_assigned", object [])
   UserSearched riderId fromLat fromLon toLat toLon ->
@@ -101,3 +108,39 @@ eventToAction = \case
     )
   UserRequestedQuotes riderId quoteCount ->
     (riderId, "ny_user_request_quotes", object ["quote_count" .= quoteCount])
+  UserOnboarded riderId signupMethod city ->
+    (riderId, "ny_user_onboarded", object ["signup_method" .= signupMethod, "city" .= city])
+  VehicleRideCompleted riderId slug catRideCount fare ->
+    (riderId, "ny_" <> slug <> "_ride_completed", object ["ride_count" .= catRideCount, "fare" .= fare])
+  VehicleFirstRideCompleted riderId slug fare ->
+    (riderId, "ny_" <> slug <> "_first_ride_completed", object ["fare" .= fare])
+  VehicleFifthRideCompleted riderId slug fare ->
+    (riderId, "ny_" <> slug <> "_user_5_ride_completed", object ["fare" .= fare])
+
+-- | Per-vehicle ride-completion events (+ first/fifth milestones). No-op for
+-- unsupported categories. Does not fork; call it from within a fork.
+trackVehicleRideCompletedEvents ::
+  (EncFlow m r, EsqDBFlow m r, CacheFlow m r) =>
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
+  Id DP.Person ->
+  BecknEnums.VehicleCategory ->
+  Int ->
+  HighPrecMoney ->
+  m ()
+trackVehicleRideCompletedEvents merchantId merchantOperatingCityId riderId vehicleCat catRideCount fare =
+  forM_ (vehicleCategorySlug vehicleCat) $ \vehicleSlug -> do
+    let eventRiderId = getId riderId
+    trackEvent merchantId merchantOperatingCityId (VehicleRideCompleted eventRiderId vehicleSlug catRideCount fare)
+    when (catRideCount == 1) $
+      trackEvent merchantId merchantOperatingCityId (VehicleFirstRideCompleted eventRiderId vehicleSlug fare)
+    when (catRideCount == 5) $
+      trackEvent merchantId merchantOperatingCityId (VehicleFifthRideCompleted eventRiderId vehicleSlug fare)
+
+-- | Slug for segmented categories; 'Nothing' for the rest (generic event only).
+vehicleCategorySlug :: BecknEnums.VehicleCategory -> Maybe Text
+vehicleCategorySlug = \case
+  BecknEnums.CAB -> Just "cab"
+  BecknEnums.AUTO_RICKSHAW -> Just "auto"
+  BecknEnums.MOTORCYCLE -> Just "bike"
+  _ -> Nothing


### PR DESCRIPTION
## What

Per-vehicle-category Moengage events on ride completion in rider-app, so Moengage can segment on **cab / auto / bike**, including per-category first-ride and 5th-ride milestones. Also fires `ny_user_onboarded` on new customer signup.

## Events

| Category | ride completed | 1st ride | 5th ride |
|---|---|---|---|
| cab | `ny_cab_ride_completed` | `ny_cab_first_ride_completed` | `ny_cab_user_5_ride_completed` |
| auto | `ny_auto_ride_completed` | `ny_auto_first_ride_completed` | `ny_auto_user_5_ride_completed` |
| bike | `ny_bike_ride_completed` | `ny_bike_first_ride_completed` | `ny_bike_user_5_ride_completed` |

`*_ride_completed` carries `{ ride_count, fare }`; milestone events carry `{ fare }`. Categories outside cab/auto/bike fire only the existing generic event. `ny_rider_ride_completed` now also carries `fare`.

## How

- `Tools/EventTracking.hs` — new `TrackingEvent` constructors for the per-vehicle and onboarding events; `fare` added to `RideCompleted`.
- `Domain/Action/Beckn/Common.hs` — per-category count reuses the cached `PersonClientProfile` count inside the existing `update first ride info` fork, so no extra query per ride.
- `Domain/Action/UI/Registration.hs` — `ny_user_onboarded` on person creation.

All events are fire-and-forget via `fork`, so a Moengage failure never affects ride completion. No schema change, no migration, no new Beckn tags.

## Testing

`cabal build rider-app` compiles clean. Manual: complete a ride per category and confirm the matching events fire with the expected `ride_count` / `fare`, plus the milestone events on rides 1 and 5 of that category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ride-completion milestones by vehicle category, including first-ride and fifth-ride tracking.
  * Enhanced ride-completion activity events to include fare details.
  * Added an additional onboarding analytics event during user registration.
* **Bug Fixes**
  * Improved first-ride handling and referral reward triggering by tracking completed rides per vehicle category.
  * Ride-completion milestone counts are now computed and tracked more accurately across supported vehicle categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
