### PR TITLE
rider-app/feat: route reward coupon-pool Redis ops through master cloud (→ Prod-release-branch-18-jul)

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Rewards/RedisPool.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Rewards/RedisPool.hs
@@ -49,7 +49,7 @@ claimFromPool ::
   Id DRCmp.RewardCampaign ->
   Id DRC.RewardCohort ->
   m (Maybe Text)
-claimFromPool cId coId = Hedis.withCrossAppRedis $ do
+claimFromPool cId coId = Hedis.runInMasterCloudRedisCellWithCrossAppRedis $ do
   mbCode <- Hedis.rPop (poolKey cId coId)
   case mbCode of
     Nothing -> pure Nothing
@@ -66,7 +66,7 @@ removeFromInflight ::
   Text ->
   m ()
 removeFromInflight cId coId code =
-  Hedis.withCrossAppRedis $ void $ Hedis.zRem (inflightKey cId coId) [code]
+  Hedis.runInMasterCloudRedisCellWithCrossAppRedis $ void $ Hedis.zRem (inflightKey cId coId) [code]
 
 pushBackToPool ::
   (Hedis.HedisFlow m env) =>
@@ -75,7 +75,7 @@ pushBackToPool ::
   Text ->
   m ()
 pushBackToPool cId coId code =
-  Hedis.withCrossAppRedis $ void $ Hedis.lPush (poolKey cId coId) (NE.singleton code)
+  Hedis.runInMasterCloudRedisCellWithCrossAppRedis $ void $ Hedis.lPush (poolKey cId coId) (NE.singleton code)
 
 staleInflightCodes ::
   (Hedis.HedisFlow m env, MonadTime m) =>
@@ -83,7 +83,7 @@ staleInflightCodes ::
   Id DRC.RewardCohort ->
   Int ->
   m [Text]
-staleInflightCodes cId coId maxAgeSeconds = Hedis.withCrossAppRedis $ do
+staleInflightCodes cId coId maxAgeSeconds = Hedis.runInMasterCloudRedisCellWithCrossAppRedis $ do
   now <- getCurrentTime
   let cutoff = realToFrac (utcTimeToPOSIXSeconds now) - fromIntegral maxAgeSeconds :: Double
   codes <- Hedis.zRangeByScore (inflightKey cId coId) 0 cutoff
@@ -95,7 +95,7 @@ poolSize ::
   Id DRC.RewardCohort ->
   m Integer
 poolSize cId coId =
-  Hedis.withCrossAppRedis $ Hedis.lLen (poolKey cId coId)
+  Hedis.runInMasterCloudRedisCellWithCrossAppRedis $ Hedis.lLen (poolKey cId coId)
 
 bulkSeedPool ::
   (Hedis.HedisFlow m env) =>
@@ -104,7 +104,7 @@ bulkSeedPool ::
   [Text] ->
   m ()
 bulkSeedPool cId coId codes =
-  Hedis.withCrossAppRedis $
+  Hedis.runInMasterCloudRedisCellWithCrossAppRedis $
     case NE.nonEmpty codes of
       Nothing -> pure ()
       Just ne -> void $ Hedis.lPush (poolKey cId coId) ne


### PR DESCRIPTION
> **Backport of #15833** — same one-commit change, cherry-picked onto this release branch (identical `RedisPool.hs` base, no conflicts).

## Type of Change

- [x] Enhancement

## Description

Wraps all six coupon-pool Redis helpers in `Backend/app/rider-platform/rider-app/Main/src/Tools/Rewards/RedisPool.hs` with `Hedis.runInMasterCloudRedisCellWithCrossAppRedis` (previously `Hedis.withCrossAppRedis`), so the reward-management feature routes its coupon-pool reads and writes to the master-cloud Redis cell under a multi-cloud deployment.

Affected helpers:
- `claimFromPool` (`rPop` + `zAdd`), `removeFromInflight` (`zRem`), `pushBackToPool` (`lPush`), `staleInflightCodes` (`zRangeByScore`) — consumer / reconcile-job path
- `poolSize` (`lLen`), `bulkSeedPool` (`lPush`) — dashboard read / seed path

The `...WithCrossAppRedis` variant preserves the existing cross-app key names (no prefix change), so already-seeded pools stay reachable. No type-signature or import changes were needed — `Hedis.HedisFlow` already carries the `TryException` / `MonadTime` constraints and the `secondaryHedisClusterEnv` env field the helper reads.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

No new config. Routing is gated by the existing global `RUN_IN_MASTER_REDIS_CELL` env var (already used by FRFS seat-booking, loyalty, and payment counters).

## Motivation and Context

In a multi-cloud (GCP + AWS) deployment, globally-consistent state must live in a single master-cloud Redis cell; otherwise each cloud holds a partial, diverging view of the pool and inflight sorted set, and the same coupon code could be handed to two riders (or codes lost). This aligns the reward coupon pool with the master-cloud routing already used elsewhere in rider-app.

## How did you test it?

- No-op safety: while `RUN_IN_MASTER_REDIS_CELL` is off (default), all calls run on primary/local Redis exactly as before — this is the regression-safe default.
- Multi-cloud path: with the flag on, all six ops route to `secondaryHedisClusterEnv` together, so seed, claim, and dashboard reads hit the same cell (read/write consistency).
- Purely a wrapper swap with no signature/import changes; expected to compile clean under `-Werror`.

## Checklist

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
