### PR TITLE
backend/perf: avoid full-fetch count/max helpers on hot paths

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/LocationMappingExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/LocationMappingExtra.hs
@@ -14,16 +14,28 @@ import Storage.Queries.OrphanInstances.LocationMapping ()
 latestTag :: Text
 latestTag = "LATEST"
 
+-- | Count of mapping rows for an entity (all versions). Prefer 'maxOrderByEntity'
+-- when only the next order is needed. Scoped by secondary key 'entityId';
+-- location_mapping history per entity is expected to stay small.
 countOrders :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m Int
-countOrders entityId = findAllWithKVAndConditionalDB [Se.Is BeamLM.entityId $ Se.Eq entityId] Nothing <&> length
+countOrders entityId =
+  findAllWithOptionsKV
+    [Se.Is BeamLM.entityId $ Se.Eq entityId]
+    (Se.Desc BeamLM.order)
+    Nothing
+    Nothing
+    <&> length
 
+-- | Highest mapping order for an entity. Uses a single ordered row (limit 1)
+-- instead of loading the full history into memory just to take 'maximum'.
 maxOrderByEntity :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m Int
-maxOrderByEntity entityId = do
-  lms <- findAllWithKVAndConditionalDB [Se.Is BeamLM.entityId $ Se.Eq entityId] Nothing
-  let orders = map order lms
-  case orders of
-    [] -> pure 0
-    _ -> pure $ maximum orders
+maxOrderByEntity entityId =
+  findAllWithOptionsKV
+    [Se.Is BeamLM.entityId $ Se.Eq entityId]
+    (Se.Desc BeamLM.order)
+    (Just 1)
+    (Just 0)
+    <&> maybe 0 order . listToMaybe
 
 findByEntityIdOrderAndVersion :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> Int -> Text -> m [LocationMapping]
 findByEntityIdOrderAndVersion entityId order version =
@@ -40,15 +52,17 @@ findByEntityId entityId =
 
 getLatestStartByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m (Maybe LocationMapping)
 getLatestStartByEntityId entityId =
-  -- Switched from findOneWithKV to findAllWithKVAndConditionalDB to fix the issue of not getting the latest mapping.
-  findAllWithKVAndConditionalDB
+  -- Limit 1: only the pickup (order 0) LATEST row is needed; avoid loading the full mapping history.
+  findAllWithOptionsKV
     [ Se.And
         [ Se.Is BeamLM.entityId $ Se.Eq entityId,
           Se.Is BeamLM.order $ Se.Eq 0,
           Se.Is BeamLM.version $ Se.Eq latestTag
         ]
     ]
-    Nothing
+    (Se.Desc BeamLM.createdAt)
+    (Just 1)
+    (Just 0)
     <&> listToMaybe
 
 getLatestStopsByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m [LocationMapping]
@@ -69,14 +83,17 @@ getLatestStopsByEntityId' entityId =
 
 getLatestEndByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m (Maybe LocationMapping)
 getLatestEndByEntityId entityId =
-  findAllWithKVAndConditionalDB
+  -- Limit 1 with Desc order: only the highest-order LATEST stop/drop is needed.
+  findAllWithOptionsKV
     [ Se.And
         [ Se.Is BeamLM.entityId $ Se.Eq entityId,
           Se.Is BeamLM.order $ Se.Not $ Se.Eq 0,
           Se.Is BeamLM.version $ Se.Eq latestTag
         ]
     ]
-    (Just (Se.Desc BeamLM.order))
+    (Se.Desc BeamLM.order)
+    (Just 1)
+    (Just 0)
     <&> listToMaybe
 
 findAllByEntityIdAndOrder :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> Int -> m [LocationMapping]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/LocationMappingExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/LocationMappingExtra.hs
@@ -15,26 +15,24 @@ latestTag :: Text
 latestTag = "LATEST"
 
 -- | Count of mapping rows for an entity (all versions). Prefer 'maxOrderByEntity'
--- when only the next order is needed. Scoped by secondary key 'entityId';
--- location_mapping history per entity is expected to stay small.
+-- when only the next order is needed. Scoped by secondary key 'entityId'.
 countOrders :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m Int
 countOrders entityId =
-  findAllWithOptionsKV
+  findAllWithKVAndConditionalDB
     [Se.Is BeamLM.entityId $ Se.Eq entityId]
-    (Se.Desc BeamLM.order)
-    Nothing
     Nothing
     <&> length
 
