### PR TITLE
backend/fix: add USING clause to bus_tracking_notification_tiers type

### DIFF
--- a/Backend/dev/migrations-read-only/rider-app/rider_config.sql
+++ b/Backend/dev/migrations-read-only/rider-app/rider_config.sql
@@ -784,4 +784,4 @@ ALTER TABLE atlas_app.rider_config ADD COLUMN bus_tracking_notification_tiers te
 
 ------- SQL updates -------
 
-ALTER TABLE atlas_app.rider_config ALTER COLUMN bus_tracking_notification_tiers TYPE text [];
+ALTER TABLE atlas_app.rider_config ALTER COLUMN bus_tracking_notification_tiers TYPE text [] USING bus_tracking_notification_tiers::text[];


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
rider_config.sql's ALTER COLUMN bus_tracking_notification_tiers TYPE text[] (from #24f5913f40) has no USING clause, so Postgres rejects it (42804: cannot be cast automatically to type text[]) — breaks every fresh local init after this migration. Adds USING bus_tracking_notification_tiers::text[], matching Postgres's own error hint; safe since the column was just added as empty text one statement earlier in the same script.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of existing bus-tracking notification tier data during database updates, helping preserve stored configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->