### PR TITLE
test: SpecialZoneEdcCommissionFlow integration scaffold + Paytm EDC mock

### DIFF
--- a/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/Local/Local_BT_Delhi_EDC.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/Local/Local_BT_Delhi_EDC.postman_environment.json
@@ -1,0 +1,42 @@
+{
+  "name": "Local - BHARAT_TAXI Delhi Special-Zone Paytm EDC",
+  "values": [
+    { "key": "envType", "value": "Local", "enabled": true },
+    { "key": "bap_dashboard_url", "value": "http://localhost:${RIDER_DASHBOARD_PORT:8017}", "enabled": true },
+    { "key": "bap_app_url", "value": "http://localhost:${RIDER_APP_PORT:8013}", "enabled": true },
+    { "key": "mockServerUrl", "value": "http://localhost:8080", "enabled": true },
+    { "key": "bap_merchant_id", "value": "c91a2f44-3a7e-4e86-8c1e-2c4f3b0b4c98", "enabled": true },
+    { "key": "merchant_operating_city_id", "value": "1e84858a-4deb-45d6-a97b-7c7504358548", "enabled": true },
+    { "key": "bap_short_id", "value": "BHARAT_TAXI", "enabled": true },
+    { "key": "city", "value": "std:011", "enabled": true },
+    { "key": "login_otp", "value": "7891", "enabled": true },
+    { "key": "switch_otp", "value": "526925", "enabled": true },
+    { "key": "customerId", "value": "c8df9029-ad09-90c8-44e0-da04c7fd38ea", "enabled": true },
+    { "key": "test_mobile_number", "value": "7325012187", "enabled": true },
+    { "key": "firstName", "value": "Test", "enabled": true },
+    { "key": "middleName", "value": "", "enabled": true },
+    { "key": "lastName", "value": "Rider", "enabled": true },
+
+    { "key": "edc_paytm_mid", "value": "kJlHHT78613139787976", "enabled": true },
+    { "key": "edc_channel_id", "value": "EDC", "enabled": true },
+    { "key": "edc_client_id", "value": "MAPLEUMTcGhMoB70yZ03", "enabled": true },
+    { "key": "edc_merchant_key", "value": "someKey", "enabled": true },
+
+    { "key": "bap_dashboard_token", "value": "", "enabled": true },
+    { "key": "riderId", "value": "", "enabled": true },
+    { "key": "authId", "value": "", "enabled": true },
+    { "key": "searchId", "value": "", "enabled": true },
+    { "key": "quoteId", "value": "", "enabled": true },
+    { "key": "bookingId", "value": "", "enabled": true },
+    { "key": "orderId", "value": "", "enabled": true },
+    { "key": "orderShortId", "value": "", "enabled": true },
+    { "key": "orderAmount", "value": "", "enabled": true },
+    { "key": "commissionCharge", "value": "", "enabled": true },
+
+    { "key": "load_test_driver_numbers", "value": "", "enabled": true },
+    { "key": "load_test_rider_numbers", "value": "", "enabled": true },
+    { "key": "load_test_reg_nos", "value": "", "enabled": true },
+    { "key": "load_test_gps_step", "value": "0.0", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/Local/Local_BT_Delhi_EDC.postman_environment.json
+++ b/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/Local/Local_BT_Delhi_EDC.postman_environment.json
@@ -22,12 +22,16 @@
     { "key": "edc_client_id", "value": "MAPLEUMTcGhMoB70yZ03", "enabled": true },
     { "key": "edc_merchant_key", "value": "someKey", "enabled": true },
 
+    { "key": "edc_commission_amount", "value": "50", "enabled": true },
+
     { "key": "bap_dashboard_token", "value": "", "enabled": true },
     { "key": "riderId", "value": "", "enabled": true },
     { "key": "authId", "value": "", "enabled": true },
     { "key": "searchId", "value": "", "enabled": true },
     { "key": "quoteId", "value": "", "enabled": true },
     { "key": "bookingId", "value": "", "enabled": true },
+    { "key": "specialLocationId", "value": "", "enabled": true },
+    { "key": "farePolicyIdsJson", "value": "", "enabled": true },
     { "key": "orderId", "value": "", "enabled": true },
     { "key": "orderShortId", "value": "", "enabled": true },
     { "key": "orderAmount", "value": "", "enabled": true },

--- a/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/README.md
+++ b/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/README.md
@@ -17,18 +17,37 @@ and the EDC order collected **only the commission** (`fareSettlementType=Commiss
    row in `merchant_service_config` whose `config_json.baseUrl` points at the mock
    (`{{mockServerUrl}}/paytm`). Without it `createRideBookingPaymentOrder` throws
    `MerchantServiceConfigNotFound`.
-3. `Seed: special zone fareSettlementType=CommissionOnly` — **TODO** (see below).
-4. `Ride Search` → `Get Quotes` → `Rider Registration` → `Update Rider Profile` — same as AirportTaxiFlow.
-5. `Confirm Booking (Paytm EDC)` — confirm with `paymentInstrument=BoothOnline&paymentMethodId=PAYTM_EDC`.
+3. `Read Special Location Id (IGI Airport)` — resolves the exact `special_location.id`
+   (`atlas_driver_offer_bpp`, `location_name LIKE '%IGI%'`) so the following steps target
+   it precisely instead of guessing with a bare `LIKE`.
+4. `Seed: special_location fareSettlementType=CommissionOnly` — sets the zone to
+   `CommissionOnly` by id. This is what makes the EDC collect only the commission
+   (`Domain/Action/UI/Payment.hs:188`).
+5. `Read Fare Policy Ids for zone` — selects `fare_product` rows whose
+   `area LIKE 'Pickup_<specialLocationId>%'` and captures their `fare_policy_id`s.
+   **This assertion is the "fare policy is configured for this location" check** — it
+   fails loudly (non-empty required) if the zone has no fare_product/fare_policy mapping,
+   which is also exactly why `Get Quotes` would otherwise time out with no useful signal.
+6. `Seed: Fare Policy commission (fixed amount, not %)` — sets
+   `commission_charge_config = {"value":"{{edc_commission_amount}}","appliesOn":["RideFare"]}`
+   on every fare_policy found in step 5. **No `%` suffix** → `parseCodeValue` parses it as
+   `ParsedFixed`, and `applyParsedValue` returns that value untouched regardless of fare
+   (`FareCalculator.hs`: `ParsedFixed amount -> amount`) — i.e. the commission is a flat
+   `{{edc_commission_amount}}` (default ₹50), not a percentage of the ride fare.
+   ⚠️ Overwrites `commission_charge_config` wholesale for every vehicle-variant fare policy
+   the zone routes to — fine for a dedicated test env, not for a shared one.
+7. `Ride Search` → `Get Quotes` → `Rider Registration` → `Update Rider Profile` — same as AirportTaxiFlow.
+8. `Confirm Booking (Paytm EDC)` — confirm with `paymentInstrument=BoothOnline&paymentMethodId=PAYTM_EDC`.
    This pair sets `requiresPaymentBeforeConfirm`, so the BPP confirm is held until payment.
-6. `Get Booking Details` — captures `commissionCharge`.
-7. `Read Payment Order` — SQL-selects the `payment_order` (by `domain_entity_id = bookingId`),
-   captures `orderId` / `orderShortId`, and asserts **EDC order amount == commission**.
-8. `Simulate Paytm EDC Callback (success)` — `POST {{bap_app_url}}/s2s/payment/paytm/edc/callback`
-   with `merchantTransactionId=orderShortId`, `resultStatus="S"`. (No checksum/auth is validated
-   on this endpoint — see `paytmEdcCallbackHandler`.)
-9. `Verify Payment Order CHARGED` — asserts the order reached `CHARGED` (→ confirm forwarded to BPP).
-10. `Cleanup` — clears mock overrides.
+9. `Get Booking Details` — captures `commissionCharge`.
+10. `Read Payment Order` — SQL-selects the `payment_order` (by `domain_entity_id = bookingId`),
+    captures `orderId` / `orderShortId`, and asserts **EDC order amount == commissionCharge**
+    AND **== the constant `edc_commission_amount`** seeded in step 6 (cross-check).
+11. `Simulate Paytm EDC Callback (success)` — `POST {{bap_app_url}}/s2s/payment/paytm/edc/callback`
+    with `merchantTransactionId=orderShortId`, `resultStatus="S"`. (No checksum/auth is validated
+    on this endpoint — see `paytmEdcCallbackHandler`.)
+12. `Verify Payment Order CHARGED` — asserts the order reached `CHARGED` (→ confirm forwarded to BPP).
+13. `Cleanup` — clears mock overrides.
 
 ## Prerequisites (must be true in the target env)
 
@@ -36,25 +55,31 @@ and the EDC order collected **only the commission** (`fareSettlementType=Commiss
   (serves `/paytm/ecr/generateChecksum`, `/ecr/payment/request`, `/ecr/payment/status`).
 - **Merchant `online_payment = false`** for BHARAT_TAXI (or `validatePaymentInstrument`
   rejects `BoothOnline`).
-- **Special zone exists** for the IGI airport pickup with a **fare policy that produces a
-  non-zero commission** (the commission arrives on the booking via `on_init`). The collection
-  cannot create fare policy — that must already be seeded.
+- **A `special_location` row exists** for the IGI airport pickup (`location_name LIKE '%IGI%'`)
+  **with at least one `fare_product` mapped to it** — the collection verifies this (step 5) and
+  seeds `fareSettlementType` + a fixed commission on top of whatever fare policy is already
+  there (steps 3–6). It does **not** create a fare policy from scratch; if step 5's assertion
+  fails, the zone isn't wired for quoting at all in this env and needs fixing before the EDC
+  parts are worth debugging.
+- Confirmed against `dev/migrations-read-only`: `atlas_driver_offer_bpp.special_location.fare_settlement_type`,
+  `atlas_driver_offer_bpp.fare_policy.commission_charge_config`, and
+  `atlas_app.payment_order.{domain_entity_id,short_id,payment_fulfillment_status}` all exist as used here.
 
 ## TODOs to make it green
 
-- **Step 3 schema/zone id:** confirm the `special_location` table's schema and the WHERE
-  that selects the airport zone. `fareSettlementType` lives on the **BPP** special location and
-  is what makes the EDC collect only the commission (`Domain/Action/UI/Payment.hs:188`). The
-  `LIKE '%IGI%'` filter is a placeholder.
-- **`payment_order` column names:** verify `domain_entity_id`, `short_id`, `amount`, `status`,
-  `payment_fulfillment_status` match the live schema.
 - **Agent + EDC machine:** this scaffold does not pass `dashboardAgentId`, so an
   `edc_machine_mapping` is not required (`createRideBookingPaymentOrder` only demands one when
   `booking.dashboardAgentId` is set). To exercise the agent-terminal path, capture the login
   user's `personId`, seed an active `edc_machine_mapping`, and pass `dashboardAgentId` on confirm.
-- **Cache:** after seeding `merchant_service_config`, the cached copy may be stale — add a
-  `POST {{mockServerUrl}}/mock/redis/del` for the merchant-service-config key if the config
-  doesn't take effect.
+- **Cache:** after seeding `merchant_service_config` / `fare_policy`, the cached copy may be
+  stale — add a `POST {{mockServerUrl}}/mock/redis/del` (pattern match on the relevant cache
+  keys) before Ride Search if the seeded config doesn't take effect.
+- **Timing:** `createRideBookingPaymentOrder` runs off a fork inside `on_init`, so `Read Payment
+  Order` may race the row being written. Add a short retry/poll (same pattern as `Get Quotes`)
+  if it comes back empty.
+- **`payment_order` other column values:** the collection selects `amount`/`status` too but
+  doesn't hard-assert their raw shape beyond what's described above — sanity check they read as
+  expected on first run.
 
 ## Run
 

--- a/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/README.md
+++ b/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/README.md
@@ -1,0 +1,66 @@
+# SpecialZoneEdcCommissionFlow
+
+Integration collection for the **special-zone booth / Paytm EDC commission** flow
+(BHARAT_TAXI, Delhi airport, `std:011`). Drives a booth booking paid via Paytm EDC,
+simulates the Paytm EDC S2S success callback, and asserts the booking is confirmed
+and the EDC order collected **only the commission** (`fareSettlementType=CommissionOnly`).
+
+> **Status: SCAFFOLD — not yet run end-to-end.** It was authored from the codebase
+> (mirrors `AirportTaxiFlow`, which is the same booth sequence paid with Cash) but has
+> not been executed against a live stack. Expect to fix the items marked **TODO** below.
+> It is intentionally checked in unverified so it can be finished in a full dev env.
+
+## What it does (step order)
+
+1. `BAP - Login` / `Switch Merchant And City` — dashboard auth (sets `bap_dashboard_token`).
+2. `Seed: Paytm EDC service config (update / insert)` — ensures a `Payment_PaytmEDC`
+   row in `merchant_service_config` whose `config_json.baseUrl` points at the mock
+   (`{{mockServerUrl}}/paytm`). Without it `createRideBookingPaymentOrder` throws
+   `MerchantServiceConfigNotFound`.
+3. `Seed: special zone fareSettlementType=CommissionOnly` — **TODO** (see below).
+4. `Ride Search` → `Get Quotes` → `Rider Registration` → `Update Rider Profile` — same as AirportTaxiFlow.
+5. `Confirm Booking (Paytm EDC)` — confirm with `paymentInstrument=BoothOnline&paymentMethodId=PAYTM_EDC`.
+   This pair sets `requiresPaymentBeforeConfirm`, so the BPP confirm is held until payment.
+6. `Get Booking Details` — captures `commissionCharge`.
+7. `Read Payment Order` — SQL-selects the `payment_order` (by `domain_entity_id = bookingId`),
+   captures `orderId` / `orderShortId`, and asserts **EDC order amount == commission**.
+8. `Simulate Paytm EDC Callback (success)` — `POST {{bap_app_url}}/s2s/payment/paytm/edc/callback`
+   with `merchantTransactionId=orderShortId`, `resultStatus="S"`. (No checksum/auth is validated
+   on this endpoint — see `paytmEdcCallbackHandler`.)
+9. `Verify Payment Order CHARGED` — asserts the order reached `CHARGED` (→ confirm forwarded to BPP).
+10. `Cleanup` — clears mock overrides.
+
+## Prerequisites (must be true in the target env)
+
+- **Mock server running** on `{{mockServerUrl}}` with the extended `services/paytm.py`
+  (serves `/paytm/ecr/generateChecksum`, `/ecr/payment/request`, `/ecr/payment/status`).
+- **Merchant `online_payment = false`** for BHARAT_TAXI (or `validatePaymentInstrument`
+  rejects `BoothOnline`).
+- **Special zone exists** for the IGI airport pickup with a **fare policy that produces a
+  non-zero commission** (the commission arrives on the booking via `on_init`). The collection
+  cannot create fare policy — that must already be seeded.
+
+## TODOs to make it green
+
+- **Step 3 schema/zone id:** confirm the `special_location` table's schema and the WHERE
+  that selects the airport zone. `fareSettlementType` lives on the **BPP** special location and
+  is what makes the EDC collect only the commission (`Domain/Action/UI/Payment.hs:188`). The
+  `LIKE '%IGI%'` filter is a placeholder.
+- **`payment_order` column names:** verify `domain_entity_id`, `short_id`, `amount`, `status`,
+  `payment_fulfillment_status` match the live schema.
+- **Agent + EDC machine:** this scaffold does not pass `dashboardAgentId`, so an
+  `edc_machine_mapping` is not required (`createRideBookingPaymentOrder` only demands one when
+  `booking.dashboardAgentId` is set). To exercise the agent-terminal path, capture the login
+  user's `personId`, seed an active `edc_machine_mapping`, and pass `dashboardAgentId` on confirm.
+- **Cache:** after seeding `merchant_service_config`, the cached copy may be stale — add a
+  `POST {{mockServerUrl}}/mock/redis/del` for the merchant-service-config key if the config
+  doesn't take effect.
+
+## Run
+
+Via the test dashboard (Collections tab) or Newman:
+
+```bash
+newman run SpecialZoneEdcCommissionFlow.json \
+  -e Local/Local_BT_Delhi_EDC.postman_environment.json
+```

--- a/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/SpecialZoneEdcCommissionFlow.json
+++ b/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/SpecialZoneEdcCommissionFlow.json
@@ -1,0 +1,845 @@
+{
+ "info": {
+  "name": "SpecialZoneEdcCommissionFlow",
+  "description": "Special-zone (booth / Paytm EDC) commission flow. Drives a BHARAT_TAXI Delhi airport booth booking paid via Paytm EDC (paymentInstrument=BoothOnline, paymentMethodId=PAYTM_EDC), simulates the Paytm EDC S2S success callback, and asserts the booking is confirmed and the EDC order collected only the commission (fareSettlementType=CommissionOnly). SCAFFOLD - not yet run end-to-end; see README.md for prerequisites and the steps marked TODO.",
+  "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+ },
+ "item": [
+  {
+   "name": "BAP - Login",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+       "pm.environment.set('bap_dashboard_token', d.authToken);"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "body": {
+     "mode": "raw",
+     "raw": "{\n    \"email\": \"juspay_admin@dashboard.com\",\n    \"password\": \"juspay_admin\"\n}"
+    },
+    "url": {
+     "raw": "{{bap_dashboard_url}}/user/login",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "user",
+      "login"
+     ]
+    }
+   }
+  },
+  {
+   "name": "BAP - Switch Merchant And City",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+       "if (d.authToken) {",
+       "    pm.environment.set('bap_dashboard_token', d.authToken);",
+       "}"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     },
+     {
+      "key": "token",
+      "value": "{{bap_dashboard_token}}"
+     }
+    ],
+    "body": {
+     "mode": "raw",
+     "raw": "{\n    \"merchantId\": \"{{bap_short_id}}\",\n    \"city\": \"{{city}}\",\n    \"otp\": \"{{switch_otp}}\"\n}"
+    },
+    "url": {
+     "raw": "{{bap_dashboard_url}}/user/switchMerchantAndCity",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "user",
+      "switchMerchantAndCity"
+     ]
+    }
+   }
+  },
+  {
+   "name": "Seed: Paytm EDC service config (update if exists)",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('update ran (2xx)', function () { pm.expect(pm.response.code).to.be.below(300); });",
+       "console.log('rows updated:', d.rowcount);"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/sql/update",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "sql",
+      "update"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_app\",\n  \"table_name\": \"merchant_service_config\",\n  \"set\": {\n    \"config_json\": \"{\\\"paytmMid\\\":\\\"{{edc_paytm_mid}}\\\",\\\"channelId\\\":\\\"{{edc_channel_id}}\\\",\\\"clientId\\\":\\\"{{edc_client_id}}\\\",\\\"merchantKey\\\":\\\"{{edc_merchant_key}}\\\",\\\"baseUrl\\\":\\\"{{mockServerUrl}}/paytm\\\",\\\"callbackUrl\\\":\\\"{{bap_app_url}}/s2s/payment/paytm/edc/callback\\\"}\"\n  },\n  \"touch_updated_at\": true,\n  \"where_clause\": [\n    {\n      \"column_name\": \"merchant_id\",\n      \"val\": \"{{bap_merchant_id}}\",\n      \"op\": \"=\"\n    },\n    {\n      \"column_name\": \"service_name\",\n      \"val\": \"Payment_PaytmEDC\",\n      \"op\": \"=\"\n    }\n  ]\n}",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     }
+    },
+    "description": "Point the Payment_PaytmEDC config at the mock server. Harmless if 0 rows (insert step follows)."
+   }
+  },
+  {
+   "name": "Seed: Paytm EDC service config (insert if missing)",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "pm.test('seed ok (2xx)', function () { pm.expect(pm.response.code).to.be.below(300); });"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/sql/insert",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "sql",
+      "insert"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_app\",\n  \"table_name\": \"merchant_service_config\",\n  \"values\": {\n    \"merchant_id\": \"{{bap_merchant_id}}\",\n    \"merchant_operating_city_id\": \"{{merchant_operating_city_id}}\",\n    \"service_name\": \"Payment_PaytmEDC\",\n    \"config_json\": \"{\\\"paytmMid\\\":\\\"{{edc_paytm_mid}}\\\",\\\"channelId\\\":\\\"{{edc_channel_id}}\\\",\\\"clientId\\\":\\\"{{edc_client_id}}\\\",\\\"merchantKey\\\":\\\"{{edc_merchant_key}}\\\",\\\"baseUrl\\\":\\\"{{mockServerUrl}}/paytm\\\",\\\"callbackUrl\\\":\\\"{{bap_app_url}}/s2s/payment/paytm/edc/callback\\\"}\"\n  },\n  \"touch_timestamps\": true,\n  \"on_conflict_do_nothing\": true\n}",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     }
+    },
+    "description": "createRideBookingPaymentOrder needs a Payment_PaytmEDC row or it throws MerchantServiceConfigNotFound."
+   }
+  },
+  {
+   "name": "Seed: special zone fareSettlementType=CommissionOnly (TODO: confirm schema/zone id)",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('update ran (2xx)', function () { pm.expect(pm.response.code).to.be.below(300); });",
+       "console.log('rows updated:', d.rowcount);"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/sql/update",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "sql",
+      "update"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_driver_offer_bpp\",\n  \"table_name\": \"special_location\",\n  \"set\": {\n    \"fare_settlement_type\": \"CommissionOnly\"\n  },\n  \"touch_updated_at\": true,\n  \"where_clause\": [\n    {\n      \"column_name\": \"location_name\",\n      \"val\": \"%IGI%\",\n      \"op\": \"LIKE\"\n    }\n  ]\n}",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     }
+    },
+    "description": "TODO: verify schema + WHERE. fareSettlementType lives on the BPP special_location and drives the EDC amount (Payment.hs:188). The fare policy for the zone must also carry a non-zero commission so the BPP returns commission on on_init."
+   }
+  },
+  {
+   "name": "Ride Search",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+       "pm.test('searchId is returned', function () { pm.expect(d.searchId).to.be.a('string'); });",
+       "pm.environment.set('searchId', d.searchId);"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     },
+     {
+      "key": "token",
+      "value": "{{bap_dashboard_token}}"
+     }
+    ],
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"fareProductType\": \"ONE_WAY\",\n  \"contents\": {\n    \"origin\": {\n      \"address\": {\n        \"area\": \"T1: IGI Airport\",\n        \"areaCode\": \"\",\n        \"building\": \"\",\n        \"city\": \"\",\n        \"country\": \"India\",\n        \"state\": \"\",\n        \"street\": \"\",\n        \"ward\": \"\"\n      },\n      \"gps\": {\n        \"lat\": 28.551335292,\n        \"lon\": 77.11669564249999\n      }\n    },\n    \"destination\": {\n      \"address\": {\n        \"area\": \"ncdc\",\n        \"areaCode\": \"\",\n        \"building\": \"\",\n        \"city\": \"\",\n        \"country\": \"India\",\n        \"state\": \"\",\n        \"street\": \"\",\n        \"ward\": \"\"\n      },\n      \"gps\": {\n        \"lat\": 28.552335292000002,\n        \"lon\": 77.1176956425\n      }\n    },\n    \"numberOfLuggages\": 1,\n    \"isReallocationEnabled\": true\n  }\n}"
+    },
+    "url": {
+     "raw": "{{bap_dashboard_url}}/bap/{{bap_short_id}}/{{city}}/rideBooking/search/{{customerId}}/rideSearch",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "bap",
+      "{{bap_short_id}}",
+      "{{city}}",
+      "rideBooking",
+      "search",
+      "{{customerId}}",
+      "rideSearch"
+     ]
+    }
+   }
+  },
+  {
+   "name": "Get Quotes",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "var hasQuotes = d.quotes && d.quotes.length > 0;",
+       "",
+       "if (hasQuotes) {",
+       "    var quote = d.quotes[0];",
+       "    var quoteId = (quote.onDemandCab && quote.onDemandCab.id) || (quote.onRentalCab && quote.onRentalCab.id);",
+       "    pm.environment.set('quoteId', quoteId);",
+       "    pm.test('Quotes found', function () { pm.expect(quoteId).to.be.a('string'); });",
+       "} else {",
+       "    var attempt = 1;",
+       "    var maxAttempts = 6;",
+       "    var pollInterval = 2000;",
+       "    var bapUrl = pm.environment.get('bap_dashboard_url');",
+       "    var token = pm.environment.get('bap_dashboard_token');",
+       "    var searchId = pm.environment.get('searchId');",
+       "    var customerId = pm.environment.get('customerId');",
+       "    var merchantId = pm.environment.get('bap_short_id');",
+       "    var city = pm.environment.get('city');",
+       "    ",
+       "    function poll() {",
+       "        attempt++;",
+       "        console.log('Polling quotes attempt ' + attempt);",
+       "        pm.sendRequest({",
+       "            url: bapUrl + '/bap/' + merchantId + '/' + city + '/rideBooking/quote/' + searchId + '/' + customerId + '/result',",
+       "            method: 'GET',",
+       "            header: {",
+       "                'Accept': 'application/json, text/plain, */*',",
+       "                'token': token",
+       "            }",
+       "        }, function (err, res) {",
+       "            if (err) {",
+       "                console.log('Error polling quotes:', err);",
+       "            } else {",
+       "                var resData = res.json() || {};",
+       "                var quotes = resData.quotes || [];",
+       "                if (quotes.length > 0) {",
+       "                    var quote = quotes[0];",
+       "                    var quoteId = (quote.onDemandCab && quote.onDemandCab.id) || (quote.onRentalCab && quote.onRentalCab.id);",
+       "                    pm.environment.set('quoteId', quoteId);",
+       "                    console.log('Found quotes on attempt ' + attempt + ', quoteId: ' + quoteId);",
+       "                    pm.test('Quotes found after polling', function () { pm.expect(quoteId).to.be.a('string'); });",
+       "                    return;",
+       "                }",
+       "            }",
+       "            if (attempt >= maxAttempts) {",
+       "                pm.test('Failed to fetch quotes after ' + maxAttempts + ' attempts', function () {",
+       "                    throw new Error('Quotes empty after ' + maxAttempts + ' attempts');",
+       "                });",
+       "            } else {",
+       "                setTimeout(poll, pollInterval);",
+       "            }",
+       "        });",
+       "    }",
+       "    ",
+       "    setTimeout(poll, pollInterval);",
+       "}"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "GET",
+    "header": [
+     {
+      "key": "token",
+      "value": "{{bap_dashboard_token}}"
+     }
+    ],
+    "url": {
+     "raw": "{{bap_dashboard_url}}/bap/{{bap_short_id}}/{{city}}/rideBooking/quote/{{searchId}}/{{customerId}}/result",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "bap",
+      "{{bap_short_id}}",
+      "{{city}}",
+      "rideBooking",
+      "quote",
+      "{{searchId}}",
+      "{{customerId}}",
+      "result"
+     ]
+    }
+   }
+  },
+  {
+   "name": "Rider Registration Auth",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+       "pm.test('authId is present', function () { pm.expect(d.authId).to.be.a('string'); });",
+       "pm.environment.set('authId', d.authId);"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     },
+     {
+      "key": "token",
+      "value": "{{bap_dashboard_token}}"
+     }
+    ],
+    "body": {
+     "mode": "raw",
+     "raw": "{\n    \"mobileCountryCode\": \"+91\",\n    \"mobileNumber\": \"{{test_mobile_number}}\",\n    \"otpChannel\": \"SMS\"\n}"
+    },
+    "url": {
+     "raw": "{{bap_dashboard_url}}/bap/{{bap_short_id}}/{{city}}/rideBooking/registration/auth",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "bap",
+      "{{bap_short_id}}",
+      "{{city}}",
+      "rideBooking",
+      "registration",
+      "auth"
+     ]
+    }
+   }
+  },
+  {
+   "name": "Rider Registration Verify",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+       "pm.test('person is present', function () { pm.expect(d.person).to.be.an('object'); });",
+       "pm.test('person id is present', function () { pm.expect(d.person.id).to.be.a('string'); });",
+       "pm.environment.set('riderId', d.person.id);"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     },
+     {
+      "key": "token",
+      "value": "{{bap_dashboard_token}}"
+     }
+    ],
+    "body": {
+     "mode": "raw",
+     "raw": "{\n    \"deviceToken\": \"booth-device-token\",\n    \"otp\": \"{{login_otp}}\",\n    \"whatsappNotificationEnroll\": \"OPT_IN\"\n}"
+    },
+    "url": {
+     "raw": "{{bap_dashboard_url}}/bap/{{bap_short_id}}/{{city}}/rideBooking/registration/{{authId}}/verify",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "bap",
+      "{{bap_short_id}}",
+      "{{city}}",
+      "rideBooking",
+      "registration",
+      "{{authId}}",
+      "verify"
+     ]
+    }
+   }
+  },
+  {
+   "name": "Update Rider Profile",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "pm.test('Status 200', function () { pm.response.to.have.status(200); });"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     },
+     {
+      "key": "token",
+      "value": "{{bap_dashboard_token}}"
+     }
+    ],
+    "body": {
+     "mode": "raw",
+     "raw": "{\n    \"firstName\": \"{{firstName}}\",\n    \"middleName\": \"{{middleName}}\",\n    \"lastName\": \"{{lastName}}\"\n}"
+    },
+    "url": {
+     "raw": "{{bap_dashboard_url}}/bap/{{bap_short_id}}/{{city}}/rideBooking/profile/update/{{riderId}}",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "bap",
+      "{{bap_short_id}}",
+      "{{city}}",
+      "rideBooking",
+      "profile",
+      "update",
+      "{{riderId}}"
+     ]
+    }
+   }
+  },
+  {
+   "name": "Confirm Booking (Paytm EDC)",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+       "pm.test('bookingId present', function () { pm.expect(d.bookingId).to.be.a('string'); });",
+       "pm.environment.set('bookingId', d.bookingId);"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "token",
+      "value": "{{bap_dashboard_token}}"
+     }
+    ],
+    "url": {
+     "raw": "{{bap_dashboard_url}}/bap/{{bap_short_id}}/{{city}}/rideBooking/confirm/rideSearch/{{riderId}}/quotes/{{quoteId}}/confirm?paymentInstrument=BoothOnline&paymentMethodId=PAYTM_EDC",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "bap",
+      "{{bap_short_id}}",
+      "{{city}}",
+      "rideBooking",
+      "confirm",
+      "rideSearch",
+      "{{riderId}}",
+      "quotes",
+      "{{quoteId}}",
+      "confirm"
+     ],
+     "query": [
+      {
+       "key": "paymentInstrument",
+       "value": "BoothOnline"
+      },
+      {
+       "key": "paymentMethodId",
+       "value": "PAYTM_EDC"
+      }
+     ]
+    }
+   }
+  },
+  {
+   "name": "Get Booking Details",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "var hasOtp = d.bookingDetails && d.bookingDetails.contents && d.bookingDetails.contents.otpCode;",
+       "",
+       "if (hasOtp) {",
+       "    var otpCode = d.bookingDetails.contents.otpCode;",
+       "    pm.environment.set('bookingOtpCode', otpCode);",
+       "    console.log('Booking OTP Code:', otpCode);",
+       "    pm.test('Booking OTP Code found', function () { pm.expect(otpCode).to.be.a('string'); });",
+       "} else {",
+       "    var attempt = 1;",
+       "    var maxAttempts = 6;",
+       "    var pollInterval = 2000;",
+       "    var bapUrl = pm.environment.get('bap_dashboard_url');",
+       "    var token = pm.environment.get('bap_dashboard_token');",
+       "    var bookingId = pm.environment.get('bookingId');",
+       "    var riderId = pm.environment.get('riderId');",
+       "    var merchantId = pm.environment.get('bap_short_id');",
+       "    var city = pm.environment.get('city');",
+       "    ",
+       "    function poll() {",
+       "        attempt++;",
+       "        console.log('Polling booking details attempt ' + attempt);",
+       "        pm.sendRequest({",
+       "            url: bapUrl + '/bap/' + merchantId + '/' + city + '/rideBooking/booking/ridebooking/' + bookingId + '/' + riderId,",
+       "            method: 'POST',",
+       "            header: {",
+       "                'Accept': 'application/json, text/plain, */*',",
+       "                'token': token,",
+       "                'Content-Length': '0'",
+       "            }",
+       "        }, function (err, res) {",
+       "            if (err) {",
+       "                console.log('Error polling booking details:', err);",
+       "            } else {",
+       "                var resData = res.json() || {};",
+       "                var otp = resData.bookingDetails && resData.bookingDetails.contents && resData.bookingDetails.contents.otpCode;",
+       "                if (otp) {",
+       "                    pm.environment.set('bookingOtpCode', otp);",
+       "                    console.log('Found OTP Code on attempt ' + attempt + ': ' + otp);",
+       "                    pm.test('Booking OTP Code found after polling', function () { pm.expect(otp).to.be.a('string'); });",
+       "                    return;",
+       "                }",
+       "            }",
+       "            if (attempt >= maxAttempts) {",
+       "                pm.test('Failed to fetch OTP Code after ' + maxAttempts + ' attempts', function () {",
+       "                    throw new Error('OTP Code empty after ' + maxAttempts + ' attempts');",
+       "                });",
+       "            } else {",
+       "                setTimeout(poll, pollInterval);",
+       "            }",
+       "        });",
+       "    }",
+       "    ",
+       "    setTimeout(poll, pollInterval);",
+       "}",
+       "",
+       "try { var b = pm.response.json();",
+       "  if (b.commissionCharge != null) { pm.environment.set('commissionCharge', b.commissionCharge); console.log('commissionCharge', b.commissionCharge); }",
+       "} catch (e) {}"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "token",
+      "value": "{{bap_dashboard_token}}"
+     }
+    ],
+    "url": {
+     "raw": "{{bap_dashboard_url}}/bap/{{bap_short_id}}/{{city}}/rideBooking/booking/ridebooking/{{bookingId}}/{{riderId}}",
+     "host": [
+      "{{bap_dashboard_url}}"
+     ],
+     "path": [
+      "bap",
+      "{{bap_short_id}}",
+      "{{city}}",
+      "rideBooking",
+      "booking",
+      "ridebooking",
+      "{{bookingId}}",
+      "{{riderId}}"
+     ]
+    }
+   }
+  },
+  {
+   "name": "Read Payment Order (capture orderId + shortId)",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('payment order exists', function () { pm.expect(d.count).to.be.above(0); });",
+       "if (d.rows && d.rows[0]) {",
+       "  pm.environment.set('orderId', d.rows[0].id);",
+       "  pm.environment.set('orderShortId', d.rows[0].short_id);",
+       "  pm.environment.set('orderAmount', d.rows[0].amount);",
+       "  console.log('order', d.rows[0].id, d.rows[0].short_id, 'amount', d.rows[0].amount, 'status', d.rows[0].status);",
+       "  // CommissionOnly: EDC amount should equal the commission",
+       "  var cc = pm.environment.get('commissionCharge');",
+       "  if (cc != null) { pm.test('EDC order amount == commission', function () { pm.expect(Number(d.rows[0].amount)).to.be.closeTo(Number(cc), 0.01); }); }",
+       "}"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/sql/select",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "sql",
+      "select"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_app\",\n  \"table_name\": \"payment_order\",\n  \"select\": [\n    \"id\",\n    \"short_id\",\n    \"amount\",\n    \"status\"\n  ],\n  \"where_clause\": [\n    {\n      \"column_name\": \"domain_entity_id\",\n      \"val\": \"{{bookingId}}\",\n      \"op\": \"=\"\n    }\n  ],\n  \"limit\": 1\n}",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     }
+    },
+    "description": "createRideBookingPaymentOrder stores the order with domain_entity_id = bookingId."
+   }
+  },
+  {
+   "name": "Simulate Paytm EDC Callback (success)",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "pm.test('callback acked (2xx)', function () { pm.expect(pm.response.code).to.be.below(300); });"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{bap_app_url}}/s2s/payment/paytm/edc/callback",
+     "host": [
+      "{{bap_app_url}}"
+     ],
+     "path": [
+      "s2s",
+      "payment",
+      "paytm",
+      "edc",
+      "callback"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     },
+     "raw": "{\n  \"head\": {\n    \"requestTimestamp\": \"2026-01-01 00:00:00\",\n    \"checksum\": \"MOCK_EDC_CHECKSUM\"\n  },\n  \"body\": {\n    \"resultInfo\": {\n      \"resultStatus\": \"S\",\n      \"resultCodeId\": \"0000\",\n      \"resultCode\": \"0000\",\n      \"resultMsg\": \"Success\"\n    },\n    \"merchantRefereneceNo\": \"{{orderId}}\",\n    \"merchantTransactionId\": \"{{orderShortId}}\"\n  }\n}"
+    },
+    "description": "No checksum/auth validation on this endpoint (see paytmEdcCallbackHandler). resultStatus=S -> CHARGED -> confirmRideBookingFromPaymentOrder sends confirm to BPP."
+   }
+  },
+  {
+   "name": "Verify Payment Order CHARGED",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('order row found', function () { pm.expect(d.count).to.be.above(0); });",
+       "if (d.rows && d.rows[0]) {",
+       "  pm.test('order CHARGED', function () { pm.expect(String(d.rows[0].status)).to.eql('CHARGED'); });",
+       "  console.log('fulfillment', d.rows[0].payment_fulfillment_status);",
+       "}"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/sql/select",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "sql",
+      "select"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_app\",\n  \"table_name\": \"payment_order\",\n  \"select\": [\n    \"status\",\n    \"payment_fulfillment_status\"\n  ],\n  \"where_clause\": [\n    {\n      \"column_name\": \"id\",\n      \"val\": \"{{orderId}}\",\n      \"op\": \"=\"\n    }\n  ],\n  \"limit\": 1\n}",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     }
+    },
+    "description": "After the success callback the order status must be CHARGED and confirm forwarded to the BPP."
+   }
+  },
+  {
+   "name": "Cleanup: clear mock overrides",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "pm.test('cleanup ok', function () { pm.expect(pm.response.code).to.be.below(300); });"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "DELETE",
+    "header": [],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/override",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "override"
+     ]
+    }
+   }
+  }
+ ],
+ "event": []
+}

