### PR TITLE
Widen issue_report.description to TEXT to prevent drainer stop on long descriptions

### DIFF
--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-alter-issue-report-description-to-text.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-alter-issue-report-description-to-text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE text;

--- a/Backend/dev/ddl-migrations/rider-app/1561-alter-issue-report-description-to-text.sql
+++ b/Backend/dev/ddl-migrations/rider-app/1561-alter-issue-report-description-to-text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_app.issue_report ALTER COLUMN description TYPE text;


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (2f/2l)

### Root cause
A driver submitted an issue report with a 347-character description. The driver drainer tried to INSERT it into atlas_driver_offer_bpp.issue_report, but the description column was character varying(255), causing SQLSTATE 22001. Because Force Sync is disabled, the drainer stopped all driver drainer pods, triggering NoDriverDrainerRunning. The same varchar(255) definition exists in atlas_app.issue_report (rider side) and is equally vulnerable.

### Evidence
_see RCA_

### Rollback
Revert the two new migration files. If already applied, run ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE varchar(255); and ALTER TABLE atlas_app.issue_report ALTER COLUMN description TYPE varchar(255); (after ensuring no rows exceed 255 chars).

---
_Draft PR — review and merge manually. Generated by Argus._