### PR TITLE
Fix/reduce false 5xx errors

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Search.hs
@@ -101,7 +101,7 @@ search transporterId authResult gatewayAuthResult reqV2 = withFlowHandlerBecknAP
         city <- Utils.getContextCity context
         merchant <- CQM.findById transporterId >>= fromMaybeM (MerchantDoesNotExist transporterId.getId)
         unless merchant.enabled $ throwError (AgencyDisabled transporterId.getId)
-        moc <- CQMOC.findByMerchantIdAndCity transporterId city >>= fromMaybeM (InternalError $ "Operating City" <> show city <> "not supported or not found ")
+        moc <- CQMOC.findByMerchantIdAndCity transporterId city >>= fromMaybeM (InvalidRequest $ "Operating City " <> show city <> " not supported or not found")
         void $ Utils.validateSearchContext context transporterId moc.id
         dSearchReq <- ACL.buildSearchReqV2 authResult.subscriber reqV2 bapUri
         msgId <- Utils.getMessageId context

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
@@ -58,7 +58,7 @@ syncSearch merchantIdRaw mbToken reqV2 = withFlowHandlerAPI $ do
     bapUri <- Utils.getContextBapUri context
     bapId <- context.contextBapId & fromMaybeM (InvalidRequest "bapId is missing")
     city <- Utils.getContextCity context
-    moc <- CQMOC.findByMerchantIdAndCity transporterId city >>= fromMaybeM (InternalError $ "Operating City" <> show city <> "not supported or not found ")
+    moc <- CQMOC.findByMerchantIdAndCity transporterId city >>= fromMaybeM (InvalidRequest $ "Operating City " <> show city <> " not supported or not found")
     void $ Utils.validateSearchContext context transporterId moc.id
     dSearchReq <- ACL.buildSearchReqV2Raw bapId bapUri reqV2 bapUri
     msgId <- Utils.getMessageId context

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverCoin.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverCoin.hs
@@ -296,7 +296,7 @@ useCoinsHandler (driverId, merchantId, merchantOpCityId) ConvertCoinToCashReq {.
             Redis.unlockRedis mkLockKey
             logDebug $ "Coins Conversion for DriverId: " <> driverId.getId <> "Converted to Cash"
         )
-    else throwError (InternalError $ "Coins Conversion Inprogress")
+    else throwError (InvalidRequest "Coins conversion already in progress, please wait")
   where
     withLockDriverId = do
       isLocked <- Redis.tryLockRedis mkLockKey 30

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
@@ -318,7 +318,7 @@ validateImage isDashboard mbUploaderRole mbDocConfigs (personId, merchantId, mer
             Redis.unlockRedis mkLockKey
             logDebug $ "Create Image Lock for PersonId: " <> personId.getId <> " Unlocked"
         )
-    else throwError (InternalError $ "Image Upload In Progress")
+    else throwError (InvalidRequest "Image upload already in progress, please wait")
   where
     withLockPersonId = do
       isLocked <- Redis.tryLockRedis mkLockKey 45

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
@@ -170,7 +170,7 @@ startRide handle rideId req = withLogTag ("rideId-" <> rideId.getId) $ do
             Redis.unlockRedis mkLockKey
             logDebug $ "Start ride for RideId: " <> rideId.getId <> " Unlocked"
         )
-    else throwError (InternalError "Start ride inprogress")
+    else throwError (InvalidRequest "Start ride already in progress, please wait")
   where
     mkLockKey = "StartTransaction:RID:-" <> rideId.getId
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
@@ -120,7 +120,7 @@ instance IsBaseError FareProductError where
 
 instance IsHTTPError FareProductError where
   toErrorCode NoFareProduct = "NO_FARE_PRODUCT"
-  toHttpCode NoFareProduct = E500
+  toHttpCode NoFareProduct = E400
 
 instance IsAPIError FareProductError
 

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/RouteServiceability.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/RouteServiceability.hs
@@ -149,9 +149,14 @@ buildRouteWithLiveVehicle routeInfo busScheduleDetails integratedBPPConfig fromS
       -- Batch-fetch all live info in one Redis HMGET instead of N individual calls
       let vehicleNos = map (.vehicle_no) busScheduleDetails'
       liveInfoResults <-
-        JMU.measureLatency
-          (JLCF.getVehicleMetadata vehicleNos integratedBPPConfig')
-          ("getBusScheduleInfo: getVehicleMetadata routeId=" <> routeId' <> " vehicles=" <> show (length vehicleNos))
+        if null vehicleNos
+          then do
+            logDebug $ "getBusScheduleInfo: No vehicles found for routeId=" <> routeId' <> ", returning empty list"
+            pure []
+          else
+            JMU.measureLatency
+              (JLCF.getVehicleMetadata vehicleNos integratedBPPConfig')
+              ("getBusScheduleInfo: getVehicleMetadata routeId=" <> routeId' <> " vehicles=" <> show (length vehicleNos))
       let busLiveInfoMap = zip vehicleNos liveInfoResults
       -- Hoist stop index lookup once (same cache key for all vehicles)
       mStopIndices <-


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Reclassifies several false E500 errors that were inflating the Grafana 5xx dashboard. Four independent fixes:

1. **Guard empty vehicle list in `getBusScheduleInfo`** (`RouteServiceability.hs`) — when a route has no buses running, the empty vehicle list was passed to `getVehicleMetadata`, which sends `HMGET` to Redis with zero fields. Redis rejects this, killing the thread with E500. Fix adds a null check before the Redis call, matching the existing pattern in `getNearbyBusesFRFS`.

2. **Reclassify unsupported operating city** (`Search.hs:104`, `SyncSearch.hs:61`) — when a Beckn search request arrives for a city not configured in the DB, it threw `InternalError` (E500). An unsupported city is a business/data issue, not a server error. Changed to `InvalidRequest` (E400). Also fixed missing spaces in the error message (`"Operating CityDurgapur"` → `"Operating City Durgapur"`).

3. **Reclassify `NoFareProduct`** (`Tools/Error.hs:122`) — during driver onboarding, a missing fare policy for a service tier + trip category combo threw E500. The code already handles this gracefully via `withTryCatch` and returns `Nothing` — user never sees the error. Changed `toHttpCode NoFareProduct` from `E500` to `E400` to stop inflating the dashboard.

4. **Reclassify Redis lock contention errors** (`StartRide.hs:173`, `DriverCoin.hs:299`, `Image.hs:321`) — when a driver double-taps "Start Ride", or concurrent requests hit coin conversion or image upload, the second request can't acquire the Redis lock and throws `InternalError` (E500). A duplicate/concurrent request is a client-side issue. Changed all three from `InternalError` to `InvalidRequest` (E400).

### Additional Changes
- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context

These errors were all classified as E500 but none represent actual internal server failures — they are expected conditions (missing config, empty input, duplicate requests) that should be 4xx or handled gracefully. Together they produce significant false 5xx noise on the Grafana dashboard, making it harder to spot real server errors.

## How did you test it?

- Full `cabal build all` passed — all packages compiled and linked successfully (rider-app-exe, dynamic-offer-driver-app-exe, rider-dashboard-exe, provider-dashboard-exe, dashboard-repl-check)

## Screenshot of test results

N/A — error reclassification changes only, no new logic.

## Checklist
- [x] I formatted the code and addressed linter errors
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated handling for unsupported or missing operating cities to return a clearer client error.
  * Improved “already in progress” messaging for coin conversion, image upload, and starting a ride.
  * Changed the “no fare products available” response to return HTTP 400 instead of HTTP 500.
  * Avoided unnecessary vehicle metadata lookups when a route has no vehicles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->