### PR TITLE
backend/feat: rehost Xyne webhook attachments to S3

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Issue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Issue.hs
@@ -57,6 +57,7 @@ handler = externalHandler
         :<|> issueReportDriverList (personId, merchantId, merchantOpCityId)
         :<|> issueMediaUpload (personId, merchantId, merchantOpCityId)
         :<|> fetchMedia (personId, merchantId, merchantOpCityId)
+        :<|> mediaFileDownloadLink (personId, merchantId, merchantOpCityId)
         :<|> getIssueCategory (personId, merchantId, merchantOpCityId)
         :<|> getIssueOption (personId, merchantId, merchantOpCityId)
         :<|> issueInfo (personId, merchantId, merchantOpCityId)
@@ -365,6 +366,10 @@ issueReportDriverList (driverId, merchantId, merchantOpCityId) language = withFl
 
 fetchMedia :: (Id SP.Person, Id DM.Merchant, Id DMOC.MerchantOperatingCity) -> Text -> FlowHandler Text
 fetchMedia (driverId, merchantId, _) filePath = withFlowHandlerAPI $ Common.fetchMedia (cast driverId, cast merchantId) filePath
+
+mediaFileDownloadLink :: (Id SP.Person, Id DM.Merchant, Id DMOC.MerchantOperatingCity) -> Id Domain.IssueReport -> Text -> FlowHandler Common.MediaFileDownloadLinkRes
+mediaFileDownloadLink (driverId, merchantId, _) issueReportId mediaFileId =
+  withFlowHandlerAPI $ Common.mediaFileDownloadLink (cast driverId, cast merchantId) Common.DRIVER issueReportId mediaFileId
 
 createIssueReport :: (Id SP.Person, Id DM.Merchant, Id DMOC.MerchantOperatingCity) -> Maybe Language -> Common.IssueReportReq -> FlowHandler Common.IssueReportRes
 createIssueReport (driverId, merchantId, _merchantOpCityId) mbLanguage req = withFlowHandlerAPI $ Common.createIssueReport (cast driverId, cast merchantId) mbLanguage req driverIssueHandle Common.DRIVER Nothing

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Rating.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Rating.hs
@@ -277,6 +277,8 @@ createMediaEntry url fileType filePath = do
             s3FilePath = Just filePath,
             status = Just D.COMPLETED,
             fileHash = Nothing,
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Message.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Message.hs
@@ -81,6 +81,8 @@ createMediaEntry Common.AddLinkAsMedia {..} = do
             s3FilePath = Nothing,
             status = Just Domain.COMPLETED,
             fileHash = Nothing,
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }
@@ -106,6 +108,8 @@ postMessageUploadFile merchantShortId opCity Common.UploadFileRequest {..} = do
             s3FilePath = Just filePath,
             status = Just Domain.PENDING,
             fileHash = Nothing,
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -2345,6 +2345,8 @@ createMediaEntry driverId Common.AddLinkAsMedia {..} filePath imageType mbRc = d
             s3FilePath = Just filePath,
             status = Just Domain.COMPLETED,
             fileHash = Nothing,
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
@@ -461,6 +461,8 @@ uploadOdometerReading merchantOpCityId rideId UploadOdometerReq {..} = do
             s3FilePath = Just fp,
             status = Just MediaFile.PENDING,
             fileHash = Nothing,
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }
@@ -517,6 +519,8 @@ uploadDeliveryImage merchantOpCityId rideId DeliveryImageUploadReq {..} = do
             s3FilePath = Just fp,
             status = Just MediaFile.PENDING,
             fileHash = Nothing,
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Sos.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Sos.hs
@@ -341,6 +341,8 @@ uploadMedia sosId personId SOSVideoUploadReq {..} = do
             s3FilePath = Just filePath,
             status = Just DMF.COMPLETED,
             fileHash = Nothing,
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/MediaFileDocument.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/MediaFileDocument.hs
@@ -72,6 +72,8 @@ mediaFileDocumentUploadLink merchantShortId opCity _requestorId req = do
         s3FilePath = Just filePath,
         status = Just DMF.PENDING,
         fileHash = Nothing,
+        name = Nothing,
+        size = Nothing,
         createdAt = now,
         updatedAt = Just now
       }

--- a/Backend/app/rider-platform/rider-app/Main/src/API/UI/Issue.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/UI/Issue.hs
@@ -94,6 +94,7 @@ handler = externalHandler
         :<|> issueReportCustomerList (personId, merchantId)
         :<|> issueMediaUpload (personId, merchantId)
         :<|> fetchMedia (personId, merchantId)
+        :<|> mediaFileDownloadLink (personId, merchantId)
         :<|> getIssueCategory (personId, merchantId)
         :<|> getIssueOption (personId, merchantId)
         :<|> issueInfo (personId, merchantId)
