### PR TITLE
Backend/fix/bug7 on status fork

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/Callback.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/Callback.hs
@@ -20,8 +20,10 @@ import EulerHS.Prelude hiding ((.~))
 import qualified EulerHS.Types as ET
 import Kernel.Streaming.Kafka.Producer.Types (KafkaProducerTools)
 import Kernel.Tools.Metrics.CoreMetrics
+import Kernel.Types.Error (BookingError (..), RideError (..))
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import Kernel.Utils.Error.BaseError.HTTPError.BecknAPIError (BecknAPICallError (..))
 import Kernel.Utils.Monitoring.Prometheus.Servant
 import Kernel.Utils.Servant.SignatureAuth
 import Servant.Client
@@ -90,6 +92,7 @@ withBecknCallback doWithCallback auth transporterId action api cbUrl internalEnd
       doWithCallback . void . callBecknAPI auth Nothing action api cbUrl internalEndPointHashMap $ result
 
 forkBecknCallback ::
+  forall m result.
   (Forkable m, MonadCatch m, Log m) =>
   (BecknAPIError -> result) ->
   (result -> m ()) ->
@@ -99,7 +102,18 @@ forkBecknCallback ::
 forkBecknCallback fromError doWithResult actionName action =
   fork actionName $
     try action >>= \case
-      Right success -> doWithResult success
+      Right success ->
+        doWithResult success `catch` handleExpectedBapRejection
       Left err -> do
         logError $ "Error executing callback action " <> actionName <> ": " <> show err
         doWithResult $ fromError (someExceptionToBecknApiError err)
+  where
+    -- A BAP rejecting our callback because its view of booking/ride state lags
+    -- ours is an EXPECTED async mismatch, not a server fault. Log at info and let
+    -- the fork complete cleanly so it doesn't land on the 5xx dashboard.
+    handleExpectedBapRejection :: SomeException -> m ()
+    handleExpectedBapRejection exc
+      | Just (BecknAPICallError _ err) <- fromException @BecknAPICallError exc,
+        err.code `elem` [toErrorCode (BookingInvalidStatus ""), toErrorCode (RideInvalidStatus "")] =
+        logInfo $ "Callback " <> actionName <> " rejected by BAP (expected state mismatch), code=" <> err.code
+      | otherwise = throwM exc

--- a/flake.lock
+++ b/flake.lock
@@ -4021,11 +4021,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1785183724,
-        "narHash": "sha256-Dz9cM5Ko6eF3OaUpoIciWTUacK9YNehZV1MOz8WrOBw=",
+        "lastModified": 1785248307,
+        "narHash": "sha256-YxGJ9g3qimSAhxNQJzWMIakDky41ovWKR1Ird27WwUI=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "16a6bb334ffe3aa0c3fa5d27983adcdd4c7f021b",
+        "rev": "bdb9aca0279bd093760ada7997b08eab02bd1fc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Fixes Bug : `forkBecknCallback` treats an expected BAP rejection (async state mismatch) as a server failure, killing the fork thread and surfacing as an E500 on the 5xx dashboard.

**Two changes bundled in this PR:**

1. **`Beckn/OnDemand/Utils/Callback.hs`** — `forkBecknCallback` now catches the callback's own exception (previously only the outer `try` was guarded). If the caught exception is a `BecknAPICallError` with code `BOOKING_INVALID_STATUS` or `RIDE_INVALID_STATUS`, it logs at info and lets the fork complete cleanly — this is an expected mismatch, since the BAP's view of booking/ride state can briefly lag ours. Any other error still rethrows and hits the existing `logError` path, unchanged from today. This fixes all 6 callbacks routed through this wrapper: on_search, on_track, on_init, on_status, on_cancel (x2).

2. **`flake.lock`** — bumps the `shared-kernel` pin to `bdb9aca`, picking up a one-character fix in `BecknAPIError.hs` (missing leading space in the error message formatting, e.g. `"400with message:"` → `"400 with message:"`), merged separately in [shared-kernel PR #1448](https://github.com/nammayatri/shared-kernel/pull/1448).

### Additional Changes
- [ ] This PR modifies the database schema (database migration added)
- [x] This PR modifies dhall configs/environment variables — flake.lock dependency bump only, no config/env values changed
- [ ] This PR contains API breaking changes

## Motivation and Context

Part of the 5xx error reduction work . BAP rejections due to async state mismatch are expected, not server faults, and were inflating the `BECKN_API_CALL_ERROR` count on the Grafana 5xx dashboard.

**Known scope note:** there is a second `forkBecknCallback` in shared-kernel (`Kernel/Utils/Callback.hs`, used by `withBecknCallbackMig`) that this PR does not cover.

**Known residual gap:** the error-callback branch (`Left err -> ... doWithResult $ fromError (...)`) is not guarded the same way — if the BAP rejects that callback with an invalid-status code, the fork can still die. Left as-is for this PR; flagging for visibility.

## How did you test it?

- `cabal build all` — compiles clean with zero errors/warnings under `-Werror`, both before and after the flake.lock bump.

## Screenshot of test results

Staging evidence will be added once sandbox deployment is available.

## Checklist
- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved callback handling for expected booking and ride status mismatches.
  * Prevented known state-related callback rejections from causing unnecessary failures.
  * Continued propagating unexpected callback errors for proper visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->