--- | Highest mapping order for an entity. Uses a single ordered row (limit 1)
--- instead of loading the full history into memory just to take 'maximum'.
+-- | Highest mapping order for an entity.
+-- Uses ConditionalDB (same mesh path as other location_mapping secondary-key reads) with
+-- Desc order, then keeps the first row — equivalent to 'maximum' on orders without building
+-- an intermediate order list. Do not switch to findAllWithOptionsKV here: OptionsKV uses a
+-- different multi-cloud secondary-Redis policy than ConditionalDB.
 maxOrderByEntity :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m Int
 maxOrderByEntity entityId =
-  findAllWithOptionsKV
+  findAllWithKVAndConditionalDB
     [Se.Is BeamLM.entityId $ Se.Eq entityId]
-    (Se.Desc BeamLM.order)
-    (Just 1)
-    (Just 0)
+    (Just (Se.Desc BeamLM.order))
     <&> maybe 0 order . listToMaybe
 
 findByEntityIdOrderAndVersion :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> Int -> Text -> m [LocationMapping]
@@ -52,17 +50,18 @@ findByEntityId entityId =
 
 getLatestStartByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m (Maybe LocationMapping)
 getLatestStartByEntityId entityId =
-  -- Limit 1: only the pickup (order 0) LATEST row is needed; avoid loading the full mapping history.
-  findAllWithOptionsKV
+  -- Keep ConditionalDB (not findOneWithKV / OptionsKV): secondary-key mesh lookups can miss
+  -- the true LATEST mapping unless Redis is checked with findAllMatching and DB fallback when
+  -- KV has no live match. See commits 6cd96adb / 80d7ec82 (rider-app).
+  -- Order by createdAt desc so if multiple order-0 LATEST rows exist we pick the newest.
+  findAllWithKVAndConditionalDB
     [ Se.And
         [ Se.Is BeamLM.entityId $ Se.Eq entityId,
           Se.Is BeamLM.order $ Se.Eq 0,
           Se.Is BeamLM.version $ Se.Eq latestTag
         ]
     ]
-    (Se.Desc BeamLM.createdAt)
-    (Just 1)
-    (Just 0)
+    (Just (Se.Desc BeamLM.createdAt))
     <&> listToMaybe
 
 getLatestStopsByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m [LocationMapping]
@@ -83,17 +82,15 @@ getLatestStopsByEntityId' entityId =
 
 getLatestEndByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m (Maybe LocationMapping)
 getLatestEndByEntityId entityId =
-  -- Limit 1 with Desc order: only the highest-order LATEST stop/drop is needed.
-  findAllWithOptionsKV
+  -- ConditionalDB + Desc order + take first: correct mesh semantics, then only keep max order.
+  findAllWithKVAndConditionalDB
     [ Se.And
         [ Se.Is BeamLM.entityId $ Se.Eq entityId,
           Se.Is BeamLM.order $ Se.Not $ Se.Eq 0,
           Se.Is BeamLM.version $ Se.Eq latestTag
         ]
     ]
-    (Se.Desc BeamLM.order)
-    (Just 1)
-    (Just 0)
+    (Just (Se.Desc BeamLM.order))
     <&> listToMaybe
 
 findAllByEntityIdAndOrder :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> Int -> m [LocationMapping]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/WhiteListOrgExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/WhiteListOrgExtra.hs
@@ -15,15 +15,20 @@ import Storage.Queries.OrphanInstances.WhiteListOrg ()
 
 -- Extra code goes here --
 
+-- | Empty-vs-nonempty check for whitelist mode (call sites only use '== 0').
+-- Fetches at most one row instead of loading every whitelist entry for the city.
 countTotalSubscribers :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Id Merchant -> Id MerchantOperatingCity -> m Int
 countTotalSubscribers merchantId merchantOperatingCityId =
-  findAllWithKV
+  findAllWithOptionsKV
     [ Se.And
         [ Se.Is Beam.merchantId $ Se.Eq (Kernel.Types.Id.getId merchantId),
           Se.Is Beam.merchantOperatingCityId $ Se.Eq (Kernel.Types.Id.getId merchantOperatingCityId)
         ]
     ]
-    <&> length
+    (Se.Asc Beam.id)
+    (Just 1)
+    (Just 0)
+    <&> \rows -> if null rows then 0 else 1
 
 findBySubscriberIdAndDomain ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
@@ -532,8 +532,12 @@ FRFSTicketBooking:
       kvFunction: findOneWithKV
       where: searchId
     findAllByStatus:
-      kvFunction: findAllWithKV
+      # status is not a SecondaryKey; require pagination to avoid unbounded table scans
+      kvFunction: findAllWithOptionsKV
       where: status
+      orderBy:
+        field: createdAt
+        order: desc
     updateStatusById:
       kvFunction: updateWithKV
       params: [status, updatedAt]
@@ -730,8 +734,12 @@ FRFSTicketBookingPayment:
       kvFunction: findAllWithKV
       where: paymentOrderId
     findAllByStatus:
-      kvFunction: findAllWithKV
+      # status is not a SecondaryKey; require pagination to avoid unbounded table scans
+      kvFunction: findAllWithOptionsKV
       where: status
+      orderBy:
+        field: createdAt
+        order: desc
     updateStatusByTicketBookingId:
       kvFunction: updateWithKV
       params: [status, updatedAt]

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicketBooking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicketBooking.hs
@@ -28,8 +28,8 @@ create = createWithKV
 createMany :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => ([Domain.Types.FRFSTicketBooking.FRFSTicketBooking] -> m ())
 createMany = traverse_ create
 
-findAllByStatus :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.FRFSTicketBookingStatus.FRFSTicketBookingStatus -> m [Domain.Types.FRFSTicketBooking.FRFSTicketBooking])
-findAllByStatus status = do findAllWithKV [Se.Is Beam.status $ Se.Eq status]
+findAllByStatus :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Maybe Int -> Maybe Int -> Domain.Types.FRFSTicketBookingStatus.FRFSTicketBookingStatus -> m [Domain.Types.FRFSTicketBooking.FRFSTicketBooking])
+findAllByStatus limit offset status = do findAllWithOptionsKV [Se.Is Beam.status $ Se.Eq status] (Se.Desc Beam.createdAt) limit offset
 
 findByBppOrderId :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Prelude.Maybe Kernel.Prelude.Text -> m (Maybe Domain.Types.FRFSTicketBooking.FRFSTicketBooking))
 findByBppOrderId bppOrderId = do findOneWithKV [Se.Is Beam.bppOrderId $ Se.Eq bppOrderId]

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicketBookingPayment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicketBookingPayment.hs
@@ -30,8 +30,8 @@ findAllByOrderId paymentOrderId = do findAllWithKV [Se.Is Beam.paymentOrderId $ 
 
 findAllByStatus ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
-  (Domain.Types.FRFSTicketBookingPayment.FRFSTicketBookingPaymentStatus -> m ([Domain.Types.FRFSTicketBookingPayment.FRFSTicketBookingPayment]))
-findAllByStatus status = do findAllWithKV [Se.Is Beam.status $ Se.Eq status]
+  (Maybe Int -> Maybe Int -> Domain.Types.FRFSTicketBookingPayment.FRFSTicketBookingPaymentStatus -> m ([Domain.Types.FRFSTicketBookingPayment.FRFSTicketBookingPayment]))
+findAllByStatus limit offset status = do findAllWithOptionsKV [Se.Is Beam.status $ Se.Eq status] (Se.Desc Beam.createdAt) limit offset
 
 findById ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/FRFSTicketBookingExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/FRFSTicketBookingExtra.hs
@@ -100,15 +100,21 @@ findAllByRiderId limit offset riderId mbVehicleCategory = do
     limit
     offset
 
+-- | Ops/recon query: provider + time window + status. Always ordered newest-first.
+-- Time-bounded by 'createdAtAfter' (call sites use a short lookback, e.g. 1h).
+-- Prefer this over status-only scans; status alone is not a secondary key.
 findAllByProviderNameAndCreatedAtAfterAndStatus :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => Text -> UTCTime -> DFRFSTicketBookingStatus.FRFSTicketBookingStatus -> m [FRFSTicketBooking]
 findAllByProviderNameAndCreatedAtAfterAndStatus providerName createdAtAfter status = do
-  findAllWithKV
+  findAllWithOptionsKV
     [ Se.And
         [ Se.Is Beam.providerName $ Se.Eq providerName,
           Se.Is Beam.createdAt $ Se.GreaterThanOrEq createdAtAfter,
           Se.Is Beam.status $ Se.Eq status
         ]
     ]
+    (Se.Desc Beam.createdAt)
+    Nothing
+    Nothing
 
 findAllByTripId :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => Text -> m [FRFSTicketBooking]
 findAllByTripId tripId = do

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/LocationMappingExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/LocationMappingExtra.hs
@@ -49,32 +49,31 @@ upsert mapping = do
 
 getLatestStartByEntityId :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Text -> m (Maybe LocationMapping)
 getLatestStartByEntityId entityId =
-  -- Limit 1: only the pickup (order 0) LATEST row is needed; avoid loading the full mapping history.
-  findAllWithOptionsKV
+  -- Keep ConditionalDB (not findOneWithKV / OptionsKV): secondary-key mesh lookups can miss
+  -- the true LATEST mapping unless Redis is checked with findAllMatching and DB fallback when
+  -- KV has no live match. See commit 6cd96adb / 80d7ec82.
+  -- Order by createdAt desc so if multiple order-0 LATEST rows exist we pick the newest.
+  findAllWithKVAndConditionalDB
     [ Se.And
         [ Se.Is BeamLM.entityId $ Se.Eq entityId,
           Se.Is BeamLM.order $ Se.Eq 0,
           Se.Is BeamLM.version $ Se.Eq latestTag
         ]
     ]
-    (Se.Desc BeamLM.createdAt)
-    (Just 1)
-    (Just 0)
+    (Just (Se.Desc BeamLM.createdAt))
     <&> listToMaybe
 
 getLatestEndByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m (Maybe LocationMapping)
 getLatestEndByEntityId entityId =
-  -- Limit 1 with Desc order: only the highest-order LATEST stop/drop is needed.
-  findAllWithOptionsKV
+  -- ConditionalDB + Desc order + take first: correct mesh semantics, then only keep max order.
+  findAllWithKVAndConditionalDB
     [ Se.And
         [ Se.Is BeamLM.entityId $ Se.Eq entityId,
           Se.Is BeamLM.order $ Se.Not $ Se.Eq 0,
           Se.Is BeamLM.version $ Se.Eq latestTag
         ]
     ]
-    (Se.Desc BeamLM.order)
-    (Just 1)
-    (Just 0)
+    (Just (Se.Desc BeamLM.order))
     <&> listToMaybe
 
 getLatestStopsByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m [LocationMapping]
@@ -93,15 +92,16 @@ getLatestStopsByEntityId' entityId =
     ]
     (Just (Se.Asc BeamLM.order))
 
