### PR TITLE
backend/fix/devbox fix for dahboards

### DIFF
--- a/Backend/dev/seed-migrations/dashboard-unification/0009-capability-seed.sql
+++ b/Backend/dev/seed-migrations/dashboard-unification/0009-capability-seed.sql
@@ -1044,7 +1044,7 @@ INSERT INTO atlas_dashboard.capability_endpoint (capability_id, server_name, end
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/GET_SELECT_RESULT'),
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/POST_SELECT_CANCEL_SEARCH'),
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/POST_SELECT_ESTIMATE')
-ON CONFLICT (server_name, endpoint_id) DO NOTHING;
+ON CONFLICT (server_name, endpoint_id, capability_id) DO NOTHING;
 -- Create curated roles that exist on NEITHER dashboard (idempotent, by name).
 -- dashboard_access_type DASHBOARD_USER: none of these are admin tiers;
 -- admin tiering now lives in person.admin_tier, not this column.

--- a/Backend/dev/seed-migrations/provider-dashboard/0003-capability-seed.sql
+++ b/Backend/dev/seed-migrations/provider-dashboard/0003-capability-seed.sql
@@ -1044,7 +1044,7 @@ INSERT INTO atlas_dashboard.capability_endpoint (capability_id, server_name, end
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/GET_SELECT_RESULT'),
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/POST_SELECT_CANCEL_SEARCH'),
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/POST_SELECT_ESTIMATE')
-ON CONFLICT (server_name, endpoint_id) DO NOTHING;
+ON CONFLICT (server_name, endpoint_id, capability_id) DO NOTHING;
 -- Create curated roles that exist on NEITHER dashboard (idempotent, by name).
 -- dashboard_access_type DASHBOARD_USER: none of these are admin tiers;
 -- admin tiering now lives in person.admin_tier, not this column.

--- a/Backend/dev/seed-migrations/rider-dashboard/0004-capability-seed.sql
+++ b/Backend/dev/seed-migrations/rider-dashboard/0004-capability-seed.sql
@@ -1044,7 +1044,7 @@ INSERT INTO atlas_bap_dashboard.capability_endpoint (capability_id, server_name,
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/GET_SELECT_RESULT'),
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/POST_SELECT_CANCEL_SEARCH'),
     ('city-operations.booth_booking.execute', 'DASHBOARD', 'RIDER_RIDE_BOOKING/SELECT/POST_SELECT_ESTIMATE')
-ON CONFLICT (server_name, endpoint_id) DO NOTHING;
+ON CONFLICT (server_name, endpoint_id, capability_id) DO NOTHING;
 -- Create curated roles that exist on NEITHER dashboard (idempotent, by name).
 -- dashboard_access_type DASHBOARD_USER: none of these are admin tiers;
 -- admin tiering now lives in person.admin_tier, not this column.


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated capability mappings so a single endpoint can be associated with multiple capabilities.
  * Prevented distinct capability mappings from being incorrectly treated as duplicates during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->