### PR TITLE
fix: Remove fleetDriverInfo validation on LinkToFleet

### DIFF
--- a/.cursor/docs/20-onboarding-action-guard.md
+++ b/.cursor/docs/20-onboarding-action-guard.md
@@ -129,7 +129,7 @@ Skipped entirely outside unified cities, and skipped when the entity row is miss
 | `Activate` | enabled, not blocked | `DI-1`, `D-BLOCKED` |
 | `Delete` | `disabledReasonFlag` is set — disable first. Uses the flag rather than `enabled`, because in unified cities an admin disable sets only the flag and leaves `enabled` derived | `D-DELETE` |
 | `LinkToFleet` | **not** enabled — use `changeFleetOwner` to move an active driver | `DI-9` |
-| `LinkToFleet` (stage 1) | `onboardingAs = FLEET_DRIVER`; and rejected only if the driver has an FDA with `isActive = True` and `associatedTill > now` **and** is enabled — a disabled driver may still be linked | `DRIVER_NOT_FLEET_DRIVER`, `DRIVER_ALREADY_LINKED_WITH_FLEET` |
+| `LinkToFleet` (stage 1) | rejected only if the driver has an FDA with `isActive = True` and `associatedTill > now` **and** is enabled — a disabled driver may still be linked. No `onboardingAs` requirement: an `INDIVIDUAL` driver can be added to a fleet | `DRIVER_ALREADY_LINKED_WITH_FLEET` |
 | `SetOnboardingAs` | **not** enabled | `DI-8` |
 | `ChangeFleetOwner` (stage 1) | `onboardingAs = FLEET_DRIVER`, and at least one FDA with `associatedTill > now` (`QFDA.findAllByDriverIdWithStatus`). The new owner is not compared against the current one, so re-transferring into the same fleet is a no-op rather than an error | `DRIVER_NOT_FLEET_DRIVER`, `DRIVER_HAS_NO_ACTIVE_FLEET_ASSOCIATION` |
 | `UnlinkDocument` | **not** enabled — invalidate the doc before unlinking documents | `DI-10` |
@@ -146,12 +146,14 @@ The rows marked **(stage 1)** live in `guardFleetMembership`, not `checkDriver`:
 | Source | `guardFleetMembership` | `checkPrecondition` |
 
 The two verbs are mirror images — `LinkToFleet` requires the driver to be free, `ChangeFleetOwner`
-requires them to be attached — and for `ChangeFleetOwner` they are the only checks that run at all.
+requires them to be attached and to already be a `FLEET_DRIVER` — and for `ChangeFleetOwner` they are
+the only checks that run at all.
 
 | Design point | Why |
 |---|---|
 | `LinkToFleet` counts only `isActive = True` rows | keeps consent flows working: `postFleetConsent` fetches its row with `FDV.findByDriverId driverId False`, so the pending association it is about to activate is invisible to the check |
 | `LinkToFleet` skipped for a disabled driver | an unenabled driver can be re-linked without first tearing down a stale association |
+| `LinkToFleet` does not require `onboardingAs = FLEET_DRIVER` | a driver who signed up as `INDIVIDUAL` must still be addable to a fleet; `onboardingAs` is set by the link flow itself, so requiring it beforehand made first-time adds impossible |
 | `ChangeFleetOwner` does not reuse `Link` | `Link` pulls in `guardAssociationAllowed`, which rejects a driver who already has an active fleet association, plus the `Link` preconditions — neither holds for a driver being moved between fleets |
 | Destination validation stays in the handler | new owner must hold a fleet role (`DCommon.checkFleetOwnerRole`) and, when `merchant.fleetOwnerEnabledCheck` is on, be enabled (`DCommon.checkFleetOwnerVerification`) |
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/OnboardingFlags/Guard.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/OnboardingFlags/Guard.hs
@@ -448,7 +448,7 @@ guardFleetMembership verb target = case (verb, target) of
     when (null activeAssocs) $ throwError DriverHasNoActiveFleetAssociation
   (ChangeFleetOwner, _) -> throwError $ InvalidRequest "ChangeFleetOwner is only supported for driver targets"
   (LinkToFleet, TargetDriver personId) -> do
-    driverInfo <- fleetDriverInfo personId
+    driverInfo <- DIQuery.findById (cast personId) >>= fromMaybeM (PersonDoesNotExist personId.getId)
     mbActiveAssoc <- QFDA.findByDriverId personId True
     when (isJust mbActiveAssoc && driverInfo.enabled) $ throwError DriverAlreadyLinkedWithFleet
   _ -> pure ()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drivers with an individual onboarding status can now be added to fleets when they have an active association and are enabled.
  * Improved handling for missing driver records by returning a clear “person does not exist” error.
  * Fleet owner changes continue to require an existing fleet association and fleet-driver status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->