### PR TITLE
Fix driver drainer stop: widen issue_report.description to TEXT

### DIFF
--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-alter-issue-report-description-to-text.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-alter-issue-report-description-to-text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE text;

--- a/Backend/dev/ddl-migrations/rider-app/1561-alter-issue-report-description-to-text.sql
+++ b/Backend/dev/ddl-migrations/rider-app/1561-alter-issue-report-description-to-text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE atlas_app.issue_report ALTER COLUMN description TYPE text;


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (2f/2l)

### Root cause
The driver drainer stopped because an INSERT into atlas_driver_offer_bpp.issue_report failed with SQLSTATE 22001 (value too long for type character varying(255)). The description field in the request exceeded 255 characters. Because Force Sync is disabled, the drainer halts on CREATE failures to avoid data loss. The Beam schema models description as unrestricted Text, but the underlying DB column is still varchar(255) from the original migration. Widening the column to TEXT removes the mismatch and lets the drainer process the backlog.

### Evidence
_see RCA_

### Rollback
If the column width change causes unexpected issues, run the reverse ALTER statements: ALTER TABLE atlas_driver_offer_bpp.issue_report ALTER COLUMN description TYPE character varying(255); ALTER TABLE atlas_app.issue_report ALTER COLUMN description TYPE character varying(255); (note this will reintroduce the drainer-stop bug for long descriptions).

---
_Draft PR — review and merge manually. Generated by Argus._