### PR TITLE
rider-app/fix: revert EasyBooking OnDemandCab tagging for testing

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Quote.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Quote.hs
@@ -322,11 +322,7 @@ getOffers searchRequest enableRideHailingOffers providerLookup quoteList0 langua
         Nothing ->
           case searchRequest.isMeterRideSearch of
             Just True -> OnMeterRide <$> quoteEntities
-            _ -> case searchRequest.riderPreferredOption of
-              -- EasyBooking is destination-less like Rental, but it's an on-demand cab
-              -- booking, not a rental — tag it accordingly so clients don't render rental-only UI.
-              DRPO.EasyBooking -> OnDemandCab <$> quoteEntities
-              _ -> OnRentalCab <$> quoteEntities
+            _ -> OnRentalCab <$> quoteEntities
   return . sortBy (compare `on` offerCreationTime) $ quotes
 
 mkQuoteAPIEntitiesWithOffers ::


### PR DESCRIPTION
Temporarily reverts the EasyBooking destination-less quote tagging special-case in getOffers, to isolate whether it affects the EasyBooking empty-quotes issue.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how destination-less ride searches are categorized, ensuring eligible searches are consistently presented as rental rides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->