### PR TITLE
backend/feat: EDC parking-charge settlement for booth bookings

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -774,7 +774,8 @@ buildQuote merchantOpCityId searchRequest transporterId pickupTime isScheduled r
           mbAdditonalChargeCategories = Nothing,
           numberOfLuggages = searchRequest.numberOfLuggages,
           govtChargesRate = Just transporterConfig.taxConfig.rideGst,
-          pickupGateId = searchRequest.pickupGateId
+          pickupGateId = searchRequest.pickupGateId,
+          fareSettlementType = fullFarePolicy.fareSettlementType
         }
   let estimatedFare = fareSum fareParams (Just [])
   quoteId <- Id <$> generateGUID
@@ -867,7 +868,8 @@ buildEstimate merchantId merchantOperatingCityId currency distanceUnit mbSearchR
               mbAdditonalChargeCategories = Nothing,
               numberOfLuggages = mbSearchReq >>= (.numberOfLuggages),
               govtChargesRate = Just transporterConfig.taxConfig.rideGst,
-              pickupGateId = mbSearchReq >>= (.pickupGateId)
+              pickupGateId = mbSearchReq >>= (.pickupGateId),
+              fareSettlementType = fullFarePolicy.fareSettlementType
             }
     fareParamsMax <- FC.calculateFareParameters params
     fareParamsMin <-

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Update.hs
@@ -273,7 +273,8 @@ handler (UAddBaggageReq AddBaggageReq {..}) = do
             mbAdditonalChargeCategories = if null origAdditionalCategories then Nothing else Just origAdditionalCategories,
             numberOfLuggages = Just numberOfLuggages,
             govtChargesRate = Just transporterCfg.taxConfig.rideGst,
-            pickupGateId = booking.pickupGateId
+            pickupGateId = booking.pickupGateId,
+            fareSettlementType = booking.fareSettlementType
           }
 
   newFareParams <- FC.calculateFareParameters params
@@ -472,7 +473,8 @@ handler (UEditLocationReq EditLocationReq {..}) = do
                     mbAdditonalChargeCategories = Just $ map (.chargeCategory) booking.fareParams.conditionalCharges,
                     numberOfLuggages = booking.numberOfLuggages,
                     govtChargesRate = Just transporterConfig.taxConfig.rideGst,
-                    pickupGateId = booking.pickupGateId
+                    pickupGateId = booking.pickupGateId,
+                    fareSettlementType = booking.fareSettlementType
                   }
             QFP.create fareParameters
             let validTill = addUTCTime (fromIntegral transporterConfig.editLocTimeThreshold) now

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -2136,6 +2136,7 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
               numberOfLuggages = searchReq.numberOfLuggages,
               govtChargesRate = Just transporterConfig.taxConfig.rideGst,
               pickupGateId = searchReq.pickupGateId,
+              fareSettlementType = farePolicy'.fareSettlementType,
               ..
             }
       driverQuote <- buildDriverQuote driver driverStats searchReq sReqFD estimateId searchTry.tripCategory fareParams mbBundleVersion' mbClientVersion' mbConfigVersion' mbReactBundleVersion' mbDevice'

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboardingV2.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboardingV2.hs
@@ -363,7 +363,8 @@ getDriverRateCard (mbPersonId, _, merchantOperatingCityId) reqDistance reqDurati
                   mbAdditonalChargeCategories = Nothing,
                   numberOfLuggages = Nothing,
                   govtChargesRate = transporterConfig <&> (.taxConfig.rideGst),
-                  pickupGateId = Nothing
+                  pickupGateId = Nothing,
+                  fareSettlementType = fullFarePolicy.fareSettlementType
                 }
           let totalFareAmount = perRideKmFareParamsSum fareParams
               perKmAmount :: Rational = totalFareAmount.getHighPrecMoney / fromIntegral (maybe 1 (getKilometers . metersToKilometers) mbDistance)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
@@ -71,6 +71,7 @@ import Kernel.Types.Price
 import Lib.ConfigPilot.Interface.Types (getConfig)
 import qualified Lib.Queries.GateInfo as QGI
 import qualified Lib.Queries.SpecialLocation as QSL
+import qualified Lib.Types.SpecialLocation as SL
 import qualified Lib.Yudhishthira.Storage.Beam.BeamFlow as LYBF
 import qualified Lib.Yudhishthira.Tools.Utils as LYTU
 import qualified Lib.Yudhishthira.Types as LYT
@@ -467,6 +468,8 @@ mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mb
       rideCommission = fromMaybe 0 ride.commission
       rideTipsAmount = fromMaybe 0 ride.tipAmount
       computedFareNet = (\fareAmt -> max 0 (fareAmt - rideCommission + rideTipsAmount)) <$> ride.fare
+      edcCollectsParking = SL.edcCollectsParking booking.fareSettlementType
+      displayParkingCharge = if edcCollectsParking then Nothing else estimatedFareParams.parkingCharge
   finalFareParams <- maybe (pure Nothing) SQFP.findById ride.fareParametersId
   let initial = "" :: Text
   (nextStopLocation, lastStopLocation) <- case booking.tripCategory of
@@ -484,23 +487,50 @@ mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mb
       pure (mbGate, mbSL)
     Nothing -> pure (Nothing, Nothing)
 
-  -- See `amount*` semantics matrix (Cash / Online):
-  --   amountToCollectInCash   : Cash   -> FinalFare - Offer (commission included)
-  --                             Online -> Nothing
-  --   amountToBeSettledOnline : Cash   -> Offer
-  --                             Online -> FinalFare - Commission (offer already applied)
+  -- See `amount*` semantics matrix (Cash / Online / booth EDC):
+  --   amountToCollectInCash   : Cash            -> FinalFare - Offer (commission included)
+  --                             Online          -> Nothing
+  --                             Booth EDC       -> FinalFare - Commission (residual the driver
+  --                                                still collects in cash; FullPayment settles
+  --                                                fully online)
+  --                             Booth ParkingOnly -> FinalFare - Offer (commission NOT collected
+  --                                                at the booth for this type, so it's still owed
+  --                                                in cash, same as the plain Cash case; it's
+  --                                                recovered separately via wallet debit, not
+  --                                                clawed back here — see
+  --                                                `commissionAlreadyCollectedAtBooth` in
+  --                                                EndRide/Internal.hs)
+  --   amountToBeSettledOnline : Cash        -> Offer
+  --                             Online      -> FinalFare - Commission (offer already applied)
+  --                             Booth EDC   -> Nothing, except FullPayment (FinalFare - Commission)
+  -- Gated on fareSettlementType (matches the existing CommissionOnly precedent elsewhere), not
+  -- paymentInstrument, since that's what actually distinguishes a booth/EDC booking here.
   let offer = fromMaybe 0 ride.discountAmount
       commission = fromMaybe 0 ride.commission
       mbAmountToCollectInCash =
