### PR TITLE
 refac : noinline getOneConfig compilation

### DIFF
--- a/Backend/app/dashboard/rider-dashboard/src/Domain/Action/RiderDashboard/Entity.hs
+++ b/Backend/app/dashboard/rider-dashboard/src/Domain/Action/RiderDashboard/Entity.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-ambiguous-fields #-}
+
 module Domain.Action.RiderDashboard.Entity
   ( CreateEntityReq (..),
     CreateEntityResp (..),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/NammaTag.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/NammaTag.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# OPTIONS_GHC -O0 #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/Backend/lib/config-pilot/src/Lib/ConfigPilot/Interface/Types.hs
+++ b/Backend/lib/config-pilot/src/Lib/ConfigPilot/Interface/Types.hs
@@ -202,6 +202,9 @@ instance ToMaybeOne [a] where
 
 -- | Fetch a single config value after dimension filtering. Works for both @Maybe@ and @[]@ return types.
 -- Throws an error if multiple rows match the given dimensions.
+-- NOINLINE: prevents GHC from inlining this into every call site (e.g. Search.hs calls it 3x
+-- with TransporterConfig which has 390+ fields), which causes simplifier ticks exhaustion at -O2.
+{-# NOINLINE getOneConfig #-}
 getOneConfig ::
   (ConfigDimensions a, ToMaybeOne (ConfigValueTypeOf a), Show a, MonadFlow m, CacheFlow m r, EsqDBFlow m r) =>
   a ->


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability and compilation stability across dashboard and configuration components.
  * Adjusted compiler settings to prevent optimization-related build warnings and processing issues.
  * No user-facing functionality, workflows, or public interfaces have changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->