### PR TITLE
backend/fix: shared-kernel flake bump for inmem sidecar x-inmem-token

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4021,11 +4021,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1786539963,
-        "narHash": "sha256-vYkft2W5b50DHsdX9qZxI99jPVZpeCEQmmSXbYIhnOQ=",
+        "lastModified": 1786606092,
+        "narHash": "sha256-4kU70Upuaipi6lLoOGkyTpgDcx0/OIzh3Yz99oSJMGM=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "ea3a29b2f36d121f31e795e68ac11ef34576df7b",
+        "rev": "cdbba0dc7d99d29896d5a93f657da3ab7fe8dff6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### What

Bumps the `shared-kernel` flake input from `ea3a29b2` to `cdbba0dc`.

### Why

Picks up the in-mem sidecar auth fix in shared-kernel: calls from the service **to** the sidecar (`POST /api/registerKey`, `POST /api/refresh`) were unauthenticated, even though the inbound management API (`/inMem/*`) already required an `x-inmem-token` header. Both outbound calls now send the same shared secret, sourced from the existing `INMEM_MANAGEMENT_TOKEN` env var already held in `InMemEnv`.

No app-side code changes are needed — the header is threaded internally in `Kernel.Storage.InMem`, and the token is omitted (as before) when `INMEM_MANAGEMENT_TOKEN` is unset.

### Commits pulled in

- `c6022e45` — feat: send x-inmem-token header on service -> inmem sidecar calls
- `cdbba0dc` — feat: implement Kafka-based external API call logging for FleetEngine client methods

### Note

This only lands the client half. The sidecar must validate `x-inmem-token` on `/api/registerKey` and `/api/refresh` for it to actually enforce anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
