### PR TITLE
Backend/enh/adding-mocid-level-api-forwarding

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -359,6 +359,8 @@ MerchantOperatingCity:
     currency: Currency
     distanceUnit: DistanceUnit
     stdCode: Maybe Text
+    cloudType: Maybe CloudType
+    cloudBaseUrl: Maybe BaseUrl
   sqlType:
     city: character varying(255)
     currency: character varying(255)
@@ -377,6 +379,8 @@ MerchantOperatingCity:
   beamType:
     currency: Maybe Currency
     distanceUnit: Maybe DistanceUnit
+    cloudType: Maybe Text
+    cloudBaseUrl: Maybe Text
   beamFields:
     location:
       lat: Double
@@ -386,10 +390,14 @@ MerchantOperatingCity:
     lon: (.lon) location|E
     currency: Just currency|E
     distanceUnit: Kernel.Prelude.Just|I
+    cloudType: (Kernel.Prelude.fmap Kernel.Prelude.show)|I
+    cloudBaseUrl: (Kernel.Prelude.fmap showBaseUrl)|I
   fromTType:
     location: Kernel.External.Maps.Types.LatLong lat lon|E
     currency: fromMaybe Kernel.Types.Common.INR currency|E
     distanceUnit: Kernel.Prelude.fromMaybe Kernel.Types.Common.Meter|I
+    cloudType: (Kernel.Prelude.>>= (Kernel.Prelude.readMaybe . Data.Text.unpack))|I
+    cloudBaseUrl: (Kernel.Prelude.pure . (Kernel.Prelude.>>= parseBaseUrl))|MI
 
   beamInstance:
     - MakeTableInstances

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/MerchantOperatingCity.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/MerchantOperatingCity.hs
@@ -11,10 +11,13 @@ import Kernel.Prelude
 import qualified Kernel.Types.Beckn.Context
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
+import qualified Kernel.Types.Version
 import qualified Tools.Beam.UtilsTH
 
 data MerchantOperatingCity = MerchantOperatingCity
   { city :: Kernel.Types.Beckn.Context.City,
+    cloudBaseUrl :: Kernel.Prelude.Maybe Kernel.Prelude.BaseUrl,
+    cloudType :: Kernel.Prelude.Maybe Kernel.Types.Version.CloudType,
     country :: Kernel.Types.Beckn.Context.Country,
     currency :: Kernel.Types.Common.Currency,
     distanceUnit :: Kernel.Types.Common.DistanceUnit,
@@ -27,4 +30,4 @@ data MerchantOperatingCity = MerchantOperatingCity
     stdCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     supportNumber :: Kernel.Prelude.Maybe Kernel.Prelude.Text
   }
-  deriving (Generic, (FromJSON), (ToJSON), (Show), (Eq), (ToSchema))
+  deriving (Generic, FromJSON, ToJSON, Show, Eq, ToSchema)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/MerchantOperatingCity.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/MerchantOperatingCity.hs
@@ -15,19 +15,21 @@ import qualified Kernel.Types.Common
 import Tools.Beam.UtilsTH
 
 data MerchantOperatingCityT f = MerchantOperatingCityT
-  { city :: (B.C f Kernel.Types.Beckn.Context.City),
-    country :: (B.C f Kernel.Types.Beckn.Context.Country),
-    currency :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.Currency)),
-    distanceUnit :: (B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit)),
-    id :: (B.C f Kernel.Prelude.Text),
-    language :: (B.C f Kernel.External.Types.Language),
-    lat :: (B.C f Kernel.Prelude.Double),
-    lon :: (B.C f Kernel.Prelude.Double),
-    merchantId :: (B.C f Kernel.Prelude.Text),
-    merchantShortId :: (B.C f Kernel.Prelude.Text),
-    state :: (B.C f Kernel.Types.Beckn.Context.IndianState),
-    stdCode :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
-    supportNumber :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text))
+  { city :: B.C f Kernel.Types.Beckn.Context.City,
+    cloudBaseUrl :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    cloudType :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    country :: B.C f Kernel.Types.Beckn.Context.Country,
+    currency :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.Currency),
+    distanceUnit :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit),
+    id :: B.C f Kernel.Prelude.Text,
+    language :: B.C f Kernel.External.Types.Language,
+    lat :: B.C f Kernel.Prelude.Double,
+    lon :: B.C f Kernel.Prelude.Double,
+    merchantId :: B.C f Kernel.Prelude.Text,
+    merchantShortId :: B.C f Kernel.Prelude.Text,
+    state :: B.C f Kernel.Types.Beckn.Context.IndianState,
+    stdCode :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    supportNumber :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)
   }
   deriving (Generic, B.Beamable)
 
@@ -37,8 +39,8 @@ instance B.Table MerchantOperatingCityT where
 
 type MerchantOperatingCity = MerchantOperatingCityT Identity
 
