### PR TITLE
backend/feat: emit scheduler job lifecycle counter

### DIFF
--- a/Backend/lib/producer/src/Producer/Flow.hs
+++ b/Backend/lib/producer/src/Producer/Flow.hs
@@ -16,6 +16,7 @@ import Environment
 import Kernel.Beam.Functions (createWithKVScheduler, updateWithKVScheduler)
 import Kernel.Prelude
 import qualified Kernel.Storage.Hedis.Queries as Hedis
+import Kernel.Tools.Metrics.CoreMetrics (addSchedulerProducerStageCount)
 import Kernel.Types.CacheFlow
 import Kernel.Types.Error
 -- import qualified EulerHS.Language as L
@@ -66,6 +67,7 @@ runProducer = do
           let myShardSetKey = getShardedKey setName myShardId
           currentJobs <- Hedis.withNonCriticalCrossAppRedis $ Hedis.zRangeByScoreByCount myShardSetKey startTime endTime 0 10000 -- 10,000 limit is good enough for a poor pod
           logDebug $ "Job chunks produced to be inserted into stream : " <> show currentJobs
+          addSchedulerProducerStageCount "picked_from_set" (length currentJobs)
           result <- insertIntoStream currentJobs
           Hedis.set producerTimestampKey endTime
           logDebug $ "Jobs inserted into stream with timeStamp :" <> show result
@@ -183,8 +185,16 @@ insertIntoStream jobs = do
     let eqIdByteString = TE.encodeUtf8 eqId
     let job_ = job
     let fieldValue = [(eqIdByteString, job_)]
-    _ <- Hedis.withNonCriticalCrossAppRedis $ Hedis.xAdd streamName entryId fieldValue
-    return ()
+    -- These XADDs are forked and the caller does not wait for them, yet it goes
+    -- on to advance the producer watermark and zRemRangeByScore the source
+    -- range. A failure here therefore drops the job permanently, so count it
+    -- rather than letting it disappear silently.
+    res <- try @_ @SomeException $ Hedis.withNonCriticalCrossAppRedis $ Hedis.xAdd streamName entryId fieldValue
+    case res of
+      Right _ -> addSchedulerProducerStageCount "inserted_to_stream" 1
+      Left err -> do
+        logError $ "failed to insert job into stream: " <> show err
+        addSchedulerProducerStageCount "stream_insert_failed" 1
 
 splitIntoBatches :: Int -> [a] -> [[a]]
 splitIntoBatches _ [] = []