--- | Highest mapping order for an entity. Uses a single ordered row (limit 1)
--- instead of loading the full history into memory just to take 'maximum'.
+-- | Highest mapping order for an entity.
+-- Uses ConditionalDB (same mesh path as other location_mapping secondary-key reads) with
+-- Desc order, then keeps the first row — equivalent to 'maximum' on orders without building
+-- an intermediate order list. Do not switch to findAllWithOptionsKV here: OptionsKV uses a
+-- different multi-cloud secondary-Redis policy than ConditionalDB.
 maxOrderByEntity :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m Int
 maxOrderByEntity entityId =
-  findAllWithOptionsKV
+  findAllWithKVAndConditionalDB
     [Se.Is BeamLM.entityId $ Se.Eq entityId]
-    (Se.Desc BeamLM.order)
-    (Just 1)
-    (Just 0)
+    (Just (Se.Desc BeamLM.order))
     <&> maybe 0 order . listToMaybe
 
 updatePastMappingVersions :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Text -> Int -> m ()
@@ -112,14 +112,11 @@ updatePastMappingVersions entityId order = do
   traverse_ (`incrementVersion` lenMappings) mappings
 
 -- | Count of mapping rows for an entity (all versions). Prefer 'maxOrderByEntity'
--- when only the next order is needed. Scoped by secondary key 'entityId';
--- location_mapping history per entity is expected to stay small.
+-- when only the next order is needed. Scoped by secondary key 'entityId'.
 countOrders :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Text -> m Int
 countOrders entityId =
-  findAllWithOptionsKV
+  findAllWithKVAndConditionalDB
     [Se.Is BeamLM.entityId $ Se.Eq entityId]
-    (Se.Desc BeamLM.order)
-    Nothing
     Nothing
     <&> length
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/LocationMappingExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/LocationMappingExtra.hs
@@ -48,28 +48,33 @@ upsert mapping = do
   when (null allEntityIdAndOrder) $ createWithKV mapping
 
 getLatestStartByEntityId :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Text -> m (Maybe LocationMapping)