-        case (booking.paymentInstrument, ride.fare) of
-          (Just DMPM.Cash, Just fareAmt) -> Just $ max 0 (fareAmt - offer + rideTipsAmount)
-          _ -> Nothing
+        case (booking.fareSettlementType, ride.fare) of
+          (Just SL.FullPayment, _) -> Nothing
+          (Just SL.ParkingOnly, Just fareAmt) -> Just $ max 0 (fareAmt - offer + rideTipsAmount)
+          (Just SL.ParkingOnly, Nothing) -> Nothing
+          (Just _, Just fareAmt) -> Just $ max 0 (fareAmt - commission + rideTipsAmount)
+          (Just _, Nothing) -> Nothing
+          (Nothing, _) ->
+            case (booking.paymentInstrument, ride.fare) of
+              (Just DMPM.Cash, Just fareAmt) -> Just $ max 0 (fareAmt - offer + rideTipsAmount)
+              _ -> Nothing
       mbAmountToBeSettledOnline =
-        case booking.paymentInstrument of
-          Just DMPM.Cash -> if offer > 0 then Just offer else Nothing
-          _ -> case ride.fare of
-            Just fareAmt -> Just $ max 0 (fareAmt - commission + rideTipsAmount)
-            Nothing -> Nothing
+        case booking.fareSettlementType of
+          Just SL.FullPayment ->
+            case ride.fare of
+              Just fareAmt -> Just $ max 0 (fareAmt - commission + rideTipsAmount)
+              Nothing -> Nothing
+          Just _ -> Nothing
+          Nothing ->
+            case booking.paymentInstrument of
+              Just DMPM.Cash -> if offer > 0 then Just offer else Nothing
+              _ -> case ride.fare of
+                Just fareAmt -> Just $ max 0 (fareAmt - commission + rideTipsAmount)
+                Nothing -> Nothing
 
   mbRideEarningsVal <- case mbEarningsLabels of
     Just earningsLabels -> Just <$> buildRideEarnings language earningsLabels booking ride estimatedFareParams finalFareParams
@@ -563,12 +593,12 @@ mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mb
         isFreeRide = ride.isFreeRide,
         customerCancellationDues = fromMaybe 0 estimatedFareParams.customerCancellationDues,
         estimatedTollCharges = estimatedFareParams.tollCharges,
-        parkingCharge = estimatedFareParams.parkingCharge,
+        parkingCharge = displayParkingCharge,
         tollCharges = ride.tollCharges,
         tollConfidence = ride.tollConfidence,
         customerCancellationDuesWithCurrency = flip PriceAPIEntity estimatedFareParams.currency $ fromMaybe 0 estimatedFareParams.customerCancellationDues,
         estimatedTollChargesWithCurrency = flip PriceAPIEntity estimatedFareParams.currency <$> estimatedFareParams.tollCharges,
-        parkingChargeWithCurrency = flip PriceAPIEntity estimatedFareParams.currency <$> estimatedFareParams.parkingCharge,
+        parkingChargeWithCurrency = flip PriceAPIEntity estimatedFareParams.currency <$> displayParkingCharge,
         tollChargesWithCurrency = flip PriceAPIEntity ride.currency <$> ride.tollCharges,
         startOdometerReading = ride.startOdometerReading,
         endOdometerReading = ride.endOdometerReading,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
@@ -895,7 +895,8 @@ recalculateFareForDistance ServiceHandle {..} booking ride recalcDistance' thres
               mbAdditonalChargeCategories = Just $ map (.chargeCategory) booking.fareParams.conditionalCharges,
               numberOfLuggages = booking.numberOfLuggages,
               govtChargesRate = Just thresholdConfig.taxConfig.rideGst,
-              pickupGateId = booking.pickupGateId
+              pickupGateId = booking.pickupGateId,
+              fareSettlementType = booking.fareSettlementType
             }
       let finalFare = Fare.fareSum fareParams Nothing
           distanceDiff = recalcDistance - oldDistance

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -102,6 +102,7 @@ import Lib.Scheduler.JobStorageType.SchedulerType (createJobIn)
 import Lib.Scheduler.Types (SchedulerType)
 import Lib.SessionizerMetrics.Types.Event (EventStreamFlow)
 import Lib.Types.SpecialLocation hiding (Merchant, MerchantOperatingCity)
+import qualified Lib.Types.SpecialLocation as SL
 import qualified SharedLogic.ActiveDriversList as ADL
 import qualified SharedLogic.AirportEntryFee as AirportEntryFee
 import SharedLogic.Allocator
@@ -297,7 +298,10 @@ processEndRideFinance merchant ride booking newFareParams driverId driverInfo th
   let totalFare = fromMaybe 0 ride.fare
       gstAmount = fromMaybe 0 newFareParams.govtCharges
       tollAmount = fromMaybe 0 newFareParams.tollCharges
