### PR TITLE
docs(cursor): index 19-stcl-membership-topup in 00-index

### DIFF
--- a/.cursor/docs/00-index.md
+++ b/.cursor/docs/00-index.md
@@ -30,6 +30,7 @@ This directory contains chunked documentation for the Nammayatri backend. Each d
 | `16-status-definitions.md` | All status enums with state transition diagrams | Understanding booking/ride/ticket state machines |
 | `17-testing-framework.md` | Test-stack index → `Backend/dev/test-tool/README.md` | Running / extending the integration test stack |
 | `18-finance-module-guide.md` | Double-entry ledger, account types, driver wallet flow | Working on earnings, payouts, invoices, cancellation/refund accounting |
+| `19-stcl-membership-topup.md` | STCL Membership share top-up: one-row-per-purchase pattern, `/buyAdditionalShares` endpoint, cap / anti-overallocation logic, per-MOC `stclConfig` tunables | Working on STCL Membership top-up flow, share-range allocation, or the `get` / `update` API contract for multi-allotment drivers |
 
 ## Cross-Reference Guide
 
@@ -40,3 +41,4 @@ This directory contains chunked documentation for the Nammayatri backend. Each d
 - **FRFS feature**: Read `10-frfs-public-transport.md` → `05-beckn-protocol-flow.md`
 - **Multi-cloud bug**: Read `12-multi-cloud.md` → `08-database-patterns.md`
 - **Driver earnings / wallet / ledger**: Read `18-finance-module-guide.md` → `06-ride-flow.md`
+- **STCL membership share top-up**: Read `19-stcl-membership-topup.md` → `18-finance-module-guide.md` → `04-driver-app.md`


### PR DESCRIPTION
## Problem

The `.cursor/docs/` directory has 20 files (`00-index.md` plus 01-19), but the **Document Catalog** table in `00-index.md` only listed docs 01 through 18. `19-stcl-membership-topup.md` (172 lines) was **orphaned from the index** and not referenced anywhere in the "Cross-Reference Guide" section either.

Doc 19 is a real, substantive design document — not a stub. It covers the "one row per purchase" pattern for STCL Membership share top-up, the new `POST /buyAdditionalShares` endpoint, the cap / anti-overallocation logic, the `get` / `update` API contract changes for multi-allotment drivers, the Redis counter bootstrap invariant, and the per-MOC `TransporterConfig.stclConfig` tunables.

Anyone (human or AI agent using Cursor / Claude Code) following the index to find STCL Membership design context will not find it through the index and has to grep for it manually.

## Evidence

```bash
$ ls .cursor/docs/ | wc -l
20

$ grep -oE '`[0-9]{2}-[a-z-]+\.md`' .cursor/docs/00-index.md | sort -u | wc -l
18
# (the returned set is exactly 01..18, with no 19)

$ wc -l .cursor/docs/19-stcl-membership-topup.md
172 .cursor/docs/19-stcl-membership-topup.md
```

## Change

Two additions to `.cursor/docs/00-index.md`, no other files touched:

1. **Document Catalog** table: new row for `19-stcl-membership-topup.md` with a one-line topic summary and a "Read when..." trigger.
2. **Cross-Reference Guide**: new bullet
   `**STCL membership share top-up**: Read 19-stcl-membership-topup.md -> 18-finance-module-guide.md -> 04-driver-app.md`

The new entries match the existing format of the index exactly.

## Diff

```diff
@@ Document Catalog table @@
 | `18-finance-module-guide.md` | Double-entry ledger, account types, driver wallet flow | Working on earnings, payouts, invoices, cancellation/refund accounting |
+| `19-stcl-membership-topup.md` | STCL Membership share top-up: one-row-per-purchase pattern, `/buyAdditionalShares` endpoint, cap / anti-overallocation logic, per-MOC `stclConfig` tunables | Working on STCL Membership top-up flow, share-range allocation, or the `get` / `update` API contract for multi-allotment drivers |

@@ Cross-Reference Guide @@
 - **Driver earnings / wallet / ledger**: Read `18-finance-module-guide.md` -> `06-ride-flow.md`
+- **STCL membership share top-up**: Read `19-stcl-membership-topup.md` -> `18-finance-module-guide.md` -> `04-driver-app.md`
```

## Scope

- One file: `.cursor/docs/00-index.md`.
- One commit, 2 insertions.
- No code change, no schema change, no API change, no dhall config change.
- Pure doc index addition.

## Backward compatibility

None. Pure doc index addition.

## Testing

This is a pure doc change. The "testing" here is `grep`:

```bash
# Before
$ grep -oE '`[0-9]{2}-[a-z-]+\.md`' .cursor/docs/00-index.md | sort -u | wc -l
18

# After
$ grep -oE '`[0-9]{2}-[a-z-]+\.md`' .cursor/docs/00-index.md | sort -u | wc -l
19

$ grep -c "19-stcl" .cursor/docs/00-index.md
2   # one table row, one cross-ref bullet
```

No build, no `cabal build`, no `nix develop`, no tests. The PR template's "I formatted the code and addressed linter errors" checkbox is N/A for a markdown change.

## Checklist

- [x] I formatted the code and addressed linter errors - N/A, markdown
- [x] I reviewed submitted code - single-file 2-insertion diff
- [ ] I added unit tests for my changes where possible - N/A, doc change
- [ ] I added integration tests for my changes where possible - N/A, doc change
- [ ] I tested the changes using integration tests - N/A, doc change
- [ ] I added a CHANGELOG entry if applicable - N/A, doc change
- [ ] No leak detected in leakcanary - N/A, doc change

Fixes #15898.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the STCL Membership share top-up flow and its related API contract.
  * Added cross-references to relevant finance and driver app guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->