### PR TITLE
[chore]: Add env for jobFanouts and then put everything in MasterCell

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Allocator/src/Environment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Allocator/src/Environment.hs
@@ -100,6 +100,7 @@ data HandlerEnv = HandlerEnv
     ssrMetrics :: SendSearchRequestToDriverMetricsContainer,
     maxShards :: Int,
     activeDriversListKeyShards :: Int,
+    enableDriverFeeShardedFanOut :: Bool,
     maxNotificationShards :: Int,
     gateNotifiedKeyShards :: Int,
     smsCfg :: SmsConfig,
@@ -183,6 +184,7 @@ buildHandlerEnv HandlerCfg {..} = do
   let internalEndPointHashMap = HMS.fromList $ MS.toList internalEndPointMap
   let requestId = Nothing
   shouldLogRequestId <- fromMaybe False . (>>= readMaybe) <$> lookupEnv "SHOULD_LOG_REQUEST_ID"
+  enableDriverFeeShardedFanOut <- fromMaybe False . (>>= readMaybe) <$> lookupEnv "ENABLE_DRIVER_FEE_SHARDED_FAN_OUT"
   let sessionId = Nothing
   let kafkaProducerForART = Just kafkaProducerTools
   hedisClusterEnv <-

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Common/PayoutRequest.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Common/PayoutRequest.hs
@@ -94,7 +94,8 @@ executeSpecialZonePayoutRequest ::
     HasKafkaProducer r,
     RideEnd.EndRideFlow m r,
     LocationUpdateFlow m r c,
-    HasField "activeDriversListKeyShards" r Int
+    HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool
   ) =>
   DPR.PayoutRequest ->
   m ()

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
@@ -191,7 +191,7 @@ data ServiceHandle m = ServiceHandle
   }
 
 buildEndRideHandle ::
-  (LocUpd.LocationUpdateFlow m r c, HasField "activeDriversListKeyShards" r Int) =>
+  (LocUpd.LocationUpdateFlow m r c, HasField "activeDriversListKeyShards" r Int, HasField "enableDriverFeeShardedFanOut" r Bool) =>
   Id DM.Merchant ->
   Id DMOC.MerchantOperatingCity ->
   Maybe (Id DRide.Ride) ->

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -170,6 +170,7 @@ endRideTransaction ::
     HasField "serviceClickhouseEnv" r CH.ClickhouseEnv,
     HasField "blackListedJobs" r [Text],
     HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool,
     HasFlowEnv m r '["appBackendBapInternal" ::: AppBackendBapInternal],
     HasFlowEnv m r '["internalEndPointHashMap" ::: HM.HashMap BaseUrl BaseUrl],
     HasField "rideEventsPublisherCfg" r (Maybe Environment.RideEventsPublisherCfg),
@@ -279,6 +280,7 @@ processEndRideFinance ::
     HasField "serviceClickhouseEnv" r CH.ClickhouseEnv,
     HasField "blackListedJobs" r [Text],
     HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool,
     Redis.HedisLTSFlowEnv r,
     BeamFlow m r
   ) =>
@@ -990,6 +992,7 @@ createDriverFee ::
     JobCreatorEnv r,
     HasField "schedulerType" r SchedulerType,
     HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool,
     HasKafkaProducer r,
     Redis.HedisLTSFlowEnv r
   ) =>
@@ -1130,7 +1133,7 @@ createDriverFee merchantId merchantOpCityId driverId rideFare currency newFarePa
       let driverFeeToCreate = driverFee{siblingFeeId = elderSiblingId}
       QDF.create driverFeeToCreate
 
