### PR TITLE
backend/imprv/using-real-pooling-config-version-nd-decrement-counter-…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
@@ -366,6 +366,7 @@ cancelSearch merchantId searchTry = do
       -- free the driver's parallel-request slot; it otherwise stays consumed
       -- against maxParallelSearchRequests until the entry's validTill passes
       DP.removeSearchReqIdFromMap merchantId driverReq.driverId driverReq.requestId
+      DP.decrementSrdSentCount driverReq.createdAt driverReq.driverId
       whenJust mbTransporterConfig $ \transporterConfig ->
         when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $
           Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverReq.driverId transporterConfig False False False True

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPool.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPool.hs
@@ -160,6 +160,20 @@ makeTaggedDriverPool ::
 makeTaggedDriverPool mOCityId timeDiffFromUtc searchReq onlyNewDrivers batchSize isOnRidePool customerNammaTags mbPoolingLogicVersion batchNum driverPoolCfg searchTryId = do
   localTime <- getLocalCurrentTime timeDiffFromUtc
   (allLogics, mbVersion) <- getAppDynamicLogic (cast mOCityId) LYT.POOLING localTime mbPoolingLogicVersion (Just $ poolingLogicVersionToss searchReq.id)
+  updateVersionInSearchReq mbVersion
+  -- A rollout toss happens here whenever mbPoolingLogicVersion is Nothing, so the version applied to
+  -- this pool can differ from the one already pinned on the SearchRequest. That divergence used to be
+  -- invisible and mislabelled scores with the wrong experiment arm; make it greppable.
+  when (isJust mbPoolingLogicVersion && mbVersion /= mbPoolingLogicVersion) $
+    logError $
+      "POOLING version mismatch: ran " <> show mbVersion <> " but SearchRequest is pinned to "
+        <> show mbPoolingLogicVersion
+        <> " (searchTryId="
+        <> searchTryId.getId
+        <> ", isOnRidePool="
+        <> show isOnRidePool
+        <> ")"
+  logInfo $ "POOLING version applied: " <> show mbVersion <> " batchNum=" <> show batchNum <> " isOnRidePool=" <> show isOnRidePool
   let onlyNewDriversWithCustomerInfo = map updateDriverPoolWithActualDistResult onlyNewDrivers
   -- Enrich drivers with their per-driver SRD sliding-window counters and idle time so the POOLING
   -- dynamic-logic rules can reference them. Batched: pipelined cross-slot MGETs for the whole batch
@@ -193,8 +207,12 @@ makeTaggedDriverPool mOCityId timeDiffFromUtc searchReq onlyNewDrivers batchSize
         )
       <> "]"
   resp <- withTimeAPI "driverPooling" "runLogics" $ LYDL.runLogicsWithDebugLog LYDL.Driver (cast mOCityId) LYT.POOLING (Just searchReq.transactionId) allLogics taggedDriverPoolInput
+  -- Stamp the version we actually ran onto every driver, after decoding, so it travels with the
+  -- `score` that version produced. Callers must read the version from here rather than from
+  -- SearchRequest.poolingLogicVersion: that field is a pre-pool snapshot and, when the version is
+  -- chosen by rollout toss on this very call, it does not yet hold the version being applied.
   sortedPool' <-
-    case (A.fromJSON resp.result :: Result TaggedDriverPoolInput) of
+    map (\d -> d {poolingLogicVersion = mbVersion}) <$> case (A.fromJSON resp.result :: Result TaggedDriverPoolInput) of
       A.Success sortedPoolData -> pure sortedPoolData.drivers
       A.Error err -> do
         logError $ "Error in parsing sortedPoolData - " <> show err
@@ -213,6 +231,10 @@ makeTaggedDriverPool mOCityId timeDiffFromUtc searchReq onlyNewDrivers batchSize
   pushTaggedPoolToKafka sortedPool
   return (mbVersion, take batchSize sortedPool)
   where
