### PR TITLE
enhance: handle verification message in status handler

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/Status.hs
@@ -304,27 +304,7 @@ fetchVehicleDocStatusesForRC rc merchantOperatingCity transporterConfig language
   vehicleDoc <-
     find (\doc -> doc.registrationNo == reqRegistrationNo) vehicleDocumentsUnverified
       & fromMaybeM (InvalidRequest $ "Vehicle doc not found for vehicle with registartionNo " <> reqRegistrationNo)
-  -- Surface the RC validation failures (invalid fuel type / vehicle class / OEM / manufacturing year, as
-  -- computed by validateRCResponse and persisted in RC.failedRules) in the RC document's verificationMessage,
-  -- mirroring the /register/status behaviour (getRCAndStatus). Only messageful callers (skipMessages == False)
-  -- get this; the validity-only caller keeps skipping translations.
-  vehicleDocWithReasons <- appendRcFailedRulesToVehicleDoc language rc vehicleDoc
-  pure (vehicleDocWithReasons, allDocumentVerificationConfigs)
-
--- | Append this RC's @failedRules@ to the RC document's verificationMessage (only when it already has a base
---   message and is not VALID); every other document is left untouched.
-appendRcFailedRulesToVehicleDoc :: Language -> RC.VehicleRegistrationCertificate -> VehicleDocumentItem -> Flow VehicleDocumentItem
-appendRcFailedRulesToVehicleDoc language rc vehicleDoc
-  | null rc.failedRules = pure vehicleDoc
-  | otherwise = do
-    documents <- forM vehicleDoc.documents $ \doc ->
-      case (doc.documentType, doc.verificationStatus, doc.verificationMessage) of
-        (DVC.VehicleRegistrationCertificate, status, Just msg)
-          | status /= VALID -> do
-            msgWithReasons <- addVerificationReasons language (Just rc.failedRules) msg
-            pure doc {verificationMessage = Just msgWithReasons}
-        _ -> pure doc
-    pure vehicleDoc {documents = documents}
+  pure (vehicleDoc, allDocumentVerificationConfigs)
 
 -- | Fetch this RC's vehicle docs and check all enabling docs are VALID (non-BOT path; matches main's ForEnabling).
 fetchAndCheckVehicleDocsValidForEnabling ::

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/VehicleDocs.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/VehicleDocs.hs
@@ -365,11 +365,13 @@ fetchProcessedVehicleDocumentsWithRC entityImagesInfo allDocumentVerificationCon
         case mbStatus of
           Just status -> do
             mbMessage <- documentStatusMessage status Nothing docType mbProcessedUrl language skipMessages
-            return $ DocumentStatusItem {documentType = docType, verificationStatus = status, verificationMessage = mbProcessedReason <|> mbMessage, verificationUrl = mbProcessedUrl, s3Path = mbS3Path, imageId = mbImageId, imageId2 = Nothing, documentExpiry = mbExpiry, metadata = mbMetadata}
+            finalMessage <- appendRcFailedRules docType status language processedVehicle.failedRules (mbProcessedReason <|> mbMessage)
+            return $ DocumentStatusItem {documentType = docType, verificationStatus = status, verificationMessage = finalMessage, verificationUrl = mbProcessedUrl, s3Path = mbS3Path, imageId = mbImageId, imageId2 = Nothing, documentExpiry = mbExpiry, metadata = mbMetadata}
           Nothing -> do
             (status, mbReason, mbUrl, _, mbS3PathInProgress, mbImageIdInProgress) <- getInProgressVehicleDocuments entityImagesInfo (Just rcImagesInfo) docType docVerificationConfigs
             mbMessage <- documentStatusMessage status mbReason docType mbUrl language skipMessages
-            return $ DocumentStatusItem {documentType = docType, verificationStatus = status, verificationMessage = mbMessage, verificationUrl = mbUrl, s3Path = mbS3PathInProgress, imageId = mbImageIdInProgress, imageId2 = Nothing, documentExpiry = mbExpiry, metadata = Nothing}
+            finalMessage <- appendRcFailedRules docType status language processedVehicle.failedRules mbMessage
+            return $ DocumentStatusItem {documentType = docType, verificationStatus = status, verificationMessage = finalMessage, verificationUrl = mbUrl, s3Path = mbS3PathInProgress, imageId = mbImageIdInProgress, imageId2 = Nothing, documentExpiry = mbExpiry, metadata = Nothing}
 
     let mbRcImage = find (\img -> img.id == processedVehicle.documentImageId) entityImagesInfo.entityImages
         rcS3Path = mbRcImage <&> (.s3Path)
@@ -867,6 +869,20 @@ documentStatusMessage status mbReason docType mbVerificationUrl language skipMes
             | otherwise -> toVerificationMessage Other language
           Nothing -> toVerificationMessage Other language
     pure $ Just msg
+
+appendRcFailedRules :: DDVC.DocumentType -> ResponseStatus -> Language -> [Text] -> Maybe Text -> Flow (Maybe Text)
+appendRcFailedRules docType status language failedRules mbMsg =
+  case (docType, mbMsg) of
+    (DDVC.VehicleRegistrationCertificate, Just msg)
+      | status /= VALID && not (null failedRules) -> do
+        translatedReasons <- forM failedRules $ \reason -> do
+          let (key, value) = T.breakOn ":" reason
+          translatedKey <- translateDynamicKey key language
+          if T.null value
+            then pure translatedKey
+            else pure $ translatedKey <> ": " <> T.drop 1 value
+        pure $ Just (msg <> T.intercalate ", " translatedReasons)
+    _ -> pure mbMsg
 
 mapStatus :: Documents.VerificationStatus -> ResponseStatus
 mapStatus = \case


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Vehicle registration certificate (RC) verification messages now include translated reasons derived from failed validation rules.
  - These additional reasons are added only for RC documents when the verification status is not `VALID` and there are non-empty failed rules.
  - For valid documents, or when no applicable failed rules exist, the existing verification messages remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->