-      parkingAmount = fromMaybe 0 newFareParams.parkingCharge
+      -- totalFare (ride.fare) already excludes parking when EDC-collected (see fareSum's gate),
+      -- so subtracting it again here would double-count; zero it out in that case.
+      edcParkingCollected = SL.edcCollectsParking newFareParams.fareSettlementType
+      parkingAmount = if edcParkingCollected then 0 else fromMaybe 0 newFareParams.parkingCharge
       baseFare = totalFare - gstAmount - tollAmount - parkingAmount
       isPrepaidSubscriptionAndWalletEnabled = fromMaybe False merchant.prepaidSubscriptionAndWalletEnabled
       vehicleCategoryScopedPrepaidEnabled = fromMaybe False thresholdConfig.subscriptionConfig.vehicleCategoryScopedPrepaidEnabled
@@ -476,8 +480,9 @@ createDriverWalletTransaction ride booking fareParams driverInfo transporterConf
       rawTaxAmount = fromMaybe 0 fareParams.govtCharges -- GST or VAT (merged by FareCalculatorV2), pre-discount
       tollAmount = fromMaybe 0 fareParams.tollCharges
       tollVatAmount = fromMaybe 0 fareParams.tollFareTax -- discount does NOT apply to toll, so not scaled
-      parkingAmount = fromMaybe 0 fareParams.parkingCharge
-      parkingVatAmount = fromMaybe 0 fareParams.parkingChargeTax
+      edcParkingCollected = SL.edcCollectsParking fareParams.fareSettlementType
+      parkingAmount = if edcParkingCollected then 0 else fromMaybe 0 fareParams.parkingCharge
+      parkingVatAmount = if edcParkingCollected then 0 else fromMaybe 0 fareParams.parkingChargeTax
       commissionAmount = fromMaybe 0 (ride.commission <|> booking.commission)
       -- Commission is stored ALV-inclusive; split only at emission (pct unset ⇒ vat 0, behaviour unchanged).
       (commissionBaseAmount, commissionVatAmount) = splitGrossByVatPct transporterConfig.taxConfig.commissionVatPercentage commissionAmount
@@ -801,7 +806,7 @@ createDriverWalletTransaction ride booking fareParams driverInfo transporterConf
       Left err -> fromEitherM (\e -> InternalError ("Failed to create driver ride invoice: " <> show e)) (Left err)
       Right _ -> pure ()
 
-    let commissionAlreadyCollectedAtBooth = booking.fareSettlementType == Just CommissionOnly
+    let commissionAlreadyCollectedAtBooth = SL.commissionCollectedAtBooth booking.fareSettlementType
     when (commissionAmount + cancellationCommissionAmount > 0) $ do
       let commissionRef = if isOnline then walletReferenceCommissionOnline else walletReferenceCommissionCash
           commissionVatRef = if isOnline then walletReferenceCommissionVATOnline else walletReferenceCommissionVATCash

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
@@ -269,7 +269,7 @@ startRideHandler ServiceHandle {..} rideId req = do
         ( booking.isDashboardRequest
             && isRideOtpTrip booking.tripCategory
             && fromMaybe False transporterConfig.payoutRideMoneyToDriver
-            && booking.fareSettlementType /= Just SL.CommissionOnly
+            && not (SL.commissionCollectedAtBooth booking.fareSettlementType)
         )
         $ do
           -- Checking iff duplicate is there.

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FareParameters.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FareParameters.hs
@@ -23,6 +23,7 @@ import Kernel.Prelude
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import Kernel.Utils.GenericPretty (PrettyShow (..))
+import qualified Lib.Types.SpecialLocation as SL
 import Tools.Beam.UtilsTH (mkBeamInstancesForEnum)
 
 data FareParameters = FareParameters
@@ -85,7 +86,8 @@ data FareParameters = FareParameters
     cancellationFeeTaxExclusive :: Maybe HighPrecMoney,
     cancellationTax :: Maybe HighPrecMoney,
     parkingChargeTaxExclusive :: Maybe HighPrecMoney,
-    parkingChargeTax :: Maybe HighPrecMoney
+    parkingChargeTax :: Maybe HighPrecMoney,
+    fareSettlementType :: Maybe SL.FareSettlementType
   }
   deriving (Generic, Show, Eq, PrettyShow, FromJSON, ToJSON, ToSchema)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy.hs
@@ -285,7 +285,8 @@ data FullFarePolicyD (s :: DTC.UsageSafety) = FullFarePolicy
     conditionalCharges :: [DTAC.ConditionalCharges],
     congestionChargeData :: Maybe CongestionChargeData,
     driverCancellationPenaltyAmount :: Maybe HighPrecMoney,
-    mbArea :: Maybe SL.Area
+    mbArea :: Maybe SL.Area,
+    fareSettlementType :: Maybe SL.FareSettlementType
   }
   deriving (Generic, Show)
 
@@ -342,6 +343,7 @@ farePolicyToFullFarePolicy merchantId' vehicleServiceTier tripCategory cancellat
   FullFarePolicy
     { merchantId = merchantId',
       mbArea = Nothing,
+      fareSettlementType = Nothing,
       ..
     }
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/AirportEntryFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/AirportEntryFee.hs
@@ -30,7 +30,7 @@ import Kernel.Storage.Esqueleto as Esq
 import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Types.Common
 import Kernel.Types.Id
-import Kernel.Utils.Common (CacheFlow, fromEitherM, fromMaybeM, throwError)
+import Kernel.Utils.Common (CacheFlow, fromEitherM, fromMaybeM, logInfo, throwError)
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import Lib.Finance
   ( AccountRole (GovtIndirect, OwnerLiability, ParkingFeeRecipient),
@@ -50,14 +50,19 @@ import qualified Storage.Queries.DriverInformation as QDI
 import Tools.Error
 
 -- | Required airport entry fee for this booking. Uses booking.pickupGateId (gate where customer is).
---   Returns Nothing if no gateId or no fee configured.
+--   Returns Nothing if no gateId, no fee configured, or the fee was already collected via booth EDC
+--   (see applyAirportEntryFee, which folds this same amount into FareParameters.parkingCharge).
 requiredEntryFeeForBooking ::
   (Esq.EsqDBFlow m r, Esq.EsqDBReplicaFlow m r, MonadFlow m, CacheFlow m r) =>
   Bool ->
   Maybe Text ->
+  Maybe SL.FareSettlementType ->
   m (Maybe HighPrecMoney)
-requiredEntryFeeForBooking enabled mbGateId
+requiredEntryFeeForBooking enabled mbGateId mbFareSettlementType
   | not enabled = pure Nothing
+  | SL.edcCollectsParking mbFareSettlementType = do
+    logInfo $ "requiredEntryFeeForBooking: skipping - parking already EDC-collected, fareSettlementType: " <> show mbFareSettlementType
+    pure Nothing
   | otherwise = do
     fee <- maybe (pure 0) (FareCalculator.entryFeeForGateId . Id) mbGateId
     pure $ if fee > 0 then Just fee else Nothing
@@ -96,7 +101,7 @@ checkAirportEntryFeeBalanceBeforeStartRide ::
   SRB.Booking ->
   m ()
 checkAirportEntryFeeBalanceBeforeStartRide enabled driverId booking = do
-  mbRequired <- requiredEntryFeeForBooking enabled booking.pickupGateId
+  mbRequired <- requiredEntryFeeForBooking enabled booking.pickupGateId booking.fareSettlementType
   whenJust mbRequired $ \required -> do
     mbAccount <- Wallet.getWalletAccountByOwner DRIVER driverId.getId
     let available = maybe 0 (.balance) mbAccount
@@ -112,7 +117,7 @@ deductAirportEntryFeeAtEndRide ::
   SRB.Booking ->
   m ()
 deductAirportEntryFeeAtEndRide enabled ride booking = do
-  mbTotalFee <- requiredEntryFeeForBooking enabled booking.pickupGateId
+  mbTotalFee <- requiredEntryFeeForBooking enabled booking.pickupGateId booking.fareSettlementType
   whenJust mbTotalFee $ \totalFee -> do
     transporterConfig <-
       getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = booking.merchantOperatingCityId.getId}) Nothing

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPoolUnified.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPoolUnified.hs
@@ -39,6 +39,7 @@ import qualified SharedLogic.Allocator.Jobs.SendSearchRequestToDrivers.Handle.In
 import qualified SharedLogic.Beckn.Common as DTS
 import SharedLogic.DriverPool
 import qualified SharedLogic.External.LocationTrackingService.Types as LT
+import qualified SharedLogic.FarePolicy as SFarePolicy
 import Storage.Beam.SpecialZone ()
 import Storage.Beam.Yudhishthira ()
 import qualified Storage.CachedQueries.Driver.GoHomeRequest as CQDGR
