### PR TITLE
backend/fix/allow-other-policies-if-1-fails

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -453,7 +453,12 @@ handler ValidatedDSearchReq {..} sReq = do
             logInfo $ "VST " <> show fp.vehicleServiceTier <> " skipped due to area restrictions for area: " <> show mbAreaForVST
           if isAllowed
             then case tripCategoryToPricingPolicy fp'.tripCategory of
-              EstimateBased {..} -> buildEstimateHelper nightShiftOverlapChecking vehicleServiceTierItem fp' >>= \est -> pure (est : estimates, quotes)
+              EstimateBased {..} ->
+                withTryCatch "buildEstimate:processPolicy" (buildEstimateHelper nightShiftOverlapChecking vehicleServiceTierItem fp') >>= \case
+                  Right est -> pure (est : estimates, quotes)
+                  Left err -> do
+                    logError $ "Skipping fare policy " <> fp'.id.getId <> " (" <> show fp'.vehicleServiceTier <> ", " <> show fp'.tripCategory <> "): estimate build failed: " <> show err
+                    pure (estimates, quotes)
               QuoteBased {..} -> buildQuoteHelper nightShiftOverlapChecking vehicleServiceTierItem fp' >>= \quote -> pure (estimates, quote : quotes)
             else pure (estimates, quotes)
         Nothing -> do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when processing estimate-based fare policies.
  * If an estimate cannot be built, the affected option is skipped and processing continues instead of failing the entire request.
  * Added error logging to support investigation of estimate-generation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->