### PR TITLE
backend/fix: prefix refilled pass photo with a data URI

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -972,7 +972,7 @@ refillProfilePictureFromS3 mbClientSdkVersion purchasedPass =
         then return Nothing
         else
           ( do
-              base64Photo <- fetchPassPhotoFromS3 purchasedPass.personId mediaId
+              base64Photo <- toPassPhotoDataUri <$> fetchPassPhotoFromS3 purchasedPass.personId mediaId
               QPurchasedPass.updateProfilePictureById (Just base64Photo) purchasedPass.id
               return (Just base64Photo)
           )
@@ -981,6 +981,11 @@ refillProfilePictureFromS3 mbClientSdkVersion purchasedPass =
               logError $ "Pass photo refill failed for purchased pass " <> purchasedPass.id.getId <> ": " <> show e
               return Nothing
     _ -> return Nothing
+
+toPassPhotoDataUri :: Text -> Text
+toPassPhotoDataUri base64Photo
+  | "data:" `T.isPrefixOf` base64Photo = base64Photo
+  | otherwise = "data:image/jpeg;base64," <> base64Photo
 
 getMultimodalPassList ::
   ( ( Kernel.Prelude.Maybe (Id.Id DP.Person),


### PR DESCRIPTION
The S3 back-fill in refillProfilePictureFromS3 wrote bare base64 into purchased_pass.profile_picture. The client renders that field directly as an image source, which only resolves a data URI — its photo hook prefixes only the copy it fetches by passPhotoMediaId and passes profilePicture through untouched. So the back-filled photo silently rendered as nothing on exactly the legacy clients the refill targets.

Wrap the fetched base64 in a data URI before storing and returning it. Already-prefixed values are left alone so a re-run cannot double-prefix.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile photos now display correctly when sourced from raw image content.
  * Existing data URI-formatted photos continue to be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->