### PR TITLE
create recent location entry for frfs booking

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
@@ -1401,6 +1401,68 @@ createRecentLocationForMultimodal journey = do
           SQRL.create recentLocation
     _ -> return ()
 
+createRecentLocationForFRFSBooking ::
+  ( MonadFlow m,
+    EsqDBFlow m r,
+    CacheFlow m r,
+    HasShortDurationRetryCfg r c,
+    CoreMetrics m
+  ) =>
+  DFRFSTicketBooking.FRFSTicketBooking ->
+  m ()
+createRecentLocationForFRFSBooking booking = do
+  (mbFromPoint, mbToPoint) <- case (booking.fromStationPoint, booking.toStationPoint) of
+    (Just fp, Just tp) -> pure (Just fp, Just tp)
+    _ -> do
+      integratedBppConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
+      mbFromStation <- OTPRest.getStationByGtfsIdAndStopCode booking.fromStationCode integratedBppConfig
+      mbToStation <- OTPRest.getStationByGtfsIdAndStopCode booking.toStationCode integratedBppConfig
+      let fp = booking.fromStationPoint <|> (LatLong <$> (mbFromStation >>= (.lat)) <*> (mbFromStation >>= (.lon)))
+          tp = booking.toStationPoint <|> (LatLong <$> (mbToStation >>= (.lat)) <*> (mbToStation >>= (.lon)))
+      pure (fp, tp)
+  case (mbFromPoint, mbToPoint) of
+    (Just fromPoint, Just toPoint) -> do
+      let entityType = convertVehicleCategoryToEntityType booking.vehicleType
+          mbRouteCode = booking.routeCode
+          fromGeohash = T.pack <$> Geohash.encode 6 (fromPoint.lat, fromPoint.lon)
+          toGeohash = T.pack <$> Geohash.encode 6 (toPoint.lat, toPoint.lon)
+      case (fromGeohash, toGeohash) of
+        (Just fg, Just tg) -> do
+          now <- getCurrentTime
+          mbRecentLocation <- SQRL.findByRiderIdAndGeohashAndEntityType booking.riderId (Just tg) (Just fg) entityType
+          case mbRecentLocation of
+            Just recentLocation -> SQRL.increaceFrequencyById recentLocation.id
+            Nothing -> do
+              uuid <- generateGUID
+              let recentLocation =
+                    DTRL.RecentLocation
+                      { id = uuid,
+                        riderId = booking.riderId,
+                        frequency = 1,
+                        entityType = entityType,
+                        address = booking.toStationAddress,
+                        fromLatLong = Just $ LatLong fromPoint.lat fromPoint.lon,
+                        routeCode = mbRouteCode,
+                        toStopCode = Just booking.toStationCode,
+                        fromStopCode = Just booking.fromStationCode,
+                        toLatLong = LatLong toPoint.lat toPoint.lon,
+                        merchantOperatingCityId = booking.merchantOperatingCityId,
+                        createdAt = now,
+                        updatedAt = now,
+                        fare = Just booking.totalPrice.amount,
+                        fromGeohash = Just fg,
+                        toGeohash = Just tg
+                      }
+              SQRL.create recentLocation
+        _ -> return ()
+    _ -> return ()
+
+-- Map a FRFS VehicleCategory to the corresponding RecentLocation EntityType
+convertVehicleCategoryToEntityType :: Spec.VehicleCategory -> DTRL.EntityType
+convertVehicleCategoryToEntityType Spec.BUS = DTRL.BUS
+convertVehicleCategoryToEntityType Spec.METRO = DTRL.METRO
+convertVehicleCategoryToEntityType Spec.SUBWAY = DTRL.SUBWAY
+
 postMultimodalPaymentUpdateOrderUtil :: (ServiceFlow m r, EncFlow m r, EsqDBReplicaFlow m r, HasField "isMetroTestTransaction" r Bool, HasFlowEnv m r '["nwAddress" ::: BaseUrl], Finance.HasActorInfo m r) => TPayment.PaymentServiceType -> Person -> Id Merchant -> Id MerchantOperatingCity -> [DFRFSTicketBooking.FRFSTicketBooking] -> Maybe Bool -> Bool -> m (Maybe DOrder.PaymentOrder)
 postMultimodalPaymentUpdateOrderUtil paymentType person merchantId merchantOperatingCityId bookings mbEnableOffer isMockPayment = do
   frfsConfig <-

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
@@ -477,6 +477,7 @@ postFrfsQuoteV2ConfirmUtil (mbPersonId, merchantId_) quote selectedQuoteCategori
   (mbJourneyId, _) <- getAllJourneyFrfsBookings dConfirmRes
   when (isNothing mbJourneyId) $ do
     fork "FRFS buildJourneyAndLeg" $ buildJourneyAndLeg dConfirmRes fareParameters
+    fork "Caching recent location for FRFS booking" $ JourneyUtils.createRecentLocationForFRFSBooking dConfirmRes
     -- Sync vehicle/driver data synchronously (NOT forked). A forked sync races with the confirm/on_init writes,
     -- which rewrite the whole booking row in KV and clobber the driver fields. Running it inline lets the
     -- subsequent sequential KV updates re-read the row and carry these fields forward.


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent locations are now automatically saved for FRFS bookings covering bus, metro, and subway journeys.
  * Matching recent location entries are updated by increasing frequency; when none exist, new entries are created with route/stop details, fare, and timing.
  * The recent-location capture now runs in parallel right after booking confirmation to keep confirmation responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->