### PR TITLE
chore: bump shared-kernel pin (includes Acko API error reclassificati…

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4004,11 +4004,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1784713546,
-        "narHash": "sha256-eRj//A20LRjfBoLRefuiSPEXsai3mIKYTKeJeTn4Ka0=",
+        "lastModified": 1784732360,
+        "narHash": "sha256-D2mxAyQ+S3mKuRxJxFokxJEpbqb74Kn7CXL8nr6qyXc=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "0fc63dd25edd126cb1af6ec998354b7a37498216",
+        "rev": "d184781d7661a1a933f2f66a844ec5fc84685fda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## Description

Bumps the `shared-kernel` pin to include the Acko API error reclassification fix https://github.com/nammayatri/shared-kernel/pull/1438

The shared-kernel change reworks `callAckoAPI` in `Kernel.External.Insurance.Acko.Flow` to pattern-match the Servant `ClientError` — a 4xx `FailureResponse` from Acko is now rethrown as `InvalidRequest` (E400) instead of `InternalError` (E500). Everything else (5xx, timeouts, connection errors) remains `InternalError`. This eliminates ~400 false 5xx entries per day on the Grafana dashboard from the `"Fork create insurance"` background thread.

### Additional Changes
- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context

The `"Fork create insurance"` background thread dies every time Acko rejects a policy request (HTTP 400, code `IVERR_015`). The framework logs this as `E500 INTERNAL_ERROR`, inflating the Grafana 5xx dashboard with ~400 false positives per day. The shared-kernel fix reclassifies downstream 4xx rejections as `InvalidRequest` (E400) so they no longer count as server errors.

## How did you test it?

- Built `mobility-core` in shared-kernel with `cabal build mobility-core` — all 622 modules compiled and linked successfully
- Full `cabal build all` in nammayatri with the updated shared-kernel pin — all packages compiled and linked successfully (rider-app-exe, dynamic-offer-driver-app-exe, rider-dashboard-exe, provider-dashboard-exe, dashboard-repl-check)

## Screenshot of test results

N/A — dependency pin update only, no logic changes in this repo.

## Checklist
- [x] I formatted the code and addressed linter errors
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary