### PR TITLE
fix: throw error for invalid status

### DIFF
--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
@@ -251,7 +251,9 @@ processXyneBearerWebhook bearerToken mbAuthHeader rawBody = do
     "TICKET_STATUS_UPDATED" ->
       case readMaybe (T.unpack (T.toUpper event.payload.status)) :: Maybe Common.IssueStatus of
         Just status -> QIR.updateIssueStatus event.payload.ticketId status
-        Nothing -> logWarning $ "Xyne bearer webhook: unrecognized status=" <> event.payload.status
+        Nothing -> do
+          logError $ "Xyne bearer webhook: unrecognized status=" <> event.payload.status
+          throwError (InvalidRequest "XYNE_BEARER_WEBHOOK_INVALID_STATUS")
     other ->
       logWarning $ "Xyne bearer webhook: ignoring unsupported eventType=" <> other
   pure Success


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Updated Xyne Webhook to throw error if invalid status is found.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid issue statuses received through bearer webhooks are now rejected with an error instead of being processed successfully.
  * Improved error reporting for malformed webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->