-scheduleJobs :: (CacheFlow m r, EsqDBFlow m r, JobCreatorEnv r, HasField "schedulerType" r SchedulerType, HasField "activeDriversListKeyShards" r Int) => TransporterConfig -> DF.DriverFee -> Id Merchant -> Id MerchantOperatingCity -> UTCTime -> m ()
+scheduleJobs :: (CacheFlow m r, EsqDBFlow m r, JobCreatorEnv r, HasField "schedulerType" r SchedulerType, HasField "activeDriversListKeyShards" r Int, HasField "enableDriverFeeShardedFanOut" r Bool) => TransporterConfig -> DF.DriverFee -> Id Merchant -> Id MerchantOperatingCity -> UTCTime -> m ()
 scheduleJobs transporterConfig driverFee merchantId merchantOpCityId now = do
   logDebug $ "scheduleJobs: for driverFee" <> show driverFee
   void $

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Environment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Environment.hs
@@ -273,6 +273,7 @@ data AppEnv = AppEnv
     maxNotificationShards :: Int,
     gateNotifiedKeyShards :: Int,
     activeDriversListKeyShards :: Int,
+    enableDriverFeeShardedFanOut :: Bool,
     version :: Metrics.DeploymentVersion,
     enableRedisLatencyLogging :: Bool,
     enablePrometheusMetricLogging :: Bool,
