### PR TITLE
backend/feat: update manual Udyam record handling to include image va…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/UdyamVerification.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/UdyamVerification.hs
@@ -78,7 +78,7 @@ verifyUdyam (personId, merchantOpCityId) req = do
   cfg <- SStatus.getFleetDocVerificationConfig merchantOpCityId ODC.UDYAMCertificate person.role
   if cfg.doStrictVerifcation
     then verifyUdyamFlow person merchantOpCityId req.uamNumber req.imageId1
-    else upsertManualUdyamRecord person req.uamNumber req.imageId1
+    else upsertManualUdyamRecord person req.uamNumber req.imageId1 cfg.markImageValidOnValidationSkip
   res <- case person.role of
     Person.DRIVER -> do
       fork "enabling driver if all the mandatory document is verified" $ do
@@ -134,18 +134,19 @@ onVerifyUdyam verificationReq output serviceName = do
     _ -> throwError $ InternalError ("Unknown Service provider webhook encountered in onVerifyUdyam. Name of provider : " <> show serviceName)
   pure Ack
 
-upsertManualUdyamRecord :: Person.Person -> Text -> Id Image.Image -> Flow ()
-upsertManualUdyamRecord person uamNumber imageId = do
+upsertManualUdyamRecord :: Person.Person -> Text -> Id Image.Image -> Maybe Bool -> Flow ()
+upsertManualUdyamRecord person uamNumber imageId markValidOnSkip = do
   encryptedUam <- encrypt uamNumber
   existing <- DUQuery.findByDriverId person.id
   now <- getCurrentTime
+  let status = if markValidOnSkip == Just True then Documents.VALID else Documents.MANUAL_VERIFICATION_REQUIRED
   case existing of
     Just driverUdyam -> do
       let updated =
             driverUdyam
               { DUdyam.udyamNumber = encryptedUam,
                 DUdyam.documentImageId = imageId,
-                DUdyam.verificationStatus = Documents.MANUAL_VERIFICATION_REQUIRED,
+                DUdyam.verificationStatus = status,
                 DUdyam.rejectReason = Nothing,
                 DUdyam.enterpriseName = Nothing,
                 DUdyam.enterpriseType = Nothing,
@@ -153,7 +154,7 @@ upsertManualUdyamRecord person uamNumber imageId = do
               }
       DUQuery.updateByPrimaryKey updated
     Nothing -> do
-      udyamCardDetails <- buildDriverUdyamCard person encryptedUam Nothing Nothing Documents.MANUAL_VERIFICATION_REQUIRED imageId
+      udyamCardDetails <- buildDriverUdyamCard person encryptedUam Nothing Nothing status imageId
       DUQuery.create udyamCardDetails
 
 buildDriverUdyamCard :: Person.Person -> EncryptedHashedField 'AsEncrypted Text -> Maybe Text -> Maybe Text -> Documents.VerificationStatus -> Id Image.Image -> Flow DUdyam.DriverUdyam


### PR DESCRIPTION
…lidation flag

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated non-strict Udyam verification to support configuration-based document status.
  * When enabled, successfully skipped validations can now mark Udyam documents as valid instead of requiring manual verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->