### PR TITLE
fix:removed 5 min block for pass list util api

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -880,9 +880,6 @@ updatePurchasedPass ::
 -- payment row (never the pass row), so this read path owns both the PhotoPending -> Active/PreBooked
 -- transition and the normal term-based reconcile. Date-expired PhotoPending passes fall through to
 -- the expiry fallback below.
-updatePurchasedPass purchasedPass _today now
-  | purchasedPass.status /= DPurchasedPass.PhotoPending && diffUTCTime now purchasedPass.updatedAt <= 300 =
-    return (purchasedPass, Nothing, False)
 updatePurchasedPass purchasedPass today now = do
   latestPayments <-
     QPurchasedPassPayment.findAllByPurchasedPassIdAndStatus


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pass status reconciliation by consistently checking the latest payment information.
  * Ensured passes can transition correctly to photo-pending, active, or expired states without being delayed by recent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->