### PR TITLE
Widen issue_report.description to TEXT to prevent driver drainer stop on long descriptions

### DIFF
--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-issue-report-description-text.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-issue-report-description-text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE TEXT;

--- a/Backend/dev/ddl-migrations/rider-app/1561-issue-report-description-text.sql
+++ b/Backend/dev/ddl-migrations/rider-app/1561-issue-report-description-text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_app.issue_report ALTER COLUMN description TYPE TEXT;


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (2f/2l)

### Root cause
atlas_driver_offer_bpp.issue_report.description was defined as character varying(255), but the IssueManagement API accepts arbitrary-length Text. A driver submitted a ~700-character description; the driver drainer's INSERT failed with SqlError 22001 ('value too long for type character varying(255)'), and because force-sync was disabled it stopped, firing NoDriverDrainerRunning.

### Evidence
_see RCA_

### Rollback
Run the reverse ALTER TABLE on both schemas: ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE character varying(255); ALTER TABLE atlas_app.issue_report ALTER COLUMN description TYPE character varying(255);

---
_Draft PR — review and merge manually. Generated by Argus._