### PR TITLE
backend/fix/rc-reupload-end-association-fix

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding.hs
@@ -75,6 +75,7 @@ import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig, getOneConfig)
 import qualified SharedLogic.Allocator.Jobs.Overlay.SendOverlay as ACOverlay
 import SharedLogic.Analytics as Analytics
+import qualified SharedLogic.Association.Change as AC
 import SharedLogic.DriverOnboarding.OnboardingFlags.Types (OnboardingFlow)
 import SharedLogic.MessageBuilder (addBroadcastMessageToKafka)
 import SharedLogic.VehicleServiceTier
@@ -1473,11 +1474,10 @@ deleteVehicleWithAllAssociations personId mbFleetOwnerId rcNumber = do
   rc <- QRC.findLastVehicleRCWrapper rcNumber >>= fromMaybeM (RCNotFound rcNumber)
   canDeleteRcAndAssociations <- validateRCStatusAndOwnershipForDeletion personId mbFleetOwnerId rc
   when canDeleteRcAndAssociations $ do
-    endDriverAssociationForRC personId rc.id
-    endFleetAssociationForRC mbFleetOwnerId rc.id
-    unlessM (checkOtherActiveAssociations personId mbFleetOwnerId rc.id) $ do
-      deleteImagesLinkedWithRC rc.id
-      hardDeleteRC rc.id
+    endDriverAssociationIfPossibleForRc rc.id
+    endFleetAssociationIfPossibleForRc rc.id
+    deleteImagesLinkedWithRC rc.id
+    hardDeleteRC rc.id
   where
     validateRCStatusAndOwnershipForDeletion ::
       (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>
@@ -1491,7 +1491,8 @@ deleteVehicleWithAllAssociations personId mbFleetOwnerId rcNumber = do
         then do
           logWarning $ "RC deletion skipped for rcId: " <> rcId <> " - status is " <> show rc.verificationStatus
           pure False
-        else
+        else do
+          AC.guardNoLiveRideByRC rc.id
           checkRCOwnership personId' mbFleetOwnerId' rc >>= \case
             True -> pure True
             False -> do
@@ -1504,50 +1505,34 @@ deleteVehicleWithAllAssociations personId mbFleetOwnerId rcNumber = do
       Maybe (Id Person.Person) ->
       VehicleRegistrationCertificate ->
       m Bool
-    checkRCOwnership pId mbFlOwnId rc = do
+    checkRCOwnership requestorId mbFlOwnId rc = do
       now <- getCurrentTime
-      hasDriverAssoc <- isJust <$> DAQuery.findLinkedByRCIdAndDriverId pId rc.id now
-      hasFleetCheck <- case mbFlOwnId of
-        Just fleetOwnerId -> do
-          hasFleetDriverAssoc <- isJust <$> QFDA.findByDriverIdAndFleetOwnerId pId fleetOwnerId.getId True
-          hasFleetAssoc <- isJust <$> FRCAssoc.findLinkedByRCIdAndFleetOwnerId fleetOwnerId rc.id now
-          pure (hasFleetDriverAssoc && hasFleetAssoc)
-        Nothing -> pure True
-      pure (hasDriverAssoc && hasFleetCheck)
+      hasDriverAssoc <- isJust <$> DAQuery.findLinkedByRCIdAndDriverId requestorId rc.id now
+      hasFleetAssoc <- case mbFlOwnId of
+        Just fleetOwnerId ->
+          isJust <$> FRCAssoc.findLinkedByRCIdAndFleetOwnerId fleetOwnerId rc.id now
+        Nothing -> pure False
+      pure (hasDriverAssoc || hasFleetAssoc)
 
-    checkOtherActiveAssociations ::
+    endDriverAssociationIfPossibleForRc ::
       (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>
-      Id Person.Person ->
-      Maybe (Id Person.Person) ->
-      Id VehicleRegistrationCertificate ->
-      m Bool
-    checkOtherActiveAssociations personId' mbFleetOwnerId' rcId = do
-      remainingDriverAssocs <- filter (\a -> a.driverId /= personId') <$> DAQuery.findAllActiveAssociationByRCId rcId
-      remainingFleetAssocs <- case mbFleetOwnerId' of
-        Just fleetOwnerId -> filter (\a -> a.fleetOwnerId /= fleetOwnerId) <$> FRCAssoc.findAllActiveAssociationByRCId rcId
-        Nothing -> FRCAssoc.findAllActiveAssociationByRCId rcId
-      let hasOthersDriverOrFleetAssoc = not (null remainingDriverAssocs && null remainingFleetAssocs)
-      when hasOthersDriverOrFleetAssoc $
-        logError $ "RC " <> rcId.getId <> " still has other active associations, skipping hard delete"
-      pure hasOthersDriverOrFleetAssoc
-
-    endDriverAssociationForRC ::
-      (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>
-      Id Person.Person ->
       Id VehicleRegistrationCertificate ->
       m ()
-    endDriverAssociationForRC driverId rcId = do
-      DAQuery.endAssociationForRC driverId rcId
-      deleteVehicleIfPossible driverId
+    endDriverAssociationIfPossibleForRc rcId = do
+      linkedDriverAssocs <- DAQuery.findAllActiveAssociationByRCId rcId
+      let linkedDriverIds = map (.driverId) linkedDriverAssocs
+      forM_ linkedDriverIds $ \driverId -> do
+        DAQuery.endAssociationForRC driverId rcId
+        deleteVehicleIfPossible driverId
 
-    endFleetAssociationForRC ::
+    endFleetAssociationIfPossibleForRc ::
       (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>
-      Maybe (Id Person.Person) ->
       Id VehicleRegistrationCertificate ->
       m ()
-    endFleetAssociationForRC mbFleetOwnerId' rcId =
-      whenJust mbFleetOwnerId' $ \fleetOwnerId ->
-        endFleetRCAssociationIfPossible fleetOwnerId rcId
+    endFleetAssociationIfPossibleForRc rcId = do
+      linkedFleetAssocs <- FRCAssoc.findAllActiveAssociationByRCId rcId
+      forM_ linkedFleetAssocs $ \assoc ->
+        FRCAssoc.endById assoc.id
 
     deleteImagesLinkedWithRC ::
       (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RC deletion is now blocked while a live ride is associated with it.
  * Deletion requests are validated against an active driver or specified fleet-owner association.
  * Deleting an RC now ends all active driver and fleet associations and removes linked images.
  * Associated vehicles are removed for every linked driver.
  * RCs are permanently deleted after successful validation, including when other active associations exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->