### PR TITLE
Backend/fix: stop defaulting unconfigured cities to Moengage event tracking

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/Merchant.yaml
@@ -387,7 +387,7 @@ MerchantServiceUsageConfig:
     getRefunds: fromMaybe (Kernel.External.Payment.Types.Stripe)|I
     createPayoutOrder: fromMaybe (Kernel.External.Payout.Types.Juspay)|I
     payoutOrderStatus: fromMaybe (Kernel.External.Payout.Types.Juspay)|I
-    eventTrackingProviders: fromMaybe [Kernel.External.EventTracking.Types.Moengage]|I
+    eventTrackingProviders: fromMaybe [] eventTrackingProviders|E
     eventTrackingOverrides: Kernel.Utils.JSON.valueToMaybe =<< eventTrackingOverrides|E
   toTType:
     cancelPaymentIntent: Kernel.Prelude.Just|I

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantServiceUsageConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/MerchantServiceUsageConfig.hs
@@ -42,7 +42,7 @@ instance FromTType' Beam.MerchantServiceUsageConfig Domain.Types.MerchantService
             deleteCard = deleteCard,
             enableDashboardSms = enableDashboardSms,
             eventTrackingOverrides = Kernel.Utils.JSON.valueToMaybe =<< eventTrackingOverrides,
-            eventTrackingProviders = fromMaybe [Kernel.External.EventTracking.Types.Moengage] eventTrackingProviders,
+            eventTrackingProviders = fromMaybe [] eventTrackingProviders,
             getCardList = getCardList,
             getDistances = getDistances,
             getDistancesForCancelRide = getDistancesForCancelRide,


### PR DESCRIPTION
## Problem

`MerchantServiceUsageConfig.eventTrackingProviders` defaulted a **NULL** column to `[Moengage]`:

```haskell
eventTrackingProviders = fromMaybe [Kernel.External.EventTracking.Types.Moengage] eventTrackingProviders
```

So every operating city that had **never been configured** was treated as Moengage-enabled. Those cities have no `EventTracking_Moengage` row in `merchant_service_config`, so each event triggers a config-pilot lookup miss — which logs at **error** level before falling back to the merchant's default city (`Storage/ConfigPilot/Config/MerchantServiceConfig.hs:96`).

## Production impact

From a log export: **~22,000 error lines in a 9-minute window**, across **37** city/merchant pairs, on every event type:

| Event | Errors |
|---|---|
| `user_searched` | 7,314 |
| `user_request_quotes` | 7,131 |
| `driver_assigned` | 3,401 |
| `ride_completed` | 1,804 |
| `user_onboarded` | 596 |
| `first_ride_completed` | 85 |

Breaking the affected cities down by cause:

| | Cities |
|---|---|
| `event_tracking_providers IS NULL` — never configured | **75** |
| `'Moengage'` stored explicitly | **3** |

**96% were opted in by this default alone**, not by anyone's configuration.

## Fix

```diff
- eventTrackingProviders: fromMaybe [Kernel.External.EventTracking.Types.Moengage]|I
+ eventTrackingProviders: fromMaybe [] eventTrackingProviders|E
```

NULL now means *no providers*, which is what "unconfigured" should mean.

The original default was reasonable when Moengage was the only provider and enabling it everywhere preserved existing behaviour (added in `17e37c5103`). Now that Moengage is merchant-specific, it silently opts in every new city — so this also prevents recurrence as cities are added.

The `|E` form is required: `fromMaybe []|I` fails to generate with `Function fromMaybe []|I not imported`, because `|I` resolves the value as a function name. This matches the existing precedent for `gatewayAndRegistryPriorityList` at `Merchant.yaml:163`.

## Scope

- Cities that opt in **explicitly are unaffected** — the default only applies when the column is NULL. BHARAT_TAXI stores `{Moengage}` explicitly and keeps working.
- This does **not** cover rows storing `'Moengage'` literally (3 cities). Those need a data fix, applied separately.

## Verification

`cabal build rider-app` compiles and links clean with `-Werror`.

## Note on the generated file

`, run-generator` currently exits non-zero on this repo and leaves `src-read-only` rewritten **and unformatted** (treefmt never runs after the crash). I confirmed the generator emits exactly `fromMaybe [] eventTrackingProviders` for this field, then reset the generated tree and applied that single line, so the diff stays at 2 lines with no incidental reformatting. The generator instability is pre-existing and worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default event-tracking configuration when no providers are specified.
  * Prevented an unintended tracking provider from being enabled automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->