--- a/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/SpecialZoneEdcCommissionFlow.json
+++ b/Backend/dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/SpecialZoneEdcCommissionFlow.json
@@ -180,7 +180,7 @@
    }
   },
   {
-   "name": "Seed: special zone fareSettlementType=CommissionOnly (TODO: confirm schema/zone id)",
+   "name": "Read Special Location Id (IGI Airport)",
    "event": [
     {
      "listen": "test",
@@ -188,8 +188,56 @@
       "type": "text/javascript",
       "exec": [
        "var d = pm.response.json();",
-       "pm.test('update ran (2xx)', function () { pm.expect(pm.response.code).to.be.below(300); });",
-       "console.log('rows updated:', d.rowcount);"
+       "pm.test('IGI special_location found', function () { pm.expect(d.count).to.be.above(0); });",
+       "if (d.rows && d.rows[0]) {",
+       "  pm.environment.set('specialLocationId', d.rows[0].id);",
+       "  console.log('specialLocationId', d.rows[0].id, 'existing fare_settlement_type', d.rows[0].fare_settlement_type);",
+       "}"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/sql/select",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "sql",
+      "select"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_driver_offer_bpp\",\n  \"table_name\": \"special_location\",\n  \"select\": [\n    \"id\",\n    \"location_name\",\n    \"fare_settlement_type\"\n  ],\n  \"where_clause\": [\n    {\n      \"column_name\": \"location_name\",\n      \"val\": \"%IGI%\",\n      \"op\": \"LIKE\"\n    }\n  ],\n  \"limit\": 50\n}",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     }
+    },
+    "description": "Resolve the exact special_location row so the following updates target it by id, not a LIKE guess."
+   }
+  },
+  {
+   "name": "Seed: special_location fareSettlementType=CommissionOnly",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('special_location updated', function () { pm.expect(d.rowcount).to.eql(1); });"
       ]
      }
     }
