### PR TITLE
backend/enh: making one endpoint id available to many capabilities

### DIFF
--- a/Backend/app/dashboard/Lib/src/Storage/Beam/CapabilityEndpoint.hs
+++ b/Backend/app/dashboard/Lib/src/Storage/Beam/CapabilityEndpoint.hs
@@ -29,12 +29,12 @@ data CapabilityEndpointT f = CapabilityEndpointT
 
 instance B.Table CapabilityEndpointT where
   data PrimaryKey CapabilityEndpointT f
-    = CapabilityEndpointKey (B.C f Text) (B.C f Text)
+    = CapabilityEndpointKey (B.C f Text) (B.C f Text) (B.C f Text)
     deriving (Generic, B.Beamable)
-  primaryKey CapabilityEndpointT {..} = CapabilityEndpointKey serverName endpointId
+  primaryKey CapabilityEndpointT {..} = CapabilityEndpointKey serverName endpointId capabilityId
 
 type CapabilityEndpoint = CapabilityEndpointT Identity
 
-$(enableKVPG ''CapabilityEndpointT ['serverName, 'endpointId] [])
+$(enableKVPG ''CapabilityEndpointT ['serverName, 'endpointId, 'capabilityId] [])
 
 $(mkTableInstancesGenericSchema ''CapabilityEndpointT "capability_endpoint")

--- a/Backend/app/dashboard/Lib/src/Storage/Queries/CapabilityEndpoint.hs
+++ b/Backend/app/dashboard/Lib/src/Storage/Queries/CapabilityEndpoint.hs
@@ -28,9 +28,14 @@ import qualified Storage.Beam.CapabilityEndpoint as BeamCE
 dashboardServerName :: Text
 dashboardServerName = "DASHBOARD"
 
-findByEndpointId :: BeamFlow m r => Text -> m (Maybe DC.CapabilityEndpoint)
-findByEndpointId endpointId =
-  findOneWithKV
+-- | Every capability an endpoint is assigned to. An endpoint may be assigned to
+-- several, so a narrow role can hold its own capability over an endpoint a
+-- broader role also reaches. Callers must treat the result as ANY-of: holding
+-- any one of the returned capabilities grants the call. An empty list means the
+-- endpoint is unmapped, which denies.
+findAllByEndpointId :: BeamFlow m r => Text -> m [DC.CapabilityEndpoint]
+findAllByEndpointId endpointId =
+  findAllWithKV
     [ Se.And
         [ Se.Is BeamCE.serverName $ Se.Eq dashboardServerName,
           Se.Is BeamCE.endpointId $ Se.Eq endpointId

--- a/Backend/app/dashboard/Lib/src/Tools/Auth/Capability.hs
+++ b/Backend/app/dashboard/Lib/src/Tools/Auth/Capability.hs
@@ -26,6 +26,7 @@ module Tools.Auth.Capability
 where
 
 import qualified Data.Set as Set
+import qualified Data.Text as T
 import qualified Domain.Types.AccessMatrix as DMatrix
 import qualified Domain.Types.Capability as DC
 import qualified Domain.Types.Person as DP
@@ -163,21 +164,24 @@ enforce person endpointId = do
       logTagError "SUPER_ADMIN_BREAKGLASS" $
         "personId: " <> person.id.getId <> ", endpointId: " <> endpointId
     else do
-      mbEndpoint <- QCE.findByEndpointId endpointId
-      case mbEndpoint of
+      -- An endpoint may be assigned to several capabilities; holding ANY of
+      -- them grants the call. Same ANY-of rule the frontend applies to
+      -- NavItem.requires.
+      endpoints <- QCE.findAllByEndpointId endpointId
+      let capabilityIds = map (.capabilityId.getId) endpoints
+      case capabilityIds of
         -- Fail closed. An unmapped endpoint is a seeding bug, not an open
         -- door: extend the shim in generate_capability_seed.py and reseed.
-        Nothing -> do
+        [] -> do
           logTagError "CAPABILITY_UNMAPPED_ENDPOINT" $
             "endpointId: " <> endpointId <> ", personId: " <> person.id.getId
           throwError AccessDenied
-        Just endpoint -> do
-          let capabilityId = endpoint.capabilityId.getId
-          unless (capabilityId `elem` access.capabilities) $ do
+        _ ->
+          unless (any (`elem` access.capabilities) capabilityIds) $ do
             logTagError "CAPABILITY_DENIED" $
               "endpointId: " <> endpointId
-                <> ", capabilityId: "
-                <> capabilityId
+                <> ", capabilityIds: "
+                <> T.intercalate "|" capabilityIds
                 <> ", personId: "
                 <> person.id.getId
                 <> ", roleId: "

--- a/Backend/dev/ddl-migrations/provider-dashboard/0096-capability-endpoint-multi-capability.sql
+++ b/Backend/dev/ddl-migrations/provider-dashboard/0096-capability-endpoint-multi-capability.sql
@@ -1,0 +1,28 @@
+-- Allow one endpoint to be reachable through more than one capability.
+--
+-- 0095 keyed capability_endpoint on (server_name, endpoint_id), so an endpoint
+-- resolved to exactly one capability. That made it impossible to give a narrow
+-- role private access to an endpoint a broad role already holds: the row had to
+-- MOVE, which took the endpoint away from everyone else. The concrete case is
+-- the BOT reviewer flow, whose detail screens read driver/vehicle/document
+-- endpoints that city-operations and fleet roles legitimately also use.
+--
+-- Widening the key to include capability_id makes the mapping a relation.
+-- Tools.Auth.Capability.enforce now allows a request when the caller holds ANY
+-- capability mapped to the endpoint, which is the same ANY-of rule the frontend
+-- already applies to NavItem.requires.
+--
+-- The fail-closed property is unchanged: zero rows for an endpoint still denies
+-- (CAPABILITY_UNMAPPED_ENDPOINT).
+--
+-- Operational note: this makes widening cheap and invisible. "Who can call this
+-- endpoint" stops being a single lookup and becomes a union, so a review of
+-- endpoints carrying more than one capability belongs in CI — see
+-- docs/access-unification/PLAN.md.
+
+ALTER TABLE atlas_dashboard.capability_endpoint
+  DROP CONSTRAINT capability_endpoint_pkey;
+
+ALTER TABLE atlas_dashboard.capability_endpoint
+  ADD CONSTRAINT capability_endpoint_pkey
+  PRIMARY KEY (server_name, endpoint_id, capability_id);

--- a/Backend/dev/ddl-migrations/rider-dashboard/0072-capability-endpoint-multi-capability.sql
+++ b/Backend/dev/ddl-migrations/rider-dashboard/0072-capability-endpoint-multi-capability.sql
@@ -1,0 +1,15 @@
+-- Mirror of provider-dashboard/0096 for the rider schema.
+--
+-- rider-dashboard is slated for deletion (PLAN.md Phase 7), but it still serves
+-- prod BAP traffic and 0062 created the same capability tables here, so the key
+-- has to widen on both sides or the two schemas disagree on what is insertable.
+--
+-- See provider-dashboard/0096-capability-endpoint-multi-capability.sql for the
+-- rationale.
+
+ALTER TABLE atlas_bap_dashboard.capability_endpoint
+  DROP CONSTRAINT capability_endpoint_pkey;
+
+ALTER TABLE atlas_bap_dashboard.capability_endpoint
+  ADD CONSTRAINT capability_endpoint_pkey
+  PRIMARY KEY (server_name, endpoint_id, capability_id);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Endpoints can now be associated with multiple capabilities.
  * Access is granted when a user has any capability mapped to the endpoint.
* **Bug Fixes**
  * Unmapped endpoints remain denied by default.
  * Authorization denial logs now include all capabilities associated with the endpoint.
* **Chores**
  * Updated database migrations to support multi-capability endpoint mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->