@@ -159,10 +160,11 @@ prepareDriverPoolBatch cityServiceTiers merchant driverPoolCfg searchReq searchT
 
     prepareDriverPoolBatch' previousBatchesDrivers batchNum merchantOpCityId txnId isValueAddNP = withLogTag ("BatchNum - " <> show batchNum <> " and txnId:- " <> show txnId) $ do
       transporterConfig <- getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = merchantOpCityId.getId}) Nothing >>= fromMaybeM (TransporterConfigDoesNotExist merchantOpCityId.getId)
+      mbFareSettlementTypeForPool <- SFarePolicy.getFareSettlementTypeForSpecialZone (searchReq.area >>= SL.pickupSpecialZoneIdFromArea)
       airportEntryFee <-
         if fromMaybe False transporterConfig.airportEntryFeeCheckAtStartRide
           then pure Nothing
-          else AirportEntryFee.requiredEntryFeeForBooking (fromMaybe False transporterConfig.airportEntryFeeEnabled) searchReq.pickupGateId
+          else AirportEntryFee.requiredEntryFeeForBooking (fromMaybe False transporterConfig.airportEntryFeeEnabled) searchReq.pickupGateId mbFareSettlementTypeForPool
       isAirportRequest <- AirportEntryFee.isAirportPickupArea searchReq.area
       blockListedDriversForSearch <- Redis.withCrossAppRedis $ Redis.getList (mkBlockListedDriversKey searchReq.id)
       blockListedDriversForRider <- maybe (pure []) (Redis.withCrossAppRedis . Redis.getList . mkBlockListedDriversForRiderKey) searchReq.riderId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
@@ -252,7 +252,8 @@ sendSearchRequestToDrivers isAllocatorBatch tripQuoteDetails oldSearchReq search
               mbAdditonalChargeCategories = Nothing,
               numberOfLuggages = searchReq.numberOfLuggages,
               govtChargesRate = Just transporterConfig.taxConfig.rideGst,
-              pickupGateId = searchReq.pickupGateId
+              pickupGateId = searchReq.pickupGateId,
+              fareSettlementType = farePolicy'.fareSettlementType
             }
       pure $ Fare.fareSum fareParams $ Just []
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareCalculator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareCalculator.hs
@@ -78,6 +78,7 @@ import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import Lib.Finance.Storage.Beam.BeamFlow (BeamFlow)
 import qualified Lib.Queries.GateInfo as QGI
 import qualified Lib.Types.GateInfo as DGI
+import qualified Lib.Types.SpecialLocation as SL
 import Storage.Beam.SpecialZone ()
 import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions (..))
 
@@ -370,9 +371,14 @@ fareSum fareParams conditionalChargeCategories =
     - (if fareParams.shouldApplyBusinessDiscount then fromMaybe 0.0 fareParams.businessDiscount else 0.0)
     - (if fareParams.shouldApplyPersonalDiscount then fromMaybe 0.0 fareParams.personalDiscount else 0.0)
   where
+    edcCollectsParking :: Bool
+    edcCollectsParking = SL.edcCollectsParking fareParams.fareSettlementType
+
     pureFareSum :: HighPrecMoney
     pureFareSum = do
       let (partOfNightShiftCharge, notPartOfNightShiftCharge, platformFee) = countFullFareOfParamsDetails fareParams.fareParametersDetails
+          parkingContribution = if edcCollectsParking then 0.0 else fromMaybe 0.0 fareParams.parkingCharge
+          parkingTaxContribution = if edcCollectsParking then 0.0 else fromMaybe 0.0 fareParams.parkingChargeTax
       fareParams.baseFare
         + fromMaybe 0.0 fareParams.serviceCharge
         + fromMaybe 0.0 fareParams.waitingCharge
@@ -388,7 +394,7 @@ fareSum fareParams conditionalChargeCategories =
         + partOfNightShiftCharge
         + notPartOfNightShiftCharge
         + platformFee
-        + (fromMaybe 0.0 fareParams.customerCancellationDues + fromMaybe 0.0 fareParams.tollCharges + fromMaybe 0.0 fareParams.parkingCharge)
+        + (fromMaybe 0.0 fareParams.customerCancellationDues + fromMaybe 0.0 fareParams.tollCharges + parkingContribution)
         + fromMaybe 0.0 fareParams.insuranceCharge
         + fromMaybe 0.0 fareParams.luggageCharge
         + fromMaybe 0.0 fareParams.returnFeeCharge
@@ -397,7 +403,7 @@ fareSum fareParams conditionalChargeCategories =
         + fromMaybe 0.0 (fareParams.cardCharge >>= (.fixed))
         + fromMaybe 0.0 fareParams.paymentProcessingFee
         + fromMaybe 0.0 fareParams.tollFareTax
-        + fromMaybe 0.0 fareParams.parkingChargeTax
+        + parkingTaxContribution
         -- Commission is intentionally excluded - stored for breakdown only
         + (sum $ map (.charge) (filter (\addCharges -> maybe True (KP.elem addCharges.chargeCategory) conditionalChargeCategories) fareParams.conditionalCharges))
 
@@ -447,7 +453,8 @@ data CalculateFareParametersParams = CalculateFareParametersParams
     mbAdditonalChargeCategories :: Maybe [DAC.ConditionalChargesCategories],
     numberOfLuggages :: Maybe Int,
     govtChargesRate :: Maybe DTC.GstBreakup, -- from TaxConfig.rideGst; summed inside calculateFareParameters
-    pickupGateId :: Maybe Text -- Optional airport pickup gate id; used by V2 to apply airport entry fee
+    pickupGateId :: Maybe Text, -- Optional airport pickup gate id; used by V2 to apply airport entry fee
+    fareSettlementType :: Maybe SL.FareSettlementType
   }
 
 calculateFareParametersHandler :: MonadFlow m => CalculateFareParametersParams -> m FareParameters
@@ -604,7 +611,8 @@ calculateFareParametersHandler params = do
             cancellationFeeTaxExclusive = Nothing,
             cancellationTax = Nothing,
             parkingChargeTaxExclusive = Nothing,
-            parkingChargeTax = Nothing
+            parkingChargeTax = Nothing,
+            fareSettlementType = params.fareSettlementType
           }
   KP.forM_ debugLogs $ logTagInfo ("FareCalculator:FarePolicyId:" <> show fp.id.getId)
   logTagInfo "FareCalculator" $ "Fare parameters calculated: " +|| fareParams ||+ ""

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FarePolicy.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FarePolicy.hs
@@ -41,6 +41,7 @@ import Kernel.Prelude
 import Kernel.Randomizer
 import Kernel.Storage.Clickhouse.Config
 import qualified Kernel.Storage.ClickhouseV2 as CH
+import Kernel.Storage.Esqueleto (Transactionable)
 import Kernel.Storage.Esqueleto.Config
 import qualified Kernel.Storage.Hedis as Hedis
 import Kernel.Types.Id