@@ -215,14 +263,114 @@
     },
     "body": {
      "mode": "raw",
-     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_driver_offer_bpp\",\n  \"table_name\": \"special_location\",\n  \"set\": {\n    \"fare_settlement_type\": \"CommissionOnly\"\n  },\n  \"touch_updated_at\": true,\n  \"where_clause\": [\n    {\n      \"column_name\": \"location_name\",\n      \"val\": \"%IGI%\",\n      \"op\": \"LIKE\"\n    }\n  ]\n}",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_driver_offer_bpp\",\n  \"table_name\": \"special_location\",\n  \"set\": {\n    \"fare_settlement_type\": \"CommissionOnly\"\n  },\n  \"touch_updated_at\": true,\n  \"where_clause\": [\n    {\n      \"column_name\": \"id\",\n      \"val\": \"{{specialLocationId}}\",\n      \"op\": \"=\"\n    }\n  ]\n}",
      "options": {
       "raw": {
        "language": "json"
       }
      }
     },
-    "description": "TODO: verify schema + WHERE. fareSettlementType lives on the BPP special_location and drives the EDC amount (Payment.hs:188). The fare policy for the zone must also carry a non-zero commission so the BPP returns commission on on_init."
+    "description": "fareSettlementType=CommissionOnly is what makes the EDC collect only the commission (Payment.hs:188)."
+   }
+  },
+  {
+   "name": "Read Fare Policy Ids for zone (asserts fare policy is configured)",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "// This is the load-bearing check that the zone actually has a fare policy wired up \u2014",
+       "// if it's empty, Get Quotes further down will time out with no useful signal.",
+       "pm.test('zone has at least one fare_product/fare_policy mapped (quotes can be produced)', function () {",
+       "  pm.expect(d.count).to.be.above(0);",
+       "});",
+       "if (d.rows && d.rows.length) {",
+       "  var ids = [...new Set(d.rows.map(function (r) { return r.fare_policy_id; }))];",
+       "  pm.environment.set('farePolicyIdsJson', JSON.stringify(ids));",
+       "  console.log('fare_policy ids for zone:', ids);",
+       "}"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/sql/select",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "sql",
+      "select"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_driver_offer_bpp\",\n  \"table_name\": \"fare_product\",\n  \"select\": [\n    \"fare_policy_id\",\n    \"area\",\n    \"vehicle_variant\"\n  ],\n  \"where_clause\": [\n    {\n      \"column_name\": \"area\",\n      \"val\": \"Pickup_{{specialLocationId}}%\",\n      \"op\": \"LIKE\"\n    }\n  ],\n  \"limit\": 50\n}",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     }
+    },
+    "description": "Confirms the special zone has a fare_product -> fare_policy mapping in this env, i.e. quotes can actually be produced for it (fare_product.area = 'Pickup_<specialLocationId>[_Gate_<id>]'). Empty result means the zone isn't configured for quoting at all \u2014 fix that before debugging EDC."
+   }
+  },
+  {
+   "name": "Seed: Fare Policy commission (fixed amount, not %)",
+   "event": [
+    {
+     "listen": "test",
+     "script": {
+      "type": "text/javascript",
+      "exec": [
+       "var d = pm.response.json();",
+       "pm.test('fare_policy commission seeded', function () { pm.expect(d.rowcount).to.be.above(0); });",
+       "console.log('fare_policy rows updated with commission:', d.rowcount);"
+      ]
+     }
+    }
+   ],
+   "request": {
+    "method": "POST",
+    "header": [
+     {
+      "key": "Content-Type",
+      "value": "application/json"
+     }
+    ],
+    "url": {
+     "raw": "{{mockServerUrl}}/mock/sql/update",
+     "host": [
+      "{{mockServerUrl}}"
+     ],
+     "path": [
+      "mock",
+      "sql",
+      "update"
+     ]
+    },
+    "body": {
+     "mode": "raw",
+     "raw": "{\n  \"db_name\": \"atlas_dev\",\n  \"db_schema\": \"atlas_driver_offer_bpp\",\n  \"table_name\": \"fare_policy\",\n  \"set\": {\"commission_charge_config\": \"{\\\"value\\\":\\\"{{edc_commission_amount}}\\\",\\\"appliesOn\\\":[\\\"RideFare\\\"]}\"},\n  \"touch_updated_at\": true,\n  \"where_clause\": [{\"column_name\": \"id\", \"val\": {{farePolicyIdsJson}}, \"op\": \"IN\"}]\n}",
+     "options": {
+      "raw": {
+       "language": "json"
+      }
+     }
+    },
+    "description": "commission_charge_config is a flat FareChargeConfig JSON. value has NO '%' suffix, so parseCodeValue treats it as ParsedFixed -> applyParsedValue ignores the fare base and returns the constant directly (FareCalculator.hs: 'ParsedFixed amount -> amount'). So the EDC commission for this zone becomes exactly {{edc_commission_amount}} regardless of ride distance/fare. NOTE: this overwrites commission_charge_config wholesale for every fare_policy the zone routes to (all vehicle variants) \u2014 acceptable for a dedicated test env, but don't run against a shared one without expecting that side effect."
    }
   },
   {
@@ -681,7 +829,9 @@
        "  // CommissionOnly: EDC amount should equal the commission",
        "  var cc = pm.environment.get('commissionCharge');",
        "  if (cc != null) { pm.test('EDC order amount == commission', function () { pm.expect(Number(d.rows[0].amount)).to.be.closeTo(Number(cc), 0.01); }); }",
-       "}"
+       "}",
+       "var expected = pm.environment.get('edc_commission_amount');",
+       "if (expected != null) { pm.test('EDC order amount == constant commission', function () { pm.expect(Number(pm.environment.get('orderAmount'))).to.be.closeTo(Number(expected), 0.01); }); }"
       ]
      }
     }

