### PR TITLE
backend/fix: populate selectedServiceTier in standalone FRFS leg info

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -743,14 +743,16 @@ getFrfsSearchQuote (mbPersonId, merchantId_) searchId_ = do
                in compare (maybe 0 (.amount) mbAdultPrice1) (maybe 0 (.amount) mbAdultPrice2)
           )
           routeFilteredQuotesWithCategories
-  let mbReprAdultPrice = listToMaybe sortedQuotesWithCategories >>= \(_, qcs) -> find (\c -> c.category == ADULT) qcs <&> (.price)
+  let mbReprQuoteWithCategories = listToMaybe sortedQuotesWithCategories
+      mbReprAdultPrice = mbReprQuoteWithCategories >>= \(_, qcs) -> find (\c -> c.category == ADULT) qcs <&> (.price)
+      mbReprServiceTier = mbReprQuoteWithCategories >>= \(quote, qcs) -> JourneyUtils.getServiceTierFromQuote qcs quote
   mbOffer <-
     if isJust mbJourneyLeg
       then pure Nothing
       else case mbReprAdultPrice of
         Nothing -> pure Nothing
         Just reprPrice -> do
-          standaloneLeg <- JMTypes.mkStandaloneFrfsMinimalLegInfo search (Just reprPrice)
+          standaloneLeg <- JMTypes.mkStandaloneFrfsMinimalLegInfo search (Just reprPrice) mbReprServiceTier
           withTryCatch
             "getFrfsSearchQuote:cumulativeOffer"
             ( SOffer.offerListCache merchantId_ personId search.merchantOperatingCityId (FRFSUtils.getPaymentType False search.vehicleType) reprPrice Nothing

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
@@ -1206,8 +1206,8 @@ castCategoryToMode Spec.METRO = DTrip.Metro
 castCategoryToMode Spec.SUBWAY = DTrip.Subway
 castCategoryToMode Spec.BUS = DTrip.Bus
 
-mkStandaloneFrfsMinimalLegInfo :: (MonadFlow m) => FRFSSR.FRFSSearch -> Maybe Price -> m LegInfo
-mkStandaloneFrfsMinimalLegInfo frfsSearch mbFare = do
+mkStandaloneFrfsMinimalLegInfo :: (MonadFlow m) => FRFSSR.FRFSSearch -> Maybe Price -> Maybe LegServiceTier -> m LegInfo
+mkStandaloneFrfsMinimalLegInfo frfsSearch mbFare mbSelectedServiceTier = do
   now <- getCurrentTime
   legId <- generateGUID
   let mbFareEntity = mkPriceAPIEntity <$> mbFare
@@ -1237,7 +1237,7 @@ mkStandaloneFrfsMinimalLegInfo frfsSearch mbFare = do
                 ticketsCreatedAt = Nothing,
                 routeName = Nothing,
                 providerName = Nothing,
-                selectedServiceTier = Nothing,
+                selectedServiceTier = mbSelectedServiceTier,
                 frequency = Nothing,
                 alternateShortNames = [],
                 ticketNo = Nothing,
@@ -1294,7 +1294,7 @@ mkStandaloneFrfsMinimalLegInfo frfsSearch mbFare = do
                 providerRouteId = Nothing,
                 deviceId = Nothing,
                 ticketTypeCode = Nothing,
-                selectedServiceTier = Nothing,
+                selectedServiceTier = mbSelectedServiceTier,
                 ticketNo = Nothing,
                 adultTicketQuantity = Just frfsSearch.quantity,
                 childTicketQuantity = Nothing,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transit journey offers now retain the representative selected service tier derived from fare quotes.
  * Bus and subway options now show more accurate service-tier information when included in search results, including standalone minimal FRFS legs.
  * Improved alignment between representative quoted adult pricing and the corresponding journey details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->