@@ -193,14 +194,15 @@ getAllFarePoliciesProduct :: (CacheFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r
 getAllFarePoliciesProduct merchantId merchantOpCityId isDashboard fromlocaton mbToLocation mbFromSpecialLocationId mbToSpecialLocationId txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion tripCategory configsInExperimentVersions = do
   let searchSources = FareProduct.getSearchSources isDashboard
   allFareProducts <- FareProduct.getAllFareProducts merchantId merchantOpCityId searchSources fromlocaton mbToLocation mbFromSpecialLocationId mbToSpecialLocationId tripCategory
+  let mbResolvedSpecialZoneId = ((.getId) <$> mbFromSpecialLocationId) <|> SL.pickupSpecialZoneIdFromArea allFareProducts.area
   (mbBaseVariantCarFareProduct :: Maybe FareProduct.FareProduct) <-
     return . getFareProduct allFareProducts
-      =<< CQVST.findBaseServiceTierTypeByCategoryAndCityIdInRideFlow (Just DVC.CAR) merchantOpCityId ((.getId) <$> mbFromSpecialLocationId)
+      =<< CQVST.findBaseServiceTierTypeByCategoryAndCityIdInRideFlow (Just DVC.CAR) merchantOpCityId mbResolvedSpecialZoneId
   transporterConfig <- getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = merchantOpCityId.getId}) Nothing >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
   -- Resolve each fareProduct's vehicle-service-tier item once and reuse it for
   -- both the per-vehicleCategory dynamic-pricing inputs and inside
   -- 'getFullFarePolicy', so the (cached) lookup isn't repeated per service tier.
-  resolvedFareProducts <- forM allFareProducts.fareProducts $ \fareProduct -> (fareProduct,) <$> CQVST.findByServiceTierTypeAndCityIdInRideFlow fareProduct.vehicleServiceTier merchantOpCityId ((.getId) <$> mbFromSpecialLocationId)
+  resolvedFareProducts <- forM allFareProducts.fareProducts $ \fareProduct -> (fareProduct,) <$> CQVST.findByServiceTierTypeAndCityIdInRideFlow fareProduct.vehicleServiceTier merchantOpCityId mbResolvedSpecialZoneId
   -- Pre-resolve the dynamic-pricing Redis inputs once for the whole search: the
   -- congestion/rain/toss part is shared and the QAR/supply-demand part is fetched
   -- per distinct vehicleCategory, so service tiers sharing a category don't
@@ -215,8 +217,8 @@ getAllFarePoliciesProduct merchantId merchantOpCityId isDashboard fromlocaton mb
             qarRadius = fromMaybe 5.0 transporterConfig.qarCalRadiusInKm
         buildDynamicPricingInputs now fromlocaton qarRadius geohash mbToLocGeohash distance.getMeters merchantOpCityId.getId vehicleCategories
       _ -> pure []
-  baseVariantFareAmountCar <- getBaseVariantFarePolicy transporterConfig (Just fromlocaton) mbToLocation merchantOpCityId mbBaseVariantCarFareProduct txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion configsInExperimentVersions allFareProducts.specialLocationName ((.getId) <$> mbFromSpecialLocationId) dpInputsList
-  farePolicies <- catMaybes <$> mapConcurrently (\(fareProduct, mbVehicleServiceTierItem) -> getFullFarePolicy (Just fromlocaton) mbToLocation mbFromLocGeohash mbToLocGeohash mbDistance mbDuration txnId Nothing baseVariantFareAmountCar mbAppDynamicLogicVersion allFareProducts.specialLocationName ((.getId) <$> mbFromSpecialLocationId) fareProduct configsInExperimentVersions dpInputsList (Just transporterConfig) (Just mbVehicleServiceTierItem)) resolvedFareProducts
+  baseVariantFareAmountCar <- getBaseVariantFarePolicy transporterConfig (Just fromlocaton) mbToLocation merchantOpCityId mbBaseVariantCarFareProduct txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion configsInExperimentVersions allFareProducts.specialLocationName mbResolvedSpecialZoneId dpInputsList
+  farePolicies <- catMaybes <$> mapConcurrently (\(fareProduct, mbVehicleServiceTierItem) -> getFullFarePolicy (Just fromlocaton) mbToLocation mbFromLocGeohash mbToLocGeohash mbDistance mbDuration txnId Nothing baseVariantFareAmountCar mbAppDynamicLogicVersion allFareProducts.specialLocationName mbResolvedSpecialZoneId fareProduct configsInExperimentVersions dpInputsList (Just transporterConfig) (Just mbVehicleServiceTierItem)) resolvedFareProducts
   return $
     FarePoliciesProduct
       { farePolicies,
@@ -242,6 +244,14 @@ getBaseVariantFarePolicy transporterConfig mbFromLocation mbToLocation merchantO
 getFareProduct :: FareProduct.FareProducts -> Maybe DVST.VehicleServiceTier -> Maybe FareProduct.FareProduct
 getFareProduct _ Nothing = Nothing
 getFareProduct fareProducts (Just vehicleServiceTier) = List.find (\fareProduct -> fareProduct.vehicleServiceTier == vehicleServiceTier.serviceTierType) fareProducts.fareProducts
+
+-- | Resolve the EDC fare-settlement type (commission/parking collection at booth) for a special zone, if any.
+getFareSettlementTypeForSpecialZone :: (Transactionable m, EsqDBReplicaFlow m r) => Maybe Text -> m (Maybe SL.FareSettlementType)
+getFareSettlementTypeForSpecialZone Nothing = pure Nothing
+getFareSettlementTypeForSpecialZone (Just specialZoneId) = do
+  mbFareSettlementType <- (>>= (.fareSettlementType)) <$> QSpecialLocation.findById (Id specialZoneId)
+  logDebug $ "getFareSettlementTypeForSpecialZone: specialZoneId: " <> specialZoneId <> ", fareSettlementType: " <> show mbFareSettlementType
+  pure mbFareSettlementType
 
 getFullFarePolicy :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r, BeamFlow m r, CH.HasClickhouseEnv CH.APP_SERVICE_CLICKHOUSE m, HasFlowEnv m r '["mlPricingInternal" ::: ML.MLPricingInternal], HasFlowEnv m r '["internalEndPointHashMap" ::: HM.HashMap BaseUrl BaseUrl], ClickhouseFlow m r) => Maybe LatLong -> Maybe LatLong -> Maybe Text -> Maybe Text -> Maybe Meters -> Maybe Seconds -> Maybe CacKey -> Maybe UTCTime -> Maybe HighPrecMoney -> Maybe Int -> Maybe Text -> Maybe Text -> FareProduct.FareProduct -> [LYT.ConfigVersionMap] -> [(Maybe DVC.VehicleCategory, DynamicPricingInputs)] -> Maybe TransporterConfig -> Maybe (Maybe DVST.VehicleServiceTier) -> m (Maybe FarePolicyD.FullFarePolicy)
 getFullFarePolicy mbFromLocation mbToLocation mbFromLocGeohash mbToLocGeohash mbDistance mbDuration txnId mbBookingStartTime mbBaseVaraintCarPrice mbAppDynamicLogicVersion mbSpecialLocName mbSpecialZoneId fareProduct _configsInExperimentVersions dpInputsList mbTransporterConfig mbPreResolvedVSTItem = do