+    updateVersionInSearchReq mbVersion =
+      when (isNothing searchReq.poolingLogicVersion && isJust mbVersion) $
+        QSR.updatePoolingLogicVersion mbVersion searchReq.id
+
     updateDriverPoolWithActualDistResult DriverPoolWithActualDistResult {..} =
       DriverPoolWithActualDistResult {driverPoolResult = updateDriverPoolResult driverPoolResult, searchTags = Just $ maybe A.emptyObject LYTU.convertTags searchReq.searchTags, tripDistance = searchReq.estimatedDistance, ..}
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPoolUnified.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPoolUnified.hs
@@ -248,27 +248,31 @@ prepareDriverPoolBatch cityServiceTiers merchant driverPoolCfg searchReq searchT
 
         calculateNormalBatch mOCityId transporterConfig onlyNewNormalDrivers txnId' onRidePoolResults airportEntryFee isAirportRequest = do
           logDebug $ "calculateNormalBatch txnId " <> show txnId'
-          (normalBatchNotOnRide, _, _) <- withTimeAPI "driverPooling" "getDriverPoolNotOnRide" $ getDriverPoolNotOnRide mOCityId transporterConfig onlyNewNormalDrivers
+          -- Resolve the POOLING version once, on the first pool, then reuse it for the on-ride pool.
+          -- Both pools used to read searchReq.poolingLogicVersion independently; while that snapshot
+          -- is Nothing (the batch that pins it) each call re-tossed the rollout, so the two halves of
+          -- a single batch could be scored by different versions and then sorted against each other
+          -- on incomparable scales.
+          (mbPoolingVersion, normalBatchNotOnRide) <- withTimeAPI "driverPooling" "getDriverPoolNotOnRide" $ getDriverPoolNotOnRide mOCityId transporterConfig onlyNewNormalDrivers
           logDebug $ "NormalBatchNotOnRide-" <> show normalBatchNotOnRide <> " and txnId " <> show txnId'
-          normalBatchOnRide <- getDriverPoolOnRide mOCityId transporterConfig NormalPool onRidePoolResults airportEntryFee isAirportRequest
+          normalBatchOnRide <- getDriverPoolOnRide mOCityId transporterConfig NormalPool onRidePoolResults airportEntryFee isAirportRequest mbPoolingVersion
           pure (normalBatchNotOnRide, normalBatchOnRide)
 
-        getDriverPoolNotOnRide mOCityId transporterConfig onlyNewNormalDrivers = do
-          (_, normalDriverPoolBatch) <- withTimeAPI "driverPooling" "mkDriverPoolBatch" $ mkDriverPoolBatch mOCityId onlyNewNormalDrivers transporterConfig batchSize False
-          pure (normalDriverPoolBatch, [], Nothing)
+        getDriverPoolNotOnRide mOCityId transporterConfig onlyNewNormalDrivers =
+          withTimeAPI "driverPooling" "mkDriverPoolBatch" $ mkDriverPoolBatch mOCityId onlyNewNormalDrivers transporterConfig batchSize False searchReq.poolingLogicVersion
 
         filtersForNormalBatch mOCityId transporterConfig normalDriverPool = do
           allNearbyNonGoHomeDrivers <- filterM (\dpr -> (CQDGR.getDriverGoHomeRequestInfo dpr.driverPoolResult.driverId mOCityId (Just goHomeConfig)) <&> (/= Just DDGR.ACTIVE) . (.status)) normalDriverPool
           pure $ bookAnyFilters transporterConfig allNearbyNonGoHomeDrivers
 
-        getDriverPoolOnRide mOCityId transporterConfig poolType allDriverPoolResults airportEntryFee isAirportRequest = do
+        getDriverPoolOnRide mOCityId transporterConfig poolType allDriverPoolResults airportEntryFee isAirportRequest mbPoolingVersion = do
           if poolType == NormalPool && driverPoolCfg.enableForwardBatching && searchTry.isAdvancedBookingEnabled
             then do
               previousDriverOnRide <- getPreviousBatchesDrivers (Just True)
               allNearbyDriversCurrentlyOnRide <- calcDriverCurrentlyOnRidePool poolType transporterConfig batchNum allDriverPoolResults airportEntryFee isAirportRequest
               logDebug $ "NormalDriverPoolBatchOnRideCurrentlyOnRide-" <> show allNearbyDriversCurrentlyOnRide
               onlyNewNormalDriversOnRide <- filtersForNormalBatch mOCityId transporterConfig allNearbyDriversCurrentlyOnRide
