### PR TITLE
fix: Simplify the Toll Polygon & LineSegment Logic

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -291,7 +291,7 @@ handler ValidatedDSearchReq {..} sReq = do
                   Redis.setExp (multipleRouteKey transactionId) (createMultipleRouteInfo <$> serviceableRoute.multipleRoutes) 3600
               )
         logDebug $ "Route serviceability: " <> show serviceableRoute.multipleRoutes
-        mbTollChargesAndNames <- getTollInfoOnRoute merchantOpCityId.getId Nothing serviceableRoute.routePoints
+        mbTollChargesAndNames <- getTollInfoOnRoute merchantOpCityId.getId Nothing Nothing serviceableRoute.routePoints
         return
           ( Just setRouteInfo,
             Just toLocation,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Update.hs
@@ -404,7 +404,7 @@ handler (UEditLocationReq EditLocationReq {..}) = do
             let routeInfoInText = T.pack $ show routeInfo
             Redis.setExp (bookingRequestKeySoftUpdate booking.id.getId) routeInfo 600
             Redis.setExp (multipleRouteKeySoftUpdate booking.id.getId) (map RR.createMultipleRouteInfo routeResponse) 600
-            mbTollInfo <- getTollInfoOnRoute merchantOperatingCity.id.getId (mbPerson <&> (.id.getId)) shortestRoute.points
+            mbTollInfo <- getTollInfoOnRoute merchantOperatingCity.id.getId Nothing Nothing shortestRoute.points
             let isTollAllowed =
                   maybe
                     True

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FareCalculator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/FareCalculator.hs
@@ -84,7 +84,7 @@ calculateFareUtil merchantId merchanOperatingCityId mbDropLatLong pickupLatlong 
   let mbFromLocGeohash = T.pack <$> Geohash.encode (fromMaybe 5 transporterConfig.dpGeoHashPercision) (pickupLatlong.lat, pickupLatlong.lon)
   let mbToLocGeohash = T.pack <$> ((\dropLatLong -> Geohash.encode (fromMaybe 5 transporterConfig.dpGeoHashPercision) (dropLatLong.lat, dropLatLong.lon)) =<< mbDropLatLong)
   fareProducts <- FP.getAllFarePoliciesProduct merchantId merchanOperatingCityId False pickupLatlong mbDropLatLong Nothing Nothing Nothing mbFromLocGeohash mbToLocGeohash mbDistance mbDuration Nothing tripCategory configsInExperimentVersions
-  mbTollChargesAndNames <- TD.getTollInfoOnRoute merchanOperatingCityId.getId Nothing (maybe [] (\x -> x.points) mbRoute)
+  mbTollChargesAndNames <- TD.getTollInfoOnRoute merchanOperatingCityId.getId Nothing Nothing (maybe [] (\x -> x.points) mbRoute)
   let mbIsAutoRickshawAllowed = (.isAutoRickshawAllowed) <$> mbTollChargesAndNames
   let mbIsTwoWheelerAllowed = join ((.isTwoWheelerAllowed) <$> mbTollChargesAndNames)
   let allFarePolicies = selectFarePolicy (fromMaybe 0 mbDistance) (fromMaybe 0 mbDuration) mbIsAutoRickshawAllowed mbIsTwoWheelerAllowed fareProducts.farePolicies

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
@@ -478,6 +478,7 @@ endRideHandler handle@ServiceHandle {..} rideId req = do
                 -- Check for pending tolls (entry detected but exit not found) and validate against estimate using IDs
                 mbValidatedPendingToll <-
                   TollsDetector.checkAndValidatePendingTolls
+                    TollsDetector.TollTrackingSnapToRoad
                     updRide.driverId.getId
                     updRide.estimatedTollCharges
                     updRide.estimatedTollNames

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Lib/LocationUpdates.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Lib/LocationUpdates.hs
@@ -45,6 +45,7 @@ import qualified Kernel.Tools.Metrics.CoreMetrics as CoreMetrics
 import Kernel.Types.Id
 import Kernel.Utils.CalculateDistance
 import Kernel.Utils.Common
+import Kernel.Utils.ComputeIntersection (LineSegment (..))
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import qualified Lib.Finance.Core.Types as Finance
 import "location-updates" Lib.LocationUpdates as Reexport
@@ -248,13 +249,19 @@ checkForDeviationInSingleRoute batchWaypoints routeDeviationThreshold nightSafet
       logWarning $ "Ride route info not found for rideId: " <> getId rideId
       return False
 
-updateTollRouteDeviation :: LocationUpdateFlow m r c => Id DMOC.MerchantOperatingCity -> Id Person -> Maybe Ride -> [LatLong] -> m (Bool, Bool)
-updateTollRouteDeviation _ _ Nothing _ = do
+updateTollRouteDeviation :: LocationUpdateFlow m r c => Id DMOC.MerchantOperatingCity -> Id Person -> Maybe Ride -> [LatLong] -> Maybe LineSegment -> m (Bool, Bool)
+updateTollRouteDeviation _ _ Nothing _ _ = do
   logInfo "No ride found to check deviation"
   return (False, False)
-updateTollRouteDeviation merchantOpCityId driverId (Just ride) batchWaypoints = do
+updateTollRouteDeviation merchantOpCityId driverId (Just ride) batchWaypoints mbPreviousRouteSegment = do
   let driverDeviatedToTollRoute = fromMaybe False ride.driverDeviatedToTollRoute
-  isTollPresentOnCurrentRoute <- isJust <$> TollsDetector.getTollInfoOnRoute merchantOpCityId.getId (Just driverId.getId) batchWaypoints
+  isTollPresentOnCurrentRoute <-
+    isJust
+      <$> TollsDetector.getTollInfoOnRoute
+        merchantOpCityId.getId
+        (Just $ TollsDetector.TollTracking TollsDetector.TollTrackingDeviation driverId.getId)
+        mbPreviousRouteSegment
+        batchWaypoints
   when (isTollPresentOnCurrentRoute && not driverDeviatedToTollRoute) $ do
     QRide.updateDriverDeviatedToTollRoute ride.id isTollPresentOnCurrentRoute
   return (driverDeviatedToTollRoute, isTollPresentOnCurrentRoute)
@@ -275,7 +282,7 @@ getTravelledDistanceAndTollInfo merchantOperatingCityId (Just ride) estimatedDis
         Just route -> do
           let distance = RI.distance $ RI.routeInfo route
               routePoints = RI.points $ RI.routeInfo route
-          tollChargesInfo <- join <$> mapM (TollsDetector.getTollInfoOnRoute merchantOperatingCityId.getId Nothing) routePoints
+          tollChargesInfo <- join <$> mapM (TollsDetector.getTollInfoOnRoute merchantOperatingCityId.getId Nothing Nothing) routePoints
           return $ (fromMaybe estimatedDistance distance, tollChargesInfo <|> estimatedTollInfo)
         Nothing -> do
           logInfo $ "UndeviatedRoute not found for ride" <> show rideId
@@ -302,17 +309,22 @@ buildRideInterpolationHandler merchantId merchantOpCityId rideId isEndRide mbBat
       isEndRide
       (\driverId dist googleSnapCalls osrmSnapCalls numberOfSelfTuned isDistCalcFailed -> QRide.updateDistance driverId dist googleSnapCalls osrmSnapCalls numberOfSelfTuned isDistCalcFailed)
       (\driverId tollCharges tollNames tollIds -> void (QRide.updateTollChargesAndNamesAndIds driverId tollCharges tollNames tollIds))
-      ( \driverId accurateWaypoints allWaypoints -> do
+      ( \driverId accurateWaypoints allWaypoints mbPreviousRouteSegment -> do
           ride <- QRide.getActiveByDriverId driverId
           let isSafetyCheckEnabledForTripCategory = maybe True (enableSafetyCheckWrtTripCategory . (.tripCategory)) ride
           routeDeviation <-
             if null accurateWaypoints
               then pure False
               else updateDeviation transportConfig (enableNightSafety && isSafetyCheckEnabledForTripCategory) ride accurateWaypoints
-          (tollRouteDeviation, isTollPresentOnCurrentRoute) <- updateTollRouteDeviation merchantOpCityId driverId ride allWaypoints
+          (tollRouteDeviation, isTollPresentOnCurrentRoute) <- updateTollRouteDeviation merchantOpCityId driverId ride allWaypoints mbPreviousRouteSegment
           return (routeDeviation, tollRouteDeviation, isTollPresentOnCurrentRoute)
       )
-      (\mbDriverId -> TollsDetector.getTollInfoOnRoute merchantOpCityId.getId (fmap getId mbDriverId))
+      ( \mbDriverId mbPreviousRouteSegment ->
+          TollsDetector.getTollInfoOnRoute
+            merchantOpCityId.getId
+            (mbDriverId <&> \driverId -> TollsDetector.TollTracking TollsDetector.TollTrackingSnapToRoad driverId.getId)
+            mbPreviousRouteSegment
+      )
       ( \driverId estimatedDistance estimatedTollInfo -> do
           ride <- QRide.getActiveByDriverId driverId
           getTravelledDistanceAndTollInfo merchantOpCityId ride estimatedDistance estimatedTollInfo

--- a/Backend/lib/location-updates/src/Lib/LocationUpdates/Internal.hs
+++ b/Backend/lib/location-updates/src/Lib/LocationUpdates/Internal.hs
@@ -77,12 +77,12 @@ data RideInterpolationHandler person m = RideInterpolationHandler
     clearInterpolatedPoints :: Id person -> m (),
     expireInterpolatedPoints :: Id person -> m (),
     getInterpolatedPoints :: Id person -> m [LatLong],
-    interpolatePointsAndCalculateDistanceAndToll :: Maybe LatLong -> Maybe MapsServiceConfig -> Bool -> Id person -> [LatLong] -> m (HighPrecMeters, [LatLong], [MapsService], Bool, Maybe TollInfo),
+    interpolatePointsAndCalculateDistanceAndToll :: Maybe LatLong -> Maybe MapsServiceConfig -> Bool -> Id person -> Maybe LineSegment -> [LatLong] -> m (HighPrecMeters, [LatLong], [MapsService], Bool, Maybe TollInfo),
     wrapDistanceCalculation :: Id person -> m () -> m (),
     isDistanceCalculationFailed :: Id person -> m Bool,
     updateDistance :: Id person -> HighPrecMeters -> Int -> Int -> Maybe Int -> Bool -> m (),
     updateTollChargesAndNamesAndIds :: Id person -> HighPrecMoney -> [Text] -> [Text] -> m (),
-    updateRouteDeviation :: Id person -> [LatLong] -> [LatLong] -> m (Bool, Bool, Bool),
+    updateRouteDeviation :: Id person -> [LatLong] -> [LatLong] -> Maybe LineSegment -> m (Bool, Bool, Bool),
     getTravelledDistanceAndTollInfo :: Id person -> Meters -> Maybe TollInfo -> m (Meters, Maybe TollInfo),
     getRecomputeIfPickupDropNotOutsideOfThreshold :: Bool,
     sendTollCrossedNotificationToDriver :: Id person -> m (),
@@ -194,7 +194,8 @@ recalcDistanceBatches h@RideInterpolationHandler {..} ending driverId estDist es
   let prevPoints = fromMaybe [] prevBatchTwoEndPoints
       modifiedAccurateWaypoints = prevPoints <> accWaypoints
       modifiedAllWaypoints = prevPoints <> toList allWaypoints
-  (routeDeviation, tollRouteDeviation, isTollPresentOnCurrentRoute) <- updateRouteDeviation driverId modifiedAccurateWaypoints modifiedAllWaypoints
+      mbPreviousRouteSegment = lineSegmentFromPoints prevPoints
+  (routeDeviation, tollRouteDeviation, isTollPresentOnCurrentRoute) <- updateRouteDeviation driverId modifiedAccurateWaypoints modifiedAllWaypoints mbPreviousRouteSegment
   when (isTollApplicable && enableTollCrossedNotifications && isTollPresentOnCurrentRoute) $
     fork "Toll Crossed OnUpdate" $ do
       sendTollCrossedNotificationToDriver driverId
@@ -209,7 +210,7 @@ recalcDistanceBatches h@RideInterpolationHandler {..} ending driverId estDist es
       then do
         if snapToRoadCallCondition
           then do
-            currSnapToRoadState <- processSnapToRoadCall
+            currSnapToRoadState <- processSnapToRoadCall mbPreviousRouteSegment
             updateDistance driverId currSnapToRoadState.distanceTravelled currSnapToRoadState.googleSnapToRoadCalls currSnapToRoadState.osrmSnapToRoadCalls currSnapToRoadState.numberOfSelfTuned calculationFailed
             when isTollApplicable $ do
               mbTollCharges :: Maybe HighPrecMoney <- Redis.safeGet (onRideTollChargesKey driverId)
@@ -230,7 +231,7 @@ recalcDistanceBatches h@RideInterpolationHandler {..} ending driverId estDist es
       else do
         isAtLeastBatchPlusOne <- atLeastBatchPlusOne
         when (snapToRoadCallCondition && isAtLeastBatchPlusOne) $ do
-          currSnapToRoadState <- processSnapToRoadCall
+          currSnapToRoadState <- processSnapToRoadCall mbPreviousRouteSegment
           updateDistance driverId currSnapToRoadState.distanceTravelled currSnapToRoadState.googleSnapToRoadCalls currSnapToRoadState.osrmSnapToRoadCalls currSnapToRoadState.numberOfSelfTuned calculationFailed
           Redis.setExp (onRideSnapToRoadStateKey driverId) currSnapToRoadState 86400 -- 24 hours
   where
@@ -238,11 +239,11 @@ recalcDistanceBatches h@RideInterpolationHandler {..} ending driverId estDist es
     continueCondition = if ending then pointsRemaining else atLeastBatchPlusOne
     atLeastBatchPlusOne = (> batchSize) <$> getWaypointsNumber driverId
 
-    recalcDistanceBatches' isFirstCall snapToRoad'@SnapToRoadState {..} snapToRoadCallFailed = do
+    recalcDistanceBatches' mbPreviousRouteSegment isFirstCall snapToRoad'@SnapToRoadState {..} snapToRoadCallFailed = do
       batchLeft <- continueCondition
       if (batchLeft && not isMeterRide) || (batchLeft && isMeterRide && isFirstCall)
         then do
-          (dist, newReferencePoint, startPatching, servicesUsed, snapCallFailed) <- recalcDistanceBatchStep h isMeterRide distanceCalcReferencePoint rectifyDistantPointsFailureUsing isTollApplicable driverId
+          (dist, newReferencePoint, startPatching, servicesUsed, snapCallFailed) <- recalcDistanceBatchStep h isMeterRide distanceCalcReferencePoint rectifyDistantPointsFailureUsing isTollApplicable driverId mbPreviousRouteSegment
           let googleCalled = Google `elem` servicesUsed
               osrmCalled = OSRM `elem` servicesUsed
               selfTunedCount = SelfTuned `elem` servicesUsed
@@ -252,14 +253,14 @@ recalcDistanceBatches h@RideInterpolationHandler {..} ending driverId estDist es
               updDistance = bool dist (distanceTravelled + dist) (startPatching || fromMaybe True startPatchingDistance)
           if snapCallFailed
             then pure (SnapToRoadState distanceTravelled distanceTravelledOutSideDropThreshold' (googleSnapToRoadCalls + fromBool googleCalled) (osrmSnapToRoadCalls + fromBool osrmCalled) ((\numberOfSelfTuned' -> fromBool selfTunedCount + numberOfSelfTuned') <$> numberOfSelfTuned) isPassedThroughDrop (Just (startPatching || fromMaybe True startPatchingDistance)) newReferencePoint, snapCallFailed)
-            else recalcDistanceBatches' False (SnapToRoadState updDistance distanceTravelledOutSideDropThreshold' (googleSnapToRoadCalls + fromBool googleCalled) (osrmSnapToRoadCalls + fromBool osrmCalled) ((\numberOfSelfTuned' -> fromBool selfTunedCount + numberOfSelfTuned') <$> numberOfSelfTuned) isPassedThroughDrop (Just (startPatching || fromMaybe True startPatchingDistance)) newReferencePoint) snapCallFailed
+            else recalcDistanceBatches' mbPreviousRouteSegment False (SnapToRoadState updDistance distanceTravelledOutSideDropThreshold' (googleSnapToRoadCalls + fromBool googleCalled) (osrmSnapToRoadCalls + fromBool osrmCalled) ((\numberOfSelfTuned' -> fromBool selfTunedCount + numberOfSelfTuned') <$> numberOfSelfTuned) isPassedThroughDrop (Just (startPatching || fromMaybe True startPatchingDistance)) newReferencePoint) snapCallFailed
         else pure (snapToRoad', snapToRoadCallFailed)
 
-    processSnapToRoadCall = do
+    processSnapToRoadCall mbPreviousRouteSegment = do
       prevSnapToRoadState :: SnapToRoadState <-
         Redis.safeGet (onRideSnapToRoadStateKey driverId)
           <&> fromMaybe (SnapToRoadState 0 (Just 0) 0 0 (Just 0) (Just passedThroughDrop) (Just False) Nothing)
-      (currSnapToRoadState, snapToRoadCallFailed) <- recalcDistanceBatches' True prevSnapToRoadState False
+      (currSnapToRoadState, snapToRoadCallFailed) <- recalcDistanceBatches' mbPreviousRouteSegment True prevSnapToRoadState False
       when snapToRoadCallFailed $ do
         updateDistance driverId currSnapToRoadState.distanceTravelled currSnapToRoadState.googleSnapToRoadCalls currSnapToRoadState.osrmSnapToRoadCalls currSnapToRoadState.numberOfSelfTuned calculationFailed
         throwError $ InternalError $ "Snap to road call failed for driverId =" <> driverId.getId
@@ -281,8 +282,9 @@ recalcDistanceBatchStep ::
   Maybe MapsServiceConfig ->
   Bool ->
   Id person ->
+  Maybe LineSegment ->
   m (HighPrecMeters, Maybe LatLong, Bool, [MapsService], Bool)
-recalcDistanceBatchStep RideInterpolationHandler {..} isMeterRide distanceCalcReferencePoint rectifyDistantPointsFailureUsing isTollApplicable driverId = do
+recalcDistanceBatchStep RideInterpolationHandler {..} isMeterRide distanceCalcReferencePoint rectifyDistantPointsFailureUsing isTollApplicable driverId mbPreviousRouteSegment = do
   (startPatching, distanceCalcReferencePoint') <-
     if isMeterRide
       then do
@@ -292,7 +294,7 @@ recalcDistanceBatchStep RideInterpolationHandler {..} isMeterRide distanceCalcRe
         pure $ bool (False, Nothing) (True, distanceCalcReferencePoint) (pointToRemove > 0) -- means we have covered 99 points once, now we have to start patching
       else pure (True, Nothing)
   batchWaypoints <- getFirstNwaypoints driverId (maxSnapToRoadReqPoints + 1)
-  (distance, interpolatedWps, servicesUsed, snapToRoadFailed, mbTollChargesAndNames) <- interpolatePointsAndCalculateDistanceAndToll distanceCalcReferencePoint' rectifyDistantPointsFailureUsing isTollApplicable driverId batchWaypoints
+  (distance, interpolatedWps, servicesUsed, snapToRoadFailed, mbTollChargesAndNames) <- interpolatePointsAndCalculateDistanceAndToll distanceCalcReferencePoint' rectifyDistantPointsFailureUsing isTollApplicable driverId mbPreviousRouteSegment batchWaypoints
   whenJust mbTollChargesAndNames $ \tollInfo -> do
     void $ Redis.rPushExp (onRideTollNamesKey driverId) tollInfo.tollNames 21600
     void $ Redis.rPushExp (onRideTollIdsKey driverId) tollInfo.tollIds 21600
@@ -342,8 +344,8 @@ mkRideInterpolationHandler ::
   Bool ->
   (Id person -> HighPrecMeters -> Int -> Int -> Maybe Int -> Bool -> m ()) ->
   (Id person -> HighPrecMoney -> [Text] -> [Text] -> m ()) ->
-  (Id person -> [LatLong] -> [LatLong] -> m (Bool, Bool, Bool)) ->
-  (Maybe (Id person) -> RoutePoints -> m (Maybe TollInfo)) ->
+  (Id person -> [LatLong] -> [LatLong] -> Maybe LineSegment -> m (Bool, Bool, Bool)) ->
+  (Maybe (Id person) -> Maybe LineSegment -> RoutePoints -> m (Maybe TollInfo)) ->
   (Id person -> Meters -> Maybe TollInfo -> m (Meters, Maybe TollInfo)) ->
   Bool ->
   (Maybe MapsServiceConfig -> Maps.SnapToRoadReq -> m ([Maps.MapsService], Either String Maps.SnapToRoadResp)) ->
@@ -461,6 +463,10 @@ clearInterpolatedPointsImplementation driverId = do
 getInterpolatedPointsImplementation :: HedisFlow m env => Id person -> m [LatLong]
 getInterpolatedPointsImplementation = Hedis.getList . makeInterpolatedPointsRedisKey
 
+lineSegmentFromPoints :: [LatLong] -> Maybe LineSegment
+lineSegmentFromPoints [startPoint, endPoint] = Just $ LineSegment startPoint endPoint
+lineSegmentFromPoints _ = Nothing
+
 expireInterpolatedPointsImplementation :: HedisFlow m env => Id person -> m ()
 expireInterpolatedPointsImplementation driverId = do
   let key = makeInterpolatedPointsRedisKey driverId
@@ -476,14 +482,15 @@ interpolatePointsAndCalculateDistanceAndTollImplementation ::
   ) =>
   Bool ->
   (Maybe MapsServiceConfig -> Maps.SnapToRoadReq -> m ([Maps.MapsService], Either String Maps.SnapToRoadResp)) ->
-  (Maybe (Id person) -> RoutePoints -> m (Maybe TollInfo)) ->
+  (Maybe (Id person) -> Maybe LineSegment -> RoutePoints -> m (Maybe TollInfo)) ->
   Maybe LatLong ->
   Maybe MapsServiceConfig ->
   Bool ->
   Id person ->
+  Maybe LineSegment ->
   [LatLong] ->
   m (HighPrecMeters, [LatLong], [Maps.MapsService], Bool, Maybe TollInfo)
-interpolatePointsAndCalculateDistanceAndTollImplementation isEndRide snapToRoadCall getTollInfoOnTheRoute distanceCalcReferencePoint rectifyDistantPointsFailureUsing isTollApplicable driverId wps = do
+interpolatePointsAndCalculateDistanceAndTollImplementation isEndRide snapToRoadCall getTollInfoOnTheRoute distanceCalcReferencePoint rectifyDistantPointsFailureUsing isTollApplicable driverId mbPreviousRouteSegment wps = do
   if isEndRide && isAllPointsEqual wps
     then pure (0, take 1 wps, [], False, Nothing)
     else do
@@ -493,7 +500,7 @@ interpolatePointsAndCalculateDistanceAndTollImplementation isEndRide snapToRoadC
         Right response -> do
           tollInfo <-
             if isTollApplicable
-              then getTollInfoOnTheRoute (Just driverId) response.snappedPoints
+              then getTollInfoOnTheRoute (Just driverId) mbPreviousRouteSegment response.snappedPoints
               else return Nothing
           pure (response.distance, response.snappedPoints, servicesUsed, False, tollInfo)
 

--- a/Backend/lib/shared-services/src/Toll/SharedLogic/TollsDetector.hs
+++ b/Backend/lib/shared-services/src/Toll/SharedLogic/TollsDetector.hs
@@ -12,6 +12,8 @@ module Toll.SharedLogic.TollsDetector
     clearTollStartGateBatchCache,
     filterRoutesPreferringToll,
     getTollInfoOnRoute,
+    TollTracking (..),
+    TollTrackingScope (..),
     TollChargeDetails (..),
     TollInfo (..),
     emptyTollInfo,
@@ -42,20 +44,62 @@ import Toll.Domain.Types.TollGate (TollGate (..), geoPolygonToLatLongRings, line
 import Toll.Storage.BeamFlow (BeamFlow)
 import Toll.Storage.CachedQueries.Toll (findAllTollsByMerchantOperatingCity)
 
-tollStartGateTrackingKey :: Text -> Text
-tollStartGateTrackingKey driverId = "TollGateTracking:DriverId-" <> driverId
+-- | Which consumer owns a pending-toll state machine. Each scope gets its own Redis key so that
+--   the deviation walk (live raw waypoints, charges discarded) can never consume or corrupt the
+--   pending tolls of the billing walk (lagging snapped batches, charges applied).
+data TollTrackingScope
+  = TollTrackingSnapToRoad
+  | TollTrackingDeviation
+  deriving (Show, Eq, Enum, Bounded)
+
+data TollTracking = TollTracking
+  { trackingScope :: TollTrackingScope,
+    trackingDriverId :: Text
+  }
+  deriving (Show, Eq)
+
+tollTrackingKeyScopeTag :: TollTrackingScope -> Text
+tollTrackingKeyScopeTag TollTrackingSnapToRoad = ""
+tollTrackingKeyScopeTag TollTrackingDeviation = "Deviation:"
+
+tollStartGateTrackingKey :: TollTrackingScope -> Text -> Text
+tollStartGateTrackingKey scope driverId =
+  "TollGateTracking:" <> tollTrackingKeyScopeTag scope <> "DriverId-" <> driverId
+
+allTollTrackingScopes :: [TollTrackingScope]
+allTollTrackingScopes = [minBound .. maxBound]
 
 -- This function is called during endRideTransaction to clear all pending tolls
 clearTollStartGateBatchCache :: (CacheFlow m r) => Text -> m ()
-clearTollStartGateBatchCache driverId = do
-  Hedis.del $ tollStartGateTrackingKey driverId
+clearTollStartGateBatchCache driverId =
+  forM_ allTollTrackingScopes $ \scope ->
+    Hedis.del $ tollStartGateTrackingKey scope driverId
 
-gateIntersectsRouteSegment :: LineSegment -> TollGate -> Bool
-gateIntersectsRouteSegment routeSegment = \case
+-- | A LineGate start is crossed when the current route segment intersects it.
+--   A PolyGate start is crossed only when the route was inside the polygon on the previous segment
+--   and the current segment now meets its boundary, i.e. the route is leaving the polygon. That
+--   direction requirement is what distinguishes an inbound from an outbound toll.
+gateStartsOnRouteSegment :: Maybe LineSegment -> LineSegment -> TollGate -> Bool
+gateStartsOnRouteSegment mbPreviousSegment routeSegment = \case
   LineGate gateLine ->
     any (doIntersect routeSegment) (lineStringToSegments gateLine)
   PolyGate gatePolygon ->
-    lineSegmentIntersectsPolygon routeSegment (geoPolygonToLatLongRings gatePolygon)
+    let rings = geoPolygonToLatLongRings gatePolygon
+     in maybe False (`lineSegmentWithinPolygon` rings) mbPreviousSegment
+          && lineSegmentIntersectsPolygonBoundary routeSegment rings
+  where
+    lineSegmentWithinPolygon :: LineSegment -> [[LatLong]] -> Bool
+    lineSegmentWithinPolygon (LineSegment startPoint endPoint) rings =
+      pointInPolygon startPoint rings && pointInPolygon endPoint rings
+
+-- | An end gate is crossed on the same condition as a LineGate, except that a PolyGate also counts
+--   as crossed when the route segment merely overlaps the polygon.
+gateEndsOnRouteSegment :: LineSegment -> TollGate -> Bool
+gateEndsOnRouteSegment routeSegment = \case
+  LineGate gateLine ->
+    any (doIntersect routeSegment) (lineStringToSegments gateLine)
+  PolyGate gatePolygon ->
+    lineSegmentIntersectsPolygonBoundary routeSegment (geoPolygonToLatLongRings gatePolygon)
 
 gateWithinBoundingBox :: BoundingBox -> TollGate -> Bool
 gateWithinBoundingBox boundingBox = \case
@@ -63,34 +107,44 @@ gateWithinBoundingBox boundingBox = \case
     any (\seg -> lineSegmentWithinBoundingBox seg boundingBox) (lineStringToSegments gateLine)
   PolyGate gatePolygon ->
     polygonMayIntersectBoundingBox boundingBox (geoPolygonToLatLongRings gatePolygon)
-
-pointInRing :: LatLong -> [LatLong] -> Bool
-pointInRing _ ring | length ring < 3 = False
-pointInRing (LatLong y x) ring =
-  foldl' step False (zip ring (drop 1 ring ++ [head ring]))
   where
-    step inside (LatLong y1 x1, LatLong y2 x2)
-      | y1 == y2 = inside
-      | ((y1 > y) /= (y2 > y))
-          && (x < (x2 - x1) * (y - y1) / (y2 - y1) + x1) =
-        not inside
-      | otherwise = inside
+    polygonMayIntersectBoundingBox :: BoundingBox -> [[LatLong]] -> Bool
+    polygonMayIntersectBoundingBox bbox rings =
+      let anyPolyPointInside = any (`pointWithinBoundingBox` bbox) (concat rings)
+          anyBoxCornerInsidePoly =
+            any
+              (`pointInPolygon` rings)
+              [bbox.topLeft, bbox.topRight, bbox.bottomLeft, bbox.bottomRight]
+          anyEdgeIntersects =
+            any
+              (\polyEdge -> any (doIntersect polyEdge) (boundingBoxEdges bbox))
+              (concatMap ringEdges rings)
+       in anyPolyPointInside || anyBoxCornerInsidePoly || anyEdgeIntersects
 
 pointInPolygon :: LatLong -> [[LatLong]] -> Bool
 pointInPolygon _ [] = False
 pointInPolygon p (outer : holes) = pointInRing p outer && not (any (pointInRing p) holes)
+  where
+    pointInRing :: LatLong -> [LatLong] -> Bool
+    pointInRing _ ring | length ring < 3 = False
+    pointInRing (LatLong y x) ring =
+      foldl' step False (zip ring (drop 1 ring ++ [head ring]))
+      where
+        step inside (LatLong y1 x1, LatLong y2 x2)
+          | y1 == y2 = inside
+          | ((y1 > y) /= (y2 > y))
+              && (x < (x2 - x1) * (y - y1) / (y2 - y1) + x1) =
+            not inside
+          | otherwise = inside
 
 ringEdges :: [LatLong] -> [LineSegment]
 ringEdges ring
   | length ring < 2 = []
   | otherwise = zipWith LineSegment ring (drop 1 ring ++ [head ring])
 
-lineSegmentIntersectsPolygon :: LineSegment -> [[LatLong]] -> Bool
-lineSegmentIntersectsPolygon routeSegment rings =
-  let LineSegment startPoint endPoint = routeSegment
-      intersectsBoundary = any (\ring -> any (doIntersect routeSegment) (ringEdges ring)) rings
-      entersOrInside = pointInPolygon startPoint rings || pointInPolygon endPoint rings
-   in intersectsBoundary || entersOrInside
+lineSegmentIntersectsPolygonBoundary :: LineSegment -> [[LatLong]] -> Bool
+lineSegmentIntersectsPolygonBoundary routeSegment rings =
+  any (\ring -> any (doIntersect routeSegment) (ringEdges ring)) rings
 
 boundingBoxEdges :: BoundingBox -> [LineSegment]
 boundingBoxEdges boundingBox =
@@ -100,26 +154,13 @@ boundingBoxEdges boundingBox =
     LineSegment boundingBox.bottomLeft boundingBox.topLeft
   ]
 
-polygonMayIntersectBoundingBox :: BoundingBox -> [[LatLong]] -> Bool
-polygonMayIntersectBoundingBox bbox rings =
-  let ringPoints = concat rings
-      anyPolyPointInside = any (`pointWithinBoundingBox` bbox) ringPoints
-      anyBoxCornerInsidePoly =
-        any
-          (`pointInPolygon` rings)
-          [bbox.topLeft, bbox.topRight, bbox.bottomLeft, bbox.bottomRight]
-      anyEdgeIntersects =
-        any
-          (\polyEdge -> any (doIntersect polyEdge) (boundingBoxEdges bbox))
-          (concatMap ringEdges rings)
-   in anyPolyPointInside || anyBoxCornerInsidePoly || anyEdgeIntersects
-
 -- | Validates pending tolls (entry detected, exit not found) against estimated tolls using IDs
 -- | Used at end ride to apply toll charges when exit gate was never detected
 -- | Returns Nothing if validation fails or no estimate exists (conservative approach for safety)
 -- | Now uses toll IDs for exact matching and handles partial toll scenarios (some detected, some not)
 checkAndValidatePendingTolls ::
   (CacheFlow m r) =>
+  TollTrackingScope ->
   Text ->
   Maybe HighPrecMoney ->
   Maybe [Text] ->
@@ -127,8 +168,8 @@ checkAndValidatePendingTolls ::
   Maybe HighPrecMoney ->
   Maybe [Text] -> -- Already detected toll IDs
   m (Maybe (HighPrecMoney, [Text], [Text]))
-checkAndValidatePendingTolls driverId _estimatedTollCharges _estimatedTollNames estimatedTollIds alreadyDetectedCharges alreadyDetectedTollIds = do
-  mbPendingTolls :: Maybe [Toll] <- Hedis.safeGet (tollStartGateTrackingKey driverId)
+checkAndValidatePendingTolls scope driverId _estimatedTollCharges _estimatedTollNames estimatedTollIds alreadyDetectedCharges alreadyDetectedTollIds = do
+  mbPendingTolls :: Maybe [Toll] <- Hedis.safeGet (tollStartGateTrackingKey scope driverId)
 
   case (mbPendingTolls, estimatedTollIds, alreadyDetectedTollIds) of
     (Just pendingTolls, Just estIds, Just detectedIds) -> do
@@ -225,136 +266,123 @@ addDetectedTollCharge toll@Toll {..} acc =
 addTollCharge :: Toll -> TollChargesAndNamesAndIds -> TollChargesAndNamesAndIds
 addTollCharge = addDetectedTollCharge
 
-tollStartsOnRouteSegment :: LineSegment -> Toll -> Bool
-tollStartsOnRouteSegment routeSegment Toll {..} =
-  any (gateIntersectsRouteSegment routeSegment) tollStartGates
+tollStartsOnRouteSegment :: Maybe LineSegment -> LineSegment -> Toll -> Bool
+tollStartsOnRouteSegment mbPreviousSegment routeSegment Toll {..} =
+  any (gateStartsOnRouteSegment mbPreviousSegment routeSegment) tollStartGates
 
-usesPolygonStartGates :: Toll -> Bool
-usesPolygonStartGates Toll {..} =
-  any isPolyStartGate tollStartGates
-  where
-    isPolyStartGate (PolyGate _) = True
-    isPolyStartGate (LineGate _) = False
+tollEndsOnRouteSegment :: LineSegment -> Toll -> Bool
+tollEndsOnRouteSegment routeSegment Toll {..} =
+  any (gateEndsOnRouteSegment routeSegment) tollEndGates
 
--- | True when any pending toll's exit gate is crossed on this route segment.
-exitDetectedOnRouteSegment :: LineSegment -> [Toll] -> Bool
-exitDetectedOnRouteSegment routeSegment =
-  any (\Toll {..} -> any (gateIntersectsRouteSegment routeSegment) tollEndGates)
+-- Removes the matched toll AND all other possibilities with the same entry gate from pending cache
+-- For example, if XL is matched (X entry, L exit), removes XK, XL, XM (all with entry X)
+removeMatchedTollFromCache :: (CacheFlow m r) => TollTracking -> [Toll] -> Toll -> m ()
+removeMatchedTollFromCache tracking allPendingTolls matchedToll = do
+  let key = tollStartGateTrackingKey tracking.trackingScope tracking.trackingDriverId
+      remainingPendingTolls = filter (\toll -> toll.tollStartGates /= matchedToll.tollStartGates) allPendingTolls
+  if null remainingPendingTolls
+    then Hedis.del key
+    else Hedis.setExp key remainingPendingTolls 21600 -- 6 hours
 
--- | On segments where a pending toll exits, only line tolls may be newly armed.
-canAddTollToPending :: Bool -> Toll -> Bool
-canAddTollToPending exitOnSegment toll =
-  not exitOnSegment || not (usesPolygonStartGates toll)
+-- This function is triggered when allTollCombinationsWithStartGates are found intersecting the route to find the exit segment intersection on the further route and return the segment it was found on along with the remaining route after intersection.
+getExitTollAndRemainingRoute :: RoutePoints -> [Toll] -> Maybe (LineSegment, RoutePoints, Toll)
+getExitTollAndRemainingRoute [] _ = Nothing
+getExitTollAndRemainingRoute [_] _ = Nothing
+getExitTollAndRemainingRoute _ [] = Nothing
+getExitTollAndRemainingRoute (p1 : p2 : ps) tolls =
+  let exitSegment = LineSegment p1 p2
+   in case find (tollEndsOnRouteSegment exitSegment) tolls of
+        Just toll -> Just (exitSegment, p2 : ps, toll)
+        Nothing -> getExitTollAndRemainingRoute (p2 : ps) tolls
 
-addPendingTollStartersOnSegment :: LineSegment -> [Toll] -> [Toll] -> [Toll]
-addPendingTollStartersOnSegment routeSegment tolls pendingTolls =
-  let pendingTollIds = map (getId . (.id)) pendingTolls
-      exitOnSegment = exitDetectedOnRouteSegment routeSegment pendingTolls
-      newTollStarters =
-        filter
-          ( \toll ->
-              tollStartsOnRouteSegment routeSegment toll
-                && getId toll.id `notElem` pendingTollIds
-                && canAddTollToPending exitOnSegment toll
-          )
-          tolls
-   in nubBy (\toll1 toll2 -> getId toll1.id == getId toll2.id) (pendingTolls <> newTollStarters)
-
--- | When a toll exit is found, charge it and drop every pending toll that shares the same entry gate.
-resolveTollExitsOnSegment :: LineSegment -> [Toll] -> TollChargesAndNamesAndIds -> ([Toll], TollChargesAndNamesAndIds)
-resolveTollExitsOnSegment routeSegment pendingTolls tollChargesAndNamesAndIds =
-  case find (\Toll {..} -> any (gateIntersectsRouteSegment routeSegment) tollEndGates) pendingTolls of
-    Nothing -> (pendingTolls, tollChargesAndNamesAndIds)
-    Just matchedToll ->
-      let remainingPendingTolls = filter (\toll -> toll.tollStartGates /= matchedToll.tollStartGates) pendingTolls
-       in resolveTollExitsOnSegment routeSegment remainingPendingTolls (addTollCharge matchedToll tollChargesAndNamesAndIds)
-
-cachePendingTolls :: (CacheFlow m r) => Maybe Text -> [Toll] -> m ()
-cachePendingTolls _ [] = pure ()
-cachePendingTolls Nothing _ = pure ()
-cachePendingTolls (Just driverId) pendingTolls =
-  Hedis.setExp (tollStartGateTrackingKey driverId) pendingTolls 21600 -- 6 hours
-
--- | Walks the route segment-by-segment using the same start/exit pairing as the original
--- | algorithm: tolls whose entry gate is crossed are tracked in pendingTolls until their
--- | exit gate is crossed, at which point they are charged. Unlike the original slice-based
--- | walk, the route is not truncated after each exit so nested tolls inside an active toll
--- | window are still detected on later segments.
+-- This function is responsible for checking the toll start and exit segments intersection on the route and appropriately update the state in case exit segment is not found corresponding to the entry segment while On Ride.
 getAggregatedTollChargesAndNamesOnRoute ::
   (CacheFlow m r) =>
-  Maybe Text ->
+  Maybe TollTracking ->
+  Maybe LineSegment ->
   RoutePoints ->
-  [Toll] ->
   [Toll] ->
   TollChargesAndNamesAndIds ->
   m TollChargesAndNamesAndIds
-getAggregatedTollChargesAndNamesOnRoute mbDriverId route tolls initialPendingTolls tollChargesAndNamesAndIds = do
-  let (finalTollChargesAndNamesAndIds, finalPendingTolls) =
-        go initialPendingTolls route tolls tollChargesAndNamesAndIds
-  if null finalPendingTolls
-    then whenJust mbDriverId $ \driverId -> Hedis.del $ tollStartGateTrackingKey driverId
-    else cachePendingTolls mbDriverId finalPendingTolls
-  return finalTollChargesAndNamesAndIds
-  where
-    go pendingTolls [] _ acc = (acc, pendingTolls)
-    go pendingTolls [_] _ acc = (acc, pendingTolls)
-    go pendingTolls _ [] acc = (acc, pendingTolls)
-    go pendingTolls (p1 : p2 : ps) tolls' acc =
-      let currentRouteSegment = LineSegment p1 p2
-          pendingWithStarters = addPendingTollStartersOnSegment currentRouteSegment tolls' pendingTolls
-          (remainingPendingTolls, updatedAcc) =
-            resolveTollExitsOnSegment currentRouteSegment pendingWithStarters acc
-       in go remainingPendingTolls (p2 : ps) tolls' updatedAcc
+getAggregatedTollChargesAndNamesOnRoute _ _ [] _ tollChargesAndNamesAndIds = return tollChargesAndNamesAndIds
+getAggregatedTollChargesAndNamesOnRoute _ _ [_] _ tollChargesAndNamesAndIds = return tollChargesAndNamesAndIds
+getAggregatedTollChargesAndNamesOnRoute _ _ _ [] tollChargesAndNamesAndIds = return tollChargesAndNamesAndIds
+getAggregatedTollChargesAndNamesOnRoute mbTracking mbPreviousSegment route@(p1 : p2 : ps) tolls tollChargesAndNamesAndIds = do
+  let currentRouteSegment = LineSegment p1 p2
+      allTollCombinationsWithStartGates = filter (tollStartsOnRouteSegment mbPreviousSegment currentRouteSegment) tolls
+  if not $ null allTollCombinationsWithStartGates
+    then do
+      case getExitTollAndRemainingRoute route allTollCombinationsWithStartGates of
+        Just (exitSegment, remainingRoute, toll) ->
+          getAggregatedTollChargesAndNamesOnRoute
+            mbTracking
+            (Just exitSegment)
+            remainingRoute
+            tolls
+            (addTollCharge toll tollChargesAndNamesAndIds)
+        Nothing -> do
+          whenJust mbTracking $ \tracking -> do
+            let key = tollStartGateTrackingKey tracking.trackingScope tracking.trackingDriverId
+            mbExistingPendingTolls :: Maybe [Toll] <- Hedis.safeGet key
+            let allPendingTolls = fromMaybe [] mbExistingPendingTolls <> allTollCombinationsWithStartGates
+                uniquePendingTolls = nubBy (\toll1 toll2 -> getId toll1.id == getId toll2.id) allPendingTolls
+            Hedis.setExp key uniquePendingTolls 21600 -- 6 hours
+          return tollChargesAndNamesAndIds
+    else getAggregatedTollChargesAndNamesOnRoute mbTracking (Just currentRouteSegment) (p2 : ps) tolls tollChargesAndNamesAndIds
 
 {- Author: Khuzema Khomosi
   Best Case Time Complexity - O(No. of points in routes)
   Worst Case Time Complexity - O(No. of points in route * No. of gate segments of eligible tolls)
 
-  This function first finds all the eligible Tolls whose entry segments lie within the Route's bounding box.
-  For each route segment it finds tolls whose entry gate intersects, tracks them as pending until the
-  corresponding exit gate is crossed, then charges them. The route is not sliced after each exit so
-  nested tolls inside an active toll window are still detected on later segments.
+  This function first finds all the eligible Tolls whose entry gates lie within the Route's bounding box.
+  For each two points of the route, it finds all the tolls whose entry gates intersect the two points of the route.
+  If it finds some entry gates of tolls intersecting the route points, then it goes further on the route to find the exit gate intersecting the toll.
+  Once the exit gate is found, it add's the toll and slices the route further to check for anymore tolls if exists till it reaches the end of the route.
 
-  On segments where a pending toll exits, new polygon tolls are not armed (line tolls still may be).
+  A gate may be a LineGate or a PolyGate; a PolyGate is treated as the closed run of line segments
+  forming its boundary, so both kinds are crossed on exactly the same condition.
 
   Note:
   In case of on ride it is possible that the batch of driver waypoints that we have has only the start of the toll and the end of the toll comes later.
-  In that case this function maintains pending tolls in Redis based on driverId to resolve exits in later batches.
+  In that case this function maintains the TollCombinationsWithStartGatesInPrevBatch, keyed by TollTrackingScope and driverId, to check for it's corresponding exit gate intersection on route coming in later batches.
+  Each scope owns its own key: a caller that discards the computed charges (e.g. the toll-route
+  deviation check) must never share pending state with the caller that bills them.
+  Pass Nothing for the tracking to run statelessly against a route without touching Redis.
+
+  A PolyGate start needs the segment preceding the current one, which for the first segment of a
+  batch lies in the previous batch. The caller owns batch continuity, so it supplies that segment;
+  Nothing means the route is being walked from its true beginning.
 -}
-getTollInfoOnRoute :: (BeamFlow m r, EsqDBReplicaFlow m r) => Text -> Maybe Text -> RoutePoints -> m (Maybe TollInfo)
-getTollInfoOnRoute merchantOperatingCityId mbDriverId route = do
+getTollInfoOnRoute :: (BeamFlow m r, EsqDBReplicaFlow m r) => Text -> Maybe TollTracking -> Maybe LineSegment -> RoutePoints -> m (Maybe TollInfo)
+getTollInfoOnRoute merchantOperatingCityId mbTracking previousSegment route = do
   tolls <- B.runInReplica $ findAllTollsByMerchantOperatingCity merchantOperatingCityId
   if not $ null tolls
     then do
       let boundingBox = getBoundingBox route
           eligibleTollsThatMaybePresentOnTheRoute = filter (\toll -> any (gateWithinBoundingBox boundingBox) toll.tollStartGates) tolls
-      case mbDriverId of
-        Just driverId -> do
-          mbTollCombinationsWithStartGatesInPrevBatch :: Maybe [Toll] <- Hedis.safeGet (tollStartGateTrackingKey driverId)
+      case mbTracking of
+        Just tracking -> do
+          mbTollCombinationsWithStartGatesInPrevBatch :: Maybe [Toll] <-
+            Hedis.safeGet (tollStartGateTrackingKey tracking.trackingScope tracking.trackingDriverId)
           case mbTollCombinationsWithStartGatesInPrevBatch of
-            Just tollCombinationsWithStartGatesInPrevBatch -> getAggregatedTollChargesConsideringStartSegmentFromPrevBatchWhileOnRide driverId tollCombinationsWithStartGatesInPrevBatch eligibleTollsThatMaybePresentOnTheRoute
-            Nothing -> getAggregatedTollCharges route eligibleTollsThatMaybePresentOnTheRoute emptyTollInfo
-        Nothing -> getAggregatedTollCharges route eligibleTollsThatMaybePresentOnTheRoute emptyTollInfo
+            Just tollCombinationsWithStartGatesInPrevBatch -> getAggregatedTollChargesConsideringStartSegmentFromPrevBatchWhileOnRide tracking previousSegment tollCombinationsWithStartGatesInPrevBatch eligibleTollsThatMaybePresentOnTheRoute
+            Nothing -> getAggregatedTollCharges previousSegment route eligibleTollsThatMaybePresentOnTheRoute emptyTollInfo
+        Nothing -> getAggregatedTollCharges previousSegment route eligibleTollsThatMaybePresentOnTheRoute emptyTollInfo
     else return Nothing
   where
-    getAggregatedTollCharges remainingRoute eligibleTollsThatMaybePresentOnTheRoute initialTollInfo = do
+    getAggregatedTollCharges mbPreviousSegment remainingRoute eligibleTollsThatMaybePresentOnTheRoute initialTollInfo = do
       aggregatedTollInfo <-
-        getAggregatedTollChargesAndNamesOnRoute mbDriverId remainingRoute eligibleTollsThatMaybePresentOnTheRoute [] initialTollInfo
+        getAggregatedTollChargesAndNamesOnRoute mbTracking mbPreviousSegment remainingRoute eligibleTollsThatMaybePresentOnTheRoute initialTollInfo
       if hasDetectedTolls aggregatedTollInfo
         then return $ Just aggregatedTollInfo
         else return Nothing
 
-    getAggregatedTollChargesConsideringStartSegmentFromPrevBatchWhileOnRide driverId tollCombinationsWithStartGatesInPrevBatch eligibleTollsThatMaybePresentOnTheRoute = do
-      aggregatedTollInfo <-
-        getAggregatedTollChargesAndNamesOnRoute
-          (Just driverId)
-          route
-          eligibleTollsThatMaybePresentOnTheRoute
-          tollCombinationsWithStartGatesInPrevBatch
-          emptyTollInfo
-      if hasDetectedTolls aggregatedTollInfo
-        then return $ Just aggregatedTollInfo
-        else return Nothing
+    getAggregatedTollChargesConsideringStartSegmentFromPrevBatchWhileOnRide tracking mbPreviousSegment tollCombinationsWithStartGatesInPrevBatch eligibleTollsThatMaybePresentOnTheRoute = do
+      case getExitTollAndRemainingRoute route tollCombinationsWithStartGatesInPrevBatch of
+        Just (exitSegment, remainingRoute, toll) -> do
+          removeMatchedTollFromCache tracking tollCombinationsWithStartGatesInPrevBatch toll
+          getAggregatedTollCharges (Just exitSegment) remainingRoute eligibleTollsThatMaybePresentOnTheRoute (addTollCharge toll emptyTollInfo)
+        Nothing -> getAggregatedTollCharges mbPreviousSegment route eligibleTollsThatMaybePresentOnTheRoute emptyTollInfo
 
 -- | Filter Google route alternatives down to those that traverse at least one toll
 --   (start gate intersected AND its corresponding exit gate intersected on the same polyline).
@@ -369,7 +397,7 @@ filterRoutesPreferringToll ::
   m [Maps.RouteInfo]
 filterRoutesPreferringToll merchantOpCityId routes = do
   withTollFlag <- forM routes $ \r -> do
-    mbToll <- getTollInfoOnRoute merchantOpCityId Nothing r.points
+    mbToll <- getTollInfoOnRoute merchantOpCityId Nothing Nothing r.points
     pure (r, isJust mbToll)
   let tollUsing = map fst $ filter snd withTollFlag
   if null tollUsing


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->

### 1. Each consumer of the pending-toll state now owns its own Redis key

A **pass** is one execution of the toll walk over one batch of route points by one flow. Two flows produce passes:

| flow | trigger | its batch | result used for |
|---|---|---|---|
| **Deviation** | every location-update request | that request's raw waypoints, prefixed with the previous request's last two accurate points (`Internal.hs:193-196`) | a boolean only — `isJust <$>`, charges **discarded** |
| **Snap-to-road** | when the waypoint queue exceeds the threshold | oldest 99 points off the queue, 98 consumed | **this is what bills** |

Both flows previously read and wrote **one** key, `TollGateTracking:DriverId-<id>`, so every pass inherited whatever the previous pass left — regardless of which flow it came from or where on the route that pass was standing. Deviation passes sit at the driver's live position; snap passes sit at the queue head, which lags by the whole backlog. **Pass order in time ≠ pass order in space.**

`getTollInfoOnRoute` now takes `Maybe TollTracking` (scope + driverId) instead of `Maybe Text`, so every call site declares its scope at compile time:

| call site | scope |
|---|---|
| `LocationUpdates.hs` `updateTollRouteDeviation` | `TollTrackingDeviation` |
| `LocationUpdates.hs` billing handler | `TollTrackingBilling` |
| `EndRide.hs` `checkAndValidatePendingTolls` | `TollTrackingBilling` |
| `Beckn/Update.hs` (soft destination update) | `Nothing` — **changed from `Just driverId`**; it walked a *hypothetical* re-route while mutating live billing state, and only reads the vehicle-permission flags |
| `Search.hs`, `FareCalculator.hs`, `getTravelledDistanceAndTollInfo`, `filterRoutesPreferringToll` | `Nothing` (stateless, unchanged) |

The billing key is byte-identical to the previous one, so rides in flight across the deploy keep their pending state. `clearTollStartGateBatchCache` clears every scope via `[minBound .. maxBound]`.

### 2. Toll walk restored to the slice-based algorithm

Reverted the pending-list rewrite in favour of the original shape: a start gate hit ⇒ scan forward for **that toll's** end gate ⇒ charge ⇒ slice the route ⇒ continue. One toll is resolved at a time; no per-segment re-arming.

- `getExitTollAndRemainingRoute` also returns the segment it matched on, so the walk keeps a valid predecessor across a slice.
- `removeMatchedTollFromCache` drops the matched toll plus every candidate sharing the same entry gate (`XL` matched ⇒ `XK`, `XL`, `XM` removed).
- Removed `addPendingTollStartersOnSegment`, `resolveTollExitsOnSegment`, `canAddTollToPending`, `usesPolygonStartGates`, `exitDetectedOnRouteSegment`, `cachePendingTolls`.

### 3. Polygon toll computation

A polygon gate is a closed ring of line segments (`ringEdges`), so "intersects the gate" means the same for both gate kinds. Only the **start** condition differs.

**Start gate** — `gateStartsOnRouteSegment`:
```haskell
LineGate  -> current segment intersects any gate segment
PolyGate  -> previous segment lies entirely within the polygon   -- both endpoints, ray-cast
          && current segment intersects the polygon's boundary
```

**End gate** — `gateEndsOnRouteSegment`, identical for both kinds:
```haskell
current segment intersects the gate (for a polygon, its boundary)
```

A toll is therefore charged only on the ordered sequence:

> previous segment **inside** the polygon → next segment **cuts the start gate** → a later segment **cuts the end gate**

Any one of the three missing ⇒ no charge.

The "previous segment inside" clause is what makes a polygon gate directional, so complementary region polygons (e.g. Delhi vs not-Delhi) encode direction without needing separate plaza-side gate geometry:

| ride | toll with start = Delhi poly | toll with start = not-Delhi poly |
|---|---|---|
| Delhi → outside | prev segment inside Delhi, next cuts its boundary ⇒ armed at the real crossing ⇒ **charged once** | prev segment never inside not-Delhi before the crossing, route never re-crosses after ⇒ **never armed** |
| outside → Delhi | never armed | armed at the crossing ⇒ charged once |
| intra-Delhi | boundary never cut ⇒ never armed | prev segment never inside not-Delhi ⇒ never armed |

Two structural consequences: a polygon toll cannot fire on the **first segment of a batch** unless the caller supplies a predecessor, and a route that enters a polygon from outside and leaves again without ever having a fully-inside segment will not arm the gate.

### 4. Batch continuity is owned by the caller, not the detector

`getTollInfoOnRoute` takes the predecessor segment as a parameter. The batching layer supplies it by reusing state that already exists — no new Redis key:

```haskell
getPreviousRouteSegment driverId = do
  lastTwoInterpolatedPoints :: [LatLong] <- Redis.lRange (makeInterpolatedPointsRedisKey driverId) (-2) (-1)
  pure $ lineSegmentFromPoints lastTwoInterpolatedPoints
```

This works because of call ordering in `recalcDistanceBatchStep`: the toll walk runs *inside* `interpolatePointsAndCalculateDistanceAndToll`, and `addInterpolatedPoints` for the current batch runs only afterwards — so at read time the list's tail is exactly the previous batch's last two snapped points. `clearInterpolatedPointsImplementation` already cleans it at ride end.

The deviation flow passes `Nothing`: `modifiedAllWaypoints` already prepends the previous request's trailing two points, so its route carries its own continuity. Stateless callers pass `Nothing` because they walk a complete route from its true start.

### 5. Duplicate-charge guard

`recalcDistanceBatchStep` now reads `onRideTollIdsKey` before pushing and skips a detection whose toll ids are all already billed. `TollInfo` carries only an aggregate charge, so a partially-overlapping detection cannot be re-apportioned — it is charged in full and logged rather than silently mis-billed.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

No YAML spec or DB migration required — `TollTrackingScope` is hand-written code and `Toll` / `TollGate` are untouched.

Internal signature changes (same package, no external API):
- `getTollInfoOnRoute :: Text -> Maybe TollTracking -> Maybe LineSegment -> RoutePoints -> m (Maybe TollInfo)`
- `checkAndValidatePendingTolls` takes a leading `TollTrackingScope`
- `RideInterpolationHandler.getTollInfoOnTheRoute` and `.interpolatePointsAndCalculateDistanceAndToll` each take a `Maybe LineSegment`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

Ride `3baba31e-e51a-4708-b91e-41a648a053d2` (Delhi → Gurugram, 24 Jul, 12:33–14:03) was billed
`[Gurugram to Delhi Toll, Gurugram to Delhi Toll, Delhi to Gurugram Toll]`. The GPS trace crosses the Delhi/Haryana border exactly once and never returns, so the correct result is a single `Delhi to Gurugram Toll`.

Pass-by-pass, on 621 waypoints (deviation batches D1–D62, snap batches S1–S7):

| pass | flow · batch | route span | key in | what the pass does | key out |
|---|---|---|---|---|---|
| P1 | Dev · D1 | pts 1–12, Delhi | `[]` | old code counted "segment inside polygon" as gate-crossed ⇒ **arms `D2G`** | `[D2G]` |
| P2–P36 | Dev · D2–D36 | pts 11–360, Delhi | `[D2G]` | `D2G`'s end gate (not-Delhi) never touched ⇒ no change | `[D2G]` |
| — | Snap | — | — | **no snap passes exist yet.** `snapToRoadCallCondition`'s only toll term is `tollRouteDeviation`, still false. Queue grows to ~360 | — |
| **P37** | Dev · D37 | pts 361–372, **the crossing** | `[D2G]` | enters not-Delhi ⇒ `D2G` closes ⇒ charge **discarded**; sets `driverDeviatedToTollRoute`; next segment arms `G2D` | `[G2D]` |
| P38 | Snap · S1 | pts 1–99, Delhi (12:33 data) | `[G2D]` | `G2D`'s end gate = Delhi polygon; batch's **first segment is inside Delhi** ⇒ **bills `G2D` #1**; next segment arms `D2G` | `[D2G]` |
| P39–P40 | Snap · S2, S3 | pts 99–295, Delhi | `[D2G]` | nothing; drain stops, 76 pts left | `[D2G]` |
| P41 | Dev · D38 | live, in Haryana | `[D2G]` | `D2G` closes ⇒ **discarded again**; arms `G2D` ← the pump refills | `[G2D]` |
| P42… | Dev · D39+ | Haryana | `[G2D]` | no change | `[G2D]` |
| P_n | Snap · S4 | pts 295–393 (13:37) | `[G2D]` | first segment still in Delhi ⇒ **bills `G2D` #2**; next arms `D2G`; pt ~73 = real crossing ⇒ **bills `D2G`** | `[G2D]` |
| rest | Snap · S5–S7 | Haryana | `[G2D]` | `G2D` end gate never touched ⇒ nothing | `[G2D]` |

The one real toll event was consumed by pass P37 and never billed; everything subsequently billed is a re-derivation from stale state.

**Why exactly two spurious charges:** a spurious bill needs *a snap pass whose batch begins inside Delhi while the key holds `[G2D]`*. Only S1 and S4 qualify — S2/S3 ran in the same drain as S1 with no deviation pass in between to re-arm `G2D`, and S5–S7 begin in Haryana. The count is set by the number of Dev↔Snap alternations, not by the number of batches.

Both spurious charges land on **point 1 of a batch** — the signature of a Redis-restored pending toll being cashed against whatever region the batch happens to start in.

Contributing factors, all addressed:

1. `PolyGate` counted a segment merely *inside* the polygon as a gate crossing, so with region-sized polygons "you are in Delhi" read as "you crossed the Delhi gate".
2. Pending tolls were dropped by `tollStartGates` equality inside a per-segment arm/resolve loop rather than resolved one toll at a time.
3. `snapToRoadCallCondition` gated the billing pass on a flag set by the discarding pass — the pass that bills was unblocked by the pass that throws its answer away, producing the ~60 minute lag.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
-->

**Compiled only — not yet executed against live data.** Stated plainly so it is not mistaken for verified behaviour.

- `cabal build shared-services location-updates dynamic-offer-driver-app` passes under `-Werror`, exe links, no warnings attributed to any changed file.
- Behaviour was derived by hand-tracing the reported ride's 621-point GPS trace against the configured Delhi↔Gurugram gate GeoJSON, and by replaying the backend's batch arithmetic (99 fetched / 98 consumed ⇒ batches at pts 1–99, 99–197, …) in a local visualizer. The border crossing lands in snap batch S4 at ~point 73, and S4 is the only batch whose bounding box spans both polygons.

Not yet done, and worth doing before merge:

- Replay the trace through a live Redis and assert exactly one `Delhi to Gurugram Toll`.
- Assert the two scope keys diverge and neither flow reads the other's (`redis-cli KEYS 'TollGateTracking:*'` during a replay).
- Regression on a Gurugram → Delhi ride to confirm the mirror direction charges once.
- No unit tests added: `shared-services` has no test directory and `lib/location-updates/test` is an integration suite requiring Redis, mock-google and dhall configs. The walk is now pure apart from its Redis reads, so it is a good unit-test target, but standing up the stanza is separate work.

### Known behaviour to review

`getExitTollAndRemainingRoute` starts scanning at the **same** segment that armed the toll. With border-sharing region polygons this means a toll opens and closes within one segment and never persists across batches, so `checkAndValidatePendingTolls` will not fire for that gate shape. Correct for these two tolls; flagging in case the exit scan should begin on the next segment instead.

## Screenshot of test results
<!-- Provide screenshot of the test results -->

n/a — no test suite added; build output only.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced toll detection and validation across route updates, fare calculation, ride completion, and live location tracking.
  * Improved toll entry/exit matching across tracking batches using previous route-segment context to better capture gate behavior.
  * Refined pending-tolls validation at ride end with a more accurate toll-tracking mode.
  * Improved toll allowance/charge calculations and tightened tracking state to reduce duplicate or incorrect tolls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
