### PR TITLE
backend/fix: send operator referral code in fleet owner res

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Fleet/API/Driver.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Fleet/API/Driver.yaml
@@ -2091,6 +2091,7 @@ types:
     - operatorContact: Maybe Text
     - operators: "[(Text, Maybe Text)]"
     - referralCode: Maybe Text
+    - operatorReferralCode: Maybe Text
     - registeredAt: Maybe UTCTime
     - businessLicenseNumber: Maybe Text
     - vatNumber: Maybe Text

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Fleet/Endpoints/Driver.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Fleet/Endpoints/Driver.hs
@@ -746,6 +746,7 @@ data FleetOwnerInfoRes = FleetOwnerInfoRes
     operatorContact :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     operators :: [(Text, Kernel.Prelude.Maybe Kernel.Prelude.Text)],
     referralCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    operatorReferralCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     registeredAt :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
     businessLicenseNumber :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     vatNumber :: Kernel.Prelude.Maybe Kernel.Prelude.Text,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Fleet/Driver.hs
@@ -2619,6 +2619,7 @@ getFleetOrOperatorInfo person = do
             lastName = person.lastName,
             fleetType = "",
             referralCode = (.referralCode.getId) <$> referral,
+            operatorReferralCode = Nothing,
             blocked = False,
             enabled = True,
             verified = True,
@@ -2678,11 +2679,15 @@ getFleetOrOperatorInfo person = do
       let (operatorName, operatorContact) = case operatorsList of
             [] -> (Nothing, Nothing)
             ((name, contact) : _) -> (Just name, contact)
-      makeFleetOwnerInfoRes fleetConfig fleetOwnerInfo person operatorName operatorContact operatorsList
+      let mbOperatorId = (\foa -> Id foa.operatorId) <$> listToMaybe fleetOperatorAssocs
+      referrals <- QDR.findAllByDriverIds (personId : maybeToList mbOperatorId)
+      let referralCodeFor pid = (.referralCode.getId) <$> find ((== pid) . (.driverId)) referrals
+          ownerReferralCode = referralCodeFor personId
+          operatorReferralCode = mbOperatorId >>= referralCodeFor
+      makeFleetOwnerInfoRes fleetConfig fleetOwnerInfo person operatorName operatorContact operatorsList ownerReferralCode operatorReferralCode
   where
-    makeFleetOwnerInfoRes :: Maybe DFC.FleetConfig -> DFOI.FleetOwnerInformation -> DP.Person -> Maybe Text -> Maybe Text -> [(Text, Maybe Text)] -> Flow Common.FleetOwnerInfoRes
-    makeFleetOwnerInfoRes mbFleetConfig DFOI.FleetOwnerInformation {..} fleetOwner operatorName operatorContact operatorsList = do
-      referral <- QDR.findById fleetOwnerPersonId
+    makeFleetOwnerInfoRes :: Maybe DFC.FleetConfig -> DFOI.FleetOwnerInformation -> DP.Person -> Maybe Text -> Maybe Text -> [(Text, Maybe Text)] -> Maybe Text -> Maybe Text -> Flow Common.FleetOwnerInfoRes
+    makeFleetOwnerInfoRes mbFleetConfig DFOI.FleetOwnerInformation {..} fleetOwner operatorName operatorContact operatorsList ownerReferralCode operatorReferralCode = do
       let fleetConfig =
             mbFleetConfig <&> \fleetConfig' ->
               Common.FleetConfig
@@ -2731,7 +2736,8 @@ getFleetOrOperatorInfo person = do
       return $
         Common.FleetOwnerInfoRes
           { fleetType = show fleetType,
-            referralCode = (.referralCode.getId) <$> referral,
+            referralCode = ownerReferralCode,
+            operatorReferralCode = operatorReferralCode,
             gstNumber = gstNumber',
             gstImageId = gstImageIdVal,
             panNumber = panNumber',

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverReferralExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverReferralExtra.hs
@@ -2,6 +2,7 @@ module Storage.Queries.DriverReferralExtra where
 
 import qualified Data.Text
 import qualified Database.Beam as B
+import qualified Domain.Types.DriverReferral
 import qualified Domain.Types.Person
 import qualified EulerHS.Language as L
 import Kernel.Beam.Functions
@@ -15,6 +16,10 @@ import qualified Storage.Beam.DriverReferral as BeamDR
 import Storage.Queries.OrphanInstances.DriverReferral ()
 
 -- Extra code goes here --
+
+findAllByDriverIds :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => [Id Domain.Types.Person.Person] -> m [Domain.Types.DriverReferral.DriverReferral]
+findAllByDriverIds driverIds =
+  findAllWithKV [Se.Is Beam.driverId $ Se.In (getId <$> driverIds)]
 
 getLastRefferalCode ::
   (MonadFlow m, EsqDBFlow m r, CacheFlow m r, Log m) =>


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `operatorReferralCode` to fleet-owner information responses (when available).
* **Bug Fixes**
  * Updated fleet-owner details to populate the operator referral code from the first available fleet-operator association.
  * Ensured operator-only responses omit `operatorReferralCode`, improving consistency across related information payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->