### PR TITLE
backend/feat: add bus-trip-schedule endpoint to frfs-fleet-op

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/FRFSFleetOperator.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/FRFSFleetOperator.yaml
@@ -3,6 +3,7 @@ imports:
   LatLong: Kernel.External.Maps.Types
   City: Kernel.Types.Beckn.Context
   VehicleCategory: BecknV2.FRFS.Enums
+  ServiceTierType: BecknV2.FRFS.Enums
   TimeBound: Kernel.Types.TimeBound
   FleetOperatorTripAction: Domain.Types.FleetOperatorTripAction
 
@@ -98,6 +99,27 @@ types:
     manifest: "[PassengerStopManifest]"
     derive: "Show"
 
+  FleetBusStopETA:
+    stopCode: Text
+    stopName: Maybe Text
+    arrivalTime: UTCTime
+    arrivalTimeUnix: Int
+    etaSeconds: Maybe Int
+    derive: "Show"
+
+  FleetBusTripSchedule:
+    eta: "[FleetBusStopETA]"
+    vehicleNo: Text
+    serviceTier: ServiceTierType
+    tripNumber: Maybe Int
+    waybillNo: Maybe Text
+    isActiveTrip: Maybe Bool
+    derive: "Show"
+
+  BusTripScheduleResp:
+    schedules: "[FleetBusTripSchedule]"
+    derive: "Show"
+
 apis:
   - GET:
       endpoint: /v2/frfs/route/{routeCode}
@@ -137,3 +159,14 @@ apis:
         type: FleetOperatorCurrentOperationReq
       response:
         type: FleetOperatorCurrentOperationResp
+
+  - GET:
+      endpoint: /v2/frfs/busTripSchedule/{routeId}
+      auth: TokenAuth PROVIDER_TYPE
+      params:
+        routeId: Text
+      mandatoryQuery:
+        waybillNo: Text
+        tripNumber: Int
+      response:
+        type: BusTripScheduleResp

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/UI/FRFSFleetOperator.hs
@@ -35,7 +35,7 @@ type API =
            "vehicleType"
            BecknV2.FRFS.Enums.VehicleCategory
       :> Get
-           ('[JSON])
+           '[JSON]
            API.Types.UI.FRFSFleetOperator.FRFSRouteAPI
       :<|> TokenAuth
       :> "v2"
@@ -50,32 +50,48 @@ type API =
            Data.Text.Text
       :> "manifest"
       :> Get
-           ('[JSON])
+           '[JSON]
            API.Types.UI.FRFSFleetOperator.FRFSTripPassengerManifestResp
       :<|> TokenAuth
       :> "frfs"
       :> "fleetOperator"
       :> "tripAction"
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            API.Types.UI.FRFSFleetOperator.FleetOperatorTripActionReq
       :> Post
-           ('[JSON])
+           '[JSON]
            API.Types.UI.FRFSFleetOperator.FleetOperatorTripActionResp
       :<|> TokenAuth
       :> "frfs"
       :> "fleetOperator"
       :> "currentOperation"
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            API.Types.UI.FRFSFleetOperator.FleetOperatorCurrentOperationReq
       :> Post
-           ('[JSON])
+           '[JSON]
            API.Types.UI.FRFSFleetOperator.FleetOperatorCurrentOperationResp
+      :<|> TokenAuth
+      :> "v2"
+      :> "frfs"
+      :> "busTripSchedule"
+      :> Capture
+           "routeId"
+           Data.Text.Text
+      :> MandatoryQueryParam
+           "tripNumber"
+           Kernel.Prelude.Int
+      :> MandatoryQueryParam
+           "waybillNo"
+           Data.Text.Text
+      :> Get
+           '[JSON]
+           API.Types.UI.FRFSFleetOperator.BusTripScheduleResp
   )
 
 handler :: Environment.FlowServer API
-handler = getV2FrfsRoute :<|> getV2FrfsTripRouteManifest :<|> postFrfsFleetOperatorTripAction :<|> postFrfsFleetOperatorCurrentOperation
+handler = getV2FrfsRoute :<|> getV2FrfsTripRouteManifest :<|> postFrfsFleetOperatorTripAction :<|> postFrfsFleetOperatorCurrentOperation :<|> getV2FrfsBusTripSchedule
 
 getV2FrfsRoute ::
   ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
@@ -83,8 +99,8 @@ getV2FrfsRoute ::
       Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity
     ) ->
     Data.Text.Text ->
-    Kernel.Prelude.Maybe (Data.Text.Text) ->
-    Kernel.Prelude.Maybe (Data.Text.Text) ->
+    Kernel.Prelude.Maybe Data.Text.Text ->
+    Kernel.Prelude.Maybe Data.Text.Text ->
     Kernel.Types.Beckn.Context.City ->
     BecknV2.FRFS.Enums.VehicleCategory ->
     Environment.FlowHandler API.Types.UI.FRFSFleetOperator.FRFSRouteAPI
@@ -121,3 +137,15 @@ postFrfsFleetOperatorCurrentOperation ::
     Environment.FlowHandler API.Types.UI.FRFSFleetOperator.FleetOperatorCurrentOperationResp
   )
 postFrfsFleetOperatorCurrentOperation a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.FRFSFleetOperator.postFrfsFleetOperatorCurrentOperation (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a2) a1
+
+getV2FrfsBusTripSchedule ::
+  ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
+      Kernel.Types.Id.Id Domain.Types.Merchant.Merchant,
+      Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity
+    ) ->
+    Data.Text.Text ->
+    Kernel.Prelude.Int ->
+    Data.Text.Text ->
+    Environment.FlowHandler API.Types.UI.FRFSFleetOperator.BusTripScheduleResp
+  )
+getV2FrfsBusTripSchedule a4 a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.FRFSFleetOperator.getV2FrfsBusTripSchedule (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a4) a3 a2 a1

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/FRFSFleetOperator.hs
@@ -2,6 +2,7 @@
 
 module API.Types.UI.FRFSFleetOperator where
 
