### PR TITLE
 fix(ticket-dashboard): scope places by selected operating city, not …

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/AppManagement/Tickets.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/AppManagement/Tickets.hs
@@ -287,9 +287,12 @@ getTicketPlaces ::
   Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant ->
   Kernel.Types.Beckn.Context.City ->
   Environment.Flow [Domain.Types.TicketPlace.TicketPlace]
-getTicketPlaces merchantShortId _opCity = do
+getTicketPlaces merchantShortId opCity = do
   m <- findMerchantByShortId merchantShortId
-  Domain.Action.UI.TicketService.getTicketPlaces (Nothing, m.id)
+  merchantOpCity <-
+    CQMOC.findByMerchantIdAndCity m.id opCity
+      >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantId: " <> m.id.getId <> " city: " <> show opCity)
+  Domain.Action.UI.TicketService.getTicketPlacesByOpCity merchantOpCity.id
 
 getTicketPlaceServices ::
   Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/TicketService.hs
@@ -143,8 +143,12 @@ convertBusinessHT (Domain.Types.BusinessHour.Duration startTime endTime) = Conve
 getTicketPlaces :: (Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant) -> Environment.Flow [Domain.Types.TicketPlace.TicketPlace]
 getTicketPlaces (_, merchantId) = do
   merchantOpCity <- CQM.getDefaultMerchantOperatingCity merchantId
+  getTicketPlacesByOpCity merchantOpCity.id
+
+getTicketPlacesByOpCity :: Kernel.Types.Id.Id MerchantOperatingCity.MerchantOperatingCity -> Environment.Flow [Domain.Types.TicketPlace.TicketPlace]
+getTicketPlacesByOpCity merchantOpCityId = do
   context <- TicketRule.getCurrentContext 330 Nothing Nothing
-  ticketPlaces' <- QTicketPlace.getTicketPlaces merchantOpCity.id
+  ticketPlaces' <- QTicketPlace.getTicketPlaces merchantOpCityId
   let ticketPlaces = TicketRule.processEntity context <$> ticketPlaces'
   pure $ sortBy (comparing (Down . (.priority))) $ filterEnforcedAsSubPlace $ filterEndedOrUnPublishedPlaces ticketPlaces
   where


### PR DESCRIPTION
## Summary

Ticket-dashboard `GET .../ticketdashboard places` (`getTicketPlaces`) returned ticket places for the **merchant's default city** instead of the **selected operating city**. For merchants that operate in many cities (e.g. Namma Yatri, which spans Bangalore, Odisha, TN, Kerala, …), selecting a non-default city returned the wrong city's places.

This PR scopes the dashboard place listing to the city actually requested.

## Problem

The dashboard proxy passes the selected `opCity` down to rider-app, but the handler ignored it:

```haskell
-- Domain/Action/Dashboard/AppManagement/Tickets.hs (before)
getTicketPlaces merchantShortId _opCity = do        -- opCity discarded
  m <- findMerchantByShortId merchantShortId
  Domain.Action.UI.TicketService.getTicketPlaces (Nothing, m.id)

-- Domain/Action/UI/TicketService.hs (before)
getTicketPlaces (_, merchantId) = do
  merchantOpCity <- CQM.getDefaultMerchantOperatingCity merchantId   -- default city, not selected
  ...

getDefaultMerchantOperatingCity resolves merchant.defaultCity (a single value per merchant), so the query ticket_place WHERE merchant_operating_city_id = <defaultCity's op-city> returns the default city's places regardless of what the dashboard selected.

Fix

Resolve the operating city from the selected opCity, and reuse the same listing logic across flows.

-- Dashboard/AppManagement/Tickets.hs (after)
getTicketPlaces merchantShortId opCity = do
  m <- findMerchantByShortId merchantShortId
  merchantOpCity <-
    CQMOC.findByMerchantIdAndCity m.id opCity
      >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantId: " <> m.id.getId <> " city: " <> show opCity)
  Domain.Action.UI.TicketService.getTicketPlacesByOpCity merchantOpCity.id

-- UI/TicketService.hs (after) — extracted, op-city-scoped helper
getTicketPlaces (_, merchantId) = do
  merchantOpCity <- CQM.getDefaultMerchantOperatingCity merchantId
  getTicketPlacesByOpCity merchantOpCity.id

getTicketPlacesByOpCity :: Id MerchantOperatingCity -> Flow [TicketPlace]
getTicketPlacesByOpCity merchantOpCityId = do
  context <- TicketRule.getCurrentContext 330 Nothing Nothing
  ticketPlaces' <- QTicketPlace.getTicketPlaces merchantOpCityId
  ... -- same rules / filtering / ordering as before

Changes

┌──────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────┐
│                       File                       │                                 Change                                  │
├──────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Domain/Action/Dashboard/AppManagement/Tickets.hs │ getTicketPlaces resolves op-city from selected opCity and lists by it   │
├──────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤
│ Domain/Action/UI/TicketService.hs                │ Extract getTicketPlacesByOpCity helper; getTicketPlaces delegates to it │
└──────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘

- No API/signature changes → no NammaDSL regen; generated callers untouched.
- Consumer (TokenAuth) flow unchanged — still resolves via merchant default. Out of scope here.
- getTicketPlacesV2 has the same latent pattern but is consumer-only (not called by the dashboard) — left untouched.

Testing

- Live-checked the endpoint via the dashboard proxy (/api/bpp/bap/{merchant}/{cityCode}/places):
  - Jatri Saathi / Kolkata (std:033) → 7 Kolkata places (Alipore Zoo, Nicco Park, Eco Park, …) ✅
  - Namma Yatri / Puri (std:06752) → ["Satapada Boating"] ✅
- Dashboard tokens are single-operating-city scoped (other cities → 403 ACCESS_DENIED), so a same-merchant cross-city comparison couldn't be forced from the client; this fix hardens the selected-city ≠ default-city code path.
- ⚠️ Needs a full CI/GHC build to confirm compilation (couldn't complete a local rider-app compile in the working environment).

Edge cases

┌────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────┐
│                    Case                    │                              Behavior                               │
├────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ City has no ticket places                  │ returns [] (correct)                                                │
├────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ (merchant, city) has no operating-city row │ 404 MerchantOperatingCityNotFound (fail-loud vs. silent wrong data) │
├────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ Selected city == merchant default          │ unchanged                                                           │
├────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│ Consumer app /ticket/places                │ unchanged (still default)                                           │
└────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────┘

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket place results are now retrieved for the requested operating city.
  * Unavailable and restricted places are filtered consistently.
  * A clear error is returned when no matching merchant operating city exists.
  * Existing ticket rules and priority ordering are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->