@@ -499,6 +500,10 @@ issueReportCustomerList (personId, merchantId) language = withFlowHandlerAPI $ d
 
 fetchMedia :: (Id SP.Person, Id DM.Merchant) -> Text -> FlowHandler Text
 fetchMedia (personId, merchantId) = withFlowHandlerAPI . Common.fetchMedia (cast personId, cast merchantId)
+
+mediaFileDownloadLink :: (Id SP.Person, Id DM.Merchant) -> Id Domain.IssueReport -> Text -> FlowHandler Common.MediaFileDownloadLinkRes
+mediaFileDownloadLink (personId, merchantId) issueReportId =
+  withFlowHandlerAPI . Common.mediaFileDownloadLink (cast personId, cast merchantId) Common.CUSTOMER issueReportId
 
 createIssueReport :: (Id SP.Person, Id DM.Merchant) -> Maybe Language -> Common.IssueReportReq -> FlowHandler Common.IssueReportRes
 createIssueReport (personId, merchantId) mbLanguage req = withFlowHandlerAPI $ do

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/AppManagement/MerchantOnboarding.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/AppManagement/MerchantOnboarding.hs
@@ -374,6 +374,8 @@ buildMediaEntry url fileType filePath = do
         s3FilePath = Just filePath,
         status = Just DMF.PENDING,
         fileHash = Nothing,
+        name = Nothing,
+        size = Nothing,
         createdAt = now,
         updatedAt = Just now
       }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PassDetails.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PassDetails.hs
@@ -521,6 +521,8 @@ postPassDetailsUploadDocument (mbPersonId, merchantId) req = do
         s3FilePath = Just s3FilePath,
         status = Just DMF.COMPLETED,
         fileHash = Nothing,
+        name = Nothing,
+        size = Nothing,
         createdAt = now,
         updatedAt = Just now
       }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PickupInstructions.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PickupInstructions.hs
@@ -316,6 +316,8 @@ createMediaFileEntry fileUrl filePath = do
         s3FilePath = Just filePath,
         status = Just DMF.COMPLETED,
         fileHash = Nothing,
+        name = Nothing,
+        size = Nothing,
         createdAt = now,
         updatedAt = Just now
       }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Sos.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Sos.hs
@@ -525,6 +525,8 @@ uploadMedia sosId personId SOSVideoUploadReq {..} = do
             s3FilePath = Just filePath,
             status = Just DMF.COMPLETED,
             fileHash = Nothing,
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }

--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0846-add-name-size-to-media-file.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0846-add-name-size-to-media-file.sql
@@ -1,0 +1,2 @@
+ALTER TABLE atlas_driver_offer_bpp.media_file ADD COLUMN name text;
+ALTER TABLE atlas_driver_offer_bpp.media_file ADD COLUMN size integer;

--- a/Backend/dev/ddl-migrations/rider-app/1555-add-name-size-to-media-file.sql
+++ b/Backend/dev/ddl-migrations/rider-app/1555-add-name-size-to-media-file.sql
@@ -1,0 +1,2 @@
+ALTER TABLE atlas_app.media_file ADD COLUMN name text;
+ALTER TABLE atlas_app.media_file ADD COLUMN size integer;

--- a/Backend/lib/beckn-services/src/AWS/S3/Types.hs
+++ b/Backend/lib/beckn-services/src/AWS/S3/Types.hs
@@ -198,3 +198,12 @@ putPublicRaw :: (MonadReader r m, HasField "s3EnvPublic" r (S3Env m)) => String 
 putPublicRaw path file_ contentType_ = do
   s3EnvPublic <- asks (.s3EnvPublic)
   putRawH s3EnvPublic path file_ contentType_
+
+-- | Store raw bytes (with a content type) in the private bucket. Unlike 'put',
+-- which writes its 'Text' argument as-is — callers there hand it base64 and the
+-- object holds base64 — this stores the actual bytes, so a presigned download
+-- serves a file a browser or player can use directly.
+putRaw :: (MonadReader r m, HasField "s3Env" r (S3Env m)) => String -> BS.ByteString -> String -> m ()
+putRaw path file_ contentType_ = do
+  s3env <- asks (.s3Env)
+  putRawH s3env path file_ contentType_

--- a/Backend/lib/shared-services/package.yaml
+++ b/Backend/lib/shared-services/package.yaml
@@ -74,7 +74,9 @@ dependencies:
   - exceptions
   - hspec
   - http-client
+  - http-client-tls
   - lens
+  - network
   - servant
   - servant-client
   - servant-client-core

--- a/Backend/lib/shared-services/shared-services.cabal
+++ b/Backend/lib/shared-services/shared-services.cabal
@@ -98,6 +98,7 @@ library
       IssueManagement.Tools.Error
       IssueManagement.Tools.UtilsTH
       IssueManagement.Utils.Html
