### PR TITLE
backend/fix/ride-tags-write-in-consumer

### DIFF
--- a/Backend/app/kafka-consumers/src/Processor/RideEvents/Handlers.hs
+++ b/Backend/app/kafka-consumers/src/Processor/RideEvents/Handlers.hs
@@ -195,8 +195,8 @@ handleNammaTags ev = withRideAndBooking ev $ \ride booking -> do
         isJust mbDriverMobileHash
           && isJust mbRiderMobileHash
           && mbDriverMobileHash == mbRiderMobileHash
-  now <- getCurrentTime
-  let merchantLocalDay = utctDay $ addUTCTime (secondsToNominalDiffTime thresholdConfig.timeDiffFromUtc) now
+  rideEndTime <- maybe getCurrentTime pure ride.tripEndTime
+  let merchantLocalDay = utctDay $ addUTCTime (secondsToNominalDiffTime thresholdConfig.timeDiffFromUtc) rideEndTime
   priorRidesSameCustomer <-
     QRide.countPriorCompletedRidesWithSameCustomer
       (cast ride.driverId)
@@ -208,8 +208,8 @@ handleNammaTags ev = withRideAndBooking ev $ \ride booking -> do
         riderBlockedForCoins
           || priorRidesSameCustomer > thresholdConfig.sameRiderDriverRideCountThreshold
       rideDurationSeconds =
-        maybe 0 (\tStart -> max 0 $ roundToIntegral (diffUTCTime now tStart)) ride.tripStartTime
-  void $
+        maybe 0 (\tStart -> max 0 $ roundToIntegral (diffUTCTime rideEndTime tStart)) ride.tripStartTime
+  nammaTags <-
     withTryCatch "ride-events:computeNammaTags" $
       LYDL.computeNammaTagsWithDebugLog
         LYDL.Driver
@@ -217,6 +217,7 @@ handleNammaTags ev = withRideAndBooking ev $ \ride booking -> do
         Yudhishthira.RideEnd
         (Just booking.transactionId)
         (Y.EndRideTagData ride booking isDriverSameAsCustomer shouldBlockCoinsForSameRiderFlow rideDurationSeconds)
+  QRide.updateRideTags (ride.rideTags <> eitherToMaybe nammaTags) ride.id
 
 ------------------------------------------------------------
 -- P1b-4 : Fleet + Operator analytics

--- a/Backend/app/kafka-consumers/src/Processor/RideEvents/Handlers.hs
+++ b/Backend/app/kafka-consumers/src/Processor/RideEvents/Handlers.hs
@@ -9,7 +9,6 @@
 module Processor.RideEvents.Handlers
   ( handleAnalyticsKafka,
     handleRideInterpolation,
-    handleNammaTags,
     handleFleetOperatorStats,
     handleGpsTollBehavior,
     handleRCStatsReminders,
@@ -20,14 +19,12 @@ module Processor.RideEvents.Handlers
 where
 
 import qualified Data.Aeson as A
-import Data.Time (addUTCTime, diffUTCTime, utctDay)
 import "dynamic-offer-driver-app" Domain.Action.UI.Ride.EndRide (RideInterpolationData (..))
 import qualified "dynamic-offer-driver-app" Domain.Types.Booking as SRB
 import "dynamic-offer-driver-app" Domain.Types.Event.RideEndedEvent (RideEndedEvent (..))
 import qualified "dynamic-offer-driver-app" Domain.Types.Ride as Ride
 import qualified "dynamic-offer-driver-app" Domain.Types.RideRelatedNotificationConfig as DRN
 import "dynamic-offer-driver-app" Domain.Types.TransporterConfig (TransporterConfig)
-import qualified "dynamic-offer-driver-app" Domain.Types.Yudhishthira as Y
 import Kernel.Beam.Lib.Utils (pushToKafka)
 import Kernel.External.Encryption (EncFlow)
 import qualified Kernel.External.Encryption as EncFlow
@@ -50,9 +47,7 @@ import Kernel.Utils.Common
     getLocalCurrentTime,
     logInfo,
     logWarning,
-    withTryCatch,
   )
-import Kernel.Utils.Time (secondsToNominalDiffTime)
 import qualified Lib.BehaviorEngine.Orchestrator as BEOrch
 import qualified Lib.BehaviorTracker.Snapshot as BTSnap
 import qualified Lib.BehaviorTracker.Types as BTT
@@ -63,7 +58,6 @@ import Lib.SessionizerMetrics.Types.Event (EventStreamFlow)
 import Lib.Yudhishthira.Storage.Beam.BeamFlow (HasYudhishthiraTablesSchema)
 import qualified Lib.Yudhishthira.Tools.DebugLog as LYDL
 import qualified Lib.Yudhishthira.Types as LYT