--- a/Backend/lib/scheduler/src/Lib/Scheduler/Environment.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/Environment.hs
@@ -168,7 +168,10 @@ type JobExecutorEnv r = (HasField "streamName" r Text, HasField "maxShards" r In
 
 type JobExecutor r m = (JobExecutorEnv r, JobMonad r m)
 
-type JobMonad r m = (HasSchemaName SchedulerJobT, HasField "schedulerType" r SchedulerType, MonadReader r m, HedisFlow m r, MonadFlow m, EsqDBFlow m r, HasField "blackListedJobs" r [Text])
+-- 'CoreMetrics m' is required so that job creation/execution can emit the
+-- scheduler_job_lifecycle_counter metric without every call site having to
+-- thread the constraint through itself.
+type JobMonad r m = (HasSchemaName SchedulerJobT, HasField "schedulerType" r SchedulerType, MonadReader r m, HedisFlow m r, MonadFlow m, EsqDBFlow m r, HasField "blackListedJobs" r [Text], Metrics.CoreMetrics m)
 
 runSchedulerM :: HasSchemaName SystemConfigsT => SchedulerConfig -> SchedulerEnv -> SchedulerM a -> IO a
 runSchedulerM schedulerConfig env action = do

--- a/Backend/lib/scheduler/src/Lib/Scheduler/Handler.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/Handler.hs
@@ -119,6 +119,11 @@ runnerIterationRedis SchedulerHandle {..} runTask = do
   groupName <- asks (.groupName)
   readyTasks <- getReadyTask
   logTagDebug "Available tasks - Count" . show $ length readyTasks
+  -- Counted before the blacklist filter and before any per-job lock, so this is
+  -- everything that came off the stream.
+  forM_ readyTasks $ \(AnyJob Job {jobInfo = jobInfo'}, _) ->
+    fork "jobLifecycleDequeued" $
+      incrementJobLifecycleCounter (show (fromSing $ jobType jobInfo')) JobDequeued
   blackListedJobs <- asks (.blackListedJobs)
   (nonBlacklistedTasks, recordIdsToDelete) <-
     if null blackListedJobs

--- a/Backend/lib/scheduler/src/Lib/Scheduler/Handler.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/Handler.hs
@@ -45,6 +45,7 @@ import Kernel.Utils.Time ()
 import Lib.Scheduler.Environment
 import Lib.Scheduler.JobHandler
 import qualified Lib.Scheduler.JobStorageType.Redis.Queries as RQ
+import Lib.Scheduler.Metrics (JobLifecycleStatus (..), incrementJobLifecycleCounter)
 import Lib.Scheduler.Types
 
 data SchedulerHandle t = SchedulerHandle
@@ -203,6 +204,9 @@ executeTask SchedulerHandle {..} (AnyJob job) = do
       diffInMill = Milliseconds (div (fromEnum diff) 1000000000)
   logDebug $ "diffTime in picking up the job : " <> show diffInMill
   fork "" $ addGenericLatency ("Job_pickup_" <> jobType') $ diffInMill
+  -- Reached only once the job's redis lock has been acquired, so this counts
+  -- jobs that actually started executing -- not everything read off the stream.
+  fork "jobLifecyclePicked" $ incrementJobLifecycleCounter jobType' JobPicked
   case findJobHandlerFunc job jobHandlers of
     Nothing -> failExecution jobType' "No handler function found for the job type = "
     Just handlerFunc_ -> do
@@ -234,35 +238,43 @@ registerExecutionResult SchedulerHandle {..} j@(AnyJob job@Job {..}) result = do
   case result of
     DuplicateExecution -> do
       logInfo $ "job id " <> show id <> " already executed "
+      fork "jobLifecycleDuplicate" $ incrementJobLifecycleCounter jobType' JobDuplicate
     Complete -> do
       logInfo $ "job successfully completed on try " <> show (currErrors + 1)
       markAsComplete jobType' job.id
       fork "" $ incrementStreamCounter ("Executor_" <> show jobType')
+      fork "jobLifecycleCompleted" $ incrementJobLifecycleCounter jobType' JobCompleted
     Terminate description -> do
       logError $ "job terminated on try " <> show (currErrors + 1) <> "; with jobId: " <> show job.id <> "; reason: " <> description
       markAsFailed jobType' job.id
       fork "" $ incrementStreamFailedCounter ("Executor_" <> show jobType')
+      fork "jobLifecycleFailed" $ incrementJobLifecycleCounter jobType' JobFailed
     ReSchedule reScheduledTime -> do
       logInfo $ "job rescheduled on time = " <> show reScheduledTime <> " jobType :" <> jobType'
       reSchedule jobType' j reScheduledTime
+      fork "jobLifecycleRescheduled" $ incrementJobLifecycleCounter jobType' JobRescheduled
     Retry -> do
       isLong <- isJobLongRunning jobType'
       if not isLong
-        then -- Non-longRunning retries are requeued onto the stream (Part B) by handleStreamRetry,
-        -- after the locks are released. Skip the DB/sorted-set reschedule here to avoid double-enqueue.
+        then do
+          -- Non-longRunning retries are requeued onto the stream (Part B) by handleStreamRetry,
+          -- after the locks are released. Skip the DB/sorted-set reschedule here to avoid double-enqueue.
           logDebug $ "retry deferred to stream requeue for non-longRunning jobId:" <> show job.id
+          fork "jobLifecycleRetried" $ incrementJobLifecycleCounter jobType' JobRetried
         else
           let newErrorsCount = job.currErrors + 1
            in if newErrorsCount >= job.maxErrors
                 then do
                   logError $ "retries amount exceeded for jobId:" <> show job.id <> ", job failed after try " <> show newErrorsCount
                   updateErrorCountAndFail jobType' job.id newErrorsCount
+                  fork "jobLifecycleRetryExhausted" $ incrementJobLifecycleCounter jobType' JobRetryExhausted
                 else do
                   logError $ "try " <> show newErrorsCount <> " was not successful for jobId:" <> show job.id <> ", trying again"
                   waitBeforeRetry <- asks (.waitBeforeRetry)
                   now <- getCurrentTime
                   reScheduleOnError jobType' j newErrorsCount $
                     fromIntegral waitBeforeRetry `addUTCTime` now
+                  fork "jobLifecycleRetried" $ incrementJobLifecycleCounter jobType' JobRetried
 
 defaultCatcher :: Text -> SomeException -> SchedulerM ExecutionResult
 defaultCatcher jobType' exep = do

--- a/Backend/lib/scheduler/src/Lib/Scheduler/Metrics.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/Metrics.hs
@@ -15,6 +15,7 @@
 module Lib.Scheduler.Metrics where
 
 import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics, incrementSchedulerJobLifecycleCounter)
 import qualified Prometheus as P
 
 newtype SchedulerMetrics = SchedulerMetrics
@@ -31,3 +32,42 @@ observeJobExecDuration :: (MonadIO m, MonadReader r m, HasField "metrics" r Sche
 observeJobExecDuration duration = do
   metrics <- asks (.metrics)
   liftIO $ P.observe metrics.durationHistogram duration
+
+-- | Points in a scheduler job's life that we count, emitted as the @status@
+-- label of @scheduler_job_lifecycle_counter@.
+--
+-- Every job contributes exactly one 'JobCreated', at most one 'JobPicked' per
+-- execution attempt, and exactly one of the remaining constructors per attempt.
+-- 'JobRescheduled' and 'JobRetried' are not terminal -- the job will be picked
+-- again -- so @created - (completed + failed + retry_exhausted)@ is the number
+-- of jobs still in flight.
+data JobLifecycleStatus
+  = JobCreated
+  | JobPicked
+  | JobCompleted
+  | JobFailed
+  | JobRescheduled
+  | JobRetried
+  | JobRetryExhausted
+  | JobDuplicate
+  deriving (Eq, Show)
+
+jobLifecycleStatusLabel :: JobLifecycleStatus -> Text
+jobLifecycleStatusLabel = \case
+  JobCreated -> "created"
+  JobPicked -> "picked"
+  JobCompleted -> "completed"
+  JobFailed -> "failed"
+  JobRescheduled -> "rescheduled"
+  JobRetried -> "retried"
+  JobRetryExhausted -> "retry_exhausted"
+  JobDuplicate -> "duplicate"
+
+-- | Record a job lifecycle transition.
+--
+-- @jobType@ must be the bare job type (e.g. @SendSearchRequestToDriver@). Do
+-- not pre-apply 'show' to it: the older @stream_jobs_counter@ call sites do,
+-- which is why their @job_type@ label values carry embedded quotes.
+incrementJobLifecycleCounter :: CoreMetrics m => Text -> JobLifecycleStatus -> m ()
+incrementJobLifecycleCounter jobType status =
+  incrementSchedulerJobLifecycleCounter jobType (jobLifecycleStatusLabel status)

--- a/Backend/lib/scheduler/src/Lib/Scheduler/Metrics.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/Metrics.hs
@@ -41,8 +41,15 @@ observeJobExecDuration duration = do
 -- 'JobRescheduled' and 'JobRetried' are not terminal -- the job will be picked
 -- again -- so @created - (completed + failed + retry_exhausted)@ is the number
 -- of jobs still in flight.
+--
+-- 'JobDequeued' counts jobs read off the redis stream, before the per-job lock
+-- is taken; 'JobPicked' counts the ones that went on to actually execute. The
+-- gap between them is jobs lost to lock contention or blacklisting. Together
+-- with @scheduler_producer_stage_counter@ these trace the full path:
+-- created -> picked_from_set -> inserted_to_stream -> dequeued -> picked.
 data JobLifecycleStatus
   = JobCreated
+  | JobDequeued
   | JobPicked
   | JobCompleted
   | JobFailed
@@ -55,6 +62,7 @@ data JobLifecycleStatus
 jobLifecycleStatusLabel :: JobLifecycleStatus -> Text
 jobLifecycleStatusLabel = \case
   JobCreated -> "created"
+  JobDequeued -> "dequeued"
   JobPicked -> "picked"
   JobCompleted -> "completed"
   JobFailed -> "failed"

--- a/Backend/lib/scheduler/src/Lib/Scheduler/ScheduleJob.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/ScheduleJob.hs
@@ -29,6 +29,7 @@ import Kernel.Types.Error (GenericError (InternalError))
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import Lib.Scheduler.Environment
+import Lib.Scheduler.Metrics (JobLifecycleStatus (..), incrementJobLifecycleCounter)
 import Lib.Scheduler.Types
 
 createJob ::
@@ -115,6 +116,10 @@ createJobImpl merchantId merchantOperatingCityId uuid createJobFunc scheduledAt 
   let shardId :: Int = idToShardNumber . fromJust $ UU.fromText uuid -- using fromJust because its never going to fail
   let job = makeJob shardId id now
   createJobFunc $ AnyJob job
+  -- Counted only after createJobFunc succeeds, so `created` never overstates
+  -- what actually reached the store.
+  fork "jobLifecycleCreated" $
+    incrementJobLifecycleCounter (show (fromSing (sing :: Sing e))) JobCreated
   pure id
   where
     idToShardNumber uuidTxt = fromIntegral ((\(a, b, c, d) -> a + b + c + d) (UU.toWords uuidTxt)) `mod` maxShards


### PR DESCRIPTION
## What

Wires up `scheduler_job_lifecycle_counter{job_type, status, version}` at every point in a scheduler job's life.

| File | Change |
|---|---|
| `Metrics.hs` | `JobLifecycleStatus` ADT + `incrementJobLifecycleCounter` helper |
| `Environment.hs` | `CoreMetrics m` added to the `JobMonad` synonym, so call sites don't each thread the constraint |
| `ScheduleJob.hs` | `created` — emitted after `createJobFunc` succeeds, so it never overstates what reached the store |
| `Handler.hs` | `picked` + every terminal branch: `completed` / `failed` / `rescheduled` / `retried` / `retry_exhausted` / `duplicate` |

## Why

Only `completed`, `failed` and `retry_exhausted` are counted today, across three differently named metrics with inconsistent labels. **Job creation isn't counted at all**, so there's no way to compare jobs entering the scheduler against jobs leaving it — which is exactly the signal that would have surfaced the 2026-08-11 allocator stall directly, independent of the producer that caused it:

```promql
sum(rate(scheduler_job_lifecycle_counter{status="created"}[5m])) by (job_type)
  - sum(rate(scheduler_job_lifecycle_counter{status=~"completed|failed|retry_exhausted"}[5m])) by (job_type)
```

## Notes

- **Purely additive** — `stream_jobs_counter`, `stream_jobs_failed_counter` and `scheduler_jobs_fail_counter` are untouched, so existing dashboards keep working.
- `picked` is recorded *after* the redis lock is acquired, so it counts jobs that actually started executing rather than everything read off the stream. Jobs skipped on lock contention are deliberately not counted here.
- `retried` covers both retry paths in the current `Retry` branch: the non-longRunning stream-requeue path and the longRunning `reScheduleOnError` path.
- `rescheduled` and `retried` are **not** terminal — the job will be picked again.
- The new metric uses the bare job type (`SendSearchRequestToDriver`). The older call sites apply `show` to an already-`Text` value, which is why their `job_type` labels carry embedded quotes (`Executor_"SendSearchRequestToDriver"`). Left alone to avoid breaking existing queries.

## Dependency

Requires nammayatri/shared-kernel#1469. **`flake.lock` still needs bumping** once that merges — this branch does not compile against the currently pinned kernel rev.

## Testing

Built with `--override-input shared-kernel` pointed at the kernel PR branch:

- `scheduler` lib — builds clean against current `main` (this branch)
- An earlier revision of this same patch also built `driver-offer-allocator` (1824 modules) and `rider-app` + `producer` (1617 modules), confirming the `JobMonad` constraint propagates to all job-creation call sites on both platforms. Worth re-running in CI after the flake bump, since `Handler.hs`'s `Retry` branch changed upstream in the interim and the counters were re-adapted to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduler metrics covering job creation, dequeueing, pickup, completion, failure, rescheduling, retries, duplicate detection, and retry exhaustion.
  * Metrics are labeled by job type and lifecycle status for improved visibility into processing outcomes.
  * Added producer metrics for jobs picked up and stream insertion success or failure.
* **Bug Fixes**
  * Stream insertion failures are now logged instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->