+      IssueManagement.Utils.RemoteFile
       MerchantDocuments.Domain.Action.UI.MerchantDocument
       MerchantDocuments.Domain.Types.Common
       MerchantDocuments.Storage.BeamFlow
@@ -218,10 +219,12 @@ library
     , geojson
     , hspec
     , http-client
+    , http-client-tls
     , lens
     , location-updates
     , mobility-core
     , mock-registry
+    , network
     , openapi3
     , persistent
     , postgresql-simple

--- a/Backend/lib/shared-services/src/IssueManagement/API/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/API/UI/Issue.hs
@@ -13,6 +13,9 @@ type IssueAPI =
       :> Common.IssueUploadAPI
     :<|> "media"
       :> Common.IssueFetchMediaAPI
+    :<|> "media"
+      :> "downloadLink"
+      :> Common.IssueMediaDownloadLinkAPI
     :<|> "category"
       :> Common.IssueCategoryAPI
     :<|> "option"

--- a/Backend/lib/shared-services/src/IssueManagement/Common/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Common/UI/Issue.hs
@@ -162,6 +162,22 @@ type IssueFetchMediaAPI =
 
 -------------------------------------------------------------------------
 
+-- | Short-lived link for opening a media file outside the app (a PDF handed to
+-- the OS viewer, say). Our own media endpoint needs an auth token, which an
+-- external viewer cannot supply, so we presign the S3 object instead.
+newtype MediaFileDownloadLinkRes = MediaFileDownloadLinkRes
+  { downloadUrl :: Text
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+type IssueMediaDownloadLinkAPI =
+  MandatoryQueryParam "issueReportId" (Id IssueReport)
+    :> MandatoryQueryParam "mediaFileId" Text
+    :> Get '[JSON] MediaFileDownloadLinkRes
+
+-------------------------------------------------------------------------
+
 type IssueDeleteAPI =
   Delete '[JSON] APISuccess
 

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
@@ -351,6 +351,10 @@ createMediaEntry url fileType filePath = do
             s3FilePath = Just filePath,
             status = Just D.PENDING,
             fileHash = Nothing,
+            -- Multipart uploads don't carry the client's original filename, and
+            -- the size is already enforced by the caller's limit check.
+            name = Nothing,
+            size = Nothing,
             createdAt = now,
             updatedAt = Just now
           }