@@ -293,7 +303,8 @@ getFullFarePolicy mbFromLocation mbToLocation mbFromLocGeohash mbToLocGeohash mb
       let farePolicy = updateCongestionChargeMultiplier farePolicy' updatedCongestionChargeMultiplier mbDriverExtraFeeBounds
       logDebug $ "farePolicy after updating driverExtraFeeBounds: " <> show farePolicy <> " and mbDriverExtraFeeBounds: " <> show mbDriverExtraFeeBounds
       let congestionChargeDetails = FarePolicyD.CongestionChargeDetails version supplyDemandRatioToLoc supplyDemandRatioFromLoc updatedCongestionChargePerMin smartTipSuggestion smartTipReason mbActualQARFromLocGeohash mbActualQARCity
-      let fullFarePolicy = (FarePolicyD.farePolicyToFullFarePolicy fareProduct.merchantId fareProduct.vehicleServiceTier fareProduct.tripCategory cancellationFarePolicy congestionChargeDetails mbcongestionChargeData farePolicy fareProduct.disableRecompute) {FarePolicyD.mbArea = Just fareProduct.area}
+      mbFareSettlementType <- getFareSettlementTypeForSpecialZone mbSpecialZoneId
+      let fullFarePolicy = (FarePolicyD.farePolicyToFullFarePolicy fareProduct.merchantId fareProduct.vehicleServiceTier fareProduct.tripCategory cancellationFarePolicy congestionChargeDetails mbcongestionChargeData farePolicy fareProduct.disableRecompute) {FarePolicyD.mbArea = Just fareProduct.area, FarePolicyD.fareSettlementType = mbFareSettlementType}
       case mbVehicleServiceTierItem of
         Just vehicleServiceTierItem -> do
           if vehicleServiceTierItem.vehicleCategory == Just DVC.CAR && isJust mbBaseVaraintCarPrice && not (fromMaybe True vehicleServiceTierItem.baseVehicleServiceTier)
@@ -339,7 +350,8 @@ getFullFarePolicy mbFromLocation mbToLocation mbFromLocGeohash mbToLocGeohash mb
                 mbActualQARFromLocGeohash = Nothing,
                 mbActualQARCity = Nothing
               }
-      let fullFarePolicy = (FarePolicyD.farePolicyToFullFarePolicy fareProduct.merchantId fareProduct.vehicleServiceTier fareProduct.tripCategory cancellationFarePolicy congestionChargeDetails mbcongestionChargeData farePolicy fareProduct.disableRecompute) {FarePolicyD.mbArea = Just fareProduct.area}
+      mbFareSettlementType <- getFareSettlementTypeForSpecialZone mbSpecialZoneId
+      let fullFarePolicy = (FarePolicyD.farePolicyToFullFarePolicy fareProduct.merchantId fareProduct.vehicleServiceTier fareProduct.tripCategory cancellationFarePolicy congestionChargeDetails mbcongestionChargeData farePolicy fareProduct.disableRecompute) {FarePolicyD.mbArea = Just fareProduct.area, FarePolicyD.fareSettlementType = mbFareSettlementType}
       parameters <- calculateFareParametersForFarePolicy transporterConfig fullFarePolicy (Just distance) mbDuration fareProduct.merchantOperatingCityId
       let fare = SFC.fareSum parameters (Just [])
       case parameters.fareParametersDetails of
@@ -416,7 +428,8 @@ calculateFareParametersForFarePolicy transporterConfig fullFarePolicy mbDistance
             mbAdditonalChargeCategories = Nothing,
             numberOfLuggages = Nothing,
             govtChargesRate = gstBreakup,
-            pickupGateId = Nothing
+            pickupGateId = Nothing,
+            fareSettlementType = fullFarePolicy.fareSettlementType
           }
   SFC.calculateFareParameters params
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SearchTry.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SearchTry.hs
@@ -337,8 +337,12 @@ buildTripQuoteDetail searchReq tripCategory vehicleServiceTier mbVehicleServiceT
       _ -> do
         farePolicy <- getFarePolicyByEstOrQuoteId (Just $ getCoordinates searchReq.fromLocation) (Just . getCoordinates =<< searchReq.toLocation) searchReq.fromLocGeohash searchReq.toLocGeohash searchReq.estimatedDistance searchReq.estimatedDuration searchReq.merchantOperatingCityId tripCategory vehicleServiceTier searchReq.area estimateOrQuoteId Nothing isDashboardRequest searchReq.dynamicPricingLogicVersion (Just (TransactionId (Id searchReq.transactionId))) searchReq.configInExperimentVersions searchReq.specialLocationName
         let mbDriverExtraFeeBounds = DFP.findDriverExtraFeeBoundsByDistance (fromMaybe 0 searchReq.estimatedDistance) <$> farePolicy.driverExtraFeeBounds
+            -- Parking already EDC-collected at the booth for these settlement types isn't the
+            -- driver's cash to hold - don't factor it into the driver's cash-wallet eligibility check.
+            edcCollectsParking = SL.edcCollectsParking farePolicy.fareSettlementType
+            driverFacingParkingCharge = if edcCollectsParking then Nothing else farePolicy.parkingCharge
         return $
