### PR TITLE
fix : xyne chat history update

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/IssueManagement/Issue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/IssueManagement/Issue.hs
@@ -371,6 +371,7 @@ postIssueChatMessage (Kernel.Types.Id.ShortId merchantShortId) city issueReportI
       (Kernel.Types.Id.cast issueReportId)
       dashboardIssueHandle
       Common.DRIVER
+      (Just "Control Centre Agent")
       req
   mbIssueReport <- QIR.findById (Kernel.Types.Id.cast issueReportId)
   Kernel.Prelude.whenJust mbIssueReport $ \issueReport ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/IssueManagement/Issue.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/IssueManagement/Issue.hs
@@ -417,6 +417,7 @@ postIssueChatMessage (Kernel.Types.Id.ShortId merchantShortId) city issueReportI
       (Kernel.Types.Id.cast issueReportId)
       dashboardIssueHandle
       Common.CUSTOMER
+      (Just "Control Centre Agent")
       req
   mbIssueReport <- QIR.findById (Kernel.Types.Id.cast issueReportId)
   Kernel.Prelude.whenJust mbIssueReport $ \issueReport ->

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/Dashboard/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/Dashboard/Issue.hs
@@ -2116,6 +2116,18 @@ mkOptionDetailResWithoutChildren _language _identifier (opt, mbTranslation) = do
 -------------------------------------------------------------------------
 -- Live chat (dashboard operator side) ----------------------------------
 
+-- | @mbForwardSenderLabel@ controls whether this message is also forwarded to
+-- the merchant's ticket service (Xyne) and under what sender name:
+--
+--   * @Just label@ — a control-centre agent's reply; forward it as @label@
+--     (e.g. "Control Centre Agent") so the Xyne agent sees the operator's side
+--     of the conversation.
+--   * @Nothing@ — the message originated from Xyne itself (inbound webhook);
+--     forwarding it back would echo the agent's own reply into an infinite
+--     loop, so it must not be forwarded.
+--
+-- Forwarding is still gated by @mbShouldForwardChatToTicketService@ on the
+-- handle, so it is a no-op for merchants/apps that don't use Xyne.
 sendDashboardChatMessage ::
   ( Esq.EsqDBReplicaFlow m r,
     BeamFlow m r
@@ -2125,9 +2137,10 @@ sendDashboardChatMessage ::
   Id DIR.IssueReport ->
   ServiceHandle m ->
   Identifier ->
+  Maybe Text ->
   Common.SendChatMessageByUserReq ->
   m CommonUI.ChatMessageItem
-sendDashboardChatMessage merchantShortId opCity issueReportId issueHandle identifier req = do
+sendDashboardChatMessage merchantShortId opCity issueReportId issueHandle identifier mbForwardSenderLabel req = do
   issueReport <- QIR.findById issueReportId >>= fromMaybeM (IssueReportDoesNotExist issueReportId.getId)
   _merchantOpCity <- checkMerchantCityAccess merchantShortId opCity issueReport Nothing issueHandle
   now <- getCurrentTime
@@ -2161,6 +2174,11 @@ sendDashboardChatMessage merchantShortId opCity issueReportId issueHandle identi
     case result of
       Right _ -> pure ()
       Left err -> logError $ "sendDashboardChatMessage: sendChatNotification failed " <> show err
+  -- Mirror the control-centre agent's reply into the merchant's ticket service.
+  -- Skipped when the label is Nothing (the inbound-Xyne-webhook path), which
+  -- avoids echoing the agent's own message straight back to Xyne.
+  whenJust mbForwardSenderLabel $ \senderLabel ->
+    UIR.forwardChatToTicketServiceAs senderLabel issueReport identifier issueHandle req.message mediaIds
   UIR.toChatMessageItem identifier chatMsg
 
 listDashboardChatMessages ::

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
@@ -228,6 +228,10 @@ getIssueOption (personId, merchantId, merchantOpCityId) issueCategoryId issueOpt
               issueReport.chats ++ (mkIssueChat IssueOption optionId.getId now) :
               map (\message -> mkIssueChat IssueMessage message.id.getId now) issueMessages
         QIR.updateChats iReportId updatedChats
+        -- Mirror the auto-generated replies shown on option selection into the
+        -- ticket service, so the Xyne agent sees the same bot conversation the
+        -- user does — not just the status-change replies.
+        mapM_ (\message -> forwardChatToTicketServiceAs "Auto Reply" issueReport identifier issueHandle message.message []) issueMessages
       _ -> return ()
     if null issueMessages
       then pure []
@@ -592,6 +596,11 @@ createIssueReport (personId, merchantId) mbLanguage Common.IssueReportReq {..} i
         QIR.updateTicketIds issueReport.id primaryResp.ticketId additionalId
       Left err -> do
         logTagInfo "Create Ticket API failed - " $ show err
+    -- Forward the auto-generated onCreateIssue replies to the ticket service so
+    -- the Xyne agent sees the bot's opening messages too. Runs inside the
+    -- shouldCreateTicket guard, after the ticket exists, so there is a thread to
+    -- append to (forwarding keys on issueReport.id as the Xyne threadId).
+    mapM_ (\message -> forwardChatToTicketServiceAs "Auto Reply" issueReport identifier issueHandle message.message []) messages
   pure $ Common.IssueReportRes {issueReportId = issueReport.id, issueReportShortId = issueReport.shortId, messages}
   where
     mkIssueReport mocId updatedChats shouldCreateTicket now = do

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/XyneWebhook.hs
@@ -175,6 +175,9 @@ handleDeskReply lookupXyneCfg issueHandle identifier payload = do
           issueReport.id
           issueHandle
           identifier
+          -- Nothing: this message came from Xyne, so it must not be forwarded
+          -- back to Xyne.
+          Nothing
           req
       Redis.setExp key resp.messageId dedupTtlSeconds
       pure $ XyneWebhookAck {externalId = resp.messageId}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Fixed auto generate message forwarding to xyne, now all bt messages as well as control centre updates are sent to xyne properly

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operator chat messages now display the “Control Centre Agent” sender label when forwarded to ticket conversations.
  * Automated issue-selection and issue-opening replies are now mirrored into the relevant ticket conversation.

* **Bug Fixes**
  * Prevented incoming ticket-service messages from being forwarded back to the same service, avoiding duplicate message loops.
  * Existing chat persistence and operator notifications remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->