-              (_, normalDriverPoolBatchOnRide) <- withTimeAPI "driverPooling" "mkDriverPoolBatchOnRide" $ mkDriverPoolBatch mOCityId onlyNewNormalDriversOnRide transporterConfig batchSizeOnRide True
+              (_, normalDriverPoolBatchOnRide) <- withTimeAPI "driverPooling" "mkDriverPoolBatchOnRide" $ mkDriverPoolBatch mOCityId onlyNewNormalDriversOnRide transporterConfig batchSizeOnRide True mbPoolingVersion
               validDriversFromPreviousBatch <-
                 filterM
                   ( \dpr -> do
@@ -306,7 +310,7 @@ prepareDriverPoolBatch cityServiceTiers merchant driverPoolCfg searchReq searchT
 
             filtered = filter (\d -> d.driverPoolResult.serviceTierDowngradeLevel >= config) results
 
-        mkDriverPoolBatch mOCityId onlyNewDrivers transporterConfig batchSize' isOnRidePool = withTimeAPI "driverPooling" "makeTaggedDriverPool" $ SDP.makeTaggedDriverPool mOCityId transporterConfig.timeDiffFromUtc searchReq onlyNewDrivers batchSize' isOnRidePool searchReq.customerNammaTags searchReq.poolingLogicVersion batchNum driverPoolCfg searchTry.id
+        mkDriverPoolBatch mOCityId onlyNewDrivers transporterConfig batchSize' isOnRidePool mbPoolingVersion = withTimeAPI "driverPooling" "makeTaggedDriverPool" $ SDP.makeTaggedDriverPool mOCityId transporterConfig.timeDiffFromUtc searchReq onlyNewDrivers batchSize' isOnRidePool searchReq.customerNammaTags mbPoolingVersion batchNum driverPoolCfg searchTry.id
 
         addDistanceSplitConfigBasedDelaysForDriversWithinBatch =
           addDelaysWithPrioritySplit driverPoolCfg.distanceBasedBatchSplit

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
@@ -392,7 +392,7 @@ sendSearchRequestToDrivers isAllocatorBatch tripQuoteDetails oldSearchReq search
                 previousDropGeoHash = dpwRes.previousDropGeoHash,
                 driverTags = Just $ addSpecialLocWarriorPreferredSpecialLocId dpwRes.specialLocWarriorPreferredSpecialLocId dpRes.driverTags,
                 customerTags = dpRes.customerTags,
-                poolingLogicVersion = searchReq.poolingLogicVersion,
+                poolingLogicVersion = dpwRes.poolingLogicVersion <|> searchReq.poolingLogicVersion,
                 poolingConfigVersion = searchReq.poolingConfigVersion,
                 notificationSource = Nothing,
                 totalRides = fromMaybe (-1) (driverStats <&> (.totalRides)),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverPool.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverPool.hs
@@ -28,6 +28,7 @@ module SharedLogic.DriverPool
     incrementCancellationCount,
     incrementSrdRejectedCount,
     incrementSrdSentCount,
+    decrementSrdSentCount,
     getSrdStatsCountersBulk,
     getLatestCancellationRatio,
     getCurrentWindowAvailability,
@@ -413,6 +414,16 @@ incrementSrdSentCount ::
   m ()
 incrementSrdSentCount driverId = Redis.withCrossAppRedis $ SWC.incrementWindowCount (mkSrdSentCountKey driverId.getId) srdStatsWindow
 
+decrementSrdSentCount ::
+  ( Redis.HedisFlow m r,
+    EsqDBFlow m r,
+    CacheFlow m r
+  ) =>
+  UTCTime ->
+  Id DP.Person ->
+  m ()
+decrementSrdSentCount sentAt driverId = Redis.withCrossAppRedis $ SWC.decrementByValueInTimeBucket sentAt 1 (mkSrdSentCountKey driverId.getId) srdStatsWindow
+
 -- Fetch all 8 per-driver sliding-window counts (today = last 1 day-bucket, weekly = last 7
 -- day-buckets) for use in the POOLING dynamic-logic data. Acceptance reuses the existing
 -- mkQuotesAcceptedKey counter and cancellation reuses mkRideCancelledKey (to avoid
@@ -771,6 +782,7 @@ filterOutGoHomeDriversAccordingToHomeLocation randomDriverPool CalculateGoHomeDr
           previousDropGeoHash = Nothing,
           specialLocWarriorPreferredSpecialLocId = mbPreferredSpecialLocId,
           score = driverGoHomePoolWithActualDistance.score,
+          poolingLogicVersion = driverGoHomePoolWithActualDistance.poolingLogicVersion,
           searchReqDriverStatsCounters = Nothing,
           idleTimeSeconds = Nothing
         }
@@ -1054,6 +1066,7 @@ calculateDriverPoolWithActualDist CalculateDriverPoolReq {..} poolType currentSe
           isForwardRequest = False,
           previousDropGeoHash = Nothing,
           score = dpr.score,
+          poolingLogicVersion = Nothing,
           searchReqDriverStatsCounters = Nothing,
           idleTimeSeconds = Nothing
         }