--- a/Backend/dev/mock-servers/services/paytm.py
+++ b/Backend/dev/mock-servers/services/paytm.py
@@ -1,15 +1,83 @@
-"""PayTM payment mock."""
+"""PayTM payment mock.
+
+Covers two surfaces:
+
+1. Notification / generic PayTM calls  -> the original SUCCESS stub.
+2. PayTM **EDC** (booth / special-zone Paytm-EDC flow) -> the `/ecr/*` endpoints
+   the rider-app hits via `Kernel.External.Payment.PaytmEDC.Flow`:
+     POST {baseUrl}/ecr/generateChecksum   (GenerateChecksumResp)
+     POST {baseUrl}/ecr/payment/request    (sale     -> PaytmEDCResponse)
+     POST {baseUrl}/ecr/payment/status     (status   -> PaytmEDCResponse)
+     POST {baseUrl}/ecr/abort/txn          (abort    -> PaytmEDCResponse)
+
+   For the EDC integration test the merchant_service_config `Payment_PaytmEDC`
+   row must set `baseUrl` to `{mockServerUrl}/paytm` so these land here.
+
+   `createOrder` only hard-requires `body.checksum` from generateChecksum
+   (it `fromMaybeM`s on it); the sale/status responses just need to parse as a
+   PaytmEDCResponse. Real settlement is driven by the S2S callback the test
+   POSTs to /s2s/payment/paytm/edc/callback, not by these responses.
+
+The `/mock/override` response dict is deep-merged into whatever this returns,
+so a test can force a checksum/sale failure if it needs the negative path.
+"""
 
 from status_store import extract_path_ids, deep_merge
