### PR TITLE
ench: send isBlockedForAirport for blocking UI

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/QueueRank.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/QueueRank.hs
@@ -1,16 +1,21 @@
 module Domain.Action.UI.QueueRank where
 
+import qualified Domain.Types.DriverInformation as DI
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.Person as DP
 import qualified Environment
 import Kernel.Prelude
 import Kernel.Types.Id
+import Kernel.Utils.Common
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTSFlow
+import qualified Storage.Queries.DriverInformation as QDI
+import Tools.Error
 
 data QueueRankResponse = QueueRankResponse
   { queuePositionRange :: Maybe (Int, Int),
-    queueSize :: Int
+    queueSize :: Int,
+    isBlockedForAirport :: Bool
   }
   deriving (Generic, FromJSON, ToJSON, ToSchema, Show)
 
@@ -20,9 +25,22 @@ getQueuePosition ::
   Text ->
   Environment.Flow QueueRankResponse
 getQueuePosition (driverId, _merchantId, _merchantOpCityId) specialLocationId vehicleType = do
-  ltsResp <- LTSFlow.getQueueDriverPosition specialLocationId vehicleType driverId
-  pure $
-    QueueRankResponse
-      { queuePositionRange = ltsResp.queuePositionRange,
-        queueSize = ltsResp.queueSize
-      }
+  driverInfo <- QDI.findById driverId >>= fromMaybeM DriverInfoNotFound
+  now <- getCurrentTime
+  enableForAirport <- QDI.resolveAirportRestriction now driverInfo
+  if enableForAirport == DI.BLOCKED
+    then
+      pure $
+        QueueRankResponse
+          { queuePositionRange = Nothing,
+            queueSize = 0,
+            isBlockedForAirport = True
+          }
+    else do
+      ltsResp <- LTSFlow.getQueueDriverPosition specialLocationId vehicleType driverId
+      pure $
+        QueueRankResponse
+          { queuePositionRange = ltsResp.queuePositionRange,
+            queueSize = ltsResp.queueSize,
+            isBlockedForAirport = False
+          }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added airport-block status to queue position information.
  * Drivers blocked from airport access now see that status with no queue position or queue size displayed.
  * Eligible drivers continue to receive their current queue position and queue size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->