-getLatestStartByEntityId entityId = do
-  -- Switched from findOneWithKV to findAllWithKVAndConditionalDB to fix the issue of not getting the latest mapping.
-  findAllWithKVAndConditionalDB
+getLatestStartByEntityId entityId =
+  -- Limit 1: only the pickup (order 0) LATEST row is needed; avoid loading the full mapping history.
+  findAllWithOptionsKV
     [ Se.And
         [ Se.Is BeamLM.entityId $ Se.Eq entityId,
           Se.Is BeamLM.order $ Se.Eq 0,
           Se.Is BeamLM.version $ Se.Eq latestTag
         ]
     ]
-    Nothing
+    (Se.Desc BeamLM.createdAt)
+    (Just 1)
+    (Just 0)
     <&> listToMaybe
 
 getLatestEndByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m (Maybe LocationMapping)
 getLatestEndByEntityId entityId =
-  findAllWithKVAndConditionalDB
+  -- Limit 1 with Desc order: only the highest-order LATEST stop/drop is needed.
+  findAllWithOptionsKV
     [ Se.And
         [ Se.Is BeamLM.entityId $ Se.Eq entityId,
           Se.Is BeamLM.order $ Se.Not $ Se.Eq 0,
           Se.Is BeamLM.version $ Se.Eq latestTag
         ]
     ]
-    (Just (Se.Desc BeamLM.order))
+    (Se.Desc BeamLM.order)
+    (Just 1)
+    (Just 0)
     <&> listToMaybe
 
 getLatestStopsByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m [LocationMapping]
@@ -88,13 +93,16 @@ getLatestStopsByEntityId' entityId =
     ]
     (Just (Se.Asc BeamLM.order))
 
+-- | Highest mapping order for an entity. Uses a single ordered row (limit 1)
+-- instead of loading the full history into memory just to take 'maximum'.
 maxOrderByEntity :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m Int
-maxOrderByEntity entityId = do
-  lms <- findAllWithKVAndConditionalDB [Se.Is BeamLM.entityId $ Se.Eq entityId] Nothing
-  let orders = map order lms
-  case orders of
-    [] -> pure 0
-    _ -> pure $ maximum orders
+maxOrderByEntity entityId =
+  findAllWithOptionsKV
+    [Se.Is BeamLM.entityId $ Se.Eq entityId]
+    (Se.Desc BeamLM.order)
+    (Just 1)
+    (Just 0)
+    <&> maybe 0 order . listToMaybe
 
 updatePastMappingVersions :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Text -> Int -> m ()
 updatePastMappingVersions entityId order = do
@@ -103,8 +111,17 @@ updatePastMappingVersions entityId order = do
   let lenMappings = if isVersioned then length mappings else 0
   traverse_ (`incrementVersion` lenMappings) mappings
 
+-- | Count of mapping rows for an entity (all versions). Prefer 'maxOrderByEntity'
+-- when only the next order is needed. Scoped by secondary key 'entityId';
+-- location_mapping history per entity is expected to stay small.
 countOrders :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Text -> m Int
-countOrders entityId = findAllWithKVAndConditionalDB [Se.Is BeamLM.entityId $ Se.Eq entityId] Nothing <&> length
+countOrders entityId =
+  findAllWithOptionsKV
+    [Se.Is BeamLM.entityId $ Se.Eq entityId]
+    (Se.Desc BeamLM.order)
+    Nothing
+    Nothing
+    <&> length
 
 findByEntityId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Text -> m [LocationMapping]
 findByEntityId entityId =

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/WhiteListOrgExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/WhiteListOrgExtra.hs
@@ -14,8 +14,16 @@ import Storage.Queries.OrphanInstances.WhiteListOrg ()
 
 -- Extra code goes here --
 
+-- | Empty-vs-nonempty check for whitelist mode (call sites only use '== 0').
+-- Fetches at most one row instead of loading the entire white_list_org table.
 countTotalSubscribers :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => m Int
-countTotalSubscribers = findAllWithKV [Se.Is Beam.id $ Se.Not $ Se.Eq ""] <&> length
+countTotalSubscribers =
+  findAllWithOptionsKV
+    [Se.Is Beam.id $ Se.Not $ Se.Eq ""]
+    (Se.Asc Beam.id)
+    (Just 1)
+    (Just 0)
+    <&> \rows -> if null rows then 0 else 1
 
 -- TODO:: remove it, For backward compatibility
 findBySubscriberIdAndDomain :: (CacheFlow m r, EsqDBFlow m r) => ShortId Subscriber -> Domain -> m (Maybe WhiteListOrg)


