### PR TITLE
backend/fix: use riderConfig.timeDiffFromUtc for pass eligibility rollout selection

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -133,7 +133,9 @@ getMultimodalPassAvailablePasses (mbPersonId, _merchantId) mbLanguage = do
   when (null passCategories) $
     logError $ "getMultimodalPassAvailablePasses: no pass categories for mocId " <> person.merchantOperatingCityId.getId
 
-  localTime <- getLocalCurrentTime (19800 :: Seconds)
+  mbRiderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) (Just (CQRC.findByMerchantOperatingCityId person.merchantOperatingCityId))
+  let timeDiffFromUtc = maybe (Seconds 19800) (.timeDiffFromUtc) mbRiderConfig
+  localTime <- getLocalCurrentTime timeDiffFromUtc
   (eligibilityLogics, _mbVersion) <-
     TDL.getAppDynamicLogic (Id.cast person.merchantOperatingCityId) LYT.PASS_PURCHASE_ELIGIBILITY localTime Nothing Nothing
 


### PR DESCRIPTION
Stacked on #16060 — the line this touches is introduced by that PR, so this targets its branch rather than `main`. Rebase onto `main` once #16060 lands, or fold it in there if you'd rather keep it to one PR.

## Problem

`getMultimodalPassAvailablePasses` hardcodes the IST offset when deriving the local time it hands to `getAppDynamicLogic`:

```haskell
localTime <- getLocalCurrentTime (19800 :: Seconds)
```

That `localTime` is what `selectAppDynamicLogicVersion` matches against a rollout's `timeBounds` to pick a version. So for any operating city that isn't IST, the version is selected against the wrong wall clock — and once `PASS_PURCHASE_ELIGIBILITY` has more than one time-bounded rollout, that means resolving the wrong ruleset. Today's rollouts are `Unbounded`, so nothing misbehaves yet; this closes the gap before one is added.

## Fix

Use the idiom this same file already applies in four other places (lines 219, 764, 969, 1035) — read `riderConfig` for the person's operating city, fall back to 19800 only when absent:

```haskell
mbRiderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) (Just (CQRC.findByMerchantOperatingCityId person.merchantOperatingCityId))
let timeDiffFromUtc = maybe (Seconds 19800) (.timeDiffFromUtc) mbRiderConfig
localTime <- getLocalCurrentTime timeDiffFromUtc
```

Every identifier used is already imported; no new dependencies. It was the only `getLocalCurrentTime` call site in rider-app passing a literal.

## Type of Change

- [x] Bugfix

## Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## How did you test it?

Not runtime-tested — behaviour is unchanged for IST cities, which is every city with passes today. The fetch mirrors line 225 exactly, and CI covers compilation.

## Checklist

- [x] I formatted the code and addressed linter errors
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible