### PR TITLE
fix : media upload status update correction

### DIFF
--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
@@ -187,7 +187,13 @@ xyneAttachmentToMediaFile att = do
             DMF._type = mimeTypeToFileType att.mimeType,
             DMF.url = att.url,
             DMF.s3FilePath = Nothing,
-            DMF.status = Just DMF.CONFIRMED,
+            -- COMPLETED, not CONFIRMED: the readiness checks that gate media on
+            -- the way out (toChatMessageItem, mkMediaFiles, recreateIssueChats)
+            -- only accept COMPLETED or a null status, so anything else is
+            -- silently filtered out of the chat response. There is no async
+            -- upload to wait on here — the Xyne URL is stored as-is — so the
+            -- row is ready the moment it is written.
+            DMF.status = Just DMF.COMPLETED,
             DMF.fileHash = Nothing,
             DMF.createdAt = now,
             DMF.updatedAt = Just now


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
The older media status update used CONFIRMED as status while the required values were only COMPLETED/NULL, now updated such that it matched the required values.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Xyne attachments are now marked as completed, ensuring they pass downstream readiness checks correctly.
  * Attachments no longer risk being treated as pending when their URLs are already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->