### PR TITLE
Increase issue_report.description column to text to fix driver drainer poison message

### DIFF
--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-issue-report-description-text.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-issue-report-description-text.sql
@@ -1,0 +1,2 @@
+-- Widen issue_report.description so long descriptions do not stall the drainer with a 22001 error.
+ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE text;

--- a/Backend/dev/ddl-migrations/rider-app/1561-issue-report-description-text.sql
+++ b/Backend/dev/ddl-migrations/rider-app/1561-issue-report-description-text.sql
@@ -1,0 +1,2 @@
+-- Widen issue_report.description so long descriptions do not stall the drainer with a 22001 error.
+ALTER TABLE atlas_app.issue_report ALTER COLUMN description TYPE text;


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (2f/4l)

### Root cause
The driver drainer is stalled on an issue_report CREATE whose description exceeds the database column limit (character varying(255)). The shared IssueReport Beam type stores description as Text, but the migration created a 255-character column. Long driver issue descriptions therefore fail with SqlError 22001, the drainer stops, and lag grows unbounded.

### Evidence
_see RCA_

### Rollback
Revert the two migration files and, if already applied, run ALTER TABLE ... ALTER COLUMN description TYPE character varying(255); under DBA supervision. Also remove the offending stream entry or fix the row if the drainer is still blocked.

---
_Draft PR — review and merge manually. Generated by Argus._