### PR TITLE
backend/fix: persist rideTags on rider-side ride completion (cherry-pick to prodHotPush-BAP)

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/RideExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/RideExtra.hs
@@ -126,6 +126,7 @@ updateMultiple rideId ride = do
       Se.Set BeamR.startOdometerReading ride.startOdometerReading,
       Se.Set BeamR.endOdometerReading ride.endOdometerReading,
       Se.Set BeamR.tollConfidence ride.tollConfidence,
+      Se.Set BeamR.rideTags ride.rideTags,
       Se.Set BeamR.estimatedEndTimeRangeStart ((.start) <$> ride.estimatedEndTimeRange),
       Se.Set BeamR.estimatedEndTimeRangeEnd ((.end) <$> ride.estimatedEndTimeRange),
       Se.Set BeamR.paymentStatus (Just ride.paymentStatus),


### PR DESCRIPTION
## Summary
- Cherry-pick of #16029 (merged to `main` as a5d67cf07a) onto `prodHotPush-BAP`
- `updateMultiple` omitted `rideTags`, so the `ValidRide#Yes/No` tag computed at ride completion was never written to `atlas_app.ride.ride_tags`. The driver app's equivalent `updateAll` already sets it.

## Test plan
- [ ] Clean cherry-pick, no conflicts — same one-line diff as #16029