### PR TITLE
backend/enh: passing extra information for cancellations in the response

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
@@ -45,6 +45,7 @@ import qualified Domain.Types as DVST
 import qualified Domain.Types.BapMetadata as DSM
 import qualified Domain.Types.Booking as DRB
 import qualified Domain.Types.BookingCancellationReason as DBCR
+import qualified Domain.Types.CancellationReason as DTCR
 import qualified Domain.Types.DriverGoHomeRequest as DDGR
 import qualified Domain.Types.DriverInformation as DI
 import qualified Domain.Types.Exophone as DExophone
@@ -205,6 +206,9 @@ data DriverRideRes = DriverRideRes
     fleetOwnerId :: Maybe Text,
     enableOtpLessRide :: Bool,
     cancellationSource :: Maybe DBCR.CancellationSource,
+    cancellationReasonCode :: Maybe Text,
+    cancellationAdditionalInfo :: Maybe Text,
+    cancellationCompensation :: Maybe PriceAPIEntity,
     tipAmount :: Maybe PriceAPIEntity,
     penalityCharge :: Maybe PriceAPIEntity,
     senderDetails :: Maybe DeliveryPersonDetailsAPIEntity,
@@ -616,6 +620,9 @@ mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mb
         fleetOwnerId = rideDetails.fleetOwnerId,
         enableOtpLessRide = fromMaybe False ride.enableOtpLessRide,
         cancellationSource = fmap (\cr -> cr.source) cancellationReason,
+        cancellationReasonCode = cancellationReason >>= (.reasonCode) <&> (\(DTCR.CancellationReasonCode code) -> code),
+        cancellationAdditionalInfo = cancellationReason >>= (.additionalInfo),
+        cancellationCompensation = flip PriceAPIEntity ride.currency <$> ride.cancellationChargesOnCancel,
         tipAmount = flip PriceAPIEntity ride.currency <$> ride.tipAmount,
         penalityCharge = flip PriceAPIEntity ride.currency <$> ride.cancellationFeeIfCancelled,
         senderDetails = booking.senderDetails <&> (\sd -> DeliveryPersonDetailsAPIEntity (sd.name) sd.primaryExophone),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Driver ride details now display the cancellation reason and any additional information.
  * Cancellation compensation is now shown with the applicable amount and currency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->