### PR TITLE
backend/enh: added slab checks for intercity and rentals

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
@@ -2802,6 +2802,17 @@ postMerchantConfigFarePolicyUpsert merchantShortId opCity req = do
               <> "(vehicleServiceTier, tripCategory, area, timeBound, searchSource). "
               <> "Please deduplicate: "
               <> show duplicateKeys
+
+      let pricingSlabIssues =
+            [ (lookupKey (head fpGroup), reason)
+              | fpGroup <- groups,
+                Just reason <- [validateGroupPricingSlabs fpGroup]
+            ]
+      unless (null pricingSlabIssues) $
+        throwError $
+          InvalidRequest $
+            "Invalid pricing slabs, rides on such a fare policy could not be ended: "
+              <> show pricingSlabIssues
       let boundedAlreadyDeletedMap = Map.empty :: Map.Map Text Bool
       (farePolicyErrors, _) <- foldlM (processFarePolicyGroup merchantOpCity allCityFareProducts) ([], boundedAlreadyDeletedMap) groups
       return $
@@ -2818,6 +2829,33 @@ postMerchantConfigFarePolicyUpsert merchantShortId opCity req = do
       case (decodeByName $ LBS.fromStrict csvData :: Either String (Header, V.Vector FarePolicyCSVRow)) of
         Left err -> throwError (InvalidRequest $ show err)
         Right (_, v) -> V.imapM (makeFarePolicy merchantId merchantOpCity distanceUnit) v >>= (pure . V.toList)
+
+    validateGroupPricingSlabs :: [(Maybe Bool, Context.City, ServiceTierType, TripCategory, SL.Area, TimeBound, DFareProduct.SearchSource, Bool, FarePolicy.FarePolicy)] -> Maybe Text
+    validateGroupPricingSlabs fpGroup =
+      case (NE.nonEmpty interCitySlabs, NE.nonEmpty rentalSlabs) of
+        (Just slabs, _) -> validateInterCityPricingSlabs slabs
+        (_, Just slabs) -> validateRentalPricingSlabs slabs
+        _ -> Nothing
+      where
+        allFarePolicyDetails = [farePolicy.farePolicyDetails | (_, _, _, _, _, _, _, _, farePolicy) <- fpGroup]
+        interCitySlabs = [slab | FarePolicy.InterCityDetails details <- allFarePolicyDetails, slab <- NE.toList details.pricingSlabs]
+        rentalSlabs = [slab | FarePolicy.RentalDetails details <- allFarePolicyDetails, slab <- NE.toList details.pricingSlabs]
+
+    validateInterCityPricingSlabs :: NonEmpty FPIDPS.FPInterCityDetailsPricingSlabs -> Maybe Text
+    validateInterCityPricingSlabs slabs
+      | not (any FPIDPS.isBasePricingSlab slabs) =
+        Just "InterCity pricing slabs must include a row with time_percentage = 0 and distance_percentage = 0"
+      | not (FPIDPS.isFullFarePricingSlab (FPIDPS.findFPInterCityDetailsByTimeAndDistancePercentage 100 100 slabs)) =
+        Just "the InterCity pricing slab picked for a fully completed ride must charge the whole fare, add a row with fare_percentage = 100 above the others"
+      | otherwise = Nothing
+
+    validateRentalPricingSlabs :: NonEmpty FPRDPS.FPRentalDetailsPricingSlabs -> Maybe Text
+    validateRentalPricingSlabs slabs
+      | not (any FPRDPS.isBasePricingSlab slabs) =
+        Just "Rental pricing slabs must include a row with time_percentage = 0 and distance_percentage = 0"
+      | not (FPRDPS.isFullFarePricingSlab (FPRDPS.findFPRentalDetailsByTimeAndDistancePercentage 100 100 slabs)) =
+        Just "the Rental pricing slab picked for a fully completed ride must charge the whole base fare, add a row with fare_percentage = 100 above the others"
+      | otherwise = Nothing
 
     groupFarePolices :: [(Maybe Bool, Context.City, ServiceTierType, TripCategory, SL.Area, TimeBound, DFareProduct.SearchSource, Bool, FarePolicy.FarePolicy)] -> [[(Maybe Bool, Context.City, ServiceTierType, TripCategory, SL.Area, TimeBound, DFareProduct.SearchSource, Bool, FarePolicy.FarePolicy)]]
     groupFarePolices = DL.groupBy (\a b -> fst7 a == fst7 b) . DL.sortBy (compare `on` fst7)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy/FarePolicyInterCityDetailsPricingSlabs.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy/FarePolicyInterCityDetailsPricingSlabs.hs
@@ -34,6 +34,13 @@ instance FromJSON (FPInterCityDetailsPricingSlabsD 'Safe)
 
 instance ToJSON (FPInterCityDetailsPricingSlabsD 'Safe)
 
+isBasePricingSlab :: FPInterCityDetailsPricingSlabsD s -> Bool
+isBasePricingSlab slab = slab.timePercentage == 0 && slab.distancePercentage == 0
+
+isFullFarePricingSlab :: FPInterCityDetailsPricingSlabsD s -> Bool
+isFullFarePricingSlab slab =
+  slab.farePercentage >= 100 || slab.includeActualTimePercentage || slab.includeActualDistPercentage
+
 findFPInterCityDetailsByTimeAndDistancePercentage :: Int -> Int -> NonEmpty (FPInterCityDetailsPricingSlabsD s) -> FPInterCityDetailsPricingSlabsD s
 findFPInterCityDetailsByTimeAndDistancePercentage timePercent distPercent slabList = do
   case NE.filter (\slab -> slab.distancePercentage <= distPercent && slab.timePercentage <= timePercent) $ NE.sortBy (comparing (.timePercentage) <> comparing (.distancePercentage)) slabList of

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy/FarePolicyRentalDetails/FarePolicyRentalDetailsPricingSlabs.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/FarePolicy/FarePolicyRentalDetails/FarePolicyRentalDetailsPricingSlabs.hs
@@ -34,6 +34,13 @@ instance FromJSON (FPRentalDetailsPricingSlabsD 'Safe)
 
 instance ToJSON (FPRentalDetailsPricingSlabsD 'Safe)
 
+isBasePricingSlab :: FPRentalDetailsPricingSlabsD s -> Bool
+isBasePricingSlab slab = slab.timePercentage == 0 && slab.distancePercentage == 0
+
+isFullFarePricingSlab :: FPRentalDetailsPricingSlabsD s -> Bool
+isFullFarePricingSlab slab =
+  slab.farePercentage >= 100 || slab.includeActualTimePercentage || slab.includeActualDistPercentage
+
 findFPRentalDetailsByTimeAndDistancePercentage :: Int -> Int -> NonEmpty (FPRentalDetailsPricingSlabsD s) -> FPRentalDetailsPricingSlabsD s
 findFPRentalDetailsByTimeAndDistancePercentage timePercent distPercent slabList = do
   case NE.filter (\slab -> slab.distancePercentage <= distPercent && slab.timePercentage <= timePercent) $ NE.sortBy (comparing (.timePercentage) <> comparing (.distancePercentage)) slabList of


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Added low and high slab check
basically for ending a ride it should find the correct slab, so a base slab should be there 
and during estimate the fare should be 100%, so that slab should also exist


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fare-policy CSV uploads now validate InterCity and Rental pricing slabs before processing.
  - Uploads are rejected when a pricing group lacks a required base slab.
  - Uploads are also rejected when a full-fare slab is configured with invalid percentage values or actual time/distance settings.
  - Error responses identify the affected pricing groups, making configuration issues easier to correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->