### PR TITLE
backend/fix: persist rideTags on rider-side ride completion

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/RideExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/RideExtra.hs
@@ -126,6 +126,7 @@ updateMultiple rideId ride = do
       Se.Set BeamR.startOdometerReading ride.startOdometerReading,
       Se.Set BeamR.endOdometerReading ride.endOdometerReading,
       Se.Set BeamR.tollConfidence ride.tollConfidence,
+      Se.Set BeamR.rideTags ride.rideTags,
       Se.Set BeamR.estimatedEndTimeRangeStart ((.start) <$> ride.estimatedEndTimeRange),
       Se.Set BeamR.estimatedEndTimeRangeEnd ((.end) <$> ride.estimatedEndTimeRange),
       Se.Set BeamR.paymentStatus (Just ride.paymentStatus),


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

`Storage.Queries.RideExtra.updateMultiple` (rider-app) omitted `rideTags` from its `updateOneWithKV` field list. The `ValidRide#Yes` / `ValidRide#No` tag computed at ride completion was therefore correct in memory but never written, leaving `atlas_app.ride.ride_tags` NULL on every ride.

One-line fix — adds the missing `Se.Set BeamR.rideTags ride.rideTags`.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

No migration needed — `ride_tags text[]` already exists (`dev/migrations-read-only/rider-app/ride.sql:466`).

## Motivation and Context

The tag flows BPP → BAP correctly and breaks only at the rider-side persistence boundary:

1. **BPP emits it** — `Beckn/ACL/Common/Order.hs:318-319` builds the `RIDE_DETAILS_INFO` / `IS_VALID_RIDE` tag group on ride completion.
2. **BAP parses it** — `Beckn/ACL/Common.hs:245` reads it into `isValidRide :: Maybe Bool`.
3. **BAP computes the tag** — `Domain/Action/Beckn/Common.hs:924` sets `rideTags` on `updRide`.
4. **BAP drops it** — `QRide.updateMultiple` at `Domain/Action/Beckn/Common.hs:1110` never writes the column.

The driver-app's equivalent `updateAll` (`Storage/Queries/RideExtra.hs:420`) already sets `rideTags`. That asymmetry was the bug.

**Scope.** In-request consumers take the parsed `Maybe Bool` directly rather than reading the column, so they were unaffected: referral payout (`Common.hs:957`), rewards evaluation (`Common.hs:1117`), offer tags (`Common.hs:967`). What was broken is anything reading `ride_tags` *after* the request — dashboards, analytics, backfills, later re-evaluation.

**Forward-only.** Existing completed rides keep `ride_tags` NULL. Backfilling history would need the BPP as source of truth.

## How did you test it?

Not built or run yet — needs a `cabal build rider-app` before merge.

The change is a single addition to an existing `Se.Set` list. `BeamR.rideTags :: B.C f (Maybe [Text])` matches the domain field `rideTags :: Maybe [Text]` directly, so no conversion helper and no new import (unlike the driver-app side, which needs `Yudhishthira.tagsNameValueToTType`). Pre-commit `treefmt` / `trailing-ws` / `hpack` passed.

Verification after deploy: complete a ride and check `atlas_app.ride.ride_tags` is `{ValidRide#Yes}` rather than NULL.

## Screenshot of test results

N/A — no tests run.

## Checklist

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ride tags are now correctly saved when updating a ride.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->