### PR TITLE
fix: use runInMasterCloudRedisCell for CRIS auth token to fix multiCl…

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/Auth.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Subway/CRIS/Auth.hs
@@ -49,14 +49,14 @@ resetAuthToken ::
   CRISConfig ->
   m Text
 resetAuthToken config = do
-  lockAcquired <- Hedis.tryLockRedis getCRISTokenRefreshLockKey 30
+  lockAcquired <- Hedis.runInMasterCloudRedisCell $ Hedis.tryLockRedis getCRISTokenRefreshLockKey 30
   if lockAcquired
     then do
       logInfo "Acquired Redis lock for token refresh"
 
       let unlockLock = do
             logInfo "Released Redis lock after token refresh"
-            Hedis.unlockRedis getCRISTokenRefreshLockKey
+            Hedis.runInMasterCloudRedisCell $ Hedis.unlockRedis getCRISTokenRefreshLockKey
 
       tokenRes <-
         ( do
@@ -68,14 +68,14 @@ resetAuthToken config = do
           )
           `finally` unlockLock
 
-      Hedis.setExp getCRISTokenKey (tokenRes.access_token) (tokenRes.expires_in * 90 `div` 100)
+      Hedis.runInMasterCloudRedisCell $ Hedis.setExp getCRISTokenKey (tokenRes.access_token) (tokenRes.expires_in * 90 `div` 100)
       return $ tokenRes.access_token
     else do
       logInfo "Redis lock already held by another pod, waiting 3 seconds for token refresh"
 
       threadDelay 3000000
 
-      mbToken <- Hedis.get getCRISTokenKey
+      mbToken <- Hedis.runInMasterCloudRedisCell $ Hedis.get getCRISTokenKey
       case mbToken of
         Nothing ->
           throwError $ CRISErrorUnhandled "Token refresh failed - no token available after waiting"
@@ -86,7 +86,7 @@ getAuthToken ::
   CRISConfig ->
   m Text
 getAuthToken config = do
-  mbToken <- Hedis.get getCRISTokenKey
+  mbToken <- Hedis.runInMasterCloudRedisCell $ Hedis.get getCRISTokenKey
   case mbToken of
     Nothing -> resetAuthToken config
     Just token -> return token


### PR DESCRIPTION
…oud invariance

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CRIS authentication reliability by using the primary Redis service for token locking, storage, and retrieval.
  * Updated token refresh and fallback handling to provide more consistent authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->