-import qualified Lib.Yudhishthira.Types as Yudhishthira
 import qualified Processor.RideEvents.InternalHelpers as IH
 import qualified "dynamic-offer-driver-app" SharedLogic.Analytics as Analytics
 import qualified "dynamic-offer-driver-app" SharedLogic.BehaviourManagement.ConsequenceDispatcher as BehaviorDispatch
@@ -76,7 +70,6 @@ import qualified "dynamic-offer-driver-app" Storage.CachedQueries.RideRelatedNot
 import qualified "dynamic-offer-driver-app" Storage.Queries.Booking as QRB
 import qualified "dynamic-offer-driver-app" Storage.Queries.DriverRCAssociation as QDRCA
 import qualified "dynamic-offer-driver-app" Storage.Queries.DriverStats as QDriverStats
-import qualified "dynamic-offer-driver-app" Storage.Queries.Person as QPerson
 import qualified "dynamic-offer-driver-app" Storage.Queries.RCStatsExtra as QRCStats
 import qualified "dynamic-offer-driver-app" Storage.Queries.Ride as QRide
 import qualified "dynamic-offer-driver-app" Storage.Queries.RiderDetails as QRiderDetails
@@ -168,56 +161,6 @@ handleRideInterpolation ev = withRideAndBooking ev $ \ride _booking -> do
            )
     )
     $ pushToKafka rideInterpolationData "ride-interpolated-waypoints" ride.id.getId
-
-------------------------------------------------------------
--- P1b-3 : LYDL Namma Tags
-------------------------------------------------------------
-
-handleNammaTags ::
-  ( CacheFlow m r,
-    Esq.EsqDBFlow m r,
-    Esq.EsqDBReplicaFlow m r,
-    MonadFlow m,
-    CoreMetrics.CoreMetrics m,
-    CHConfig.ClickhouseFlow m r,
-    HasYudhishthiraTablesSchema
-  ) =>
-  RideEndedEvent ->
-  m ()
-handleNammaTags ev = withRideAndBooking ev $ \ride booking -> do
-  thresholdConfig <- fetchTransporterConfig ride
-  mbDriver <- QPerson.findById ride.driverId
-  mbRiderDetails <- join <$> QRiderDetails.findById `mapM` booking.riderId
-  riderBlockedForCoins <- QRiderDetails.isRiderFlaggedForCoinZero booking.riderId
-  let mbDriverMobileHash = (.hash) <$> (mbDriver >>= (.mobileNumber))
-      mbRiderMobileHash = (.hash) . (.mobileNumber) <$> mbRiderDetails
-      isDriverSameAsCustomer =
-        isJust mbDriverMobileHash
-          && isJust mbRiderMobileHash
-          && mbDriverMobileHash == mbRiderMobileHash
-  rideEndTime <- maybe getCurrentTime pure ride.tripEndTime
-  let merchantLocalDay = utctDay $ addUTCTime (secondsToNominalDiffTime thresholdConfig.timeDiffFromUtc) rideEndTime
-  priorRidesSameCustomer <-
-    QRide.countPriorCompletedRidesWithSameCustomer
-      (cast ride.driverId)
-      booking.riderId
-      ride.id
-      merchantLocalDay
-      thresholdConfig.sameRiderDriverRideCountLookbackDays
-  let shouldBlockCoinsForSameRiderFlow =
-        riderBlockedForCoins
-          || priorRidesSameCustomer > thresholdConfig.sameRiderDriverRideCountThreshold
-      rideDurationSeconds =
-        maybe 0 (\tStart -> max 0 $ roundToIntegral (diffUTCTime rideEndTime tStart)) ride.tripStartTime
-  nammaTags <-
-    withTryCatch "ride-events:computeNammaTags" $
-      LYDL.computeNammaTagsWithDebugLog
-        LYDL.Driver
-        (cast booking.merchantOperatingCityId)
-        Yudhishthira.RideEnd
-        (Just booking.transactionId)
-        (Y.EndRideTagData ride booking isDriverSameAsCustomer shouldBlockCoinsForSameRiderFlow rideDurationSeconds)
-  QRide.updateRideTags (ride.rideTags <> eitherToMaybe nammaTags) ride.id
 
 ------------------------------------------------------------
 -- P1b-4 : Fleet + Operator analytics

--- a/Backend/app/kafka-consumers/src/Processor/RideEvents/Processor.hs
+++ b/Backend/app/kafka-consumers/src/Processor/RideEvents/Processor.hs
@@ -29,7 +29,6 @@ processRideEnded event =
       withTimeGeneric "rs-event:RideEndedEvent" $ do
         runHandler "publishToAnalyticsKafka" event Handlers.handleAnalyticsKafka
         runHandler "publishRideInterpolation" event Handlers.handleRideInterpolation
