### PR TITLE
backend/fix: base FRFS booking startTime on actual trip schedule

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
@@ -313,6 +313,21 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
       let mbRouteName = mbFirstRouteStation <&> (.longName)
       let mbServiceTierType = mbFirstRouteStation >>= (.vehicleServiceTier) <&> (._type)
 
+      -- Derive the real scheduled departure time for the trip so time-tiered logic
+      -- (e.g. cancellation charges in ExternalBPP/Flow/Common.hs) is measured against the
+      -- actual bus departure rather than the booking creation time. Bus-only: metro/subway
+      -- have no waybill schedule and leave firstTripId Nothing, so they fall back to `now`.
+      bookingStartTime <-
+        case (firstTripId, mbRouteCode) of
+          (Just tripId, Just routeCode) -> do
+            mbScheduledStartTime <- getScheduledTripStartTime tripId routeCode quote'.fromStationCode integratedBppConfig
+            case mbScheduledStartTime of
+              Just scheduledStartTime -> pure scheduledStartTime
+              Nothing -> do
+                logWarning $ "buildAndCreateBooking: no scheduled departure resolved for tripId=" <> tripId <> ", falling back to booking time for startTime"
+                pure now
+          _ -> pure now
+
       let booking =
             DFRFSTicketBooking.FRFSTicketBooking
               { id = uuid,
@@ -337,7 +352,7 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
                 cashbackStatus = if isJust quote.discountedTickets then Just DFTB.PENDING else Nothing,
                 bppDelayedInterest = quote.bppDelayedInterest,
                 journeyOnInitDone = Nothing,
-                startTime = Just now, -- TODO
+                startTime = Just bookingStartTime,
                 isFareChanged = Just isFareChanged,
                 integratedBppConfigId = quote.integratedBppConfigId,
                 googleWalletJWTUrl = Nothing,
@@ -420,6 +435,38 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
                 bufferTime + max 0 timeUntilTripSec
           logInfo $ "Dynamic TTL calculated: tripStart=" <> show tripStartTime <> " ttl=" <> show finalTtl
           pure finalTtl
+
+    -- Resolve the scheduled departure time for a bus trip from the live waybill schedule.
+    -- Prefers the rider's boarding stop (matched on stop code); falls back to the trip's
+    -- earliest stop when the boarding stop is not present. Returns Nothing when the schedule
+    -- is unavailable or empty so callers can fall back safely.
+    getScheduledTripStartTime ::
+      ( MonadFlow m,
+        ServiceFlow m r,
+        HasShortDurationRetryCfg r c,
+        HasBAPMetrics m r
+      ) =>
+      Text -> -- tripId (format: waybillNo-tripNumber)
+      Text -> -- routeCode
+      Text -> -- boarding stop code
+      DIBC.IntegratedBPPConfig ->
+      m (Maybe UTCTime)
+    getScheduledTripStartTime tripId routeCode boardingStopCode integratedBPPConfig = do
+      let (waybillNo, tripNo) = JourneyUtils.getWaybillNoAndTripNoFromTripId tripId
+      mbSchedule <- withTryCatch "getScheduledTripStartTime:getBusTripSchedule" (OTPRest.getBusTripSchedule waybillNo tripNo routeCode integratedBPPConfig)
+      case mbSchedule of
+        Left err -> do
+          logWarning $ "getScheduledTripStartTime: failed to fetch bus trip schedule for tripId=" <> tripId <> ": " <> show err
+          pure Nothing
+        Right schedule ->
+          case concatMap (.eta) schedule of
+            [] -> do
+              logWarning $ "getScheduledTripStartTime: empty schedule for tripId=" <> tripId
+              pure Nothing
+            allEtas -> do
+              let mbBoardingEta = listToMaybe (filter (\e -> e.stopCode == boardingStopCode) allEtas)
+                  chosenEta = fromMaybe (minimumBy (comparing (.arrivalTimeUnix)) allEtas) mbBoardingEta
+              pure $ Just (unixToUTC chosenEta.arrivalTimeUnix)
 
 postFrfsQuoteV2ConfirmUtil :: (CallExternalBPP.FRFSConfirmFlow m r c, HasField "blackListedJobs" r [Text], HasField "cloudType" r (Maybe CloudType), HasMasterCloudForwarder r) => (Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant) -> DFRFSQuote.FRFSQuote -> [API.Types.UI.FRFSTicketService.FRFSCategorySelectionReq] -> Maybe CrisSdkResponse -> Maybe Bool -> Maybe Bool -> Maybe Bool -> DIBC.IntegratedBPPConfig -> Maybe Text -> m API.Types.UI.FRFSTicketService.FRFSTicketBookingStatusAPIRes
 postFrfsQuoteV2ConfirmUtil (mbPersonId, merchantId_) quote selectedQuoteCategories crisSdkResponse isSingleMode mbEnableOffer mbIsMockPayment integratedBppConfig mbTripId = do


### PR DESCRIPTION
## Problem

`FRFSTicketBooking.startTime` was hardcoded to `Just now` (booking creation time) in `buildAndCreateBooking`:

```haskell
startTime = Just now, -- TODO
```

This value is the clock that time-tiered logic reads. In particular, `calculateCancellationCharges` (`ExternalBPP/Flow/Common.hs`) computes:

```haskell
departureTime = fromMaybe booking.validTill booking.startTime
minutesBefore = floor (diffUTCTime departureTime now / 60)
```

Because `startTime` was the creation timestamp, any cancellation happens *after* it, so `minutesBefore` is always negative. That negative value lands in the "less than 60 minutes before departure" cancellation tier, so a booking made days ahead of the trip was charged the full-forfeit (100%) tier on cancellation, even when cancelled well in advance.

## Fix

Populate `startTime` with the trip's actual scheduled departure, reusing the existing live-schedule source already used by `calculateDynamicSeatHoldTTL`:

- New helper `getScheduledTripStartTime` fetches the waybill schedule via `OTPRest.getBusTripSchedule`, prefers the rider's boarding stop (matched on `fromStationCode`), and falls back to the trip's earliest stop.
- Bus-only and guarded: metro/subway have no waybill schedule and leave `firstTripId` as `Nothing`, so they fall back to `now` as before.
- Safe fallback: if the schedule is unavailable/empty, it logs a warning and falls back to booking time rather than failing the confirm.

## Impact

Cancellations are now measured against the real bus departure time, so advance cancellations correctly hit the appropriate (e.g. 0%) tier instead of the 100% tier.

## Known limitation

If a trip's waybill is not yet published in the live schedule at booking time (far-future advance bookings), the helper returns `Nothing` and falls back to `now`. A follow-up can add the journey-planner/search-selected departure time as a secondary fallback for that case.

## Testing

Not built locally (nix toolchain unavailable in the authoring environment). Needs `cabal build rider-app` + `treefmt` verification via CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Booking start times now reflect the trip’s scheduled departure time when available.
  * Departure times are chosen based on the rider’s boarding stop, with a fallback to the earliest available departure.
  * When schedule data can’t be retrieved or no matching ETA exists, bookings continue to use the creation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->