-$(enableKVPG (''MerchantOperatingCityT) [('id)] [])
+$(enableKVPG ''MerchantOperatingCityT ['id] [])
 
-$(mkTableInstances (''MerchantOperatingCityT) "merchant_operating_city")
+$(mkTableInstances ''MerchantOperatingCityT "merchant_operating_city")
 
-$(Domain.Types.UtilsTH.mkCacParseInstance (''MerchantOperatingCityT))
+$(Domain.Types.UtilsTH.mkCacParseInstance ''MerchantOperatingCityT)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantOperatingCity.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantOperatingCity.hs
@@ -3,6 +3,7 @@
 
 module Storage.Queries.OrphanInstances.MerchantOperatingCity where
 
+import qualified Data.Text
 import qualified Domain.Types.MerchantOperatingCity
 import Kernel.Beam.Functions
 import Kernel.External.Encryption
@@ -17,10 +18,13 @@ import qualified Storage.Beam.MerchantOperatingCity as Beam
 
 instance FromTType' Beam.MerchantOperatingCity Domain.Types.MerchantOperatingCity.MerchantOperatingCity where
   fromTType' (Beam.MerchantOperatingCityT {..}) = do
+    cloudBaseUrl' <- (Kernel.Prelude.pure . (Kernel.Prelude.>>= parseBaseUrl)) cloudBaseUrl
     pure $
       Just
         Domain.Types.MerchantOperatingCity.MerchantOperatingCity
           { city = city,
+            cloudBaseUrl = cloudBaseUrl',
+            cloudType = (Kernel.Prelude.>>= (Kernel.Prelude.readMaybe . Data.Text.unpack)) cloudType,
             country = country,
             currency = fromMaybe Kernel.Types.Common.INR currency,
             distanceUnit = Kernel.Prelude.fromMaybe Kernel.Types.Common.Meter distanceUnit,
@@ -38,6 +42,8 @@ instance ToTType' Beam.MerchantOperatingCity Domain.Types.MerchantOperatingCity.
   toTType' (Domain.Types.MerchantOperatingCity.MerchantOperatingCity {..}) = do
     Beam.MerchantOperatingCityT
       { Beam.city = city,
+        Beam.cloudBaseUrl = Kernel.Prelude.fmap showBaseUrl cloudBaseUrl,
+        Beam.cloudType = Kernel.Prelude.fmap Kernel.Prelude.show cloudType,
         Beam.country = country,
         Beam.currency = Just currency,
         Beam.distanceUnit = Kernel.Prelude.Just distanceUnit,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App/CrossCloudProxy.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App/CrossCloudProxy.hs
@@ -27,6 +27,7 @@ import Kernel.Types.Version (CloudType (..))
 import qualified Network.HTTP.Client as Http
 import qualified Network.Wai as Wai
 import qualified Storage.CachedQueries.Merchant as CQM
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import qualified Storage.Queries.RegistrationToken as QRT
 import Tools.Auth (authTokenCacheKey, merchantIdFallback)
 import qualified "utils" Utils.Common.CrossCloudProxy as CCP
@@ -40,11 +41,16 @@ crossCloudProxy manager env =
 resolveOwner :: Text -> Flow (Maybe (CloudType, BaseUrl))
 resolveOwner token = do
   mbAuthCached :: Maybe (Id DP.Person, Id DM.Merchant, Id DMOC.MerchantOperatingCity) <- Redis.safeGet (authTokenCacheKey token)
-  mbMerchantId <- case mbAuthCached of
-    Just (_, merchantId, _) -> pure (Just merchantId)
-    Nothing -> fmap (merchantIdFallback . Id @DM.Merchant . (.merchantId)) <$> QRT.findByToken token
-  case mbMerchantId of
+  mbIds <- case mbAuthCached of
+    Just (_, merchantId, mocId) -> pure (Just (merchantId, mocId))
+    Nothing -> fmap (\sr -> (merchantIdFallback (Id sr.merchantId), Id sr.merchantOperatingCityId)) <$> QRT.findByToken token
+  case mbIds of
     Nothing -> pure Nothing
-    Just merchantId -> IM.withInMemCache ["crossCloudProxy:merchantCloud", merchantId.getId] 60 $ do
-      mbMerchant :: Maybe DM.Merchant <- CQM.findById merchantId
-      pure $ mbMerchant >>= \merchant -> (,) <$> merchant.cloudType <*> merchant.cloudBaseUrl
+    Just (merchantId, mocId) -> IM.withInMemCache ["crossCloudProxy:mocCloud", mocId.getId] 60 $ do
+      mbMoc :: Maybe DMOC.MerchantOperatingCity <- CQMOC.findById mocId
+      let mocPair = mbMoc >>= \moc -> (,) <$> moc.cloudType <*> moc.cloudBaseUrl
+      case mocPair of
+        Just p -> pure (Just p)
+        Nothing -> do
+          mbMerchant :: Maybe DM.Merchant <- CQM.findById merchantId
+          pure $ mbMerchant >>= \merchant -> (,) <$> merchant.cloudType <*> merchant.cloudBaseUrl

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
@@ -3917,7 +3917,9 @@ postMerchantConfigOperatingCityCreate merchantShortId city req = do
           stdCode = Just cityStdCode,
           language = fromMaybe baseCity.language req.primaryLanguage,
           currency = fromMaybe baseCity.currency req.currency,
-          distanceUnit = fromMaybe baseCity.distanceUnit req.distanceUnit
+          distanceUnit = fromMaybe baseCity.distanceUnit req.distanceUnit,
+          cloudType = Nothing,
+          cloudBaseUrl = Nothing
         }
 
     buildIntelligentPoolConfig mId newCityId currentTime DDIPC.DriverIntelligentPoolConfig {..} =

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -794,6 +794,7 @@ library
       Storage.Queries.Transformers.PartnerOrgConfig
       Storage.Queries.Transformers.Person
       Storage.Queries.Transformers.Quote
+      Storage.Queries.Transformers.RegistrationToken
       Storage.Queries.Transformers.RentalDetails
       Storage.Queries.Transformers.SearchReqLocation
       Storage.Queries.Transformers.SearchRequest

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/RegistrationToken.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/RegistrationToken.yaml
@@ -29,11 +29,21 @@ RegistrationToken:
     tokenExpiry : Int
     entityId : Text
     merchantId : Text
+    merchantOperatingCityId : Text
     entityType : RTEntityType
     createdAt : UTCTime
     updatedAt : UTCTime
     info : Maybe Text
     createdViaPartnerOrgId : Maybe (Id PartnerOrganization)
+
+  beamType:
+    merchantOperatingCityId: Maybe Text
+  sqlType:
+    merchantOperatingCityId: character (36)
+  toTType:
+    merchantOperatingCityId: Kernel.Prelude.Just|I
+  fromTType:
+    merchantOperatingCityId: Storage.Queries.Transformers.RegistrationToken.getMerchantOperatingCityId merchantOperatingCityId merchantId|EM
 
   excludedFields: [merchantOperatingCityId]
   constraints:

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/configs.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/configs.yaml
@@ -4,6 +4,8 @@ imports:
   Country: Kernel.Types.Beckn.Context
   Merchant: Domain.Types.Merchant
   ShortId: Kernel.Types.Id
+  CloudType: Kernel.Types.Version
+  BaseUrl: Kernel.Prelude
 
 MerchantOperatingCity:
   tableName: merchant_operating_city
@@ -20,14 +22,23 @@ MerchantOperatingCity:
     long: Double
     distanceUnit: Kernel.Types.Common.DistanceUnit
     stdCode: Maybe Text
+    cloudType: Maybe CloudType
+    cloudBaseUrl: Maybe BaseUrl
 
   beamFields:
     distanceUnit:
       distanceUnit: Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit
+  beamType:
+    cloudType: Maybe Text
+    cloudBaseUrl: Maybe Text
   toTType:
     distanceUnit: Kernel.Prelude.Just|I
+    cloudType: (Kernel.Prelude.fmap Kernel.Prelude.show)|I
+    cloudBaseUrl: (Kernel.Prelude.fmap Kernel.Prelude.showBaseUrl)|I
   fromTType:
     distanceUnit: Kernel.Prelude.fromMaybe Kernel.Types.Common.Meter |I
+    cloudType: (Kernel.Prelude.>>= (Kernel.Prelude.readMaybe . Data.Text.unpack))|I
+    cloudBaseUrl: (Kernel.Prelude.pure . (Kernel.Prelude.>>= Kernel.Prelude.parseBaseUrl))|MI
 
   excludedFields: [merchantOperatingCityId]
 

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantOperatingCity.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/MerchantOperatingCity.hs
@@ -9,10 +9,13 @@ import Kernel.Prelude
 import qualified Kernel.Types.Beckn.Context
 import qualified Kernel.Types.Common
 import qualified Kernel.Types.Id
+import qualified Kernel.Types.Version
 import qualified Tools.Beam.UtilsTH
 
 data MerchantOperatingCity = MerchantOperatingCity
   { city :: Kernel.Types.Beckn.Context.City,
+    cloudBaseUrl :: Kernel.Prelude.Maybe Kernel.Prelude.BaseUrl,
+    cloudType :: Kernel.Prelude.Maybe Kernel.Types.Version.CloudType,
     country :: Kernel.Types.Beckn.Context.Country,
     distanceUnit :: Kernel.Types.Common.DistanceUnit,
     driverOfferMerchantOperatingCityId :: Kernel.Prelude.Maybe Kernel.Prelude.Text,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/RegistrationToken.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/RegistrationToken.hs
@@ -22,6 +22,7 @@ data RegistrationToken = RegistrationToken
     id :: Kernel.Types.Id.Id Domain.Types.RegistrationToken.RegistrationToken,
     info :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
     merchantId :: Kernel.Prelude.Text,
+    merchantOperatingCityId :: Kernel.Prelude.Text,
     token :: Kernel.Prelude.Text,
     tokenExpiry :: Kernel.Prelude.Int,
     updatedAt :: Kernel.Prelude.UTCTime,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantOperatingCity.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/MerchantOperatingCity.hs
@@ -14,6 +14,8 @@ import Tools.Beam.UtilsTH
 
 data MerchantOperatingCityT f = MerchantOperatingCityT
   { city :: B.C f Kernel.Types.Beckn.Context.City,
+    cloudBaseUrl :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    cloudType :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     country :: B.C f Kernel.Types.Beckn.Context.Country,
     distanceUnit :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit),
     driverOfferMerchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/RegistrationToken.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/RegistrationToken.hs
@@ -24,6 +24,7 @@ data RegistrationTokenT f = RegistrationTokenT
     id :: B.C f Kernel.Prelude.Text,
     info :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     merchantId :: B.C f Kernel.Prelude.Text,
+    merchantOperatingCityId :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
     token :: B.C f Kernel.Prelude.Text,
     tokenExpiry :: B.C f Kernel.Prelude.Int,
     updatedAt :: B.C f Kernel.Prelude.UTCTime,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/MerchantOperatingCity.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/MerchantOperatingCity.hs
@@ -54,6 +54,8 @@ updateByPrimaryKey (Domain.Types.MerchantOperatingCity.MerchantOperatingCity {..
   _now <- getCurrentTime
   updateWithKV
     [ Se.Set Beam.city city,
+      Se.Set Beam.cloudBaseUrl (Kernel.Prelude.fmap Kernel.Prelude.showBaseUrl cloudBaseUrl),
+      Se.Set Beam.cloudType (Kernel.Prelude.fmap Kernel.Prelude.show cloudType),
       Se.Set Beam.country country,
       Se.Set Beam.distanceUnit (Kernel.Prelude.Just distanceUnit),
       Se.Set Beam.driverOfferMerchantOperatingCityId driverOfferMerchantOperatingCityId,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantOperatingCity.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantOperatingCity.hs
@@ -3,6 +3,7 @@
 
 module Storage.Queries.OrphanInstances.MerchantOperatingCity where
 
+import qualified Data.Text
 import qualified Domain.Types.MerchantOperatingCity
 import Kernel.Beam.Functions
 import Kernel.External.Encryption
@@ -16,10 +17,13 @@ import qualified Storage.Beam.MerchantOperatingCity as Beam
 
 instance FromTType' Beam.MerchantOperatingCity Domain.Types.MerchantOperatingCity.MerchantOperatingCity where
   fromTType' (Beam.MerchantOperatingCityT {..}) = do
+    cloudBaseUrl' <- (Kernel.Prelude.pure . (Kernel.Prelude.>>= Kernel.Prelude.parseBaseUrl)) cloudBaseUrl
     pure $
       Just
         Domain.Types.MerchantOperatingCity.MerchantOperatingCity
           { city = city,
+            cloudBaseUrl = cloudBaseUrl',
+            cloudType = (Kernel.Prelude.>>= (Kernel.Prelude.readMaybe . Data.Text.unpack)) cloudType,
             country = country,
             distanceUnit = Kernel.Prelude.fromMaybe Kernel.Types.Common.Meter distanceUnit,
             driverOfferMerchantOperatingCityId = driverOfferMerchantOperatingCityId,
@@ -38,6 +42,8 @@ instance ToTType' Beam.MerchantOperatingCity Domain.Types.MerchantOperatingCity.
   toTType' (Domain.Types.MerchantOperatingCity.MerchantOperatingCity {..}) = do
     Beam.MerchantOperatingCityT
       { Beam.city = city,
+        Beam.cloudBaseUrl = Kernel.Prelude.fmap Kernel.Prelude.showBaseUrl cloudBaseUrl,
+        Beam.cloudType = Kernel.Prelude.fmap Kernel.Prelude.show cloudType,
         Beam.country = country,
         Beam.distanceUnit = Kernel.Prelude.Just distanceUnit,
         Beam.driverOfferMerchantOperatingCityId = driverOfferMerchantOperatingCityId,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/RegistrationToken.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/RegistrationToken.hs
@@ -7,13 +7,16 @@ import qualified Domain.Types.RegistrationToken
 import Kernel.Beam.Functions
 import Kernel.External.Encryption
 import Kernel.Prelude
+import qualified Kernel.Prelude
 import Kernel.Types.Error
 import qualified Kernel.Types.Id
 import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
 import qualified Storage.Beam.RegistrationToken as Beam
+import qualified Storage.Queries.Transformers.RegistrationToken
 
 instance FromTType' Beam.RegistrationToken Domain.Types.RegistrationToken.RegistrationToken where
   fromTType' (Beam.RegistrationTokenT {..}) = do
+    merchantOperatingCityId' <- Storage.Queries.Transformers.RegistrationToken.getMerchantOperatingCityId merchantOperatingCityId merchantId
     pure $
       Just
         Domain.Types.RegistrationToken.RegistrationToken
@@ -29,6 +32,7 @@ instance FromTType' Beam.RegistrationToken Domain.Types.RegistrationToken.Regist
             id = Kernel.Types.Id.Id id,
             info = info,
             merchantId = merchantId,
+            merchantOperatingCityId = merchantOperatingCityId',
             token = token,
             tokenExpiry = tokenExpiry,
             updatedAt = updatedAt,
@@ -50,6 +54,7 @@ instance ToTType' Beam.RegistrationToken Domain.Types.RegistrationToken.Registra
         Beam.id = Kernel.Types.Id.getId id,
         Beam.info = info,
         Beam.merchantId = merchantId,
+        Beam.merchantOperatingCityId = Kernel.Prelude.Just merchantOperatingCityId,
         Beam.token = token,
         Beam.tokenExpiry = tokenExpiry,
         Beam.updatedAt = updatedAt,

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/RegistrationToken.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/RegistrationToken.hs
@@ -48,6 +48,7 @@ updateByPrimaryKey (Domain.Types.RegistrationToken.RegistrationToken {..}) = do
       Se.Set Beam.entityType entityType,
       Se.Set Beam.info info,
       Se.Set Beam.merchantId merchantId,
+      Se.Set Beam.merchantOperatingCityId (Kernel.Prelude.Just merchantOperatingCityId),
       Se.Set Beam.token token,
       Se.Set Beam.tokenExpiry tokenExpiry,
       Se.Set Beam.updatedAt _now,

--- a/Backend/app/rider-platform/rider-app/Main/src/App/CrossCloudProxy.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/App/CrossCloudProxy.hs
@@ -16,6 +16,7 @@ module App.CrossCloudProxy (crossCloudProxy) where
 
 import qualified API.UI as UI
 import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.Person as DP
 import Environment
 import Kernel.Prelude
@@ -26,6 +27,7 @@ import Kernel.Types.Version (CloudType (..))
 import qualified Network.HTTP.Client as Http
 import qualified Network.Wai as Wai
 import qualified Storage.CachedQueries.Merchant as CQM
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import qualified Storage.Queries.RegistrationToken as QRT
 import Tools.Auth (authTokenCacheKey, merchantIdFallback)
 import qualified "utils" Utils.Common.CrossCloudProxy as CCP
@@ -38,12 +40,17 @@ crossCloudProxy manager env =
 
 resolveOwner :: Text -> Flow (Maybe (CloudType, BaseUrl))
 resolveOwner token = do
-  mbAuthCached :: Maybe (Id DP.Person, Id DM.Merchant) <- Redis.safeGet (authTokenCacheKey token)
-  mbMerchantId <- case mbAuthCached of
-    Just (_, merchantId) -> pure (Just merchantId)
-    Nothing -> fmap (merchantIdFallback . Id @DM.Merchant . (.merchantId)) <$> QRT.findByToken token
-  case mbMerchantId of
+  mbAuthCached :: Maybe (Id DP.Person, Id DM.Merchant, Id DMOC.MerchantOperatingCity) <- Redis.safeGet (authTokenCacheKey token)
+  mbIds <- case mbAuthCached of
+    Just (_, merchantId, mocId) -> pure (Just (merchantId, mocId))
+    Nothing -> fmap (\sr -> (merchantIdFallback (Id sr.merchantId), Id sr.merchantOperatingCityId)) <$> QRT.findByToken token
+  case mbIds of
     Nothing -> pure Nothing
-    Just merchantId -> IM.withInMemCache ["crossCloudProxy:merchantCloud", merchantId.getId] 60 $ do
-      mbMerchant :: Maybe DM.Merchant <- CQM.findById merchantId
-      pure $ mbMerchant >>= \merchant -> (,) <$> merchant.cloudType <*> merchant.cloudBaseUrl
+    Just (merchantId, mocId) -> IM.withInMemCache ["crossCloudProxy:mocCloud", mocId.getId] 60 $ do
+      mbMoc :: Maybe DMOC.MerchantOperatingCity <- CQMOC.findById mocId
+      let mocPair = mbMoc >>= \moc -> (,) <$> moc.cloudType <*> moc.cloudBaseUrl
+      case mocPair of
+        Just p -> pure (Just p)
+        Nothing -> do
+          mbMerchant :: Maybe DM.Merchant <- CQM.findById merchantId
+          pure $ mbMerchant >>= \merchant -> (,) <$> merchant.cloudType <*> merchant.cloudBaseUrl

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Merchant.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Merchant.hs
@@ -882,6 +882,8 @@ postMerchantConfigOperatingCityCreate merchantShortId city req = do
           stdCode = Just cityStdCode,
           country = req.country,
           distanceUnit = fromMaybe Meter req.distanceUnit,
+          cloudType = Nothing,
+          cloudBaseUrl = Nothing,
           createdAt = currentTime,
           updatedAt = currentTime
         }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerOrganizationFRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerOrganizationFRFS.hs
@@ -334,7 +334,8 @@ makeSessionViaPartner ::
 makeSessionViaPartner sessionConfig entityId mId fakeOtp partnerOrgId isApiKeyAuth = do
   logDebug $ "We are in makeSessionViaPartner Creating session for entityId:" +|| entityId ||+ " merchantId:" +|| mId ||+ " partnerOrgId:" +|| partnerOrgId ||+ ""
   let authMedium = SR.PARTNER_ORG
-  regToken <- makeSession authMedium sessionConfig entityId mId (Just fakeOtp) partnerOrgId
+  person <- Person.findById (Id entityId) >>= fromMaybeM (PersonNotFound entityId)
+  regToken <- makeSession authMedium sessionConfig entityId mId person.merchantOperatingCityId.getId (Just fakeOtp) partnerOrgId
   void $ RegistrationToken.create regToken
   when isApiKeyAuth $ void $ RegistrationToken.setDirectAuth regToken.id authMedium
   return (regToken, True)
@@ -344,10 +345,11 @@ makeSession ::
   SmsSessionConfig ->
   Text ->
   Text ->
+  Text ->
   Maybe Text ->
   Id PartnerOrganization ->
   Flow SR.RegistrationToken
-makeSession authMedium SmsSessionConfig {..} entityId merchantId fakeOtp partnerOrgId = do
+makeSession authMedium SmsSessionConfig {..} entityId merchantId merchantOperatingCityId fakeOtp partnerOrgId = do
   otp <- maybe generateOTPCode return fakeOtp
   rtid <- L.generateGUID
   token <- L.generateGUID
@@ -365,6 +367,7 @@ makeSession authMedium SmsSessionConfig {..} entityId merchantId fakeOtp partner
         tokenExpiry = tokenExpiry,
         entityId = entityId,
         merchantId = merchantId,
+        merchantOperatingCityId = merchantOperatingCityId,
         entityType = SR.USER,
         createdAt = now,
         updatedAt = now,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
@@ -432,13 +432,14 @@ auth req' mbBundleVersion mbClientVersion mbClientConfigVersion mbRnVersion mbDe
             tokenExpiry = scfg.tokenExpiry,
             entityId = entityId,
             merchantId = mkId,
+            merchantOperatingCityId = person.merchantOperatingCityId.getId,
             entityType = SR.USER,
             createdAt = currentTime,
             updatedAt = currentTime,
             info = Nothing,
             createdViaPartnerOrgId = Nothing
           }
-    Nothing -> makeSession (castChannelToMedium otpChannel) scfg entityId mkId useFakeOtpM False
+    Nothing -> makeSession (castChannelToMedium otpChannel) scfg entityId mkId person.merchantOperatingCityId.getId useFakeOtpM False
 
   let isDashboardEmailDirectAuth = mbIsDashboardRequest == Just True && identifierType == SP.EMAIL
   if (fromMaybe False req.allowBlockedUserLogin) || not person.blocked
@@ -552,7 +553,7 @@ conductorTokenAuth req mbBundleVersion mbClientVersion mbClientConfigVersion mbR
       useFakeOtpM = (show <$> useFakeSms smsCfg) <|> person.useFakeOtp
       scfg = sessionConfig smsCfg
       mkId = getId $ merchant.id
-  regToken <- makeSession SR.SIGNATURE scfg entityId mkId useFakeOtpM False
+  regToken <- makeSession SR.SIGNATURE scfg entityId mkId person.merchantOperatingCityId.getId useFakeOtpM False
   if not person.blocked
     then do
       deploymentVersion <- asks (.version)
@@ -601,7 +602,7 @@ mobileSignatureAuth req mbBundleVersion mbClientVersion mbClientConfigVersion mb
       useFakeOtpM = (show <$> useFakeSms smsCfg) <|> person.useFakeOtp
       scfg = sessionConfig smsCfg
   let mkId = getId $ merchant.id
-  regToken <- makeSession SR.SIGNATURE scfg entityId mkId useFakeOtpM False
+  regToken <- makeSession SR.SIGNATURE scfg entityId mkId person.merchantOperatingCityId.getId useFakeOtpM False
   if not person.blocked
     then do
       deploymentVersion <- asks (.version)
@@ -743,7 +744,7 @@ passwordBasedAuth req = do
             authExpiry = 30,
             tokenExpiry = 30
           }
-  registrationToken <- makeSession method scfg person.id.getId req.userMerchantId.getId Nothing True
+  registrationToken <- makeSession method scfg person.id.getId req.userMerchantId.getId person.merchantOperatingCityId.getId Nothing True
   _ <- RegistrationToken.create registrationToken
   _ <- RegistrationToken.deleteByPersonIdExceptNew person.id registrationToken.id
   return $ AuthRes registrationToken.id 1 SR.PASSWORD (Just registrationToken.token) Nothing person.blocked mbDepotCode mbIsDepotAdmin
@@ -884,10 +885,11 @@ makeSession ::
   SmsSessionConfig ->
   Text ->
   Text ->
+  Text ->
   Maybe Text ->
   Bool ->
   m SR.RegistrationToken
-makeSession authMedium SmsSessionConfig {..} entityId merchantId fakeOtp verified = do
+makeSession authMedium SmsSessionConfig {..} entityId merchantId merchantOperatingCityId fakeOtp verified = do
   otp <- maybe generateOTPCode return fakeOtp
   rtid <- L.generateGUID
   token <- L.generateGUID
@@ -905,6 +907,7 @@ makeSession authMedium SmsSessionConfig {..} entityId merchantId fakeOtp verifie
         tokenExpiry = tokenExpiry,
         entityId = entityId,
         merchantId = merchantId,
+        merchantOperatingCityId = merchantOperatingCityId,
         entityType = SR.USER,
         createdAt = now,
         updatedAt = now,
@@ -965,19 +968,18 @@ verify tokenId req mbClientId mbXForwardedFor = do
   unless (authValueHash == req.otp) $ throwError InvalidAuthData
   person <- checkPersonExists entityId
   when (isNothing person.clientId && isJust mbClientId) $ Person.updateClientId mbClientId person.id
-  let merchantOperatingCityId = person.merchantOperatingCityId
   let deviceToken = Just req.deviceToken
   personWithSameDeviceToken <- listToMaybe <$> runInReplica (Person.findBlockedByDeviceToken deviceToken)
   let isBlockedBySameDeviceToken = maybe False (.blocked) personWithSameDeviceToken
   cleanCachedTokens person.id
   when isBlockedBySameDeviceToken $ do
-    merchantConfig <- getConfig (MerchantServiceUsageConfigDimensions {merchantOperatingCityId = merchantOperatingCityId.getId}) (Just (CQMSUC.findByMerchantOperatingCityId merchantOperatingCityId)) >>= fromMaybeM (MerchantServiceUsageConfigNotFound $ "merchantOperatingCityId:- " <> merchantOperatingCityId.getId)
+    merchantConfig <- getConfig (MerchantServiceUsageConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) Nothing >>= fromMaybeM (MerchantServiceUsageConfigNotFound $ "merchantOperatingCityId:- " <> person.merchantOperatingCityId.getId)
     when merchantConfig.useFraudDetection $ SMC.blockCustomer person.id ((.blockedByRuleId) =<< personWithSameDeviceToken)
   void $ RegistrationToken.setVerified True tokenId
   fork "Decrement Auth IP Counter" $ do
     mbClientIP <- extractClientIP mbXForwardedFor
     whenJust mbClientIP $ \clientIP -> do
-      merchantConfigs <- getConfig (MerchantConfigDimensions {merchantOperatingCityId = merchantOperatingCityId.getId}) (Just (CQMerchantCfg.findAllByMerchantOperatingCityId merchantOperatingCityId (Just [])))
+      merchantConfigs <- getConfig (MerchantConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) (Just (CQMerchantCfg.findAllByMerchantOperatingCityId person.merchantOperatingCityId (Just [])))
       SMC.decrementCustomerAuthCountersByIP clientIP merchantConfigs
   void $ Person.updateDeviceToken deviceToken person.id
   personAPIEntity <- verifyFlow person regToken req.whatsappNotificationEnroll deviceToken
@@ -1129,10 +1131,9 @@ resend tokenId mbSenderHash = do
   SR.RegistrationToken {..} <- getRegistrationTokenE tokenId
   person <- checkPersonExists entityId
   unless (attempts > 0) $ throwError $ AuthBlocked "Attempts limit exceed."
-  let merchantOperatingCityId = person.merchantOperatingCityId
   let otpCode = authValueHash
   otpChannel <- getPersonOTPChannel person.id
-  riderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) (Just (CQRC.findByMerchantOperatingCityId person.merchantOperatingCityId)) >>= fromMaybeM (RiderConfigDoesNotExist $ "merchantOperatingCityId:- " <> merchantOperatingCityId.getId)
+  riderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) (Just (CQRC.findByMerchantOperatingCityId person.merchantOperatingCityId)) >>= fromMaybeM (RiderConfigDoesNotExist $ "merchantOperatingCityId:- " <> person.merchantOperatingCityId.getId)
 
   mobileNumber <- mapM decrypt person.mobileNumber
   receiverEmail <- mapM decrypt person.email
@@ -1142,7 +1143,7 @@ resend tokenId mbSenderHash = do
     otpCode
     person.id
     person.merchantId
-    merchantOperatingCityId
+    person.merchantOperatingCityId
     person.mobileCountryCode
     mobileNumber
     receiverEmail
@@ -1321,6 +1322,7 @@ sendBusinessEmailVerification personId merchantId merchantOperatingCityId = do
             tokenExpiry = 30, -- 30 minutes token expiry
             entityId = getId personId,
             merchantId = getId merchantId,
+            merchantOperatingCityId = person.merchantOperatingCityId.getId,
             entityType = SR.USER,
             createdAt = now,
             updatedAt = now,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/SocialLogin.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/SocialLogin.hs
@@ -72,7 +72,7 @@ postSocialLogin req = do
               cloudType <- asks (.cloudType)
               PR.createPerson authReq SP.EMAIL Nothing Nothing Nothing Nothing Nothing Nothing cloudType merchant Nothing Nothing
       QR.deleteByPersonId person.id
-      token <- makeSession person.id.getId merchant.id.getId
+      token <- makeSession person.id.getId merchant.id.getId person.merchantOperatingCityId.getId
       _ <- QR.create token
       pure $ SL.SocialLoginRes isNew token.token
     Left _ -> throwError . InternalError $ show req.oauthProvider <> ", idToken: " <> req.tokenId <> " error: "
@@ -108,8 +108,9 @@ postSocialLogin req = do
 makeSession ::
   Text ->
   Text ->
+  Text ->
   Environment.Flow SR.RegistrationToken
-makeSession entityId merchantId = do
+makeSession entityId merchantId merchantOperatingCityId = do
   otp <- generateOTPCode
   rtid <- L.generateGUID
   token <- L.generateGUID
@@ -127,6 +128,7 @@ makeSession entityId merchantId = do
         tokenExpiry = 356,
         entityId = entityId,
         merchantId = merchantId,
+        merchantOperatingCityId = merchantOperatingCityId,
         entityType = SR.USER,
         createdAt = now,
         updatedAt = now,

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Transformers/RegistrationToken.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/Transformers/RegistrationToken.hs
@@ -1,0 +1,17 @@
+module Storage.Queries.Transformers.RegistrationToken where
+
+import Kernel.Prelude
+import Kernel.Types.Error
+import Kernel.Types.Id
+import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM)
+import qualified Storage.CachedQueries.Merchant as CQM
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+
+getMerchantOperatingCityId :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Maybe Kernel.Prelude.Text -> Text -> m Kernel.Prelude.Text
+getMerchantOperatingCityId merchantOperatingCityId merchantId = do
+  case merchantOperatingCityId of
+    Just opCityId -> return opCityId
+    Nothing -> do
+      merchant <- CQM.findById (Id merchantId) >>= fromMaybeM (MerchantNotFound merchantId)
+      mOpCId <- CQMOC.getMerchantOpCityId merchant Nothing
+      return $ mOpCId.getId

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Auth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Auth.hs
@@ -22,6 +22,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.Text.Encoding as TE
 import qualified Domain.Types.Merchant as Merchant
+import qualified Domain.Types.MerchantOperatingCity as DMOC
 import Domain.Types.PartnerOrganization as PO
 import qualified Domain.Types.Person as Person
 import qualified Domain.Types.RegistrationToken as SR
@@ -71,15 +72,16 @@ verifyPerson ::
 verifyPerson token = do
   let key = authTokenCacheKey token
   authTokenCacheExpiry <- getSeconds <$> asks (.authTokenCacheExpiry)
-  result <- Redis.safeGet key
+  result :: Maybe (Id Person.Person, Id Merchant.Merchant, Id DMOC.MerchantOperatingCity) <- Redis.safeGet key
   case result of
-    Just (personId, merchantId) -> return (personId, merchantIdFallback merchantId)
+    Just (personId, merchantId, _mocId) -> return (personId, merchantIdFallback merchantId)
     Nothing -> do
       sr <- verifyToken token
       let expiryTime = min sr.tokenExpiry authTokenCacheExpiry
       let personId = Id sr.entityId
       let merchantId = merchantIdFallback (Id sr.merchantId)
-      Redis.setExp key (personId, merchantId) expiryTime
+      let merchantOperatingCityId = Id sr.merchantOperatingCityId
+      Redis.setExp key (personId, merchantId, merchantOperatingCityId) expiryTime
       return (personId, merchantId)
 
 merchantIdFallback :: Id Merchant.Merchant -> Id Merchant.Merchant

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/merchant_operating_city.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/merchant_operating_city.sql
@@ -23,3 +23,9 @@ ALTER TABLE atlas_driver_offer_bpp.merchant_operating_city ADD COLUMN distance_u
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.merchant_operating_city ADD COLUMN std_code text ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_driver_offer_bpp.merchant_operating_city ADD COLUMN cloud_type text ;
+ALTER TABLE atlas_driver_offer_bpp.merchant_operating_city ADD COLUMN cloud_base_url text ;

--- a/Backend/dev/migrations-read-only/rider-app/merchant_operating_city.sql
+++ b/Backend/dev/migrations-read-only/rider-app/merchant_operating_city.sql
@@ -38,3 +38,9 @@ ALTER TABLE atlas_app.merchant_operating_city ADD COLUMN driver_offer_merchant_o
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.merchant_operating_city ADD COLUMN std_code text ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.merchant_operating_city ADD COLUMN cloud_type text ;
+ALTER TABLE atlas_app.merchant_operating_city ADD COLUMN cloud_base_url text ;

--- a/Backend/dev/migrations-read-only/rider-app/registration_token.sql
+++ b/Backend/dev/migrations-read-only/rider-app/registration_token.sql
@@ -21,3 +21,8 @@ ALTER TABLE atlas_app.registration_token ADD PRIMARY KEY ( id);
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.registration_token ADD COLUMN created_via_partner_org_id character varying(36) ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.registration_token ADD COLUMN merchant_operating_city_id character (36) ;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cloud type and base URL configuration for each merchant operating city.
  * Cross-cloud requests now prioritize operating-city configuration, with merchant-level fallback.
  * Registration, OTP, password, partner, and social sign-in sessions now retain the associated operating city.
* **Data Updates**
  * Added support for operating-city cloud settings and registration-token city associations.
  * Existing merchant operating cities continue to work without cloud-specific configuration.
  * Operating-city details are preserved across authentication and registration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->