### PR TITLE
backend/docs: #15898 add missing 19-stcl-membership-topup.md entry to…

### DIFF
--- a/.cursor/docs/00-index.md
+++ b/.cursor/docs/00-index.md
@@ -30,7 +30,7 @@ This directory contains chunked documentation for the Nammayatri backend. Each d
 | `16-status-definitions.md` | All status enums with state transition diagrams | Understanding booking/ride/ticket state machines |
 | `17-testing-framework.md` | Test-stack index → `Backend/dev/test-tool/README.md` | Running / extending the integration test stack |
 | `18-finance-module-guide.md` | Double-entry ledger, account types, driver wallet flow | Working on earnings, payouts, invoices, cancellation/refund accounting |
-
+| `19-stcl-membership-topup.md` | STCL share top-up flow — adding shares to an existing membership without breaking global share continuity | Working on STCL membership purchases, top-ups, or share allocation |
 ## Cross-Reference Guide
 
 - **Adding a new API endpoint**: Read `07-namma-dsl.md` → `15-conventions.md`


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Added the missing `19-stcl-membership-topup.md` entry to the Document Catalog in `.cursor/docs/00-index.md`.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context

The STCL membership top-up documentation was missing from the document catalog. This change adds the entry so it can be properly discovered and referenced.

## How did you test it?

Verified the updated document catalog using `git diff` and confirmed that the new entry appears immediately after `18-finance-module-guide.md`.

## Screenshot of test results

Not applicable — documentation-only change.

## Checklist

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

Fixes #15898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation covering STCL membership share top-ups and share allocation.
  * Updated the documentation catalog to include the new guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->