@@ -396,6 +397,7 @@ buildAppEnv cfg@AppCfg {searchRequestExpirationSeconds = _searchRequestExpiratio
       Right env -> pure (Just env)
   let requestId = Nothing
   shouldLogRequestId <- fromMaybe False . (>>= readMaybe) <$> lookupEnv "SHOULD_LOG_REQUEST_ID"
+  enableDriverFeeShardedFanOut <- fromMaybe False . (>>= readMaybe) <$> lookupEnv "ENABLE_DRIVER_FEE_SHARDED_FAN_OUT"
   let sessionId = Nothing
   let kafkaProducerForART = Just kafkaProducerTools
   bppMetrics <- registerBPPMetricsContainer metricsSearchDurationTimeout

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/ActiveDriversList.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/ActiveDriversList.hs
@@ -39,14 +39,16 @@ mkActiveDriversSetKeyForShard :: Int -> UTCTime -> NominalDiffTime -> Text
 mkActiveDriversSetKeyForShard shardNum referenceTime diffTimeFromUTC =
   "ActiveDrivers:Set:" <> localDateStr referenceTime diffTimeFromUTC <> ":{shard-" <> show shardNum <> "}"
 
-getActiveDriversForShard :: Redis.HedisFlow m r => Int -> UTCTime -> NominalDiffTime -> m [Text]
+getActiveDriversForShard :: (Redis.HedisFlow m r, TryException m) => Int -> UTCTime -> NominalDiffTime -> m [Text]
 getActiveDriversForShard shardNum referenceTime diffTimeFromUTC =
-  Redis.sMembers (mkActiveDriversSetKeyForShard shardNum referenceTime diffTimeFromUTC)
+  Redis.runInMasterCloudRedisCell $
+    Redis.sMembers (mkActiveDriversSetKeyForShard shardNum referenceTime diffTimeFromUTC)
 
-getShardNumsForFanOut :: forall r m. (MonadReader r m, HasField "activeDriversListKeyShards" r Int) => m [Maybe Int]
+getShardNumsForFanOut :: forall r m. (MonadReader r m, HasField "activeDriversListKeyShards" r Int, HasField "enableDriverFeeShardedFanOut" r Bool) => m [Maybe Int]
 getShardNumsForFanOut = do
   n <- asks @r (.activeDriversListKeyShards)
-  pure $ if n <= 0 then [Nothing] else Just <$> [0 .. n - 1]
+  shardingEnabled <- asks @r (.enableDriverFeeShardedFanOut)
+  pure $ if shardingEnabled && n > 0 then Just <$> [0 .. n - 1] else [Nothing]
 
 getTTLForActiveDriversList :: MonadTime m => NominalDiffTime -> m Int
 getTTLForActiveDriversList diffTimeFromUTC = do
@@ -60,7 +62,7 @@ getTTLForActiveDriversList diffTimeFromUTC = do
 
 addDriverToActiveList ::
   forall r m.
-  (MonadThrow m, Log m, MonadTime m, Redis.HedisFlow m r, HasField "activeDriversListKeyShards" r Int) =>
+  (MonadThrow m, Log m, MonadTime m, Redis.HedisFlow m r, TryException m, HasField "activeDriversListKeyShards" r Int) =>
   Id DP.Person ->
   NominalDiffTime ->
   m ()
@@ -68,7 +70,7 @@ addDriverToActiveList driverId diffTimeFromUTC = do
   shards <- asks @r (.activeDriversListKeyShards)
   ttl <- getTTLForActiveDriversList diffTimeFromUTC
   key <- mkActiveDriversSetKey shards (driverId.getId) diffTimeFromUTC
-  void $ Redis.sAddExp key [driverId.getId] ttl
+  void $ Redis.runInMasterCloudRedisCell $ Redis.sAddExp key [driverId.getId] ttl
 
 mkDriverQueueKey :: Text -> Int -> UTCTime -> NominalDiffTime -> Text
 mkDriverQueueKey jobKeyPrefix shardNum referenceTime diffTimeFromUTC =
@@ -94,7 +96,7 @@ mkDriverQueueLockKey jobKeyPrefix shardNum referenceTime diffTimeFromUTC =
 --   concurrent caller still mid-populate, and drain an empty, not-yet-filled queue — silently
 --   treating an unprocessed shard as fully drained.
 getNextDriverBatch ::
-  (Redis.HedisFlow m r, MonadMask m) =>
+  (Redis.HedisFlow m r, MonadMask m, TryException m) =>
   Text ->
   Int ->
   UTCTime ->
@@ -102,14 +104,15 @@ getNextDriverBatch ::
   Int ->
   m [Text]
 getNextDriverBatch jobKeyPrefix shardNum referenceTime diffTimeFromUTC limit =
-  Redis.withWaitAndLockRedis (mkDriverQueueLockKey jobKeyPrefix shardNum referenceTime diffTimeFromUTC) 30 100000 $ do
-    let queueKey = mkDriverQueueKey jobKeyPrefix shardNum referenceTime diffTimeFromUTC
-        flagKey = mkDriverQueuePopulatedFlagKey jobKeyPrefix shardNum referenceTime diffTimeFromUTC
-    isFirstCall <- Redis.setNxExpire flagKey (2 * 24 * 3600) True
-    when isFirstCall $ do
-      activeDriverIds <- getActiveDriversForShard shardNum referenceTime diffTimeFromUTC
-      unless (null activeDriverIds) $
-        Redis.rPushExp queueKey activeDriverIds (2 * 24 * 3600)
-    batch <- Redis.lRange queueKey 0 (fromIntegral limit - 1)
-    Redis.lTrim queueKey (fromIntegral limit) (-1)
-    pure batch
+  Redis.runInMasterCloudRedisCell $
+    Redis.withWaitAndLockRedis (mkDriverQueueLockKey jobKeyPrefix shardNum referenceTime diffTimeFromUTC) 30 100000 $ do
+      let queueKey = mkDriverQueueKey jobKeyPrefix shardNum referenceTime diffTimeFromUTC
+          flagKey = mkDriverQueuePopulatedFlagKey jobKeyPrefix shardNum referenceTime diffTimeFromUTC
+      isFirstCall <- Redis.setNxExpire flagKey (2 * 24 * 3600) True
+      when isFirstCall $ do
+        activeDriverIds <- getActiveDriversForShard shardNum referenceTime diffTimeFromUTC
+        unless (null activeDriverIds) $
+          Redis.rPushExp queueKey activeDriverIds (2 * 24 * 3600)
+      batch <- Redis.lRange queueKey 0 (fromIntegral limit - 1)
+      Redis.lTrim queueKey (fromIntegral limit) (-1)
+      pure batch

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
@@ -92,6 +92,7 @@ calculateDriverFeeForDrivers ::
     HasShortDurationRetryCfg r c,
     HasField "maxShards" r Int,
     HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool,
     HasField "schedulerSetName" r Text,
     HasField "schedulerType" r SchedulerType,
     HasField "jobInfoMap" r (M.Map Text Bool),
@@ -694,7 +695,7 @@ mkInvoiceAgainstDriverFee driverFee (isCoinCleared, isAutoPay) = do
       }
 
 scheduleJobs ::