@@ -1289,6 +1302,7 @@ computeActualDistance distanceUnit orgId merchantOpCityId prevRideDropLatLn pick
           isForwardRequest = False,
           previousDropGeoHash = prevRideDropGeoHash,
           score = distDur.origin.score,
+          poolingLogicVersion = Nothing,
           searchReqDriverStatsCounters = Nothing,
           idleTimeSeconds = Nothing
         }
@@ -1350,6 +1364,7 @@ computeActualDistanceOneToOneSrcAndDestMapping distanceUnit orgId merchantOpCity
           isForwardRequest = False,
           previousDropGeoHash = prevRideDropGeoHash,
           score = distDur.origin.score,
+          poolingLogicVersion = Nothing,
           searchReqDriverStatsCounters = Nothing,
           idleTimeSeconds = Nothing
         }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverPool/Types.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverPool/Types.hs
@@ -284,6 +284,10 @@ data DriverPoolWithActualDistResult = DriverPoolWithActualDistResult
     goHomeReqId :: Maybe (Id DDGR.DriverGoHomeRequest),
     specialLocWarriorPreferredSpecialLocId :: Maybe (Id SL.SpecialLocation),
     score :: Maybe A.Value,
+    -- The POOLING logic version that produced `score`. Stamped by makeTaggedDriverPool from the
+    -- version it actually ran, never read back from the SearchRequest -- the two used to be
+    -- sourced independently and could disagree, which silently mislabelled experiment arms.
+    poolingLogicVersion :: Maybe Int,
     searchReqDriverStatsCounters :: Maybe SearchReqDriverStatsCounters,
     idleTimeSeconds :: Maybe Double
   }
@@ -308,6 +312,7 @@ instance Default DriverPoolWithActualDistResult where
         goHomeReqId = Nothing,
         specialLocWarriorPreferredSpecialLocId = Nothing,
         score = Nothing,
+        poolingLogicVersion = Nothing,
         searchReqDriverStatsCounters = Nothing,
         idleTimeSeconds = Nothing
       }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
@@ -632,6 +632,7 @@ pullExistingRideRequests merchantOpCityId driverSearchReqs merchantId quoteDrive
     unless (driverId == quoteDriverId) $ do
       DP.decrementTotalQuotesCount merchantId merchantOpCityId (cast driverReq.driverId) driverReq.requestId
       DP.removeSearchReqIdFromMap merchantId driverId driverReq.requestId
+      DP.decrementSrdSentCount driverReq.createdAt driverId
       when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False False False True
       void $ QSRD.updateDriverResponse (Just SReqD.Pulled) SReqD.Inactive Nothing driverReq.renderedAt driverReq.respondedAt driverReq.id
       driver_ <- QPerson.findById driverId >>= fromMaybeM (PersonNotFound driverId.getId)


### PR DESCRIPTION
…on-cancelserach-and-pulled

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver search request tracking when requests are cancelled or cleared.
  * Kept pooling logic versions consistent across driver matching, scoring, and search results.
  * Added clearer handling for missing or mismatched pooling versions.
  * Preserved pooling version details for applicable driver distance results.
  * Improved consistency when applying pooling logic across multiple driver pools in the same search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->