### PR TITLE
Backend/feat: per-event provider routing for event tracking

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
@@ -38,6 +38,8 @@ imports:
   EventTrackingService: Kernel.External.EventTracking
   Currency: Kernel.Utils.Common
   CloudType: Kernel.Types.Version
+  Map: Data.Map.Strict
+  Value: Data.Aeson
 
 Merchant:
   derives: "Generic,Show,'UsageSafety"
@@ -358,6 +360,7 @@ MerchantServiceUsageConfig:
     getMultimodalWalkDistance: MapsService
     insuranceService: InsuranceService
     eventTrackingProviders: "[EventTrackingService]"
+    eventTrackingOverrides: "Maybe (Map Text [EventTrackingService])"
 
   beamType:
     cancelPaymentIntent: Maybe PaymentService
@@ -371,6 +374,7 @@ MerchantServiceUsageConfig:
     createPayoutOrder: Maybe PayoutService
     payoutOrderStatus: Maybe PayoutService
     eventTrackingProviders: Maybe [EventTrackingService]
+    eventTrackingOverrides: Maybe Value
     additionalIssueTicketServices: Maybe [IssueTicketService]
   fromTType:
     cancelPaymentIntent: fromMaybe (Kernel.External.Payment.Types.Stripe) cancelPaymentIntent|E
@@ -384,6 +388,7 @@ MerchantServiceUsageConfig:
     createPayoutOrder: fromMaybe (Kernel.External.Payout.Types.Juspay)|I
     payoutOrderStatus: fromMaybe (Kernel.External.Payout.Types.Juspay)|I
     eventTrackingProviders: fromMaybe [Kernel.External.EventTracking.Types.Moengage]|I
+    eventTrackingOverrides: Kernel.Utils.JSON.valueToMaybe =<< eventTrackingOverrides|E
   toTType:
     cancelPaymentIntent: Kernel.Prelude.Just|I
     getFrfsAutocompleteDistances: Kernel.Prelude.Just|I
@@ -396,6 +401,7 @@ MerchantServiceUsageConfig:
     createPayoutOrder: Kernel.Prelude.Just|I
     payoutOrderStatus: Kernel.Prelude.Just|I
     eventTrackingProviders: Kernel.Prelude.Just|I
+    eventTrackingOverrides: Data.Aeson.toJSON <$> eventTrackingOverrides|E
   beamInstance:
     - MakeTableInstances
     - Custom Domain.Types.UtilsTH.mkCacParseInstance <MerchantServiceUsageConfigT>
@@ -432,6 +438,7 @@ MerchantServiceUsageConfig:
     autoComplete: character varying(30)
     smsProvidersPriorityList: "text[]"
     eventTrackingProviders: "text[]"
+    eventTrackingOverrides: jsonb
     whatsappProvidersPriorityList: "text[]"
     initiateCall: character varying(30)
     issueTicketService: character varying(30)

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantServiceUsageConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantServiceUsageConfig.hs
@@ -4,6 +4,7 @@
 module Domain.Types.MerchantServiceUsageConfig where
 
 import Data.Aeson
+import qualified Data.Map.Strict
 import Domain.Types.Common (UsageSafety (..))
 import qualified Domain.Types.Merchant
 import qualified Domain.Types.MerchantOperatingCity
@@ -38,6 +39,7 @@ data MerchantServiceUsageConfigD (s :: UsageSafety) = MerchantServiceUsageConfig
     createdAt :: Kernel.Prelude.UTCTime,
     deleteCard :: Kernel.External.Payment.Types.PaymentService,
     enableDashboardSms :: Kernel.Prelude.Bool,
+    eventTrackingOverrides :: Kernel.Prelude.Maybe (Data.Map.Strict.Map Kernel.Prelude.Text [Kernel.External.EventTracking.EventTrackingService]),
     eventTrackingProviders :: [Kernel.External.EventTracking.EventTrackingService],
     getCardList :: Kernel.External.Payment.Types.PaymentService,
     getDistances :: Kernel.External.Maps.Types.MapsService,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantServiceUsageConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantServiceUsageConfig.hs
@@ -3,6 +3,7 @@
 
 module Storage.Beam.MerchantServiceUsageConfig where
 
+import qualified Data.Aeson
 import qualified Database.Beam as B
 import Domain.Types.Common ()
 import qualified Domain.Types.UtilsTH
@@ -38,6 +39,7 @@ data MerchantServiceUsageConfigT f = MerchantServiceUsageConfigT
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     deleteCard :: B.C f Kernel.External.Payment.Types.PaymentService,
     enableDashboardSms :: B.C f Kernel.Prelude.Bool,
