### PR TITLE
fix:pass upload to s3 with base64 as fallback

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -816,7 +816,6 @@ passOrderStatusHandler paymentOrderId _merchantId status = do
             when (purchasedPass.status `notElem` activeLikeStatuses) $ do
               QPurchasedPass.updatePurchaseData purchasedPass.id purchasedPassPayment.startDate purchasedPassPayment.endDate passStatus purchasedPassPayment.benefitDescription purchasedPassPayment.benefitType purchasedPassPayment.benefitValue purchasedPassPayment.amount
             when (passStatus `elem` activeLikeStatuses) $ do
-              QPurchasedPass.updateProfilePictureById purchasedPassPayment.profilePicture purchasedPass.id
               -- Don't touch passPhotoMediaId here: the async upload writes it to the payment row,
               -- and the pass-list reconcile (updatePurchasedPass) is the single owner that projects
               -- it onto the pass at each transition — so the webhook never races the upload for it.
@@ -923,6 +922,7 @@ updatePurchasedPass purchasedPass today now = do
           hasChanged =
             purchasedPass.status /= newStatus
               || firstPayment.status /= newStatus
+              || firstPayment.passPhotoMediaId /= purchasedPass.passPhotoMediaId
        in return (newPass, Just newPassPayment, hasChanged)
     Nothing ->
       let newPass =
@@ -1564,17 +1564,24 @@ postMultimodalPassUploadProfilePicture (mbCallerPersonId, merchantId) purchasedP
     throwError (InvalidRequest "Pass has no purchase in progress and is not awaiting a photo")
 
   merchant <- CQM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
-  uploadRes <- IssueAction.mediaUploadToS3 merchant.mediaFileSizeUpperLimit merchant.mediaFileUrlPattern req "pass-photo" personId.getId
-  let mediaId = uploadRes.fileId
+  let attachableStatuses = [DPurchasedPass.Pending, DPurchasedPass.PhotoPending, DPurchasedPass.PreBooked]
 
-  -- Attach-only: write the media id to the attachable payment row(s), never to the pass row. The
-  -- pass-list reconcile (updatePurchasedPass) is the single owner that projects the payment row's
-  -- photo onto the pass when its term activates — so an unpaid renewal or a stale Pending row
-  -- can't overwrite the photo on a currently-live pass, and a photo changed on a paid future
-  -- (PreBooked) term takes effect only when that term starts.
-  QPurchasedPassPayment.updatePassPhotoMediaIdByPurchasedPassIdAndStatus (Just mediaId) purchasedPass.id [DPurchasedPass.Pending, DPurchasedPass.PhotoPending, DPurchasedPass.PreBooked]
+  (mbUploadRes, mbFallbackBase64) <- IssueAction.mediaUploadToS3WithFallback merchant.mediaFileSizeUpperLimit merchant.mediaFileUrlPattern req "pass-photo" personId.getId
 
-  return uploadRes
+  -- Attach-only: write to the attachable payment row(s), never to the pass row. The pass-list
+  -- reconcile (updatePurchasedPass) is the single owner that projects the payment row's photo onto
+  -- the pass when its term activates — so an unpaid renewal or a stale Pending row can't overwrite
+  -- the photo on a currently-live pass, and a photo changed on a paid future (PreBooked) term takes
+  -- effect only when that term starts. If the S3 put failed, fall back to the inline base64 copy
+  -- instead of attaching a media id that can never be fetched.
+  case (mbUploadRes, mbFallbackBase64) of
+    (Just uploadRes, _) -> do
+      QPurchasedPassPayment.updatePassPhotoMediaIdByPurchasedPassIdAndStatus (Just uploadRes.fileId) purchasedPass.id attachableStatuses
+      return uploadRes
+    (Nothing, Just base64Photo) -> do
+      QPurchasedPassPayment.updateProfilePictureByPurchasedPassIdAndStatus (Just base64Photo) purchasedPass.id attachableStatuses
+      throwError (InvalidRequest "Pass photo S3 upload failed; stored as inline base64 fallback")
+    (Nothing, Nothing) -> throwError (InvalidRequest "Pass photo upload failed")
 
 -- | Fetch a pass photo's raw content from S3 by its media id, for rendering.
 -- Only the owner (whose id is embedded in the S3 path) may fetch it.

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
@@ -456,6 +456,46 @@ mediaUploadToS3 mediaFileSizeUpperLimit mediaFileUrlPattern Common.IssueMediaUpl
         QMF.updateStatusById D.FAILED uploadRes.fileId
   return uploadRes
 
+-- | Same as 'mediaUploadToS3', but the S3 put runs synchronously (not in a
+-- background fork), so a failure can be reported back to the caller instead of
+-- only being recorded on the media-file status. Returns the base64-encoded
+-- file alongside the upload result whenever the S3 put failed — 'Nothing' on
+-- success — so the caller can persist that as an inline fallback (e.g. in its
+-- own row) in place of the (now-unreachable) S3 media id.
+mediaUploadToS3WithFallback ::
+  ( BeamFlow m r,
+    MonadTime m,
+    MonadReader r m,
+    HasField "s3Env" r (S3.S3Env m)
+  ) =>
+  Int ->
+  Text ->
+  Common.IssueMediaUploadReq ->
+  Text ->
+  Text ->
+  m (Maybe Common.IssueMediaUploadRes, Maybe Text)
+mediaUploadToS3WithFallback mediaFileSizeUpperLimit mediaFileUrlPattern Common.IssueMediaUploadReq {..} domain identifier = do
+  contentType <- validateContentType fileType reqContentType
+  fileSize <- L.runIO $ withFile file ReadMode hFileSize
+  when (fileSize > fromIntegral mediaFileSizeUpperLimit) $
+    throwError $ FileSizeExceededError (show fileSize)
+  mediaFile <- L.runIO $ base64Encode <$> BS.readFile file
+  filePath <- S3.createFilePath (domain <> "/") identifier fileType contentType
+  let fileUrl =
+        mediaFileUrlPattern
+          & T.replace "<DOMAIN>" domain
+          & T.replace "<FILE_PATH>" filePath
+  uploadRes <- createMediaEntry fileUrl fileType filePath
+  ( do
+      S3.put (T.unpack filePath) mediaFile
+      QMF.updateStatusById D.COMPLETED uploadRes.fileId
+      return (Just uploadRes, Nothing)
+    )
+    `catch` \(e :: SomeException) -> do
+      logError $ "S3 upload failed for issue media file " <> uploadRes.fileId.getId <> ": " <> show e
+      QMF.updateStatusById D.FAILED uploadRes.fileId
+      return (Nothing, Just mediaFile)
+
 issueMediaUpload ::
   ( BeamFlow m r,
     MonadTime m,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pass payment processing so profile photos are updated reliably during reconciliation.
  * Profile-picture uploads now validate file type and size before processing.
  * Failed storage uploads now preserve the image as a fallback and clearly report the upload error.
  * Successful uploads attach photos only to eligible payment records, preventing incorrect pass-photo updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->