+
+
+def _result_info(status="S"):
+    # Mirrors PaytmEDCResultInfo (resultStatus/resultCode/resultMsg/resultCodeId).
+    return {
+        "resultStatus": status,
+        "resultCode": "0000",
+        "resultMsg": "Success",
+        "resultCodeId": "0000",
+    }
+
+
+def _response_head():
+    # Mirrors PaytmEDCResponseHead (all Maybe fields).
+    return {"responseTimeStamp": "2026-01-01 00:00:00", "channelId": "EDC", "version": "1.0"}
+
+
+def _checksum_response():
+    # GenerateChecksumResp { head, body { checksum, resultInfo } }
+    return {
+        "head": _response_head(),
+        "body": {"checksum": "MOCK_EDC_CHECKSUM", "resultInfo": _result_info("S")},
+    }
+
+
+def _edc_txn_response():
+    # PaytmEDCResponse for sale / status / abort. Kept permissive; the fields the
+    # rider-app reads are result status + the echoed ids. Extend if a stricter
+    # decode is needed for a given assertion.
+    return {
+        "head": _response_head(),
+        "body": {
+            "resultInfo": _result_info("A"),  # "A" = Accepted at the terminal
+            "merchantTransactionId": None,
+            "transactionId": None,
+        },
+    }
 
 
 def handle(handler, path, body):
     path_ids = extract_path_ids(path)
     override_status, extra = handler._get_override("paytm", *path_ids)
