### PR TITLE
fix: handle ONDC gateway NACK as expected rejection instead of E500

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPP.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPP.hs
@@ -83,7 +83,7 @@ searchV2 gatewayUrl req merchantId = do
       callBecknAPIWithSignature' merchantId bapId "search" API.searchAPIV2 gatewayUrl internalEndPointHashMap req
   case eRes of
     Right res -> do
-      fork ("Logging Internal API Call") $ do
+      fork "Logging Internal API Call" $ do
         let transactionId = req.searchReqContext.contextTransactionId <&> UUID.toText
         ApiCallLogger.pushInternalApiCallDataToKafka "searchV2" "BAP" transactionId (Just req) res
       pure res
@@ -149,7 +149,7 @@ selectV2 providerUrl req merchantId = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   bapId <- req.selectReqContext.contextBapId & fromMaybeM (InvalidRequest "BapId is missing")
   res <- callBecknAPIWithSignature' merchantId bapId "select" API.selectAPIV2 providerUrl internalEndPointHashMap req
-  fork ("Logging Internal API Call") $ do
+  fork "Logging Internal API Call" $ do
     let transactionId = req.selectReqContext.contextTransactionId <&> UUID.toText
     ApiCallLogger.pushInternalApiCallDataToKafka "selectV2" "BAP" transactionId (Just req) res
   pure res
@@ -171,7 +171,7 @@ initV2 providerUrl req merchantId = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   bapId <- fromMaybeM (InvalidRequest "BapId is missing") req.initReqContext.contextBapId
   res <- callBecknAPIWithSignature' merchantId bapId "init" API.initAPIV2 providerUrl internalEndPointHashMap req
-  fork ("Logging Internal API Call") $ do
+  fork "Logging Internal API Call" $ do
     let transactionId = req.initReqContext.contextTransactionId <&> UUID.toText
     ApiCallLogger.pushInternalApiCallDataToKafka "initV2" "BAP" transactionId (Just req) res
   pure res
@@ -193,7 +193,7 @@ confirmV2 providerUrl req merchantId = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   bapId <- fromMaybeM (InvalidRequest "BapId is missing") req.confirmReqContext.contextBapId
   res <- callBecknAPIWithSignature' merchantId bapId "confirm" API.confirmAPIV2 providerUrl internalEndPointHashMap req
-  fork ("Logging Internal API Call") $ do
+  fork "Logging Internal API Call" $ do
     let transactionId = req.confirmReqContext.contextTransactionId <&> UUID.toText
     ApiCallLogger.pushInternalApiCallDataToKafka "confirmV2" "BAP" transactionId (Just req) res
   pure res
@@ -215,7 +215,7 @@ cancelV2 merchantId providerUrl req = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   bapId <- fromMaybeM (InvalidRequest "BapId is missing") req.cancelReqContext.contextBapId
   res <- callBecknAPIWithSignature' merchantId bapId "cancel" API.cancelAPIV2 providerUrl internalEndPointHashMap req
-  fork ("Logging Internal API Call") $ do
+  fork "Logging Internal API Call" $ do
     let transactionId = req.cancelReqContext.contextTransactionId <&> UUID.toText
     ApiCallLogger.pushInternalApiCallDataToKafka "cancelV2" "BAP" transactionId (Just req) res
   pure res
@@ -247,7 +247,7 @@ updateV2 providerUrl req = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   bapId <- fromMaybeM (InvalidRequest "BapId is missing") req.updateReqContext.contextBapId
   res <- callBecknAPIWithSignature bapId "update" API.updateAPIV2 providerUrl internalEndPointHashMap req
-  fork ("Logging Internal API Call") $ do
+  fork "Logging Internal API Call" $ do
     let transactionId = req.updateReqContext.contextTransactionId <&> UUID.toText
     ApiCallLogger.pushInternalApiCallDataToKafka "updateV2" "BAP" transactionId (Just req) res
   pure res