+    eventTrackingOverrides :: B.C f (Kernel.Prelude.Maybe Data.Aeson.Value),
     eventTrackingProviders :: B.C f (Kernel.Prelude.Maybe [Kernel.External.EventTracking.EventTrackingService]),
     getCardList :: B.C f Kernel.External.Payment.Types.PaymentService,
     getDistances :: B.C f Kernel.External.Maps.Types.MapsService,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantServiceUsageConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantServiceUsageConfig.hs
@@ -3,6 +3,7 @@
 
 module Storage.Queries.OrphanInstances.MerchantServiceUsageConfig where
 
+import qualified Data.Aeson
 import qualified Domain.Types.MerchantServiceUsageConfig
 import Kernel.Beam.Functions
 import Kernel.External.Encryption
@@ -18,6 +19,7 @@ import qualified Kernel.Prelude
 import Kernel.Types.Error
 import qualified Kernel.Types.Id
 import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
+import qualified Kernel.Utils.JSON
 import qualified Storage.Beam.MerchantServiceUsageConfig as Beam
 
 instance FromTType' Beam.MerchantServiceUsageConfig Domain.Types.MerchantServiceUsageConfig.MerchantServiceUsageConfig where
@@ -39,6 +41,7 @@ instance FromTType' Beam.MerchantServiceUsageConfig Domain.Types.MerchantService
             createdAt = createdAt,
             deleteCard = deleteCard,
             enableDashboardSms = enableDashboardSms,
+            eventTrackingOverrides = Kernel.Utils.JSON.valueToMaybe =<< eventTrackingOverrides,
             eventTrackingProviders = fromMaybe [Kernel.External.EventTracking.Types.Moengage] eventTrackingProviders,
             getCardList = getCardList,
             getDistances = getDistances,
@@ -90,6 +93,7 @@ instance ToTType' Beam.MerchantServiceUsageConfig Domain.Types.MerchantServiceUs
         Beam.createdAt = createdAt,
         Beam.deleteCard = deleteCard,
         Beam.enableDashboardSms = enableDashboardSms,
+        Beam.eventTrackingOverrides = Data.Aeson.toJSON <$> eventTrackingOverrides,
         Beam.eventTrackingProviders = Kernel.Prelude.Just eventTrackingProviders,
         Beam.getCardList = getCardList,
         Beam.getDistances = getDistances,

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/EventTracking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/EventTracking.hs
@@ -9,6 +9,7 @@ where
 
 import qualified BecknV2.OnDemand.Enums as BecknEnums
 import Data.Aeson (object, (.=))
+import qualified Data.Map.Strict as Map
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.MerchantServiceConfig as DMSC
@@ -58,7 +59,25 @@ trackEvent merchantId merchantOperatingCityId event = do
                     EventTracking.attributes = attrs,
                     EventTracking.timestamp = Just now
                   }
-          forM_ providers $ \provider ->
+              -- An event absent from the overrides map goes to every provider
+              -- live in this city. When present, the override can only narrow
+              -- that list -- never activate a provider that has no service
+              -- config row -- so the city-level list stays the source of truth.
+              targetProviders =
+                case Map.lookup actionName =<< merchantConfig.eventTrackingOverrides of
+                  Nothing -> providers
+                  Just allowed -> filter (`elem` allowed) providers
+              skipped = filter (`notElem` targetProviders) providers
+              -- Providers the build supports but this city has not enabled.
+              -- Without this, a provider that is simply absent from
+              -- eventTrackingProviders produces no log line at all, and its
+              -- silence is indistinguishable from a delivery failure.
+              notEnabled = filter (`notElem` providers) EventTracking.availableEventTrackingServices
+          unless (null notEnabled) $
+            logDebug $ "EventTracking: providers not enabled for this merchantOperatingCity: " <> show notEnabled
+          forM_ skipped $ \provider ->
+            logDebug $ "EventTracking: event " <> actionName <> " not routed to " <> show provider <> " by override config"
+          forM_ targetProviders $ \provider ->
             sendToProvider merchantId merchantOperatingCityId provider actionName req
 
 sendToProvider ::