-        runHandler "computeAndStoreNammaTags" event Handlers.handleNammaTags
         runHandler "updateFleetAndOperatorStats" event Handlers.handleFleetOperatorStats
         runHandler "checkGpsTollBehavior" event Handlers.handleGpsTollBehavior
         runHandler "incrementRCStatsAndReminders" event Handlers.handleRCStatsReminders

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
@@ -31,6 +31,8 @@ where
 
 import qualified Beckn.OnDemand.Utils.Common as BODUC
 -- import qualified Lib.Yudhishthira.Event as Yudhishthira
+
+import Data.Either.Extra (eitherToMaybe)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (listToMaybe)
@@ -56,6 +58,7 @@ import qualified Domain.Types.Ride as DRide
 import qualified Domain.Types.RiderDetails as RD
 import qualified Domain.Types.TransporterConfig as DTConf
 import qualified Domain.Types.VehicleVariant as DTVeh
+import qualified Domain.Types.Yudhishthira as Y
 import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (id, pi)
 import Kernel.Beam.Functions (runInMasterDbAndRedis)
@@ -89,6 +92,7 @@ import qualified Lib.LocationUpdates as LocUpd
 import qualified Lib.LocationUpdates.Internal as LocUpdInternal
 import Lib.Scheduler.Environment (JobCreator)
 import qualified Lib.Types.SpecialLocation as SL
+import qualified Lib.Yudhishthira.Tools.DebugLog as LYDL
 import qualified Lib.Yudhishthira.Types as LYT
 import qualified SharedLogic.CallBAP as CallBAP
 import qualified SharedLogic.CallBAPInternal as CallBAPInternal
@@ -602,14 +606,18 @@ endRideHandler handle@ServiceHandle {..} rideId req = do
           CallBasedReq callBasedReq -> Just callBasedReq.requestor
           _ -> Nothing
     mbDriver <- maybe (QP.findById driverId) (pure . Just) mbDriverFromReq
+    mbRiderDetails <- join <$> (QRiderDetails.findById `mapM` booking.riderId)
     riderBlockedForCoins <- QRiderDetails.isRiderFlaggedForCoinZero booking.riderId
-    let merchantLocalDay = utctDay $ addUTCTime (secondsToNominalDiffTime thresholdConfig.timeDiffFromUtc) now
+    let mbDriverMobileHash = (.hash) <$> (mbDriver >>= (.mobileNumber))
+        mbRiderMobileHash = (.hash) . (.mobileNumber) <$> mbRiderDetails
+        isDriverSameAsCustomer = isJust mbDriverMobileHash && isJust mbRiderMobileHash && mbDriverMobileHash == mbRiderMobileHash
+        merchantLocalDay = utctDay $ addUTCTime (secondsToNominalDiffTime thresholdConfig.timeDiffFromUtc) now
+        rideDurationSeconds = maybe 0 (\tStart -> max 0 $ roundToIntegral (diffUTCTime now tStart)) updRide'.tripStartTime
     priorRidesSameCustomer <- QRide.countPriorCompletedRidesWithSameCustomer (cast driverId) booking.riderId updRide'.id merchantLocalDay thresholdConfig.sameRiderDriverRideCountLookbackDays
     let shouldBlockCoinsForSameRiderFlow = riderBlockedForCoins || priorRidesSameCustomer > thresholdConfig.sameRiderDriverRideCountThreshold
     when shouldBlockCoinsForSameRiderFlow $ QRiderDetails.flagRiderForCoinZero booking.riderId
-    -- Namma-tags computation moved to kafka-consumers RIDE_EVENTS_CONSUMER. Tags are
-    -- written back to the ride asynchronously by the handler.
-    let updRide = updRide'
+    newRideTags <- withTryCatch "computeNammaTags:RideEnd" (LYDL.computeNammaTagsWithDebugLog LYDL.Driver (cast booking.merchantOperatingCityId) LYT.RideEnd (Just booking.transactionId) (Y.EndRideTagData updRide' booking isDriverSameAsCustomer shouldBlockCoinsForSameRiderFlow rideDurationSeconds))
+    let updRide = updRide' {DRide.rideTags = ride.rideTags <> eitherToMaybe newRideTags}
     QRide.incrementDriverRiderRideCountForDay (cast driverId) booking.riderId
     when (thresholdConfig.enableMobilityBilling == Just True) $
       fork "report Google mobility billable event" $


### PR DESCRIPTION
Moved Ride Tags Calculation Back to End Ride (Synchronous)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ride tags now use the ride’s actual trip end time to determine the local end day and duration.
  * Successfully computed tags are now saved and merged with existing ride tags.
  * Ride tags are now computed and applied during ride completion, improving their availability immediately after the ride ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->