@@ -281,7 +281,7 @@ callTrack booking ride = do
           }
   trackBecknReq <- TrackACL.buildTrackReqV2 trackBuildReq
   res <- callBecknAPIWithSignature' booking.merchantId merchant.bapId "track" API.trackAPIV2 booking.providerUrl internalEndPointHashMap trackBecknReq
-  fork ("Logging Internal API Call") $ do
+  fork "Logging Internal API Call" $ do
     ApiCallLogger.pushInternalApiCallDataToKafka "callTrack" "BAP" (Just booking.transactionId) (Just trackBecknReq) res
   pure ()
 
@@ -323,7 +323,7 @@ feedbackV2 providerUrl req merchantId = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   bapId <- fromMaybeM (InvalidRequest "BapId is missing") req.ratingReqContext.contextBapId
   res <- callBecknAPIWithSignature' merchantId bapId "feedback" API.ratingAPIV2 providerUrl internalEndPointHashMap req
-  fork ("Logging Internal API Call") $ do
+  fork "Logging Internal API Call" $ do
     let transactionId = req.ratingReqContext.contextTransactionId <&> UUID.toText
     ApiCallLogger.pushInternalApiCallDataToKafka "feedbackV2" "BAP" transactionId (Just req) res
   pure res
@@ -346,7 +346,7 @@ callStatusV2 providerUrl req merchantId = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   bapId <- fromMaybeM (InvalidRequest "BapId is missing") req.statusReqContext.contextBapId
   res <- callBecknAPIWithSignature' merchantId bapId "status" API.statusAPIV2 providerUrl internalEndPointHashMap req
-  fork ("Logging Internal API Call") $ do
+  fork "Logging Internal API Call" $ do
     let transactionId = req.statusReqContext.contextTransactionId <&> UUID.toText
     ApiCallLogger.pushInternalApiCallDataToKafka "statusV2" "BAP" transactionId (Just req) res
   pure res

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPP.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/CallBPP.hs
@@ -25,6 +25,7 @@ import Beckn.Types.Core.Taxi.API.Select as API
 import Beckn.Types.Core.Taxi.API.Status as API
 import Beckn.Types.Core.Taxi.API.Track as API
 import Beckn.Types.Core.Taxi.API.Update as API
+import qualified Data.Aeson as Aeson
 import qualified Data.HashMap.Strict as HM
 import qualified Data.UUID as UUID
 import qualified Domain.Types.Booking as DB
@@ -44,6 +45,7 @@ import Kernel.Utils.InternalAPICallLogging as ApiCallLogger
 import Kernel.Utils.Monitoring.Prometheus.Servant (SanitizedUrl)
 import Kernel.Utils.Servant.SignatureAuth
 import Servant hiding (throwError)
+import Servant.Client (ClientError (DecodeFailure), ResponseF (responseBody))
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import Tools.Error
@@ -51,8 +53,17 @@ import Tools.Metrics (CoreMetrics)
 import TransactionLogs.PushLogs
 import TransactionLogs.Types
 
