### PR TITLE
 refac : prod workflow to be same in main

### DIFF
--- a/.github/workflows/cabal-prod-hot-fix-push.yaml
+++ b/.github/workflows/cabal-prod-hot-fix-push.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Compute cache key
         id: cache-key
         run: |
-          KEY=$(cat flake.lock Backend/cabal.project Backend/cabal.project.driver Backend/cabal.project.rider | sha256sum | cut -c1-16)
+          KEY=$(cat flake.lock Backend/cabal.project | sha256sum | cut -c1-16)
           echo "key=$KEY" >> $GITHUB_OUTPUT
 
       - name: Restore cabal cache
@@ -94,7 +94,7 @@ jobs:
           if [ -f "$KEY_FILE" ] && [ "$(cat $KEY_FILE)" != "$CURRENT_KEY" ]; then
             echo "Cache key changed, busting dist-newstyle, cabal store and HIE caches"
             rm -rf "$CACHE_ROOT/dist-newstyle"
-            rm -rf "$CACHE_ROOT/.cabal-dir"
+            rm -rf "$CACHE_ROOT/.cabal-dir/store"
             rm -rf "$CACHE_ROOT/hie"
           fi
 
@@ -136,14 +136,11 @@ jobs:
       - name: Build (incremental cabal)
         run: |
           set -o pipefail
-          case "${{ github.ref_name }}" in
-            prodHotPush-BPP) PROJECT=cabal.project.driver ;;
-            prodHotPush-BAP) PROJECT=cabal.project.rider ;;
-            *)               PROJECT=cabal.project ;;
-          esac
-          echo "Selected cabal project file for ${{ github.ref_name }}: $PROJECT"
           nix develop .#backend --command bash -c "
             export CABAL_DIR=$HOME/ny-cabal-prod-cache/${RUNNER_NAME}/${{ github.ref_name }}/.cabal-dir
+            mkdir -p \$CABAL_DIR
+            printf 'active-repositories: :none\n' > \$CABAL_DIR/config
+            export CABAL_CONFIG=\$CABAL_DIR/config
             cd Backend
             # Clear cabal store to prevent stale package registrations that
             # reference runner-local nix paths. Does not affect CI incrementality
@@ -153,9 +150,9 @@ jobs:
             ghc-pkg init \$CABAL_DIR/store/ghc-\$(ghc --numeric-version)/package.db 2>/dev/null || true
             echo \"GHC libdir: \$(ghc --print-libdir)\"
             echo '--- cabal dry-run (what it plans to rebuild) ---'
-            cabal build all --project-file=$PROJECT --flags=-Local --dry-run 2>&1 | tail -20
+            cabal build all --flags=-Local --dry-run 2>&1 | tail -20
             echo '--- real build ---'
-            cabal build all --project-file=$PROJECT --flags=-Local 2>&1
+            cabal build all --flags=-Local 2>&1
             BUILD_EXIT=\$?
             if [ \$BUILD_EXIT -ne 0 ]; then
               # Stale cache detection: 'which is not loaded' or '<no location info>' means
@@ -164,7 +161,7 @@ jobs:
               if grep -qE 'which is not loaded|<no location info>' prod-build-log.txt 2>/dev/null; then
                 echo '--- stale cache detected, clearing dist-newstyle and retrying clean build ---'
                 rm -rf dist-newstyle
-                cabal build all --project-file=$PROJECT --flags=-Local 2>&1
+                cabal build all --flags=-Local 2>&1
                 BUILD_EXIT=\$?
               fi
             fi


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production hot-fix builds by making incremental caching more reliable.
  * Prevented unnecessary removal of Cabal configuration files when refreshing stale build caches.
  * Standardized build configuration and retry behavior to reduce build failures caused by outdated or inconsistent cache state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->