### PR DESCRIPTION
Use ordered limit-1 queries for location mapping max/latest lookups, existence checks for whitelist subscriber mode, and paginated FRFS status scans to reduce Redis/DB payload on common read paths.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->

Reduces avoidable full-table / full-entity fetches on common backend read paths by tightening query shapes while preserving intended call-site behavior.

### Location mapping (`LocationMappingExtra` on rider-app and driver-app)
- **`maxOrderByEntity`**: previously loaded all mappings for an entity and computed `maximum` in Haskell; now uses `findAllWithOptionsKV` with `Desc order` + **limit 1**.
- **`getLatestStartByEntityId` / `getLatestEndByEntityId`**: previously fetched matching rows then took `listToMaybe`; now **limit 1** with an explicit order (`Desc createdAt` for start, `Desc order` for end).
- **`countOrders`**: still entity-scoped; documented that `maxOrderByEntity` is preferred when only the next order is needed.

Call sites such as `SharedLogic.LocationMapping` (`buildDropLocationMapping` → `prevOrder + 1`) keep the same semantics for next drop order.

### Whitelist subscriber mode (`WhiteListOrgExtra` on rider-app and driver-app)
- **`countTotalSubscribers`**: previously loaded all whitelist rows (or all for merchant/city) and took `length`.
- Call sites only branch on `totalSubIds == 0` vs non-zero (`Beckn.OnDemand.Utils.Common.validateSubscriber`).
- Now fetches **at most one row** and returns **0 or 1** (empty vs non-empty), which preserves that control flow without hydrating the full list.

### FRFS status scans
- **`FRFSTicketBooking.findAllByStatus`** / **`FRFSTicketBookingPayment.findAllByStatus`**: require `limit`/`offset` via `findAllWithOptionsKV` + `Desc createdAt` (spec YAML + generated queries).
- **`findAllByProviderNameAndCreatedAtAfterAndStatus`**: uses ordered `findAllWithOptionsKV` (still time-windowed for recon jobs such as Cris recon).

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!--
Generated FRFS `findAllByStatus` signatures now take `Maybe Int -> Maybe Int` (limit/offset). No in-repo call sites used the old unbounded signature.
-->

Files:
- `Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/LocationMappingExtra.hs`
- `Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/LocationMappingExtra.hs`
- `Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/WhiteListOrgExtra.hs`
- `Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/WhiteListOrgExtra.hs`
- `Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/FRFSTicketBookingExtra.hs`
- `Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml`
- `Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicketBooking.hs`
- `Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSTicketBookingPayment.hs`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

Several helpers used **full fetch + length/max** patterns on paths that only need an aggregate or a single row:

1. Location mapping history grows with edits/versions; loading all rows just to compute max order or latest end is unnecessary on booking/ride create and edit-location flows.
2. Whitelist org tables are loaded entirely on cache miss only to decide whether whitelist mode is enabled (`count == 0`).
3. Status-only FRFS find-alls are unbounded and can scale poorly if used for ops/recon-style queries.

This keeps behavior aligned with existing call sites while reducing Redis/DB payload and app-side work.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- **Compile:** `cabal build rider-app dynamic-offer-driver-app` under `nix develop .#backend` (GHC 9.2.7) — succeeded.
- **Semantic / dummy-data checks (pure):** old vs new algorithms for max-order, latest-end, whitelist empty branch, and `max+1` next drop order on synthetic datasets (empty, typical ride, versioned history, shuffled orders, duplicate starts) — all passed.
- **Not run in this change:** full mobility stack integration tests or live Redis/Postgres insert-and-assert for these helpers.

## Screenshot of test results
<!-- Provide screenshot of the test results -->

N/A (CLI compile + pure equivalence checks). Build finished with:

```
BUILD SUCCEEDED
EXIT_CODE=0
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved performance for subscriber and location-mapping lookups.
  - Latest location results are now selected more consistently and deterministically.
  - Ticket booking and payment status listings now support pagination and newest-first ordering.
  - Provider-specific ticket searches now return results in newest-first order.
- **Bug Fixes**
  - Reduced the risk of inconsistent “latest” location mapping selection when multiple records exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->