### PR TITLE
feat: dedicate drainer threads to the critical DB-sync stream

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
@@ -63,8 +63,9 @@ main = do
           threadPerPodCount <- Env.getThreadPerPodCount
           let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool appCfg.esqDBCfg
           R.runFlow flowRt (runReaderT DBSync.fetchAndSetKvConfigs environment)
+          -- min two threads; on odd totals the normal stream gets the extra thread
           let totalThreads = max 2 (threadPerPodCount + 1)
-              criticalThreads = (totalThreads + 1) `div` 2
+              criticalThreads = totalThreads `div` 2
               normalThreads = totalThreads - criticalThreads
           spawnDrainerThread criticalThreads True flowRt environment
           spawnDrainerThread (normalThreads - 1) False flowRt environment

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
@@ -63,15 +63,20 @@ main = do
           threadPerPodCount <- Env.getThreadPerPodCount
           let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool appCfg.esqDBCfg
           R.runFlow flowRt (runReaderT DBSync.fetchAndSetKvConfigs environment)
-          spawnDrainerThread threadPerPodCount flowRt environment
-          R.runFlow flowRt (runReaderT DBSync.startDBSync environment)
+          let totalThreads = max 2 (threadPerPodCount + 1)
+              criticalThreads = (totalThreads + 1) `div` 2
+              normalThreads = totalThreads - criticalThreads
+          spawnDrainerThread criticalThreads True flowRt environment
+          spawnDrainerThread (normalThreads - 1) False flowRt environment
+          R.runFlow flowRt (runReaderT (DBSync.startDBSync False) environment)
       )
 
-spawnDrainerThread :: Int -> R.FlowRuntime -> TDB.Env -> IO ()
-spawnDrainerThread 0 _ _ = pure ()
-spawnDrainerThread count flowRt env = do
-  void . forkIO $ R.runFlow flowRt (runReaderT DBSync.startDBSync env)
-  spawnDrainerThread (count -1) flowRt env
+spawnDrainerThread :: Int -> Bool -> R.FlowRuntime -> TDB.Env -> IO ()
+spawnDrainerThread count isCritical flowRt env
+  | count <= 0 = pure ()
+  | otherwise = do
+    void . forkIO $ R.runFlow flowRt (runReaderT (DBSync.startDBSync isCritical) env)
+    spawnDrainerThread (count -1) isCritical flowRt env
 
 getConnectionString :: EsqDBConfig -> ByteString
 getConnectionString dbConfig =

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
@@ -3,7 +3,7 @@ module Main where
 -- import Config.Config as Config
 import Config.Env as Env
 import qualified Constants as C
-import Control.Concurrent (forkIO)
+import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (async, cancel)
 import qualified DBSync.DBSync as DBSync
 import qualified Data.HashSet as HS
@@ -60,16 +60,14 @@ main = do
             )
 
           dbSyncMetric <- Event.mkDBSyncMetric
-          threadPerPodCount <- Env.getThreadPerPodCount
+          normalThreadCount <- Env.getThreadPerPodCount
+          criticalThreadCount <- Env.getCriticalThreadPerPodCount
           let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool appCfg.esqDBCfg
           R.runFlow flowRt (runReaderT DBSync.fetchAndSetKvConfigs environment)
-          -- min two threads; on odd totals the normal stream gets the extra thread
-          let totalThreads = max 2 (threadPerPodCount + 1)
-              criticalThreads = totalThreads `div` 2
-              normalThreads = totalThreads - criticalThreads
-          spawnDrainerThread criticalThreads True flowRt environment
-          spawnDrainerThread (normalThreads - 1) False flowRt environment
-          R.runFlow flowRt (runReaderT (DBSync.startDBSync False) environment)
+          -- one thread per stream by default; set either env count to 0 to stop draining that stream
+          spawnDrainerThread criticalThreadCount True flowRt environment
+          spawnDrainerThread normalThreadCount False flowRt environment
+          forever $ threadDelay 60000000
       )
 
 spawnDrainerThread :: Int -> Bool -> R.FlowRuntime -> TDB.Env -> IO ()

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
@@ -40,7 +40,10 @@ defaultDBSyncConfig =
     }
 
 getThreadPerPodCount :: IO Int
-getThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
+getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
+
+getCriticalThreadPerPodCount :: IO Int
+getCriticalThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
 
 isPushToKafka :: IO Bool
 isPushToKafka = fromMaybe False . (>>= readMaybe) <$> SE.lookupEnv pushToKafkaEnvKey

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
@@ -43,7 +43,7 @@ getThreadPerPodCount :: IO Int
 getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
 
 getCriticalThreadPerPodCount :: IO Int
-getCriticalThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
+getCriticalThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
 
 isPushToKafka :: IO Bool
 isPushToKafka = fromMaybe False . (>>= readMaybe) <$> SE.lookupEnv pushToKafkaEnvKey

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
@@ -43,7 +43,7 @@ getThreadPerPodCount :: IO Int
 getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
 
 getCriticalThreadPerPodCount :: IO Int
-getCriticalThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
+getCriticalThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
 
 isPushToKafka :: IO Bool
 isPushToKafka = fromMaybe False . (>>= readMaybe) <$> SE.lookupEnv pushToKafkaEnvKey

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
@@ -39,9 +39,8 @@ defaultDBSyncConfig =
       _streamReadCount = 1000 -- 1000
     }
 
--- at least one normal-stream drainer thread always runs, regardless of env value
 getThreadPerPodCount :: IO Int
-getThreadPerPodCount = max 1 . fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
+getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
 
 getCriticalThreadPerPodCount :: IO Int
 getCriticalThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Config/Env.hs
@@ -39,8 +39,9 @@ defaultDBSyncConfig =
       _streamReadCount = 1000 -- 1000
     }
 
+-- at least one normal-stream drainer thread always runs, regardless of env value
 getThreadPerPodCount :: IO Int
-getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
+getThreadPerPodCount = max 1 . fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
 
 getCriticalThreadPerPodCount :: IO Int
 getCriticalThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Constants.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Constants.hs
@@ -190,6 +190,9 @@ drainerExecutionDelayEnvKey = "DRAINER_EXECUTION_DELAY"
 threadPerPodCount :: String
 threadPerPodCount = "THREAD_PER_POD_COUNT"
 
+criticalThreadPerPodCount :: String
+criticalThreadPerPodCount = "CRITICAL_THREAD_PER_POD_COUNT"
+
 pushToKafkaEnvKey :: String
 pushToKafkaEnvKey = "PUSH_TO_KAFKA"
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/DBSync.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/DBSync.hs
@@ -244,8 +244,8 @@ process dbStreamKey count = do
           pure cnt
         Right cnt -> pure cnt
 
-startDBSync :: Flow ()
-startDBSync = do
+startDBSync :: Bool -> Flow ()
+startDBSync isCritical = do
   sessionId <- EL.runIO genSessionId
   EL.setLoggerContext "session-id" (DTE.decodeUtf8 sessionId)
   readinessFlag <- EL.runIO newEmptyMVar
@@ -263,10 +263,11 @@ startDBSync = do
   EL.logInfo ("Stream read count: " :: Text) (show $ _streamReadCount syncConfig)
 
   dbSyncStreamEnv <- EL.runIO Env.getDBSyncStream
-  let dbSyncStream =
+  let dbSyncStream' =
         if dbSyncStreamEnv == ""
           then C.ecRedisDBStream
           else dbSyncStreamEnv
+      dbSyncStream = if isCritical then dbSyncStream' <> "-critical" else dbSyncStream'
   stateRef <-
     EL.runIO $
       newIORef $

--- a/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Config.Env as Env
 import qualified Constants as C
-import Control.Concurrent (forkIO)
+import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (async, cancel)
 import qualified DBSync.DBSync as DBSync
 import qualified Data.HashSet as HS
@@ -59,15 +59,13 @@ main = do
 
           dbSyncMetric <- Event.mkDBSyncMetric
           let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool (appCfg.esqDBCfg)
-          threadPerPodCount <- Env.getThreadPerPodCount
+          normalThreadCount <- Env.getThreadPerPodCount
+          criticalThreadCount <- Env.getCriticalThreadPerPodCount
           R.runFlow flowRt (runReaderT DBSync.fetchAndSetKvConfigs environment)
-          -- min two threads; on odd totals the normal stream gets the extra thread
-          let totalThreads = max 2 (threadPerPodCount + 1)
-              criticalThreads = totalThreads `div` 2
-              normalThreads = totalThreads - criticalThreads
-          spawnDrainerThread criticalThreads True flowRt environment
-          spawnDrainerThread (normalThreads - 1) False flowRt environment
-          R.runFlow flowRt (runReaderT (DBSync.startDBSync False) environment)
+          -- one thread per stream by default; set either env count to 0 to stop draining that stream
+          spawnDrainerThread criticalThreadCount True flowRt environment
+          spawnDrainerThread normalThreadCount False flowRt environment
+          forever $ threadDelay 60000000
       )
 
 spawnDrainerThread :: Int -> Bool -> R.FlowRuntime -> TDB.Env -> IO ()