--- a/Backend/dev/ddl-migrations/rider-app/1554-add-event-tracking-overrides-to-msuc.sql
+++ b/Backend/dev/ddl-migrations/rider-app/1554-add-event-tracking-overrides-to-msuc.sql
@@ -1,0 +1,9 @@
+-- Per-event provider routing for event tracking.
+--
+-- Maps an event name to the subset of providers that should receive it, e.g.
+--   {"ny_user_first_ride_completed": ["Moengage"]}
+--
+-- An event absent from this map is sent to every provider listed in
+-- event_tracking_providers. NULL therefore preserves existing behaviour, so no
+-- backfill is required.
+ALTER TABLE atlas_app.merchant_service_usage_config ADD COLUMN IF NOT EXISTS event_tracking_overrides jsonb;

--- a/Backend/dev/migrations-read-only/rider-app/merchant_service_usage_config.sql
+++ b/Backend/dev/migrations-read-only/rider-app/merchant_service_usage_config.sql
@@ -115,3 +115,8 @@ ALTER TABLE atlas_app.merchant_service_usage_config ADD COLUMN sos_ticket_servic
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.merchant_service_usage_config ADD COLUMN additional_issue_ticket_services text[] ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.merchant_service_usage_config ADD COLUMN event_tracking_overrides jsonb ;


### PR DESCRIPTION
> **Rescoped.** This PR originally also carried the shared-kernel interface adaptation and the Clevertap provider wiring. Those were split out and merged separately as #15841 (which unblocked `main`). What remains here is **only the per-event routing feature**, rebased onto latest `main`.

## What

Adds an optional per-event override so an event can be sent to a **subset** of the event-tracking providers live in a city, instead of always fanning out to all of them.

New optional `eventTrackingOverrides` on `MerchantServiceUsageConfig`:

```json
{"ny_user_first_ride_completed": ["Moengage"],
 "ny_rider_ride_completed":      ["Moengage"]}
```

**An event absent from the map goes to every provider live in the city**, so a `NULL` column preserves today's behaviour exactly. No backfill.

## Design notes

- **Intersect, don't replace.** An override can only ever *narrow* `eventTrackingProviders`. Without that, an override could name a provider with no `merchant_service_config` row and produce a silent skip that's hard to diagnose. The city-level list stays the single source of truth for who is live.
- **Routing lives in rider-app, not shared-kernel.** Event names are a rider-app concept; shared-kernel stays "given a config and a request, push it", so future consumers don't inherit rider-app's vocabulary.
- **Free `Text` keys**, matching the existing precedent at driver-app `Merchant.yaml` (`categoryBasedVerificationPriorityList: "Maybe (Map Text [VerificationService])"`). This is config ops edit by hand; a typed key would make every new event a two-repo change.

## Observability

Two debug lines close gaps found while testing locally:

- Providers **skipped by an override** are logged, so a routing decision doesn't read as a delivery failure.
- Providers the build supports but **this city hasn't enabled** are logged. Previously a provider simply absent from `eventTrackingProviders` produced *no log line at all*, and its silence was indistinguishable from a delivery failure — this cost real time while bringing up Clevertap locally.

Both are `debug` deliberately: they fire per-event-per-provider and describe intended states. The genuinely wrong case (provider enabled but **no credentials row**) already logs at `warning`.

## Migration

`1554-add-event-tracking-overrides-to-msuc.sql` — one nullable `jsonb` column, no backfill.

## Verification

- `cabal build rider-app` compiles and links clean with `-Werror`.
- Exercised end-to-end against the live Clevertap API from a real ride flow: four events accepted (`ny_user_source_and_destination`, `ny_user_request_quotes`, `ny_user_first_ride_completed`, `ny_rider_ride_completed`).
- ⚠️ The **routing filter itself has not been exercised at runtime** — local testing ran with `event_tracking_overrides = NULL`, i.e. the fan-out-to-all path. The narrowing path is compile-verified only.

## Note on the generated files

Regenerating via `, run-generator` rewrote unrelated lines in `src-read-only` — adding redundant brackets (`fromMaybe (Kernel.External.Payment.Types.Stripe)`, `MerchantServiceUsageConfigD ('Safe)`) and reordering the Beam record. That is pre-existing drift between the pinned namma-dsl and whatever produced the committed `src-read-only`, not part of this change, and HLint flagged it.

Those files have been reset to `main` with only the new field applied by hand, so the generated diff is now **8 lines, all additions, no deletions and no redundant brackets**. Worth a separate ticket to realign the generator — anyone regenerating rider-app specs will hit the same noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable event-tracking overrides by event/action name, allowing events to be routed to a selected subset of providers.
  * Default routing remains unchanged for actions not present in the overrides.
  * Persisted the overrides in merchant service usage configuration via a new JSONB column.
* **Logging & Observability**
  * Added debug logging for providers skipped due to overrides, and for globally available services that are not enabled for a merchant’s operating city.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->