-  (CacheFlow m r, EsqDBFlow m r, JobCreatorEnv r, HasField "schedulerType" r SchedulerType, HasField "activeDriversListKeyShards" r Int) =>
+  (CacheFlow m r, EsqDBFlow m r, JobCreatorEnv r, HasField "schedulerType" r SchedulerType, HasField "activeDriversListKeyShards" r Int, HasField "enableDriverFeeShardedFanOut" r Bool) =>
   TransporterConfig ->
   UTCTime ->
   UTCTime ->

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Mandate/Notification.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Mandate/Notification.hs
@@ -55,6 +55,7 @@ sendPDNNotificationToDriver ::
     HasShortDurationRetryCfg r c,
     HasField "maxShards" r Int,
     HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool,
     HasField "schedulerSetName" r Text,
     HasField "schedulerType" r SchedulerType,
     HasField "jobInfoMap" r (M.Map Text Bool),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Payout/SpecialZonePayout.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Payout/SpecialZonePayout.hs
@@ -59,7 +59,8 @@ sendSpecialZonePayout ::
     HasKafkaProducer r,
     RideEnd.EndRideFlow m r,
     LocationUpdateFlow m r c,
-    HasField "activeDriversListKeyShards" r Int
+    HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool
   ) =>
   Job 'SpecialZonePayout ->
   m ExecutionResult
@@ -86,7 +87,8 @@ handleNewFlow ::
     HasKafkaProducer r,
     RideEnd.EndRideFlow m r,
     LocationUpdateFlow m r c,
-    HasField "activeDriversListKeyShards" r Int
+    HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool
   ) =>
   Id DPR.PayoutRequest ->
   m ExecutionResult
@@ -116,7 +118,8 @@ executeSpecialZonePayout ::
     HasKafkaProducer r,
     RideEnd.EndRideFlow m r,
     LocationUpdateFlow m r c,
-    HasField "activeDriversListKeyShards" r Int
+    HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool
   ) =>
   DPR.PayoutRequest ->
   m ExecutionResult
@@ -171,7 +174,8 @@ handleOldFlow ::
     HasKafkaProducer r,
     RideEnd.EndRideFlow m r,
     LocationUpdateFlow m r c,
-    HasField "activeDriversListKeyShards" r Int
+    HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool
   ) =>
   Id DSP.ScheduledPayout ->
   m ExecutionResult
@@ -227,7 +231,8 @@ executeOldSpecialZonePayout ::
     HasKafkaProducer r,
     RideEnd.EndRideFlow m r,
     LocationUpdateFlow m r c,
-    HasField "activeDriversListKeyShards" r Int
+    HasField "activeDriversListKeyShards" r Int,
+    HasField "enableDriverFeeShardedFanOut" r Bool
   ) =>
   DSP.ScheduledPayout ->
   m ExecutionResult


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature flag to control whether driver-fee fan-out is sharded (`ENABLE_DRIVER_FEE_SHARDED_FAN_OUT`). When disabled (default), behavior remains unchanged.
* **Bug Fixes**
  * Improved reliability of Redis-backed active-driver operations by running key Redis steps in the appropriate Redis execution context and tightening error-handling behavior.
* **Chores**
  * Propagated the new fan-out flag through the driver-fee and special-zone payout execution paths so it’s consistently applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->