-    base = {
-        "status": override_status or "SUCCESS",
-        "resultInfo": {"resultCode": "0000"},
-    }
+
+    p = path.lower()
+    if "generatechecksum" in p:
+        base = _checksum_response()
+    elif "/ecr/payment/request" in p or "/ecr/payment/status" in p or "/ecr/abort" in p:
+        base = _edc_txn_response()
+    else:
+        # Original generic PayTM stub (notifications etc.)
+        base = {
+            "status": override_status or "SUCCESS",
+            "resultInfo": {"resultCode": "0000"},
+        }
+
     if extra:
         base = deep_merge(base, extra)
     handler._json(base)


### PR DESCRIPTION
## Type of Change

- [x] New feature (test tooling)

## Description

Adds a backend integration-test **scaffold** for the special-zone booth / Paytm EDC commission flow, plus the mock support it needs.

- **`dev/mock-servers/services/paytm.py`** — extend the Paytm mock to serve the EDC endpoints the rider-app hits (`/ecr/generateChecksum`, `/ecr/payment/request`, `/ecr/payment/status`) with the correct `GenerateChecksumResp` / `PaytmEDCResponse` shapes. Previously it only returned a generic `SUCCESS` stub, which `createRideBookingPaymentOrder` cannot use (it `fromMaybeM`s on `body.checksum`).
- **`dev/integration-tests/collections/SpecialZoneEdcCommissionFlow/`** — new Postman collection (BHARAT_TAXI, Delhi `std:011`), modelled on `AirportTaxiFlow` (same booth sequence, paid Cash). It: seeds a `Payment_PaytmEDC` `merchant_service_config` pointing at the mock; sets the zone to `fareSettlementType=CommissionOnly`; confirms with `paymentInstrument=BoothOnline&paymentMethodId=PAYTM_EDC`; reads the created `payment_order`; simulates the Paytm EDC S2S success callback; and asserts the order reaches `CHARGED` and its amount equals the commission.
- **`README.md`** in the collection documents prerequisites and the remaining TODOs.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

Only touches `dev/` test tooling — no app code, schema, or configs.

## Motivation and Context

Automates verification that a special-zone (`CommissionOnly`) booth booking paid via Paytm EDC confirms correctly and that the EDC collects only the commission — the flow that is otherwise only testable by hand through the control-center booth UI.

## How did you test it?

**Not yet run end-to-end** — this is an intentionally checked-in scaffold. All files are JSON/Python-validated (collection + env parse, `paytm.py` parses), but the flow has not been executed against a live stack. The README lists the TODOs to make it green (special_location schema/zone-id for the CommissionOnly seed, `payment_order` column names, optional agent + `edc_machine_mapping` path, and cache invalidation).

## Checklist

- [x] I reviewed submitted code
- [x] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0177d6osxW8LHEjaC13CiFs1)_