### PR TITLE
Backend/fix/reduce 5xx errors batch 2

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Rating.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Rating.hs
@@ -171,9 +171,14 @@ syncServiceTiersOnRatingChange ::
   m ()
 syncServiceTiersOnRatingChange driverStats newRating personId merchantOpCityId = do
   let updatedDriverStats = driverStats {DDriverStats.rating = newRating}
-  tierResults <- fetchVehicleTierForDriverWithUsageRestriction SelectedServiceTiers Nothing Nothing (Just updatedDriverStats) Nothing personId merchantOpCityId
-  let newTiers = (.serviceTierType) . fst <$> filter (not . snd) tierResults
-  QVehicle.updateSelectedServiceTiers newTiers personId
+  try (fetchVehicleTierForDriverWithUsageRestriction SelectedServiceTiers Nothing Nothing (Just updatedDriverStats) Nothing personId merchantOpCityId) >>= \case
+    Left (VehicleNotFound _) -> do
+      logWarning $ "Vehicle not found for driver " <> personId.getId <> ". Skipping service tier sync on rating change."
+      pure ()
+    Left err -> throwError err
+    Right tierResults -> do
+      let newTiers = (.serviceTierType) . fst <$> filter (not . snd) tierResults
+      QVehicle.updateSelectedServiceTiers newTiers personId
 
 calculateAverageRating ::
   (CacheFlow m r, EsqDBFlow m r, EncFlow m r, Redis.HedisFlow m r, HasField "serviceClickhouseCfg" r CH.ClickhouseCfg, HasField "serviceClickhouseEnv" r CH.ClickhouseEnv) =>

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs
@@ -168,20 +168,23 @@ callOnStatus currBooking = do
 
 checkBookingsForStatus :: [SRB.Booking] -> Flow ()
 checkBookingsForStatus (currBooking : bookings) = do
-  riderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = currBooking.merchantOperatingCityId.getId}) (Just (CQRC.findByMerchantOperatingCityId currBooking.merchantOperatingCityId)) >>= fromMaybeM (RiderConfigDoesNotExist currBooking.merchantOperatingCityId.getId)
-  case (riderConfig.bookingSyncStatusCallSecondsDiffThreshold, currBooking.estimatedDuration) of
-    (Just timeDiffThreshold, Just estimatedEndDuration) -> do
-      now <- getCurrentTime
-      let estimatedEndTime = DT.addUTCTime (fromIntegral estimatedEndDuration.getSeconds) currBooking.startTime
-      let diff = DT.diffUTCTime now estimatedEndTime
-      let callStatusConditionNew = (currBooking.status == SRB.NEW && diff > fromIntegral timeDiffThreshold) || (currBooking.status == SRB.CONFIRMED && diff > fromIntegral timeDiffThreshold)
-          callStatusConditionTripAssigned = currBooking.status == SRB.TRIP_ASSIGNED && diff > fromIntegral timeDiffThreshold
-      when callStatusConditionNew $ do
-        callOnStatus currBooking
-      when callStatusConditionTripAssigned $ do
-        callOnStatus currBooking
-      checkBookingsForStatus bookings
-    (_, _) -> logError "Nothing values for time diff threshold or booking end duration"
+  case currBooking.bppBookingId of
+    Nothing -> checkBookingsForStatus bookings
+    Just _ -> do
+      riderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = currBooking.merchantOperatingCityId.getId}) (Just (CQRC.findByMerchantOperatingCityId currBooking.merchantOperatingCityId)) >>= fromMaybeM (RiderConfigDoesNotExist currBooking.merchantOperatingCityId.getId)
+      case (riderConfig.bookingSyncStatusCallSecondsDiffThreshold, currBooking.estimatedDuration) of
+        (Just timeDiffThreshold, Just estimatedEndDuration) -> do
+          now <- getCurrentTime
+          let estimatedEndTime = DT.addUTCTime (fromIntegral estimatedEndDuration.getSeconds) currBooking.startTime
+          let diff = DT.diffUTCTime now estimatedEndTime
+          let callStatusConditionNew = (currBooking.status == SRB.NEW && diff > fromIntegral timeDiffThreshold) || (currBooking.status == SRB.CONFIRMED && diff > fromIntegral timeDiffThreshold)
+              callStatusConditionTripAssigned = currBooking.status == SRB.TRIP_ASSIGNED && diff > fromIntegral timeDiffThreshold
+          when callStatusConditionNew $ do
+            callOnStatus currBooking
+          when callStatusConditionTripAssigned $ do
+            callOnStatus currBooking
+          checkBookingsForStatus bookings
+        (_, _) -> logError "Nothing values for time diff threshold or booking end duration"
 checkBookingsForStatus [] = pure ()
 
 getBookingList :: (Maybe (Id Person.Person), Id Merchant.Merchant) -> Maybe Text -> Bool -> Maybe Integer -> Maybe Integer -> Maybe Bool -> Maybe SRB.BookingStatus -> Maybe (Id DC.Client) -> Maybe Integer -> Maybe Integer -> [SRB.BookingStatus] -> Maybe (Id DMOC.MerchantOperatingCity) -> Flow ([SRB.Booking], [SRB.Booking])


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Two fixes to prevent false E500 errors from background fork threads:

**1. Guard `checkBookingsForStatus` against bookings without `bppBookingId`** (`Booking.hs`)

When a rider opens their booking list, a background thread (`checkBookingsForStatus`) iterates over all bookings to sync stale ones with the BPP via `callOnStatus`. Bookings in `NEW` status don't have a `bppBookingId` yet (the BPP hasn't confirmed them), so `callOnStatus` → `buildStatusReqV2` crashes with `E500 BOOKING_FIELD_NOT_PRESENT` when it tries to extract the null field.

Fix adds an early guard using `case currBooking.bppBookingId of Nothing -> skip`. Bookings without a `bppBookingId` can't be synced with a BPP that doesn't know about them — skipping is the correct behavior.

**2. Catch `VehicleNotFound` in `syncServiceTiersOnRatingChange`** (`Rating.hs`)

Riders can rate a ride days or weeks after completion. The rating fork saves the rating and recalculates the driver's average successfully, but as a final step calls `syncServiceTiersOnRatingChange` → `fetchVehicleTierForDriverWithUsageRestriction`, which strictly expects the driver's vehicle to exist. If the driver has unlinked their vehicle since the ride, `VehicleNotFound` is thrown unhandled, killing the fork and logging E500.

Fix wraps the `fetchVehicleTierForDriverWithUsageRestriction` call in `try` and pattern-matches `VehicleNotFound` — if no vehicle exists, we log a warning and skip the tier sync (which isn't needed without a vehicle). Any other exception is rethrown.

### Additional Changes
- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context

Both errors are false E500s inflating the Grafana 5xx dashboard. Neither represents an actual server failure — they are expected conditions (booking not yet confirmed by BPP, driver vehicle unlinked after ride completion) that the code should handle gracefully instead of crashing the fork thread.

## How did you test it?

- Built both `rider-app-exe` and `dynamic-offer-driver-app-exe` locally with `cabal build` — all modules compiled and linked successfully.

## Screenshot of test results

N/A — error handling changes only, no new logic.

## Checklist
- [x] I formatted the code and addressed linter errors
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rating updates when vehicle information is unavailable by safely skipping service-tier synchronization and recording a warning.
  * Prevented status synchronization attempts for bookings without a booking provider reference.
  * Preserved status updates for eligible bookings based on configured timing thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->