### PR TITLE
fix(schema): widen issue_report.description to text on driver DB to unblock drainer

### DIFF
--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0830-alter-issue-report-description-to-text.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0830-alter-issue-report-description-to-text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE text;


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/1l)

### Root cause
The GCP driver drainer was stuck retrying poison KV INSERT messages for atlas_driver_offer_bpp.issue_report because the description column was defined as character varying(255) while the application emits longer free-text descriptions. Each attempt failed with SqlError 22001 ("value too long for type character varying(255)"), preventing the affected shard(s) from advancing and causing DriverDrainerLag to grow past 60 minutes. The Beam schema already models description as Text; the rider-side issue_report table is already text in production. The fix adds a DDL migration to alter the driver column to text.

### Evidence
_see RCA_

### Rollback
If the migration causes issues, revert by removing the migration file and, if no long descriptions have been inserted yet, run ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE character varying(255);. If long descriptions have already drained, reverting would require truncating those rows (DBA action).

---
_Draft PR — review and merge manually. Generated by Argus._