### PR TITLE
backend/fix: fleet vehicle docs auto approve bug

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/Image.hs
@@ -56,6 +56,7 @@ import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig, getOneConfig)
 import qualified SharedLogic.DriverFleetOperatorAssociation as DFOA
 import SharedLogic.DriverOnboarding
+import qualified SharedLogic.DriverOnboarding.OnboardingFlags.Guard as SGuard
 import qualified SharedLogic.DriverOnboarding.Status as SStatus
 import qualified Storage.CachedQueries.Merchant as CQM
 import Storage.ConfigPilot.Config.DocumentVerificationConfig (DocumentVerificationConfigDimensions (..))
@@ -235,8 +236,16 @@ validateImageHandler isDashboard mbUploaderRole mbDocConfigs (personId, _, merch
       Query.create imageEntity
 
       -- skipping validation for rc as validation not available in idfy
+      let validationFromDocConfigs =
+            let mbDocCfg = find (\c -> c.vehicleCategory == fromMaybe CAR vehicleCategory) docConfigs
+             in ( maybe True (.isImageValidationRequired) mbDocCfg,
+                  mbDocCfg >>= (.markImageValidOnValidationSkip)
+                )
       (isImageValidationRequired, markValidOnSkip) <-
-        if person.role `elem` [Person.FLEET_OWNER, Person.FLEET_BUSINESS]
+        -- A fleet upload carrying an rcNumber is a VEHICLE document; those are governed by
+        -- docConfigs like driver uploads. The fleet-owner table only describes the fleet
+        -- owner's own identity documents.
+        if person.role `elem` [Person.FLEET_OWNER, Person.FLEET_BUSINESS] && isNothing rcNumber
           then do
             --------------- Image validation for fleet (different config table than docConfigs)
             fleetDocConfigs <- listToMaybe <$> getConfig (FleetOwnerDocumentVerificationConfigDimensions {merchantOperatingCityId = merchantOpCityId.getId, documentType = Just imageType, role = Nothing}) Nothing
@@ -244,25 +253,34 @@ validateImageHandler isDashboard mbUploaderRole mbDocConfigs (personId, _, merch
               ( maybe True (.isImageValidationRequired) fleetDocConfigs,
                 fleetDocConfigs >>= (.markImageValidOnValidationSkip)
               )
-          else do
-            let mbDocCfg = find (\c -> c.vehicleCategory == fromMaybe CAR vehicleCategory) docConfigs
-            return
-              ( maybe True (.isImageValidationRequired) mbDocCfg,
-                mbDocCfg >>= (.markImageValidOnValidationSkip)
-              )
+          else return validationFromDocConfigs
+      let guardTarget = case mbRcId of
+            Just rcId -> SGuard.TargetVehicleById rcId
+            Nothing
+              | person.role `elem` [Person.FLEET_OWNER, Person.FLEET_BUSINESS] -> SGuard.TargetFleetOwner personId
+              | otherwise -> SGuard.TargetDriver personId
+          -- Status writes go through the onboarding-action wrapper: entity lock + flag recompute.
+          setVerificationStatus status =
+            SGuard.withOnboardingAction transporterConfig SGuard.None SGuard.Approve guardTarget $
+              Query.updateVerificationStatusOnlyById status imageEntity.id
+          markStatusOnValidationSkip =
+            setVerificationStatus $
+              if markValidOnSkip == Just True
+                then Documents.VALID
+                else Documents.MANUAL_VERIFICATION_REQUIRED
       if isImageValidationRequired && isNothing validationStatus
         then do
           validationOutput <-
             Verification.validateImage merchantId merchantOpCityId $
               Verification.ValidateImageReq {image, imageType = castImageType imageType, driverId = person.id.getId}
-          when validationOutput.validationAvailable $ do
-            checkErrors imageEntity.id imageType validationOutput.detectedImage
-          Query.updateVerificationStatusOnlyById Documents.VALID imageEntity.id
-        else
-          when (isNothing validationStatus) $
-            if markValidOnSkip == Just True
-              then Query.updateVerificationStatusOnlyById Documents.VALID imageEntity.id
-              else Query.updateVerificationStatusOnlyById Documents.MANUAL_VERIFICATION_REQUIRED imageEntity.id
+          if validationOutput.validationAvailable
+            then do
+              checkErrors imageEntity.id imageType validationOutput.detectedImage
+              setVerificationStatus Documents.VALID
+            else -- the provider cannot validate this document type: a doc that was never checked
+            -- must follow the validation-skip semantics, not get stamped VALID
+              markStatusOnValidationSkip
+        else when (isNothing validationStatus) markStatusOnValidationSkip
       when (imageType == DVC.ProfilePhoto) $
         fork "deferred face match on selfie upload" $ do
           runDeferredFaceMatchOnSelfie person imageEntity.createdAt


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver onboarding image validation for vehicle documents and fleet-owner identity documents.
  * Validation results are now assigned to the correct onboarding document based on ownership.
  * Images are marked as valid only after available verification checks succeed.
  * When verification is skipped or unavailable, images receive the configured fallback status.
  * Improved fallback behavior when fleet-specific validation settings are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->