@@ -478,6 +482,51 @@ issueMediaUpload (personId, merchantId) issueHandle Common.IssueMediaUploadReq {
 fetchMedia :: (HasField "s3Env" r (S3.S3Env m), MonadReader r m, BeamFlow m r) => (Id Person, Id Merchant) -> Text -> m Text
 fetchMedia _personId filePath =
   S3.get $ T.unpack filePath
+
+-- | Presigned, time-limited link for opening a media file outside the app.
+--
+-- 'fetchMedia' above returns base64 behind our token auth, which works for
+-- anything the app renders itself but not for handing a file to an external
+-- viewer — a browser opening a PDF cannot present the token. Presigning the S3
+-- object gives a url that stands on its own for a few minutes.
+--
+-- Rows with no @s3FilePath@ (a third-party attachment whose rehost failed, or a
+-- legacy row predating rehosting) fall back to their stored url, so older
+-- attachments keep opening.
+--
+-- The link it hands out needs no auth, so access is checked first: the caller
+-- must own the issue, and the file must actually belong to that issue — either
+-- as media attached to the report itself or on one of its chat messages.
+-- @media_file@ carries no owner of its own, so the issue is what scopes it;
+-- without that any authenticated user could presign any file by id.
+mediaFileDownloadLink ::
+  (HasField "s3Env" r (S3.S3Env m), MonadReader r m, BeamFlow m r) =>
+  (Id Person, Id Merchant) ->
+  Identifier ->
+  Id D.IssueReport ->
+  Text ->
+  m Common.MediaFileDownloadLinkRes
+mediaFileDownloadLink (personId, _merchantId) identifier issueReportId mediaFileId = do
+  issueReport <-
+    QIR.findById issueReportId
+      >>= fromMaybeM (IssueReportDoesNotExist issueReportId.getId)
+  unless (issueReport.personId == personId) $
+    throwError (InvalidRequest "This issue does not belong to the caller.")
+  chatMessages <- QCM.findChatMessagesAfter issueReportId Nothing Nothing
+  let issueMediaIds = issueReport.mediaFiles <> concatMap (.mediaFileIds) chatMessages
+  unless (Id mediaFileId `elem` issueMediaIds) $
+    throwError (InvalidRequest "This media file does not belong to the issue.")
+  mediaFile <-
+    CQMF.findById (Id mediaFileId) identifier
+      >>= fromMaybeM (FileDoesNotExist mediaFileId)
+  let isReady = mediaFile.status == Just D.COMPLETED || isNothing mediaFile.status
+  unless isReady . throwError $ InvalidRequest "Media file is not ready to download."
+  downloadUrl <- case mediaFile.s3FilePath of
+    Just s3Path -> S3.generateDownloadUrl (T.unpack s3Path) mediaFileLinkExpiry
+    Nothing -> pure mediaFile.url
+  pure Common.MediaFileDownloadLinkRes {downloadUrl}
+  where
+    mediaFileLinkExpiry = Seconds 300
 
 createIssueReport ::
   ( EsqDBReplicaFlow m r,

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
@@ -187,7 +187,13 @@ xyneAttachmentToMediaFile att = do
             DMF._type = mimeTypeToFileType att.mimeType,
             DMF.url = att.url,
             DMF.s3FilePath = Nothing,
-            DMF.status = Just DMF.CONFIRMED,
+            -- COMPLETED, not CONFIRMED: the readiness checks that gate media on
+            -- the way out (toChatMessageItem, mkMediaFiles, recreateIssueChats)
+            -- only accept COMPLETED or a null status, so anything else is
+            -- silently filtered out of the chat response. There is no async
+            -- upload to wait on here — the Xyne URL is stored as-is — so the
+            -- row is ready the moment it is written.
+            DMF.status = Just DMF.COMPLETED,
             DMF.fileHash = Nothing,
             DMF.createdAt = now,
             DMF.updatedAt = Just now

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
@@ -44,10 +44,12 @@ import qualified IssueManagement.Domain.Action.UI.Issue as DUI
 import qualified IssueManagement.Domain.Types.Issue.IssueReport as DIR
 import qualified IssueManagement.Domain.Types.MediaFile as DMF
 import IssueManagement.Storage.BeamFlow
+import qualified IssueManagement.Storage.CachedQueries.MediaFile as CQMF
 import qualified IssueManagement.Storage.Queries.Issue.IssueReport as QIR
 import qualified IssueManagement.Storage.Queries.MediaFile as QMF
 import IssueManagement.Tools.Error
 import IssueManagement.Utils.Html (stripHtml)
+import qualified IssueManagement.Utils.RemoteFile as RF
 import qualified Kernel.External.Ticket.XyneSpaces.Config as Xyne
 import qualified Kernel.External.Ticket.XyneSpaces.Types as Xyne
 import Kernel.External.Ticket.XyneSpaces.Webhook (RawByteString (..), verifyXyneSignature)
@@ -82,7 +84,8 @@ processXyneWebhook ::
   ( Esq.EsqDBReplicaFlow m r,
     BeamFlow m r,
     CoreMetrics m,
-    Redis.HedisFlow m r
+    Redis.HedisFlow m r,
+    HasField "s3Env" r (S3.S3Env m)
   ) =>
   -- | Global signing secret paired with the @/internal/xyne/webhook@ URL.
   Text ->
@@ -117,7 +120,8 @@ handleDeskReply ::
   ( Esq.EsqDBReplicaFlow m r,
     BeamFlow m r,
     CoreMetrics m,
-    Redis.HedisFlow m r
+    Redis.HedisFlow m r,
+    HasField "s3Env" r (S3.S3Env m)
   ) =>
   (Id Common.Merchant -> Id Common.MerchantOperatingCity -> m Xyne.XyneSpacesCfg) ->
   DUI.ServiceHandle m ->
@@ -152,7 +156,12 @@ handleDeskReply lookupXyneCfg issueHandle identifier payload = do
               then stripHtml payload.body
               else payload.body
           senderUserIdText = fromMaybe cfg.xyneAgentUserId payload.replierUserId
-      mediaIds <- maybe (pure []) (mapM xyneAttachmentToMediaFile) payload.attachments
+      merchantConfig <- issueHandle.findMerchantConfig merchantId mocId (Just $ cast issueReport.personId)
+      mediaIds <-
+        maybe
+          (pure [])
+          (mapM $ xyneAttachmentToMediaFile merchantConfig identifier issueReport.personId)
+          payload.attachments
       let req =
             DCI.SendChatMessageByUserReq
               { DCI.message = messageText,
@@ -170,21 +179,32 @@ handleDeskReply lookupXyneCfg issueHandle identifier payload = do
       Redis.setExp key resp.messageId dedupTtlSeconds
       pure $ XyneWebhookAck {externalId = resp.messageId}
 
--- | Persist a Xyne attachment as a @MediaFile@ row that points at the
--- third-party URL directly. We do not rehost on our S3 yet — if Xyne URLs turn
--- out to be short-lived, a fetch + S3.put step can be added here without
--- changing the call site.
+-- | Persist a Xyne attachment and rehost it on our own S3.
+--
+-- The row is created pointing at the third-party url first, then upgraded in
+-- place once the copy lands. That ordering is deliberate: a working url already
+-- exists, so starting from @PENDING@ (as the rider upload path does, where the
+-- file genuinely is not available yet) would hide the attachment for the
+-- duration of the fetch, and hide it permanently if the fetch failed. Creating
+-- it ready and upgrading on success means a failed rehost degrades to the old
+-- url-only behaviour instead of losing the attachment.
 xyneAttachmentToMediaFile ::
-  BeamFlow m r =>
+  ( BeamFlow m r,
+    HasField "s3Env" r (S3.S3Env m)
+  ) =>
+  Common.MerchantConfig ->
+  Common.Identifier ->
+  Id Common.Person ->
   Xyne.XyneAttachment ->
   m (Id DMF.MediaFile)
-xyneAttachmentToMediaFile att = do
+xyneAttachmentToMediaFile merchantConfig identifier personId att = do
   fid <- generateGUID
   now <- getCurrentTime
-  let mf =
+  let fileType = mimeTypeToFileType att.mimeType
+      mf =
         DMF.MediaFile
           { DMF.id = fid,
-            DMF._type = mimeTypeToFileType att.mimeType,
+            DMF._type = fileType,
             DMF.url = att.url,
             DMF.s3FilePath = Nothing,
             -- COMPLETED, not CONFIRMED: the readiness checks that gate media on
@@ -195,11 +215,67 @@ xyneAttachmentToMediaFile att = do
             -- row is ready the moment it is written.
             DMF.status = Just DMF.COMPLETED,
             DMF.fileHash = Nothing,
+            DMF.name = Just att.name,
+            DMF.size = att.size,
             DMF.createdAt = now,
             DMF.updatedAt = Just now
           }
   QMF.create mf
+  fork "S3 Put Xyne Attachment" $ rehostToS3 merchantConfig identifier personId att fileType fid
   pure fid
+
+-- | Copy a Xyne-hosted attachment into our own S3 and repoint the row at it.
+--
+-- Best effort by design: every failure path leaves the row untouched, still
+-- serving the original third-party url, so a rehost problem degrades to the
+-- previous behaviour rather than breaking the attachment.
+rehostToS3 ::
+  ( BeamFlow m r,
+    HasField "s3Env" r (S3.S3Env m)
+  ) =>
+  Common.MerchantConfig ->
+  Common.Identifier ->
+  Id Common.Person ->
+  Xyne.XyneAttachment ->
+  S3.FileType ->
+  Id DMF.MediaFile ->
+  m ()
+rehostToS3 merchantConfig identifier personId att fileType fid =
+  handleFailure $ case mimeTypeToExtension att.mimeType of
+    -- No sensible extension: leave it pointing at Xyne rather than storing a
+    -- file we cannot label or serve correctly.
+    Nothing ->
+      logWarning $ "Xyne rehost skipped, unsupported mimeType=" <> fromMaybe "<none>" att.mimeType <> " mediaFileId=" <> fid.getId
+    Just ext -> do
+      -- Cheap pre-screen on the size Xyne advertises, before spending a fetch.
+      if maybe False (> merchantConfig.mediaFileSizeUpperLimit) att.size
+        then logWarning $ "Xyne rehost skipped, advertised size exceeds limit, mediaFileId=" <> fid.getId
+        else
+          RF.fetchRemoteFile att.url merchantConfig.mediaFileSizeUpperLimit >>= \case
+            Nothing -> logWarning $ "Xyne rehost skipped, body exceeded size limit, mediaFileId=" <> fid.getId
+            Just remote -> do
+              filePath <- S3.createFilePath "issue-media/" ("xyne-" <> personId.getId) fileType ext
+              -- Store the raw bytes, not base64: a presigned download of this
+              -- object has to serve a file the browser/player can use directly.
+              -- Prefer Xyne's declared type, fall back to what the server sent,
+              -- then to a generic type.
+              let contentType =
+                    fromMaybe "application/octet-stream" $
+                      find (not . T.null) [fromMaybe "" att.mimeType, remote.contentType]
+              S3.putRaw (T.unpack filePath) remote.content (T.unpack contentType)
+              let fileUrl =
+                    merchantConfig.mediaFileUrlPattern
+                      & T.replace "<DOMAIN>" "issue"
+                      & T.replace "<FILE_PATH>" filePath
+              QMF.updateRehostedById fileUrl filePath fid
+              -- Without this the pre-rehost row stays cached and clients keep
+              -- being handed the third-party url until the entry expires.
+              CQMF.clearMediaFileByIdCache identifier fid
+              logInfo $ "Xyne attachment rehosted to " <> filePath
+  where
+    handleFailure action =
+      action `catch` \(e :: SomeException) ->
+        logError $ "Xyne rehost failed for mediaFileId=" <> fid.getId <> ", keeping original url: " <> show e
 
 mimeTypeToFileType :: Maybe Text -> S3.FileType
 mimeTypeToFileType Nothing = S3.PDF
@@ -209,6 +285,33 @@ mimeTypeToFileType (Just mt)
   | "video/" `T.isPrefixOf` mt = S3.Video
   | mt == "application/pdf" = S3.PDF
   | otherwise = S3.PDF
+
+-- | Extension for the S3 object key. Deliberately separate from
+-- 'validateContentType', which is the rider-upload allowlist and rejects
+-- @application/pdf@ outright — agents can attach documents that customers
+-- cannot upload. 'Nothing' means "do not rehost this".
+mimeTypeToExtension :: Maybe Text -> Maybe Text
+mimeTypeToExtension Nothing = Nothing
+mimeTypeToExtension (Just mt) = case T.toLower (T.strip (T.takeWhile (/= ';') mt)) of
+  "image/png" -> Just "png"
+  "image/jpeg" -> Just "jpg"
+  "image/jpg" -> Just "jpg"
+  "image/gif" -> Just "gif"
+  "image/webp" -> Just "webp"
+  "image/heic" -> Just "heic"
+  "image/heif" -> Just "heif"
+  "application/pdf" -> Just "pdf"
+  "audio/mpeg" -> Just "mp3"
+  "audio/mp3" -> Just "mp3"
+  "audio/mp4" -> Just "m4a"
+  "audio/aac" -> Just "aac"
+  "audio/wav" -> Just "wav"
+  "audio/wave" -> Just "wav"
+  "audio/webm" -> Just "webm"
+  "audio/ogg" -> Just "ogg"
+  "video/mp4" -> Just "mp4"
+  "video/webm" -> Just "webm"
+  _ -> Nothing
 
 -- | Payload for a Xyne @TICKET_STATUS_UPDATED@ event, delivered to the
 -- Bearer-token webhook. Independent of the DESK_REPLY event/payload used by

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Types/MediaFile.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Types/MediaFile.hs
@@ -28,6 +28,12 @@ data MediaFile = MediaFile
     s3FilePath :: Maybe Text,
     status :: Maybe MediaFileUploadStatus,
     fileHash :: Maybe Text,
+    -- | Original filename as supplied by the source (e.g. a Xyne attachment's
+    -- @name@). Absent for uploads that never carried one — callers fall back to
+    -- deriving a label from the url/s3 key.
+    name :: Maybe Text,
+    -- | Size in bytes, when the source reported it.
+    size :: Maybe Int,
     createdAt :: UTCTime,
     updatedAt :: Maybe UTCTime
   }

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/MediaFile.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/MediaFile.hs
@@ -27,6 +27,8 @@ data MediaFileT f = MediaFileT
     s3FilePath :: B.C f (Maybe Text),
     status :: B.C f (Maybe Text),
     fileHash :: B.C f (Maybe Text),
+    name :: B.C f (Maybe Text),
+    size :: B.C f (Maybe Int),
     createdAt :: B.C f LocalTime,
     updatedAt :: B.C f (Maybe LocalTime)
   }

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/Queries/MediaFile.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/Queries/MediaFile.hs
@@ -49,6 +49,20 @@ updateStatusAndHashById newStatus fileHash (Id mediaFileId) = do
     [Set BeamMF.status (Just $ DT.pack $ show newStatus), Set BeamMF.fileHash fileHash, Set BeamMF.updatedAt (Just $ T.utcToLocalTime T.utc now)]
     [Is BeamMF.id $ Eq mediaFileId]
 
+-- | Point a row at our own S3 copy after rehosting a third-party attachment.
+-- Callers must follow this with 'clearMediaFileByIdCache', otherwise a client
+-- that read the row before the upload finished keeps being served the old
+-- third-party url until the cache expires.
+updateRehostedById :: BeamFlow m r => Text -> Text -> Id MediaFile -> m ()
+updateRehostedById newUrl s3Key (Id mediaFileId) = do
+  now <- getCurrentTime
+  updateWithKV
+    [ Set BeamMF.url newUrl,
+      Set BeamMF.s3FilePath (Just s3Key),
+      Set BeamMF.updatedAt (Just $ T.utcToLocalTime T.utc now)
+    ]
+    [Is BeamMF.id $ Eq mediaFileId]
+
 instance FromTType' BeamMF.MediaFile MediaFile where
   fromTType' BeamMF.MediaFileT {..} = do
     pure $
@@ -60,6 +74,8 @@ instance FromTType' BeamMF.MediaFile MediaFile where
             s3FilePath = s3FilePath,
             status = status >>= readMaybe . DT.unpack,
             fileHash = fileHash,
+            name = name,
+            size = size,
             createdAt = T.localTimeToUTC T.utc createdAt,
             updatedAt = T.localTimeToUTC T.utc <$> updatedAt
           }