-          ( farePolicy.parkingCharge,
+          ( driverFacingParkingCharge,
             farePolicy.tollCharges,
             USRD.extractDriverPickupCharges farePolicy.farePolicyDetails,
             mbDriverExtraFeeBounds <&> (.minFee),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -291,7 +291,8 @@ computeAirportPerKmFare merchantId merchantOpCityId gateLatLong pickupGateId cal
               mbAdditonalChargeCategories = Nothing,
               numberOfLuggages = Nothing,
               govtChargesRate = mbTransporterConfig <&> (.taxConfig.rideGst),
-              pickupGateId = Just pickupGateId
+              pickupGateId = Just pickupGateId,
+              fareSettlementType = fullFarePolicy.fareSettlementType
             }
       let estimatedFare = SFC.fareSum fareParams (Just [])
           -- Tolls and gate parking (which now includes airport entry fee added by

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareParameters.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Beam/FareParameters.hs
@@ -19,6 +19,7 @@ import qualified Domain.Types.FareParameters as Domain
 import qualified Domain.Types.FarePolicy as FP
 import Kernel.Prelude
 import Kernel.Types.Common hiding (id)
+import qualified Lib.Types.SpecialLocation as SL
 import Tools.Beam.UtilsTH
 
 data FareParametersT f = FareParametersT
@@ -84,7 +85,8 @@ data FareParametersT f = FareParametersT
     cancellationFeeTaxExclusive :: B.C f (Maybe HighPrecMoney),
     cancellationTax :: B.C f (Maybe HighPrecMoney),
     parkingChargeTaxExclusive :: B.C f (Maybe HighPrecMoney),
-    parkingChargeTax :: B.C f (Maybe HighPrecMoney)
+    parkingChargeTax :: B.C f (Maybe HighPrecMoney),
+    fareSettlementType :: B.C f (Maybe SL.FareSettlementType)
   }
   deriving (Generic, B.Beamable)
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/FareParameters.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/FareParameters.hs
@@ -193,7 +193,8 @@ instance FromTType' BeamFP.FareParameters FareParameters where
                 cancellationFeeTaxExclusive = cancellationFeeTaxExclusive,
                 cancellationTax = cancellationTax,
                 parkingChargeTaxExclusive = parkingChargeTaxExclusive,
-                parkingChargeTax = parkingChargeTax
+                parkingChargeTax = parkingChargeTax,
+                fareSettlementType = fareSettlementType
               }
       Nothing -> return Nothing
 
@@ -262,5 +263,6 @@ instance ToTType' BeamFP.FareParameters FareParameters where
         BeamFP.platformFee = platformFee,
         BeamFP.sgst = sgst,
         BeamFP.cgst = cgst,
-        BeamFP.driverCancellationPenaltyAmount = driverCancellationPenaltyAmount
+        BeamFP.driverCancellationPenaltyAmount = driverCancellationPenaltyAmount,
+        BeamFP.fareSettlementType = fareSettlementType
       }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Payment.hs
@@ -35,6 +35,7 @@ where
 import qualified API.Types.UI.Payment as PaymentAPI
 import qualified Beckn.ACL.Cancel as CancelACL
 import qualified Beckn.ACL.Confirm as ACL
+import qualified BecknV2.OnDemand.Enums as Enums
 import Control.Applicative ((<|>))
 -- import Data.Aeson (defaultOptions, withObject, (.:?))
 import Data.Aeson.Types ()
@@ -47,6 +48,7 @@ import qualified Domain.Action.UI.FRFSTicketService as FRFSTicketService
 import qualified Domain.Action.UI.ParkingBooking as ParkingBooking
 import qualified Domain.Action.UI.Pass as Pass
 import qualified Domain.Action.UI.RidePayment as DRidePayment
+import qualified Domain.SharedLogic.RideDiscount as RD
 import qualified Domain.Types.Booking as DRB
 import qualified Domain.Types.BookingCancellationReason as SBCR
 import qualified Domain.Types.BookingStatus as SRB