+import qualified BecknV2.FRFS.Enums
 import Data.OpenApi (ToSchema)
 import qualified Data.Text
 import qualified Domain.Types.FleetOperatorTripAction
@@ -12,6 +13,10 @@ import qualified Kernel.Types.Common
 import qualified Kernel.Types.TimeBound
 import Servant
 import Tools.Auth
+
+data BusTripScheduleResp = BusTripScheduleResp {schedules :: [FleetBusTripSchedule]}
+  deriving stock (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data FRFSRouteAPI = FRFSRouteAPI
   { code :: Data.Text.Text,
@@ -48,6 +53,27 @@ data FRFSStationAPI = FRFSStationAPI
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data FRFSTripPassengerManifestResp = FRFSTripPassengerManifestResp {manifest :: [PassengerStopManifest]}
+  deriving stock (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+data FleetBusStopETA = FleetBusStopETA
+  { arrivalTime :: Kernel.Prelude.UTCTime,
+    arrivalTimeUnix :: Kernel.Prelude.Int,
+    etaSeconds :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    stopCode :: Data.Text.Text,
+    stopName :: Kernel.Prelude.Maybe Data.Text.Text
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+data FleetBusTripSchedule = FleetBusTripSchedule
+  { eta :: [FleetBusStopETA],
+    isActiveTrip :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
+    serviceTier :: BecknV2.FRFS.Enums.ServiceTierType,
+    tripNumber :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    vehicleNo :: Data.Text.Text,
+    waybillNo :: Kernel.Prelude.Maybe Data.Text.Text
+  }
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FRFSFleetOperator.hs
@@ -3,6 +3,7 @@ module Domain.Action.UI.FRFSFleetOperator
     getV2FrfsTripRouteManifest,
     postFrfsFleetOperatorTripAction,
     postFrfsFleetOperatorCurrentOperation,
+    getV2FrfsBusTripSchedule,
   )
 where
 
@@ -143,6 +144,48 @@ getV2FrfsRoute (_, _merchantId, merchantOpCityId) routeCode mbConfigId mbPlatfor
         waypoints = route.encodedPolyline <&> decode <&> fmap (\point -> LatLong {lat = point.latitude, lon = point.longitude}),
         integratedBppConfigId = getId integratedBPPConfig.id
       }
+
+-- | Get bus trip schedule (per-stop ETAs) directly from GIMS for a given waybill/trip/route.
+-- Unlike the manifest above (proxied to rider-app), this hits GIMS' `bus-trip-schedule` endpoint
+-- directly via OTPRest, the same way route/stop lookups do.
+getV2FrfsBusTripSchedule ::
+  ( ( Maybe (Id Domain.Types.Person.Person),
+      Id Domain.Types.Merchant.Merchant,
+      Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity
+    ) ->
+    Text ->
+    Int ->
+    Text ->
+    Flow BusTripScheduleResp
+  )
+getV2FrfsBusTripSchedule (_, _merchantId, merchantOpCityId) routeId tripNumber waybillNo = do
+  logInfo $ "FRFSFleetOperator: Getting bus trip schedule for routeId: " <> routeId <> ", waybillNo: " <> waybillNo <> ", tripNumber: " <> show tripNumber
+  integratedBPPConfig <-
+    findFirstIbppConfigByCityAndVehicle
+      merchantOpCityId
+      (show BUS)
+  schedules <- OTPRest.getBusTripSchedule integratedBPPConfig waybillNo tripNumber routeId
+  return $ BusTripScheduleResp {schedules = map mkFleetBusTripSchedule schedules}
+  where
+    mkFleetBusTripSchedule :: BusScheduleDetail -> FleetBusTripSchedule
+    mkFleetBusTripSchedule detail =
+      FleetBusTripSchedule
+        { eta = map mkFleetBusStopETA detail.eta,
+          isActiveTrip = detail.is_active_trip,
+          serviceTier = detail.service_tier,
+          tripNumber = detail.trip_number,
+          vehicleNo = detail.vehicle_no,
+          waybillNo = detail.waybill_no
+        }
+    mkFleetBusStopETA :: BusStopETA -> FleetBusStopETA
+    mkFleetBusStopETA e =
+      FleetBusStopETA
+        { arrivalTime = e.arrivalTime,
+          arrivalTimeUnix = fromIntegral e.arrivalTimeUnix,
+          etaSeconds = fromIntegral <$> e.etaSeconds,
+          stopCode = e.stopCode,
+          stopName = e.stopName
+        }
 
 -- | Get trip manifest - still proxied to rider-app (needs booking data)
 getV2FrfsTripRouteManifest ::

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/CachedQueries/OTPRest/OTPRest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/CachedQueries/OTPRest/OTPRest.hs
@@ -53,6 +53,17 @@ getExampleTrip integratedBPPConfig routeId = IM.withInMemCache ["ExampleTrip", i
   baseUrl <- getGimsBaseUrl integratedBPPConfig
   Flow.getExampleTrip baseUrl (integratedBPPConfig.feedKey) routeId
 
+getBusTripSchedule ::
+  (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, Log m, CacheFlow m r, EsqDBFlow m r) =>
+  IntegratedBPPConfig ->
+  Text ->
+  Int ->
+  Text ->
+  m BusScheduleDetails
+getBusTripSchedule integratedBPPConfig waybillNo tripNumber routeId = IM.withInMemCache ["BusTripSchedule", integratedBPPConfig.id.getId, waybillNo, show tripNumber, routeId] 300 $ do
+  baseUrl <- getGimsBaseUrl integratedBPPConfig
+  Flow.getBusTripSchedule baseUrl (integratedBPPConfig.feedKey) waybillNo tripNumber routeId
+
 -- Parse Functions
 
 parseRouteStopMappingInMemoryServer ::

--- a/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/API/Nandi.hs
+++ b/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/API/Nandi.hs
@@ -14,6 +14,8 @@ type RouteByRouteIdAPI = "route" :> Capture "gtfs_id" Text :> Capture "route_id"
 
 type ExampleTripAPI = "example-trip" :> Capture "gtfs_id" Text :> Capture "route_id" Text :> Get '[JSON] TripDetails
 
+type BusTripScheduleAPI = "bus-trip-schedule" :> Capture "gtfs_id" Text :> Capture "waybill_no" Text :> Capture "trip_number" Int :> Capture "route_id" Text :> Get '[JSON] BusScheduleDetails
+
 type OperatorCurrentOperationAPI =
   "internal" :> "fleet-operator" :> Capture "gtfs_id" Text :> "currentOperation"
     :> ReqBody '[JSON] GimsOperationAnchor
@@ -55,6 +57,9 @@ nandiRouteByRouteIdAPI = Proxy
 nandiExampleTripAPI :: Proxy ExampleTripAPI
 nandiExampleTripAPI = Proxy
 
+nandiBusTripScheduleAPI :: Proxy BusTripScheduleAPI
+nandiBusTripScheduleAPI = Proxy
+
 operatorCurrentOperationAPI :: Proxy OperatorCurrentOperationAPI
 operatorCurrentOperationAPI = Proxy
 
@@ -87,6 +92,9 @@ getNandiRouteByRouteId = ET.client nandiRouteByRouteIdAPI
 
 getNandiExampleTrip :: Text -> Text -> ET.EulerClient TripDetails
 getNandiExampleTrip = ET.client nandiExampleTripAPI
+
+getNandiBusTripSchedule :: Text -> Text -> Int -> Text -> ET.EulerClient BusScheduleDetails
+getNandiBusTripSchedule = ET.client nandiBusTripScheduleAPI
 
 postOperatorCurrentOperation :: Text -> GimsOperationAnchor -> ET.EulerClient GimsCurrentOperationResp
 postOperatorCurrentOperation = ET.client operatorCurrentOperationAPI

--- a/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Flow.hs
+++ b/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Flow.hs
@@ -45,6 +45,10 @@ getExampleTrip baseUrl gtfsId routeId =
         logError $ "Error getting example trip: " <> show err
         pure Nothing
 
+getBusTripSchedule :: (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, HasRequestId r) => BaseUrl -> Text -> Text -> Int -> Text -> m BusScheduleDetails
+getBusTripSchedule baseUrl gtfsId waybillNo tripNumber routeId =
+  withShortRetry $ callAPI baseUrl (NandiAPI.getNandiBusTripSchedule gtfsId waybillNo tripNumber routeId) "getBusTripSchedule" NandiAPI.nandiBusTripScheduleAPI >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_NANDI_GET_BUS_TRIP_SCHEDULE_API") baseUrl)
+
 gimsCurrentOperation :: (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, HasRequestId r) => BaseUrl -> Text -> GimsOperationAnchor -> m GimsCurrentOperationResp
 gimsCurrentOperation baseUrl gtfsId req =
   withShortRetry $ callAPI baseUrl (NandiAPI.postOperatorCurrentOperation gtfsId req) "gimsCurrentOperation" NandiAPI.operatorCurrentOperationAPI >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_GIMS_CURRENT_OPERATION_API") baseUrl)

--- a/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
+++ b/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
@@ -7,6 +7,8 @@ import Data.Aeson
 import Data.OpenApi ()
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
+import Data.Time.Clock (addUTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
 import Kernel.External.Maps (HasCoordinates (..))
 import Kernel.External.Maps.Types (LatLong)
 import Kernel.Prelude
@@ -56,6 +58,51 @@ data RouteInfoNandi = RouteInfoNandi
     encodedPolyline :: Maybe Text
   }
   deriving (Generic, FromJSON, ToJSON, Show)
+
+-- | Per-stop ETA entry returned by GIMS' `bus-trip-schedule` endpoint. GIMS sends the arrival as a
+-- Unix epoch under snake_case keys, so JSON is hand-written (mirrors the rider app's `BusStopETA`).
+utcToIST :: UTCTime -> UTCTime
+utcToIST = addUTCTime 19800
+
+data BusStopETA = BusStopETA
+  { stopCode :: Text,
+    stopName :: Maybe Text,
+    arrivalTime :: UTCTime,
+    arrivalTimeUnix :: Integer,
+    etaSeconds :: Maybe Integer
+  }
+  deriving (Generic, Show, Eq)
+
+instance FromJSON BusStopETA where
+  parseJSON = withObject "BusStopETA" $ \v -> do
+    stopCode <- v .: "stop_id"
+    arrivalTimeUnix <- v .: "arrival_time"
+    etaSeconds <- v .:? "eta_seconds"
+    stopName <- v .:? "stop_name"
+    let arrivalTime = utcToIST $ posixSecondsToUTCTime $ realToFrac arrivalTimeUnix
+    return $ BusStopETA {..}
+
+instance ToJSON BusStopETA where
+  toJSON BusStopETA {..} =
+    object
+      [ "stop_id" .= stopCode,
+        "arrival_time" .= (floor (realToFrac (utcTimeToPOSIXSeconds arrivalTime) :: Double) :: Integer),
+        "eta_seconds" .= etaSeconds,
+        "stop_name" .= stopName,
+        "arrival_time_unix" .= arrivalTimeUnix
+      ]
+
+data BusScheduleDetail = BusScheduleDetail
+  { eta :: [BusStopETA],
+    vehicle_no :: Text,
+    service_tier :: BecknV2.FRFS.Enums.ServiceTierType,
+    trip_number :: Maybe Int,
+    waybill_no :: Maybe Text,
+    is_active_trip :: Maybe Bool
+  }
+  deriving (Generic, FromJSON, ToJSON, Show)
+
+type BusScheduleDetails = [BusScheduleDetail]
 
 data ExtraInfo = ExtraInfo
   { fareStageNumber :: Maybe Text,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API to retrieve bus trip schedules by route, waybill number, and trip number.
  * Responses now include vehicle details, service tier, trip status, and stop-level arrival times and ETAs.
  * Added support for fetching and caching schedule data from the connected transit service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->