@@ -73,6 +89,8 @@ instance ToTType' BeamMF.MediaFile MediaFile where
         BeamMF.s3FilePath = s3FilePath,
         BeamMF.status = DT.pack . show <$> status,
         BeamMF.fileHash = fileHash,
+        BeamMF.name = name,
+        BeamMF.size = size,
         BeamMF.createdAt = T.utcToLocalTime T.utc createdAt,
         -- The column is NOT NULL, so never write a NULL: a domain-level Nothing
         -- only ever means "legacy KV entry", for which createdAt is the best value.

--- a/Backend/lib/shared-services/src/IssueManagement/Utils/RemoteFile.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Utils/RemoteFile.hs
@@ -1,0 +1,178 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+-- | Fetch a file from an arbitrary third-party URL so it can be rehosted on our
+-- own S3. Used by the Xyne webhook, which receives attachments as links rather
+-- than bytes.
+--
+-- The url comes from an inbound payload, so this is a server-side fetch of a
+-- caller-influenced address: the reads are bounded and the destination is
+-- screened before connecting.
+module IssueManagement.Utils.RemoteFile
+  ( RemoteFile (..),
+    fetchRemoteFile,
+  )
+where
+
+import Data.Bits (shiftR, (.&.))
+import qualified Data.ByteString as BS
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Word (Word16, Word8)
+import Kernel.Prelude
+import qualified Network.HTTP.Client as HC
+import qualified Network.HTTP.Client.TLS as HCT
+import qualified Network.Socket as NS
+import System.IO.Unsafe (unsafePerformIO)
+
+data RemoteFile = RemoteFile
+  { content :: BS.ByteString,
+    -- | @Content-Type@ with any @;charset=…@ parameters stripped. Empty when the
+    -- server did not send one.
+    contentType :: Text
+  }
+
+-- | How long a single fetch may take before it is abandoned. Without this the
+-- manager default applies and a slow endpoint can park a thread indefinitely.
+fetchTimeoutSeconds :: Int
+fetchTimeoutSeconds = 30
+
+-- | Connection pool shared across fetches.
+--
+-- A manager owns a connection pool and is designed to be long-lived; building
+-- one per request throws that pool away every time. This module has no access
+-- to the app environment, so it keeps a single lazily-initialised manager
+-- instead.
+sharedManager :: IORef (Maybe HC.Manager)
+sharedManager = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE sharedManager #-}
+
+getManager :: IO HC.Manager
+getManager =
+  readIORef sharedManager >>= \case
+    Just m -> pure m
+    Nothing -> do
+      m <- HCT.newTlsManager
+      -- A race here only means two managers are built and one is dropped;
+      -- harmless, and cheaper than holding a lock on every fetch.
+      atomicModifyIORef' sharedManager $ \case
+        Just existing -> (Just existing, existing)
+        Nothing -> (Just m, m)
+
+-- | GET the url and return its bytes, or 'Nothing' if the body exceeds
+-- @maxBytes@.
+--
+-- Built on 'HC.parseUrlThrow', so a non-2xx response raises an exception rather
+-- than yielding a body of error HTML. Connection failures, blocked destinations
+-- and timeouts throw too — callers are expected to run this inside a @try@ and
+-- fall back to leaving the original url in place, so a fetch failure degrades
+-- rather than losing the attachment.
+--
+-- The body is read incrementally and abandoned as soon as it exceeds
+-- @maxBytes@, so an oversized (or endless) response cannot be buffered into
+-- memory before being rejected.
+fetchRemoteFile :: MonadIO m => Text -> Int -> m (Maybe RemoteFile)
+fetchRemoteFile url maxBytes = liftIO $ do
+  parsed <- HC.parseUrlThrow (T.unpack url)
+  let req =
+        parsed
+          { HC.responseTimeout = HC.responseTimeoutMicro (fetchTimeoutSeconds * 1000000),
+            -- Redirects are not followed. 'parseUrlThrow' defaults to following
+            -- up to 10, which would sail straight past the destination screen
+            -- below: an attacker-supplied url can answer 302 and point at an
+            -- internal host, and the manager would connect there unchecked.
+            HC.redirectCount = 0
+          }
+  assertDestinationAllowed (HC.host req) (HC.port req)
+  manager <- getManager
+  HC.withResponse req manager $ \resp -> do
+    mbBody <- readAtMost (HC.responseBody resp) maxBytes
+    pure $ (\body -> RemoteFile body (responseContentType resp)) <$> mbBody
+
+-- | Read a streaming response body, giving up as soon as @limit@ is exceeded.
+readAtMost :: HC.BodyReader -> Int -> IO (Maybe BS.ByteString)
+readAtMost bodyReader limit = go 0 []
+  where
+    go acc chunks = do
+      chunk <- HC.brRead bodyReader
+      if BS.null chunk
+        then pure . Just . BS.concat $ reverse chunks
+        else do
+          let acc' = acc + BS.length chunk
+          if acc' > limit
+            then pure Nothing
+            else go acc' (chunk : chunks)
+
+-- | Refuse to fetch anything that resolves to a loopback, private or otherwise
+-- internal address.
+--
+-- The url is attacker-influenced, so without this the webhook becomes an SSRF
+-- primitive: a request for @http://169.254.169.254/…@ or an internal service
+-- would be issued with our network position. Resolution happens here rather
+-- than matching on the literal host, because a public hostname can resolve to a
+-- private address.
+--
+-- Note this does not close the gap entirely — the connection re-resolves, so a
+-- name that changes answers between this check and the connect (DNS rebinding)
+-- can still slip through. Closing that needs a custom connection hook.
+assertDestinationAllowed :: BS.ByteString -> Int -> IO ()
+assertDestinationAllowed hostBs port = do
+  let host = T.unpack $ TE.decodeUtf8With (\_ _ -> Just '?') hostBs
+      hints = NS.defaultHints {NS.addrSocketType = NS.Stream}
+  addrs <- NS.getAddrInfo (Just hints) (Just host) (Just (show port))
+  when (any (isInternal . NS.addrAddress) addrs) $
+    ioError . userError $ "refusing to fetch internal address for host " <> host
+
+isInternal :: NS.SockAddr -> Bool
+isInternal = \case
+  NS.SockAddrInet _ ha -> isInternalV4 (NS.hostAddressToTuple ha)
+  NS.SockAddrInet6 _ _ ha6 _ -> isInternalV6 (NS.hostAddress6ToTuple ha6)
+  -- Unix-domain and anything unrecognised: nothing legitimate for us to fetch.
+  _ -> True
+
+isInternalV4 :: (Word8, Word8, Word8, Word8) -> Bool
+isInternalV4 (a, b, _, _) =
+  a == 0 -- 0.0.0.0/8 "this network"
+    || a == 10 -- private
+    || a == 127 -- loopback
+    || (a == 100 && b >= 64 && b <= 127) -- carrier-grade NAT
+    || (a == 169 && b == 254) -- link-local, incl. cloud metadata
+    || (a == 172 && b >= 16 && b <= 31) -- private
+    || (a == 192 && b == 168) -- private
+    || a >= 224 -- multicast and reserved
+
+isInternalV6 :: (Word16, Word16, Word16, Word16, Word16, Word16, Word16, Word16) -> Bool
+isInternalV6 (a, b, c, d, e, f, g, h) =
+  all (== 0) [a, b, c, d, e, f, g] && (h == 0 || h == 1) -- :: and ::1
+    || (a .&. 0xfe00) == 0xfc00 -- unique local fc00::/7
+    || (a .&. 0xffc0) == 0xfe80 -- link-local fe80::/10
+    -- An internal target can also arrive wrapped in IPv6. Both forms carry the
+    -- v4 address in the low 32 bits, so unwrap and re-check it — otherwise
+    -- ::ffff:169.254.169.254 reads as external and the refusal is bypassed.
+    || (all (== 0) [a, b, c, d, e] && f == 0xffff && isInternalV4 embeddedV4) -- IPv4-mapped ::ffff:0:0/96
+    || (a == 0x0064 && b == 0xff9b && all (== 0) [c, d, e, f] && isInternalV4 embeddedV4) -- NAT64 64:ff9b::/96
+  where
+    embeddedV4 =
+      ( fromIntegral (g `shiftR` 8),
+        fromIntegral (g .&. 0xff),
+        fromIntegral (h `shiftR` 8),
+        fromIntegral (h .&. 0xff)
+      )
+
+responseContentType :: HC.Response a -> Text
+responseContentType resp =
+  case lookup "Content-Type" (HC.responseHeaders resp) of
+    Nothing -> ""
+    Just bs -> T.strip . T.takeWhile (/= ';') $ TE.decodeUtf8With (\_ _ -> Just '?') bs


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Inbound Xyne attachments were stored as a URL pointer only — xyneAttachmentToMediaFile wrote a media_file row with url = att.url, s3FilePath = Nothing, and never fetched the bytes. This makes attachments in chat history a live dependency on a third party: if Xyne expires or deletes a URL, the row stays intact but the link dies silently. It also means every view is a request from the customer's device straight to Xyne.

This PR fetches each attachment on ingest and stores it in our own S3, mirroring the existing rider-upload path, and persists the name/size Xyne already sends but which we were discarding

### Additional Changes

- [x] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added download-link support for issue media files via a short-lived URL.
  * Added optional media metadata (filename and file size) for uploaded/processed media.
  * Introduced managed rehosting for third-party attachments into service storage, with best-effort fallback to the original source.
* **Improvements**
  * Download links are generated for media only when it’s ready; otherwise the request is rejected.
  * Rehosting enforces safety checks and size limits to improve reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->