### PR TITLE
backend/fix: removing stale drivers from queue

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/SpecialZoneQueue.hs
@@ -16,6 +16,7 @@ import Data.List (nub)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Data.Time (NominalDiffTime, addUTCTime)
+import qualified Data.Vector as V
 import qualified Domain.Types.Merchant
 import qualified Domain.Types.Person as DP
 import qualified Domain.Types.ServiceTierType as DVST
@@ -162,6 +163,23 @@ postSpecialZoneQueueManualQueueRemove merchantShortId opCity req = do
   logInfo $ "Dashboard: removed driver " <> req.driverId <> " from queue for " <> req.specialLocationId <> "/" <> req.vehicleType
   pure Kernel.Types.APISuccess.Success
 
+mkQueueLastTsKey :: Text -> Text -> Kernel.Types.Id.Id DP.Person -> Text
+mkQueueLastTsKey specialLocationId vehicleType driverId =
+  "lts:queue_last_ts:" <> specialLocationId <> ":" <> vehicleType <> ":" <> driverId.getId
+
+queueReadFailSafeSize :: Int
+queueReadFailSafeSize = 10
+
+readQueueLastTsPresence :: [Text] -> Environment.Flow [Bool]
+readQueueLastTsPresence [] = pure []
+readQueueLastTsPresence keys = do
+  primary <- Redis.withLTSRedis $ Redis.withCrossAppRedis $ V.toList <$> Redis.mGetStandaloneRaw keys
+  mbSecondary <- asks (.secondaryLTSHedisEnv)
+  secondary <- case mbSecondary of
+    Nothing -> pure $ map (const Nothing) keys
+    Just _ -> Redis.withSecondaryLTSRedis $ Redis.withCrossAppRedis $ V.toList <$> Redis.mGetStandaloneRaw keys
+  pure $ zipWith (\p s -> isJust p || isJust s) primary secondary
+
 getSpecialZoneQueueQueueStats :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Text -> Environment.Flow SZQT.SpecialZoneQueueStatsRes)
 getSpecialZoneQueueQueueStats merchantShortId opCity gateId = do
   merchant <- findMerchantByShortId merchantShortId
@@ -187,6 +205,36 @@ getSpecialZoneQueueQueueStats merchantShortId opCity gateId = do
       uniqVariantsList = nub $ concatMap getCalloutVars cityServiceTiers
   uniqVariantsQueueList <- mapM (\vt' -> do resp <- LTSFlow.getQueueDrivers specialLocationId (show vt'); pure (vt', resp)) uniqVariantsList
   let uniqVariantsQueueMap = Map.fromList uniqVariantsQueueList
+
+  fork "reapStaleQueueMembers" $
+    forM_ uniqVariantsQueueList $ \(vt', qResp) -> do
+      let qDriverIds = map (.driverId) qResp.drivers
+      unless (null qDriverIds) $ do
+        let lastTsKeys = map (mkQueueLastTsKey specialLocationId (show vt')) qDriverIds
+        present <- readQueueLastTsPresence lastTsKeys
+        let staleDriverIds = [did | (did, isPresent) <- zip qDriverIds present, not isPresent]
+            total = length qDriverIds
+            staleCount = length staleDriverIds
+        if staleCount == total && total >= queueReadFailSafeSize
+          then
+            logError $
+              "[reapStaleQueueMembers] skipping eviction (suspected LTS read failure): all "
+                <> show total
+                <> " queued drivers reported stale for specialLocationId="
+                <> specialLocationId
+                <> " vehicleType="
+                <> show vt'
+          else unless (null staleDriverIds) $ do
+            logInfo $
+              "[reapStaleQueueMembers] specialLocationId=" <> specialLocationId
+                <> " vehicleType="
+                <> show vt'
+                <> " queued="
+                <> show total
+                <> " evictedStale="
+                <> show staleCount
+            forM_ staleDriverIds $ \did ->
+              void $ LTSFlow.manualQueueRemove specialLocationId (show vt') merchant.id did (Just "stale_queue_last_ts_expired")
 
   let driverLocMap = Map.fromList $ map (\dl -> (dl.driverId.getId, dl)) driversNearGate
   vehicleStats <- forM cityServiceTiers $ \vst -> do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Removing stake drivers from queue by calling manualQueueRemove during queueStats api

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue statistics by removing drivers whose queue activity is no longer current.
  * Added safeguards to prevent valid queue entries from being removed when queue data cannot be reliably retrieved.
  * Queue status now more accurately reflects active drivers across available queue data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->