--- a/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
@@ -61,8 +61,9 @@ main = do
           let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool (appCfg.esqDBCfg)
           threadPerPodCount <- Env.getThreadPerPodCount
           R.runFlow flowRt (runReaderT DBSync.fetchAndSetKvConfigs environment)
+          -- min two threads; on odd totals the normal stream gets the extra thread
           let totalThreads = max 2 (threadPerPodCount + 1)
-              criticalThreads = (totalThreads + 1) `div` 2
+              criticalThreads = totalThreads `div` 2
               normalThreads = totalThreads - criticalThreads
           spawnDrainerThread criticalThreads True flowRt environment
           spawnDrainerThread (normalThreads - 1) False flowRt environment

--- a/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
@@ -61,15 +61,20 @@ main = do
           let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool (appCfg.esqDBCfg)
           threadPerPodCount <- Env.getThreadPerPodCount
           R.runFlow flowRt (runReaderT DBSync.fetchAndSetKvConfigs environment)
-          spawnDrainerThread threadPerPodCount flowRt environment
-          R.runFlow flowRt (runReaderT DBSync.startDBSync environment)
+          let totalThreads = max 2 (threadPerPodCount + 1)
+              criticalThreads = (totalThreads + 1) `div` 2
+              normalThreads = totalThreads - criticalThreads
+          spawnDrainerThread criticalThreads True flowRt environment
+          spawnDrainerThread (normalThreads - 1) False flowRt environment
+          R.runFlow flowRt (runReaderT (DBSync.startDBSync False) environment)
       )
 
-spawnDrainerThread :: Int -> R.FlowRuntime -> TDB.Env -> IO ()
-spawnDrainerThread 0 _ _ = pure ()
-spawnDrainerThread count flowRt env = do
-  void . forkIO $ R.runFlow flowRt (runReaderT DBSync.startDBSync env)
-  spawnDrainerThread (count -1) flowRt env
+spawnDrainerThread :: Int -> Bool -> R.FlowRuntime -> TDB.Env -> IO ()
+spawnDrainerThread count isCritical flowRt env
+  | count <= 0 = pure ()
+  | otherwise = do
+    void . forkIO $ R.runFlow flowRt (runReaderT (DBSync.startDBSync isCritical) env)
+    spawnDrainerThread (count -1) isCritical flowRt env
 
 getConnectionString :: EsqDBConfig -> ByteString
 getConnectionString dbConfig =

--- a/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
@@ -49,7 +49,7 @@ getThreadPerPodCount :: IO Int
 getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
 
 getCriticalThreadPerPodCount :: IO Int
-getCriticalThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
+getCriticalThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
 
 isPushToKafka :: IO Bool
 isPushToKafka = fromMaybe False . (>>= readMaybe) <$> SE.lookupEnv pushToKafkaEnvKey

--- a/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
@@ -45,9 +45,8 @@ getMaxRetries = fromMaybe 3 . (>>= readMaybe) <$> SE.lookupEnv maxDbFailureRetri
 getDrainerExecutionDelay :: IO Int
 getDrainerExecutionDelay = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv drainerExecutionDelayEnvKey
 
--- at least one normal-stream drainer thread always runs, regardless of env value
 getThreadPerPodCount :: IO Int
-getThreadPerPodCount = max 1 . fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
+getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
 
 getCriticalThreadPerPodCount :: IO Int
 getCriticalThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount

--- a/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
@@ -46,7 +46,10 @@ getDrainerExecutionDelay :: IO Int
 getDrainerExecutionDelay = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv drainerExecutionDelayEnvKey
 
 getThreadPerPodCount :: IO Int
-getThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
+getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
+
+getCriticalThreadPerPodCount :: IO Int
+getCriticalThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
 
 isPushToKafka :: IO Bool
 isPushToKafka = fromMaybe False . (>>= readMaybe) <$> SE.lookupEnv pushToKafkaEnvKey

--- a/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
@@ -49,7 +49,7 @@ getThreadPerPodCount :: IO Int
 getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
 
 getCriticalThreadPerPodCount :: IO Int
-getCriticalThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
+getCriticalThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount
 
 isPushToKafka :: IO Bool
 isPushToKafka = fromMaybe False . (>>= readMaybe) <$> SE.lookupEnv pushToKafkaEnvKey

--- a/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Config/Env.hs
@@ -45,8 +45,9 @@ getMaxRetries = fromMaybe 3 . (>>= readMaybe) <$> SE.lookupEnv maxDbFailureRetri
 getDrainerExecutionDelay :: IO Int
 getDrainerExecutionDelay = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv drainerExecutionDelayEnvKey
 
+-- at least one normal-stream drainer thread always runs, regardless of env value
 getThreadPerPodCount :: IO Int
-getThreadPerPodCount = fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
+getThreadPerPodCount = max 1 . fromMaybe 1 . (>>= readMaybe) <$> SE.lookupEnv threadPerPodCount
 
 getCriticalThreadPerPodCount :: IO Int
 getCriticalThreadPerPodCount = fromMaybe 0 . (>>= readMaybe) <$> SE.lookupEnv criticalThreadPerPodCount

--- a/Backend/app/rider-platform/rider-app-drainer/src/Constants.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Constants.hs
@@ -60,6 +60,9 @@ drainerExecutionDelayEnvKey = "DRAINER_EXECUTION_DELAY"
 threadPerPodCount :: String
 threadPerPodCount = "THREAD_PER_POD_COUNT"
 
+criticalThreadPerPodCount :: String
+criticalThreadPerPodCount = "CRITICAL_THREAD_PER_POD_COUNT"
+
 pushToKafkaEnvKey :: String
 pushToKafkaEnvKey = "PUSH_TO_KAFKA"
 

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/DBSync.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/DBSync.hs
@@ -230,8 +230,8 @@ process dbStreamKey count = do
           pure cnt
         Right cnt -> pure cnt
 
-startDBSync :: Flow ()
-startDBSync = do
+startDBSync :: Bool -> Flow ()
+startDBSync isCritical = do
   sessionId <- EL.runIO genSessionId
   EL.setLoggerContext "session-id" (DTE.decodeUtf8 sessionId)
   readinessFlag <- EL.runIO newEmptyMVar
@@ -249,10 +249,11 @@ startDBSync = do
   EL.logInfo ("Stream read count: " :: Text) (show $ _streamReadCount syncConfig)
 
   dbSyncStreamEnv <- EL.runIO Env.getDBSyncStream
-  let dbSyncStream =
+  let dbSyncStream' =
         if dbSyncStreamEnv == ""
           then C.ecRedisDBStream
           else dbSyncStreamEnv
+      dbSyncStream = if isCritical then dbSyncStream' <> "-critical" else dbSyncStream'
   stateRef <-
     EL.runIO $
       newIORef $


### PR DESCRIPTION
## Description

Companion to nammayatri/shared-kernel#1461, which routes tables listed in `tablesForCriticalStream` (kv_configs) to a dedicated `<stream>-critical` Redis stream.

Changes in **both** `dynamic-offer-driver-drainer` and `rider-app-drainer`:
- `startDBSync` now takes an `isCritical :: Bool`; critical threads read `<base>-critical{shard-N}` with the same shard/lock logic as the normal stream.
- Thread counts are fully env-controlled, one thread per stream by default:
  - `THREAD_PER_POD_COUNT` — normal-stream drainer threads (default **1**)
  - `CRITICAL_THREAD_PER_POD_COUNT` — critical-stream drainer threads (default **1**)
  - Setting either to `0` stops draining that stream entirely.
- The main thread no longer runs a drainer loop; it only keeps the process alive, so the env counts are exact.

## Deployment note
Previously a pod ran `THREAD_PER_POD_COUNT + 1` normal threads (env + main). Now it runs exactly the env value — bump the env by 1 if identical normal-stream capacity is needed.

## Notes
- No-op until tables are enabled via `tablesForCriticalStream` in `kv_configs` (requires the shared-kernel bump).
- Verified: `cabal build dynamic-offer-driver-drainer rider-app-drainer` passes (`-Werror` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Drainer services now process critical and standard workloads through separate streams.
  - Critical workloads receive dedicated processing capacity and clearer prioritization.
  - Critical and standard worker counts can be configured independently.
  - Processing remains active while both workload streams are running.

- **Bug Fixes**
  - Standard processing now defaults to at least one worker when configuration is missing or invalid.
  - Non-positive worker counts no longer start unnecessary processing streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->