### PR TITLE
rider/fix: send 5 variables for shuttle booking confirmation whatsapp

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Notifications.hs
@@ -2102,9 +2102,13 @@ notifyShuttleBookingConfirmed personId bookingId = do
             [("routeName", routeName)]
             Nothing
             Nothing
-          -- WhatsApp (secondary, opt-in): template `shuttle_booking_confirmation`.
-          let origin = fromMaybe "" booking.fromStationName
+          -- WhatsApp (secondary, opt-in): template `shuttle_booking_confirmation` expects 5 vars,
+          -- in order: name, source, destination, departure, vehicle. Non-empty fallbacks because
+          -- Meta rejects empty template variables (drops the whole message).
+          let riderName = fromMaybe "Rider" person.firstName
+              origin = fromMaybe "" booking.fromStationName
               destination = fromMaybe "" booking.toStationName
               departure = maybe "" showTimeIst booking.startTime
-          sendWhatsAppTemplateIfOptedIn person DMM.WHATSAPP_SHUTTLE_BOOKING_CONFIRMED [Just routeName, Just origin, Just destination, Just departure]
+              vehicle = fromMaybe "your shuttle" booking.vehicleNumber
+          sendWhatsAppTemplateIfOptedIn person DMM.WHATSAPP_SHUTTLE_BOOKING_CONFIRMED [Just riderName, Just origin, Just destination, Just departure, Just vehicle]
           pure True


### PR DESCRIPTION
## What
`notifyShuttleBookingConfirmed` now sends **5 variables** to the `shuttle_booking_confirmation` (`fin_shuttle_booking_confirmed`) WhatsApp template, matching its approved shape:

`[name, source, destination, departure, vehicle]`

Previously it sent 4 — `[routeName, origin, destination, departure]` — which (a) put `routeName` where the greeting name (`{{1}}`) belongs, and (b) omitted the vehicle (`{{5}}`).

## Why
The GupShup template expects 5 positional variables. On a count/parameter mismatch GupShup still returns `status: success` at submit, but **Meta silently drops the message** — so the booking-confirmation WhatsApp never delivered even though logs looked clean. Confirmed by a direct GupShup send: `template_id=8756354` delivers only with all 5 vars.

## Details
- `{{1}}` = `person.firstName` (fallback `"Rider"`) — was wrongly `routeName`
- `{{2}}` = `booking.fromStationName`
- `{{3}}` = `booking.toStationName`
- `{{4}}` = departure (`booking.startTime`)
- `{{5}}` = `booking.vehicleNumber` (fallback `"your shuttle"`)

Non-empty fallbacks are used because Meta rejects empty template variable values.

## Not in this PR (data, per environment)
`merchant_message` for `WHATSAPP_SHUTTLE_BOOKING_CONFIRMED` and `WHATSAPP_BUS_TRIP_STARTED` must have the approved YS `template_id` and `contains_url_button = true` (the `isTemplate=true` flag path already exists on `main`). Applied as data updates per env, not schema migration.

## Testing
- Direct GupShup send with 5 vars + `isTemplate=true` on the YS account (`2000229802`) delivers `8756354`.
- No schema/codegen change; pure application logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the optional WhatsApp shuttle booking confirmation message to display the rider’s name, route, departure time, and vehicle details in the proper order.
  * Added fallback values so confirmation messages are sent with complete template information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->