+-- Deliberately permissive: we only need "does the body carry an error object?",
+-- NOT a parse into the strict Beckn `Error` type — the ONDC gateway omits its
+-- required `type` field. Observed NACK shapes vary.
+newtype GatewayNackBody = GatewayNackBody Aeson.Value
+
+instance FromJSON GatewayNackBody where
+  parseJSON = Aeson.withObject "GatewayNackBody" $ \v -> GatewayNackBody <$> v Aeson..: "error"
+
 searchV2 ::
   ( MonadFlow m,
+    MonadCatch m,
     CoreMetrics m,
     HasFlowEnv m r '["internalEndPointHashMap" ::: HM.HashMap BaseUrl BaseUrl],
     CacheFlow m r,
@@ -67,11 +78,25 @@ searchV2 ::
 searchV2 gatewayUrl req merchantId = do
   internalEndPointHashMap <- asks (.internalEndPointHashMap)
   bapId <- req.searchReqContext.contextBapId & fromMaybeM (InvalidRequest "BapId is missing")
-  res <- callBecknAPIWithSignature' merchantId bapId "search" API.searchAPIV2 gatewayUrl internalEndPointHashMap req
-  fork ("Logging Internal API Call") $ do
-    let transactionId = req.searchReqContext.contextTransactionId <&> UUID.toText
-    ApiCallLogger.pushInternalApiCallDataToKafka "searchV2" "BAP" transactionId (Just req) res
-  pure res
+  eRes <-
+    try @_ @ExternalAPICallError $
+      callBecknAPIWithSignature' merchantId bapId "search" API.searchAPIV2 gatewayUrl internalEndPointHashMap req
+  case eRes of
+    Right res -> do
+      fork ("Logging Internal API Call") $ do
+        let transactionId = req.searchReqContext.contextTransactionId <&> UUID.toText
+        ApiCallLogger.pushInternalApiCallDataToKafka "searchV2" "BAP" transactionId (Just req) res
+      pure res
+    Left e -> case gatewayNackDetail e of
+      Just errVal -> do
+        logInfo $ "Gateway NACK for search (expected): " <> show errVal
+        pure Ack
+      Nothing -> throwM e
+  where
+    gatewayNackDetail :: ExternalAPICallError -> Maybe Aeson.Value
+    gatewayNackDetail (ExternalAPICallError _ _ (DecodeFailure _ resp)) =
+      (\(GatewayNackBody v) -> v) <$> Aeson.decode (responseBody resp)
+    gatewayNackDetail _ = Nothing
 
 type InternalSyncSearchAPI = "internal" :> API.SyncSearchAPI
 


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Handles ONDC gateway NACK responses as expected business rejections instead of letting them surface as E500 `EXTERNAL_API_CALL_ERROR` on the dashboard.

**Problem:** When the gateway returns a NACK (e.g. invalid city code), `callBecknAPIWithSignature'` throws an `ExternalAPICallError` wrapping a `DecodeFailure` — the NACK body doesn't decode into the expected `AckResponse` type. This lands on the 5xx dashboard as a server error, even though it's an expected business rejection.

**Fix:** Wraps the gateway call in `try`, catches `ExternalAPICallError`, and checks whether the underlying `DecodeFailure` response body contains an `"error"` key (using a permissive `GatewayNackBody` decoder that tolerates missing fields the ONDC gateway omits). If it's a NACK, logs at info and returns `Ack`. All other errors rethrow losslessly.

**Why a permissive decoder:** The strict Beckn `Error` type requires a non-optional `_type` field. The ONDC gateway omits it, so `Aeson.decode :: Maybe BecknAPIError` returns `Nothing`. The permissive `GatewayNackBody` only checks for a top-level `"error"` key, tolerating the observed NACK shapes.

**Additional structural improvements:**
- Kafka logging (`pushInternalApiCallDataToKafka`) now only runs on the success path — previously a NACK would still log a fabricated `Ack`, poisoning the API-call log.
- Rethrows the original `ExternalAPICallError` on non-NACK failures (preserving the post-remap `baseUrl`), rather than reconstructing it.

### Additional Changes
- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context

Part of the 5xx error reduction work (Bug #9). Gateway NACKs for invalid city codes and similar business rejections are expected responses, not server faults. They inflate the E500 count on the Grafana 5xx panel and obscure real failures.

## How did you test it?

- `cabal build rider-app` — compiles clean with zero errors/warnings under `-Werror`.
- **Staging verification pending:** will capture real NACK bodies, confirm the new `logInfo` fires on an invalid-city search, confirm no `EXTERNAL_API_CALL_ERROR` E500 is emitted for it, and confirm real failures (unreachable endpoint) still surface as E500. Evidence will be added to this PR before merge.

## Screenshot of test results

Staging evidence will be added once sandbox deployment is available.

## Checklist
- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of gateway rejection (NACK) payloads during search requests.
  * Properly decodes and acknowledges gateway-provided `"error"` details instead of treating them as unexpected failures.
  * Maintains the original error behavior when the gateway response body can’t be interpreted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->