@@ -56,6 +58,7 @@ import Domain.Types.CancellationReason (CancellationReasonCode (..), Cancellatio
 
 import Domain.Types.Extra.MerchantPaymentMethod ()
 import qualified Domain.Types.Extra.MerchantPaymentMethod as DMPM
+import qualified Domain.Types.FareBreakup as DFareBreakup
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.MerchantServiceConfig as DMSC
@@ -95,6 +98,7 @@ import qualified Lib.Payment.Storage.Queries.PersonWallet as QPersonWallet
 import qualified Lib.Types.SpecialLocation as SL
 import Servant (BasicAuthData)
 import qualified SharedLogic.CallBPP as CallBPP
+import qualified SharedLogic.FareBreakupInfo as SFareBreakupInfo
 import qualified SharedLogic.Finance.RidePayment as RidePaymentFinance
 import qualified SharedLogic.Payment as SPayment
 import qualified SharedLogic.Utils as SLUtils
@@ -106,6 +110,7 @@ import Storage.ConfigPilot.Config.MerchantServiceConfig (MerchantServiceConfigDi
 import qualified Storage.Queries.Booking as QRideB
 import qualified Storage.Queries.BookingPartiesLink as QBPL
 import qualified Storage.Queries.EDCMachineMappingExtra as QEDCMachineMapping
+import qualified Storage.Queries.FareBreakup as QFareBreakup
 import qualified Storage.Queries.Person as QP
 import qualified Storage.Queries.RefundRequest as QRefundRequest
 import qualified Storage.Queries.Ride as QRide
@@ -185,10 +190,34 @@ createRideBookingPaymentOrder booking = do
   staticCustomerId <- SLUtils.getStaticCustomerId person customerPhone
   paymentOrderId <- generateGUID
   orderShortId <- generateShortId
-  let amount =
-        if booking.fareSettlementType == Just SL.CommissionOnly
-          then fromMaybe 0 booking.commission
-          else booking.estimatedTotalFare.amount
+  -- Parking amount (when EDC-collected) has to be read back from the fare breakup persisted at
+  -- on_init (createFareBreakup) - the rider-app's Booking only carries fare totals, not an
+  -- itemized breakdown, so there's no other source for "just the parking portion" on this side.
+  parkingAmount <-
+    if SL.edcCollectsParking booking.fareSettlementType
+      then do
+        breakups <-
+          SFareBreakupInfo.getFareBreakupsWithFallback
+            booking.id.getId
+            DFareBreakup.BOOKING
+            (QFareBreakup.findAllByEntityIdAndEntityType booking.id.getId DFareBreakup.BOOKING)
+        let resolvedParkingAmount = case RD.parseProjectFareParamsBreakup ((\b -> (b.description, b.amount.amount)) <$> breakups) of
+              Just b -> b.parkingChargeTaxExclusive + b.parkingChargeTax
+              Nothing -> sumByDescription (show Enums.PARKING_CHARGE) breakups
+        when (resolvedParkingAmount == 0) $
+          logError $
+            "createRideBookingPaymentOrder: resolved parking amount is 0 for bookingId="
+              <> booking.id.getId
+              <> ", fareSettlementType="
+              <> show booking.fareSettlementType
+        pure resolvedParkingAmount
+      else pure 0
+  let commissionAmount = fromMaybe 0 booking.commission
+      amount = case booking.fareSettlementType of
+        Just SL.CommissionOnly -> commissionAmount
+        Just SL.ParkingOnly -> parkingAmount
+        Just SL.CommissionAndParking -> commissionAmount + parkingAmount
+        _ -> booking.estimatedTotalFare.amount
   isSplitEnabled <- Payment.getIsSplitEnabled booking.merchantId merchantOperatingCityId Nothing DOrder.RideBooking
   isPercentageSplitEnabled <- Payment.getIsPercentageSplit booking.merchantId merchantOperatingCityId Nothing DOrder.RideBooking
   splitSettlementDetails <- Payment.mkSplitSettlementDetails isSplitEnabled amount [] isPercentageSplitEnabled False
@@ -254,6 +283,11 @@ createRideBookingPaymentOrder booking = do
     fork "RideBooking:PaytmEDC:StatusPoll" $
       pollPaytmEdcPaymentStatus booking.merchantId booking.merchantOperatingCityId booking.riderId (Id paymentOrderId)
   pure mbOrderResp
+
+-- | Sum fare breakup line items matching an exact description (fallback path when the breakup
+--   isn't in the canonical V2 tax-slot shape parseProjectFareParamsBreakup expects).
+sumByDescription :: Text -> [DFareBreakup.FareBreakup] -> HighPrecMoney
+sumByDescription description_ = sum . map (.amount.amount) . filter ((== description_) . (.description))
 
 -- | Background polling for Paytm EDC payment status.
 -- Reuses orderStatusHandler (via syncOrderStatus): one status fetch + fulfillment handling per attempt.

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Booking/API.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Types/Booking/API.hs
@@ -64,6 +64,7 @@ import qualified Lib.Payment.Domain.Types.Refunds as DRefunds
 import qualified Lib.Payment.Storage.Beam.BeamFlow as PaymentBeamFlow
 import qualified Lib.Payment.Storage.HistoryQueries.Refunds as HQRefunds
 import qualified Lib.Payment.Storage.Queries.PaymentOrder as QPaymentOrder
+import qualified Lib.Types.SpecialLocation as SL
 import Lib.Yudhishthira.Storage.Beam.BeamFlow (BeamFlow)
 import qualified Safety.Domain.Types.Sos as SafetyDSos
 import qualified Safety.Storage.CachedQueries.Sos as SafetyCQSos
@@ -162,7 +163,8 @@ data BookingAPIEntity = BookingAPIEntity
     driverPreference :: Maybe [Text],
     specialLocationSupportNumber :: Maybe Text,
     commissionCharge :: Maybe HighPrecMoney,
-    refunds :: [RideRefundInfo]
+    refunds :: [RideRefundInfo],
+    fareSettlementType :: Maybe SL.FareSettlementType
   }
   deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
 
@@ -415,7 +417,8 @@ makeBookingAPIEntity requesterId booking activeRide allRides estimatedFareBreaku
         driverPreference = booking.driverPreference,
         specialLocationSupportNumber = booking.specialLocationSupportNumber,
         commissionCharge = booking.commission,
-        refunds = refunds
+        refunds = refunds,
+        fareSettlementType = booking.fareSettlementType
       }
   where
     getRideDuration :: Maybe DRide.Ride -> Maybe Seconds

--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0849-add-fare-settlement-type-fare-parameters.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0849-add-fare-settlement-type-fare-parameters.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_driver_offer_bpp.fare_parameters ADD COLUMN fare_settlement_type text;

--- a/Backend/lib/special-zone/src/Lib/Types/SpecialLocation.hs
+++ b/Backend/lib/special-zone/src/Lib/Types/SpecialLocation.hs
@@ -56,9 +56,18 @@ defaultPaymentModes = [CASH]
 data FareSettlementType
   = CommissionOnly
   | FullPayment
+  | ParkingOnly
+  | CommissionAndParking
   deriving (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON, ToSchema)
+  deriving (PrettyShow) via Showable FareSettlementType
 
 $(mkBeamInstancesForEnum ''FareSettlementType)
+
+edcCollectsParking :: Maybe FareSettlementType -> Bool
+edcCollectsParking = (`elem` [Just ParkingOnly, Just CommissionAndParking])
+
+commissionCollectedAtBooth :: Maybe FareSettlementType -> Bool
+commissionCollectedAtBooth = (`elem` [Just CommissionOnly, Just CommissionAndParking])
 
 parsePaymentModes :: Maybe Text -> Either Text (Maybe [PaymentMode])
 parsePaymentModes mbRaw =


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Extends the existing booth EDC settlement feature (`FareSettlementType`) with two new options so a booth can also collect **parking charges** via card machine, in addition to the existing commission-only option:
- `ParkingOnly` — EDC collects only the parking charge; driver collects the rest of the fare in cash.
- `CommissionAndParking` — EDC collects commission + parking together; driver collects the residual in cash.

Key changes:
- Resolve `fareSettlementType` once inside `getFullFarePolicy` (BPP) and carry it through `FullFarePolicyD`/`FareParameters` (new column + migration on `fare_parameters`).
- Exclude EDC-collected parking from `fareSum`'s total everywhere it's computed (driver earnings, final fare), while keeping the raw `parkingCharge`/`parkingChargeTax` fields populated so the rider-facing fare breakup still itemizes parking separately.
- Freeze the settlement type to the booking's original value at end-ride recalculation and destination-edit — the EDC payment already happened at `on_init` and can't be re-derived from a switched fare policy.
- Skip the airport-entry-fee wallet clawback (`AirportEntryFee.hs`) and the driver cash-wallet eligibility check (`SearchTry.hs`'s `buildTripQuoteDetail`) for parking already collected via EDC, to avoid charging the driver twice for the same amount.
- Compute the BAP-side EDC charge amount (`Payment.hs`, `createRideBookingPaymentOrder`) as commission and/or parking based on settlement type, reading the parking amount from the confirmed booking's fare breakup (`BOOKING` entity type).
- Driver-app-facing fare display (`Common.hs`) no longer shows parking as part of the driver's fare/earnings when EDC-collected, and the cash-to-collect / settled-online split is now settlement-type-aware.

Backend-only change; driver app and control-center updates are tracked separately.

### Additional Changes
- [x] This PR modifies the database schema (database migration added)
  - `Backend/dev/ddl-migrations/dynamic-offer-driver-app/0849-add-fare-settlement-type-fare-parameters.sql`
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context
Booth operators need to collect parking charges via the same EDC card machine used for commission, rather than relying on the driver to collect it in cash. Without this, EDC-collected parking would still count toward the driver's fare/earnings and could be collected from the driver a second time via the separate airport-entry-fee wallet debit.

## How did you test it?
Manual code review only in this session — no build/test run yet (this environment doesn't have the Nix/cabal toolchain available). Please run `cabal build all` and the relevant integration tests before merge.

## Screenshot of test results
N/A

## Checklist
- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FUXeXLsTULY8yG8uTDvwbX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUXeXLsTULY8yG8uTDvwbX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for parking-only and commission-and-parking fare settlements.
  * Fare quotes, estimates, recalculations, and payment orders now apply settlement types consistently.
  * Fare breakdowns retain applicable parking charges while driver-facing totals reflect the correct collection method.

* **Bug Fixes**
  * Prevented duplicate parking charges in driver fares, payment orders, and airport-entry fee calculations.
  * Preserved settlement types during baggage, destination, and end-ride recalculations.
  * Corrected payout, earnings, wallet, and commission calculations when charges are collected at the booth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->