### PR TITLE
fix(bpp-metrics): backend_version rename, distance_bucket + pooling version labels

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
@@ -130,7 +130,7 @@ cancel req merchant booking mbActiveSearchTry = do
     bookingCR <- buildBookingCancellationReason disToPickup currentLocation mbRide
     QBCR.upsert bookingCR
     cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
-    Metrics.incrementRideCancelledCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCR.source)
+    Metrics.incrementRideCancelledCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCR.source) (SML.distanceBucketLabel booking.estimatedDistance)
     QRB.updateStatus booking.id SRB.CANCELLED
     when booking.isScheduled $ removeBookingFromRedis booking
     fork "DriverRideCancelledCoin" $ do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
@@ -238,7 +238,7 @@ handler merchant req validatedQuote = do
 
     mkDConfirmResp mbRideInfo uBooking riderDetails = do
       cityLabel <- SML.getCityLabel uBooking.merchantOperatingCityId
-      Metrics.incrementBookingCreatedCount merchant.shortId.getShortId cityLabel (show uBooking.vehicleServiceTier)
+      Metrics.incrementBookingCreatedCount merchant.shortId.getShortId cityLabel (show uBooking.vehicleServiceTier) (SML.distanceBucketLabel uBooking.estimatedDistance)
       mDriverStats <-
         if isNothing mbRideInfo
           then pure Nothing

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -97,6 +97,7 @@ import SharedLogic.FarePolicy
 import SharedLogic.GoogleMaps
 import qualified SharedLogic.Merchant as SMerchant
 import qualified SharedLogic.MerchantPaymentMethod as DMPM
+import qualified SharedLogic.MetricsLabels as SML
 import SharedLogic.Ride
 import qualified SharedLogic.RiderDetails as SRD
 import qualified SharedLogic.Type as SLT
@@ -275,7 +276,7 @@ handler ValidatedDSearchReq {..} sReq = do
   CQBapMetaData.createIfNotPresent bapMetadata (Id sReq.bapId) (show Domain.MOBILITY)
   searchMetricsMVar <- Metrics.startSearchMetrics merchant.name
   let merchantId' = merchant.id
-  Metrics.incrementSearchRequestCount merchant.shortId.getShortId (show bapCity)
+  Metrics.incrementSearchRequestCount merchant.shortId.getShortId (show bapCity) (SML.distanceBucketLabel sReq.routeDistance)
   sessiontoken <- generateGUIDText
   let fromLocGeohashh = T.pack <$> Geohash.encode (fromMaybe 5 transporterConfig.dpGeoHashPercision) (sReq.pickupLocation.lat, sReq.pickupLocation.lon)
   let toLocGeohash = join $ fmap (\(LatLong lat lng) -> T.pack <$> Geohash.encode (fromMaybe 5 transporterConfig.dpGeoHashPercision) (lat, lng)) sReq.dropLocation

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -1959,7 +1959,7 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
             when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False True False False
             QSRD.updateDriverResponse (Just Accept) Inactive req.notificationSource req.renderedAt req.respondedAt sReqFD.id
             cityLabel <- SML.getCityLabel merchantOpCityId
-            Metrics.incrementDriverResponseCounter merchant.shortId.getShortId cityLabel (show sReqFD.vehicleServiceTier) (show sReqFD.batchNumber) (show req.response)
+            Metrics.incrementDriverResponseCounter merchant.shortId.getShortId cityLabel (show sReqFD.vehicleServiceTier) (show sReqFD.batchNumber) (show req.response) (SML.searchReqFunnelLabels searchReq)
             DS.driverScoreEventHandler merchantOpCityId $ buildDriverRespondEventPayload searchTry.id searchTry.requestId driverFCMPulledList
             unless (sReqFD.isForwardRequest) $ Redis.unlockRedis (editDestinationLockKey driverId)
           else do
@@ -1970,8 +1970,13 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
     Reject -> do
       when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False False True False
       QSRD.updateDriverResponse (Just Reject) Inactive req.notificationSource req.renderedAt req.respondedAt sReqFD.id
-      (merchantLabel, cityLabel) <- SML.getMetricsLabels merchantId merchantOpCityId
-      Metrics.incrementDriverResponseCounter merchantLabel cityLabel (show sReqFD.vehicleServiceTier) (show sReqFD.batchNumber) (show req.response)
+      -- Forked off the respond hot path (same idiom as the special-zone hop below): the
+      -- label lookup adds a KV read that must not cost the driver any latency, and metrics
+      -- must never alter the respond flow (a lookup miss degrades labels to "unknown").
+      fork "driver-response-metrics" $ do
+        (merchantLabel, cityLabel) <- SML.getMetricsLabels merchantId merchantOpCityId
+        mbSearchReqForMetrics <- QSR.findById searchTry.requestId
+        Metrics.incrementDriverResponseCounter merchantLabel cityLabel (show sReqFD.vehicleServiceTier) (show sReqFD.batchNumber) (show req.response) (maybe ("unknown", "unknown", "unknown") SML.searchReqFunnelLabels mbSearchReqForMetrics)
       DP.removeSearchReqIdFromMap merchantId driverId searchTry.requestId
       -- Handle queue skip for special zone rides — forked so a slow Redis/LTS hop
       -- can't add latency to the driver-respond hot path.
@@ -1982,8 +1987,13 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
     Pulled -> do
       when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False False False True
       QSRD.updateDriverResponse (Just Pulled) Inactive req.notificationSource req.renderedAt req.respondedAt sReqFD.id
-      (merchantLabel, cityLabel) <- SML.getMetricsLabels merchantId merchantOpCityId
-      Metrics.incrementDriverResponseCounter merchantLabel cityLabel (show sReqFD.vehicleServiceTier) (show sReqFD.batchNumber) (show req.response)
+      -- Forked off the respond hot path (same idiom as the special-zone hop below): the
+      -- label lookup adds a KV read that must not cost the driver any latency, and metrics
+      -- must never alter the respond flow (a lookup miss degrades labels to "unknown").
+      fork "driver-response-metrics" $ do
+        (merchantLabel, cityLabel) <- SML.getMetricsLabels merchantId merchantOpCityId
+        mbSearchReqForMetrics <- QSR.findById searchTry.requestId
+        Metrics.incrementDriverResponseCounter merchantLabel cityLabel (show sReqFD.vehicleServiceTier) (show sReqFD.batchNumber) (show req.response) (maybe ("unknown", "unknown", "unknown") SML.searchReqFunnelLabels mbSearchReqForMetrics)
       throwError UnexpectedResponseValue
   pure Success
   where

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -294,7 +294,7 @@ cancelRideTransaction booking ride bookingCReason merchant rideEndedBy mbCharges
   void $ QRide.updateStatusAndRideEndedBy ride.id DRide.CANCELLED rideEndedBy
   QBCR.upsert bookingCReason
   cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
-  Metrics.incrementRideCancelledCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCReason.source)
+  Metrics.incrementRideCancelledCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCReason.source) (SML.distanceBucketLabel booking.estimatedDistance)
   void $ QRB.updateStatus booking.id SRB.CANCELLED
   when (bookingCReason.source == SBCR.ByDriver) $ QDriverStats.updateIdleTime driverId
   case (mbChargesOutcome >>= (.fee), booking.riderId) of

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -191,7 +191,7 @@ endRideTransaction ::
   m ()
 endRideTransaction driverId booking ride mbFareParams mbRiderDetailsId newFareParams thresholdConfig = do
   (merchantLabel, cityLabel) <- SML.getMetricsLabels booking.providerId booking.merchantOperatingCityId
-  Metrics.incrementRideCompletedCount merchantLabel cityLabel (show booking.vehicleServiceTier)
+  Metrics.incrementRideCompletedCount merchantLabel cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel booking.estimatedDistance)
   updateOnRideStatusWithAdvancedRideCheck ride.driverId (Just ride)
   oldDriverInfo <- QDI.findById (cast ride.driverId) >>= fromMaybeM (PersonNotFound ride.driverId.getId)
   let newFlowStatus = DDriverMode.getDriverFlowStatus oldDriverInfo.mode oldDriverInfo.active

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
@@ -266,7 +266,7 @@ startRideHandler ServiceHandle {..} rideId req = do
       fork "Push Start Ride Metric" $ do
         incrementRideStartCounter "startRide"
         (merchantLabel, cityLabel) <- SML.getMetricsLabels booking.providerId booking.merchantOperatingCityId
-        TMetrics.incrementRideStartedCount merchantLabel cityLabel (show booking.vehicleServiceTier)
+        TMetrics.incrementRideStartedCount merchantLabel cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel booking.estimatedDistance)
       -- Schedule payout for special zone rides if enabled
       let paymentInstrument = fromMaybe DMPM.Cash booking.paymentInstrument
       when

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
@@ -181,11 +181,11 @@ sendSearchRequestToDrivers isAllocatorBatch tripQuoteDetails oldSearchReq search
   whenM (anyM (\driverId -> CQDGR.getDriverGoHomeRequestInfo driverId searchReq.merchantOperatingCityId (Just goHomeConfig) <&> isNothing . (.status)) prevBatchDrivers) $ do
     -- these unresponded requests are being retracted here: count them as expired
     forM_ (M.toList $ M.fromListWith (+) $ map (\srfd -> (srfd.vehicleServiceTier, 1 :: Int)) unrespondedSRFDs) $ \(serviceTier, expiredCount) ->
-      TM.addSearchRequestExpiredCount merchantLabel cityLabel (show serviceTier) expiredCount
+      TM.addSearchRequestExpiredCount merchantLabel cityLabel (show serviceTier) (SML.searchReqFunnelLabels searchReq) expiredCount
     QSRD.setInactiveBySTId Nothing searchTry.id.getId -- inactive previous request by drivers so that they can make new offers.
   _ <- QSRD.createMany searchRequestsForDrivers
   forM_ (M.toList $ M.fromListWith (+) $ map (\srfd -> (srfd.vehicleServiceTier, 1 :: Int)) searchRequestsForDrivers) $ \(serviceTier, sentCount) ->
-    TM.addSearchRequestSentToDriverCount merchantLabel cityLabel (show serviceTier) sentCount
+    TM.addSearchRequestSentToDriverCount merchantLabel cityLabel (show serviceTier) (SML.searchReqFunnelLabels searchReq) sentCount
 
   -- Count one "request sent" per driver in this batch for the SRDStats sliding-window counters
   -- and reset each driver's idle clock, both surfaced in the POOLING dynamic-logic data.

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Booking.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Booking.hs
@@ -86,7 +86,7 @@ cancelBooking booking mbDriver transporter = do
     when booking.isScheduled $ removeBookingFromRedis booking
     QBCR.upsert bookingCancellationReason
     cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
-    Metrics.incrementRideCancelledCount transporter.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCancellationReason.source)
+    Metrics.incrementRideCancelledCount transporter.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCancellationReason.source) (SML.distanceBucketLabel booking.estimatedDistance)
     whenJust mbRide $ \ride -> do
       void $ CQDGR.setDriverGoHomeIsOnRideStatus ride.driverId booking.merchantOperatingCityId False
       QRide.updateStatus ride.id SRide.CANCELLED

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/MetricsLabels.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/MetricsLabels.hs
@@ -12,10 +12,11 @@
  the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
-module SharedLogic.MetricsLabels (getMetricsLabels, getCityLabel) where
+module SharedLogic.MetricsLabels (getMetricsLabels, getCityLabel, distanceBucketLabel, poolingVersionLabel, searchReqFunnelLabels) where
 
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.SearchRequest as DSR
 import Kernel.Prelude
 import Kernel.Types.Id
 import Kernel.Utils.Common
@@ -37,3 +38,35 @@ getCityLabel :: (CacheFlow m r, EsqDBFlow m r) => Id DMOC.MerchantOperatingCity 
 getCityLabel merchantOpCityId = do
   mbCity <- CQMOC.findById merchantOpCityId
   pure $ maybe merchantOpCityId.getId (show . (.city)) mbCity
+
+-- | Distance bucket label for funnel counters. Edges deliberately match the analytics
+-- stack's trip_distance_bin (ClickHouse) so Grafana and warehouse views agree by
+-- construction. "unknown" when no estimate exists — never drop a metric over a label.
+-- NOT the same as SharedLogic.Pricing.getDistanceBin (fine-grained 2km bins for
+-- dynamic-pricing Redis keys) — that granularity would blow up metric cardinality.
+distanceBucketLabel :: Maybe Meters -> Text
+distanceBucketLabel Nothing = "unknown"
+distanceBucketLabel (Just d)
+  | m < 5000 = "0-5km"
+  | m < 12000 = "5-12km"
+  | m < 30000 = "12-30km"
+  | otherwise = ">30km"
+  where
+    m = d.getMeters
+
+poolingVersionLabel :: Maybe Int -> Text
+poolingVersionLabel = maybe "unknown" show
+
+-- | The three allocation-funnel label values rendered from the search request, so every
+-- call site emits identical values for the same journey:
+-- (distance_bucket, pooling_logic_version, pooling_config_version).
+-- NOTE: pooling versions are assigned during the first driver-pool computation
+-- (ensurePoolingLogicVersion / getDriverPoolConfig) — only pass search requests read
+-- AFTER that point (allocator batch flow, driver respond flow); earlier reads
+-- legitimately carry Nothing and would label everything "unknown".
+searchReqFunnelLabels :: DSR.SearchRequest -> (Text, Text, Text)
+searchReqFunnelLabels searchReq =
+  ( distanceBucketLabel searchReq.estimatedDistance,
+    poolingVersionLabel searchReq.poolingLogicVersion,
+    poolingVersionLabel searchReq.poolingConfigVersion
+  )

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
@@ -185,7 +185,7 @@ initializeRide merchant driver booking mbOtpCode enableFrequentLocationUpdates m
   QRB.updateStatus booking.id DBooking.TRIP_ASSIGNED
   QRide.createRide ride
   cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
-  Metrics.incrementRideCreatedCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier)
+  Metrics.incrementRideCreatedCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel booking.estimatedDistance)
   QRideD.create rideDetails
   fork "updateRiderDetails" $ do
     whenJust booking.riderId (QRiderD.updateTotalBookingsCount . getId)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SearchTry.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SearchTry.hs
@@ -232,7 +232,7 @@ initiateDriverSearchBatch searchBatchInput@DriverSearchBatchInput {..} = do
               <> "; estimated base fare:"
               <> show estimatedFare
           cityLabel <- SML.getCityLabel searchReq.merchantOperatingCityId
-          Metrics.incrementSearchTryCount merchant.shortId.getShortId cityLabel (show searchTry.vehicleServiceTier) (show searchTry.searchRepeatType)
+          Metrics.incrementSearchTryCount merchant.shortId.getShortId cityLabel (show searchTry.vehicleServiceTier) (show searchTry.searchRepeatType) (SML.distanceBucketLabel searchReq.estimatedDistance)
           return searchTry
 
 buildSearchTry ::

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics.hs
@@ -33,59 +33,59 @@ putFareAndDistanceDeviations agencyName fareDiff distanceDiff = do
   liftIO $ P.withLabel countingDeviationMetric.realFareDeviation (agencyName, version.getDeploymentVersion) (`P.observe` fromIntegral fareDiff)
   liftIO $ P.withLabel countingDeviationMetric.realDistanceDeviation (agencyName, version.getDeploymentVersion) (`P.observe` fromIntegral distanceDiff)
 
-incrementSearchRequestCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> m ()
-incrementSearchRequestCount merchantId merchantOpCityId = do
+incrementSearchRequestCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> m ()
+incrementSearchRequestCount merchantId merchantOpCityId distanceBucket = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.searchRequestCounter (merchantId, merchantOpCityId, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.searchRequestCounter (merchantId, merchantOpCityId, distanceBucket, version.getDeploymentVersion) P.incCounter
 
-incrementSearchTryCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
-incrementSearchTryCount merchantId merchantOpCityId vehicleServiceTier searchRepeatType = do
+incrementSearchTryCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> m ()
+incrementSearchTryCount merchantId merchantOpCityId vehicleServiceTier searchRepeatType distanceBucket = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.searchTryCounter (merchantId, merchantOpCityId, vehicleServiceTier, searchRepeatType, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.searchTryCounter (merchantId, merchantOpCityId, vehicleServiceTier, searchRepeatType, distanceBucket, version.getDeploymentVersion) P.incCounter
 
-addSearchRequestSentToDriverCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Int -> m ()
-addSearchRequestSentToDriverCount merchantId merchantOpCityId vehicleServiceTier count = do
+addSearchRequestSentToDriverCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> (Text, Text, Text) -> Int -> m ()
+addSearchRequestSentToDriverCount merchantId merchantOpCityId vehicleServiceTier (distanceBucket, poolingLogicV, poolingConfigV) count = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.searchRequestSentToDriverCounter (merchantId, merchantOpCityId, vehicleServiceTier, version.getDeploymentVersion) (void . (`P.addCounter` fromIntegral count))
+  liftIO $ P.withLabel bmContainer.searchRequestSentToDriverCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, poolingLogicV, poolingConfigV, version.getDeploymentVersion) (void . (`P.addCounter` fromIntegral count))
 
-addSearchRequestExpiredCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Int -> m ()
-addSearchRequestExpiredCount merchantId merchantOpCityId vehicleServiceTier count = do
+addSearchRequestExpiredCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> (Text, Text, Text) -> Int -> m ()
+addSearchRequestExpiredCount merchantId merchantOpCityId vehicleServiceTier (distanceBucket, poolingLogicV, poolingConfigV) count = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.searchRequestExpiredCounter (merchantId, merchantOpCityId, vehicleServiceTier, version.getDeploymentVersion) (void . (`P.addCounter` fromIntegral count))
+  liftIO $ P.withLabel bmContainer.searchRequestExpiredCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, poolingLogicV, poolingConfigV, version.getDeploymentVersion) (void . (`P.addCounter` fromIntegral count))
 
-incrementBookingCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> m ()
-incrementBookingCreatedCount merchantId merchantOpCityId vehicleServiceTier = do
+incrementBookingCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
+incrementBookingCreatedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.bookingCreatedCounter (merchantId, merchantOpCityId, vehicleServiceTier, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.bookingCreatedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
 
-incrementRideCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> m ()
-incrementRideCreatedCount merchantId merchantOpCityId vehicleServiceTier = do
+incrementRideCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
+incrementRideCreatedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.rideCreatedCounter (merchantId, merchantOpCityId, vehicleServiceTier, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.rideCreatedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
 
-incrementRideStartedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> m ()
-incrementRideStartedCount merchantId merchantOpCityId vehicleServiceTier = do
+incrementRideStartedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
+incrementRideStartedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.rideStartedCounter (merchantId, merchantOpCityId, vehicleServiceTier, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.rideStartedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
 
-incrementRideCompletedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> m ()
-incrementRideCompletedCount merchantId merchantOpCityId vehicleServiceTier = do
+incrementRideCompletedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
+incrementRideCompletedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.rideCompletedCounter (merchantId, merchantOpCityId, vehicleServiceTier, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.rideCompletedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
 
-incrementRideCancelledCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
-incrementRideCancelledCount merchantId merchantOpCityId vehicleServiceTier cancellationSource = do
+incrementRideCancelledCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> m ()
+incrementRideCancelledCount merchantId merchantOpCityId vehicleServiceTier cancellationSource distanceBucket = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.rideCancelledCounter (merchantId, merchantOpCityId, vehicleServiceTier, cancellationSource, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.rideCancelledCounter (merchantId, merchantOpCityId, vehicleServiceTier, cancellationSource, distanceBucket, version.getDeploymentVersion) P.incCounter
 
 type SearchMetricsMVar = MVar Milliseconds
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics/Types.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics/Types.hs
@@ -32,17 +32,28 @@ type SearchDurationMetric = (P.Vector P.Label2 P.Histogram, P.Vector P.Label2 P.
 -- Label values are human-readable: merchant = merchant shortId, city = operating city name
 -- (resolved via SharedLogic.MetricsLabels.getMetricsLabels at the call sites).
 
--- Labels: (merchant, city, version)
-type SearchRequestCounterMetric = P.Vector P.Label3 P.Counter
+-- "backend_version" is the deployment version; pooling_{logic,config}_version are the
+-- experiment-arm versions assigned at driver-pool computation. They change on different
+-- schedules and must stay separate labels.
 
--- Labels: (merchant, city, vehicle_service_tier, search_repeat_type, version)
-type SearchTryCounterMetric = P.Vector P.Label5 P.Counter
+-- Labels: (merchant, city, distance_bucket, backend_version)
+type SearchRequestCounterMetric = P.Vector P.Label4 P.Counter
 
--- Labels: (merchant, city, vehicle_service_tier, version)
-type RideFunnelCounterMetric = P.Vector P.Label4 P.Counter
+-- Labels: (merchant, city, vehicle_service_tier, search_repeat_type, distance_bucket, backend_version)
+-- No pooling labels here: INITIAL tries are created BEFORE the first pool computation
+-- assigns pooling versions (ensurePoolingLogicVersion), so the label would encode try
+-- order ("unknown" for INITIAL, populated for retries), not pooling.
+type SearchTryCounterMetric = P.Vector P.Label6 P.Counter
 
--- Labels: (merchant, city, vehicle_service_tier, cancellation_source, version)
-type RideCancelledCounterMetric = P.Vector P.Label5 P.Counter
+-- Labels: (merchant, city, vehicle_service_tier, distance_bucket, pooling_logic_version, pooling_config_version, backend_version)
+-- For counters emitted inside the allocation flow, where pooling versions are assigned.
+type AllocationFunnelCounterMetric = P.Vector P.Label7 P.Counter
+
+-- Labels: (merchant, city, vehicle_service_tier, distance_bucket, backend_version)
+type RideFunnelCounterMetric = P.Vector P.Label5 P.Counter
+
+-- Labels: (merchant, city, vehicle_service_tier, cancellation_source, distance_bucket, backend_version)
+type RideCancelledCounterMetric = P.Vector P.Label6 P.Counter
 
 data BPPMetricsContainer = BPPMetricsContainer
   { searchDurationTimeout :: Seconds,
@@ -50,8 +61,8 @@ data BPPMetricsContainer = BPPMetricsContainer
     countingDeviation :: CountingDeviationMetric,
     searchRequestCounter :: SearchRequestCounterMetric,
     searchTryCounter :: SearchTryCounterMetric,
-    searchRequestSentToDriverCounter :: RideFunnelCounterMetric,
-    searchRequestExpiredCounter :: RideFunnelCounterMetric,
+    searchRequestSentToDriverCounter :: AllocationFunnelCounterMetric,
+    searchRequestExpiredCounter :: AllocationFunnelCounterMetric,
     bookingCreatedCounter :: RideFunnelCounterMetric,
     rideCreatedCounter :: RideFunnelCounterMetric,
     rideStartedCounter :: RideFunnelCounterMetric,
@@ -70,8 +81,8 @@ registerBPPMetricsContainer searchDurationTimeout = do
   countingDeviation <- registerCountingDeviationMetric
   searchRequestCounter <- registerSearchRequestCounter
   searchTryCounter <- registerSearchTryCounter
-  searchRequestSentToDriverCounter <- registerRideFunnelCounter "BPP_search_request_sent_to_driver_count" "Count of search requests fanned out to drivers, batched per driver"
-  searchRequestExpiredCounter <- registerRideFunnelCounter "BPP_search_request_expired_count" "Count of driver search requests retracted without any driver response"
+  searchRequestSentToDriverCounter <- registerAllocationFunnelCounter "BPP_search_request_sent_to_driver_count" "Count of search requests fanned out to drivers, batched per driver"
+  searchRequestExpiredCounter <- registerAllocationFunnelCounter "BPP_search_request_expired_count" "Count of driver search requests retracted without any driver response"
   bookingCreatedCounter <- registerRideFunnelCounter "BPP_booking_created_count" "Count of bookings confirmed on the BPP"
   rideCreatedCounter <- registerRideFunnelCounter "BPP_ride_created_count" "Count of rides created (driver assigned to booking)"
   rideStartedCounter <- registerRideFunnelCounter "BPP_ride_started_count" "Count of rides started"
@@ -81,22 +92,27 @@ registerBPPMetricsContainer searchDurationTimeout = do
 
 registerSearchRequestCounter :: IO SearchRequestCounterMetric
 registerSearchRequestCounter =
-  P.register . P.vector ("merchant", "city", "version") . P.counter $
+  P.register . P.vector ("merchant", "city", "distance_bucket", "backend_version") . P.counter $
     P.Info "BPP_search_request_count" "Count of search requests received by the BPP"
 
 registerSearchTryCounter :: IO SearchTryCounterMetric
 registerSearchTryCounter =
-  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "search_repeat_type", "version") . P.counter $
+  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "search_repeat_type", "distance_bucket", "backend_version") . P.counter $
     P.Info "BPP_search_try_count" "Count of search tries (driver allocation attempts) created"
+
+registerAllocationFunnelCounter :: Text -> Text -> IO AllocationFunnelCounterMetric
+registerAllocationFunnelCounter name description =
+  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "distance_bucket", "pooling_logic_version", "pooling_config_version", "backend_version") . P.counter $
+    P.Info name description
 
 registerRideFunnelCounter :: Text -> Text -> IO RideFunnelCounterMetric
 registerRideFunnelCounter name description =
-  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "version") . P.counter $
+  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "distance_bucket", "backend_version") . P.counter $
     P.Info name description
 
 registerRideCancelledCounter :: IO RideCancelledCounterMetric
 registerRideCancelledCounter =
-  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "cancellation_source", "version") . P.counter $
+  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "cancellation_source", "distance_bucket", "backend_version") . P.counter $
     P.Info "BPP_ride_cancelled_count" "Count of bookings cancelled, labelled by cancellation source"
 
 registerCountingDeviationMetric :: IO CountingDeviationMetric

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSearchRequestResponseMetrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSearchRequestResponseMetrics.hs
@@ -25,17 +25,20 @@ import Prometheus as P
 import Tools.Metrics.DriverSearchRequestResponseMetrics.Types as Reexport
 
 -- | Increment the driver-respond counter for a single response to a search request.
--- Labels emitted: (merchant id, merchant operating city id, vehicle service tier,
--- deployment version, batch number, response type e.g. "Accept"/"Reject"/"Pulled").
+-- Labels emitted: (merchant shortId, city name, vehicle service tier, batch number,
+-- response type e.g. "Accept"/"Reject"/"Pulled", distance bucket, pooling logic version,
+-- pooling config version, deployment version). The (distance, pooling, pooling-config)
+-- triple comes from SharedLogic.MetricsLabels.searchReqFunnelLabels on a search request
+-- read AFTER pool computation, so pooling versions are populated.
 -- All labels are passed pre-rendered as Text by the caller so this module stays
 -- decoupled from domain types.
-incrementDriverResponseCounter :: HasDriverSearchRequestResponseMetrics m r => Text -> Text -> Text -> Text -> Text -> m ()
-incrementDriverResponseCounter merchantId merchantOpCityId vehicleServiceTier batchNumber response = do
+incrementDriverResponseCounter :: HasDriverSearchRequestResponseMetrics m r => Text -> Text -> Text -> Text -> Text -> (Text, Text, Text) -> m ()
+incrementDriverResponseCounter merchantId merchantOpCityId vehicleServiceTier batchNumber response funnelLabels = do
   metricsContainer <- asks (.driverSearchRequestResponseMetrics)
   version <- asks (.version)
-  incrementDriverResponseCounter' metricsContainer merchantId merchantOpCityId vehicleServiceTier batchNumber response version
+  incrementDriverResponseCounter' metricsContainer merchantId merchantOpCityId vehicleServiceTier batchNumber response funnelLabels version
 
-incrementDriverResponseCounter' :: L.MonadFlow m => DriverSearchRequestResponseMetricsContainer -> Text -> Text -> Text -> Text -> Text -> DeploymentVersion -> m ()
-incrementDriverResponseCounter' metricsContainer merchantId merchantOpCityId vehicleServiceTier batchNumber response version = do
+incrementDriverResponseCounter' :: L.MonadFlow m => DriverSearchRequestResponseMetricsContainer -> Text -> Text -> Text -> Text -> Text -> (Text, Text, Text) -> DeploymentVersion -> m ()
+incrementDriverResponseCounter' metricsContainer merchantId merchantOpCityId vehicleServiceTier batchNumber response (distanceBucket, poolingLogicV, poolingConfigV) version = do
   let driverResponseCounter = metricsContainer.driverResponseCounter
-  L.runIO $ P.withLabel driverResponseCounter (merchantId, merchantOpCityId, vehicleServiceTier, version.getDeploymentVersion, batchNumber, response) P.incCounter
+  L.runIO $ P.withLabel driverResponseCounter (merchantId, merchantOpCityId, vehicleServiceTier, batchNumber, response, distanceBucket, poolingLogicV, poolingConfigV, version.getDeploymentVersion) P.incCounter

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSearchRequestResponseMetrics/Types.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSearchRequestResponseMetrics/Types.hs
@@ -28,9 +28,11 @@ import Prometheus as P
 type HasDriverSearchRequestResponseMetrics m r =
   HasFlowEnv m r ["driverSearchRequestResponseMetrics" ::: DriverSearchRequestResponseMetricsContainer, "version" ::: DeploymentVersion]
 
--- Labels: (merchant, city, vehicle_service_tier, version, batch_number, response)
--- merchant = merchant shortId, city = operating city name
-type DriverResponseCounterMetric = P.Vector P.Label6 P.Counter
+-- Labels: (merchant, city, vehicle_service_tier, batch_number, response, distance_bucket, pooling_logic_version, pooling_config_version, backend_version)
+-- merchant = merchant shortId, city = operating city name.
+-- NOTE: Label9 is the prometheus-client maximum — adding any further label to this
+-- counter requires restructuring (e.g. splitting the metric).
+type DriverResponseCounterMetric = P.Vector P.Label9 P.Counter
 
 newtype DriverSearchRequestResponseMetricsContainer = DriverSearchRequestResponseMetricsContainer
   { driverResponseCounter :: DriverResponseCounterMetric
@@ -43,5 +45,5 @@ registerDriverSearchRequestResponseMetricsContainer = do
 
 registerDriverResponseCounter :: IO DriverResponseCounterMetric
 registerDriverResponseCounter =
-  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "version", "batch_number", "response") . P.counter $
-    P.Info "driver_search_request_response_count" "Count of driver responses to a search request, labelled by merchant shortId, city name, vehicle service tier, deployment version, batch number and response type"
+  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "batch_number", "response", "distance_bucket", "pooling_logic_version", "pooling_config_version", "backend_version") . P.counter $
+    P.Info "driver_search_request_response_count" "Count of driver responses to a search request, labelled by merchant shortId, city name, vehicle service tier, batch number, response type, distance bucket, pooling logic/config versions and deployment version"


### PR DESCRIPTION
## What

Follow-up to the BPP funnel metrics PR — label-schema fixes reviewed and validated before broad dashboard adoption (metrics are 3 days old, so the breaking rename is cheap now and impossible later).

- **Rename** deployment `version` label → `backend_version` on all BPP funnel counters + driver response counter. Legacy 2023 metrics (`BPP_search_time`, deviation histograms) keep their old label. Existing integ Grafana panels referencing `version` on the new counters need updating.
- **`distance_bucket` label** on every funnel counter, from search-time estimated distance. Edges intentionally match ClickHouse `trip_distance_bin` (`0-5km / 5-12km / 12-30km / >30km`) so Grafana and warehouse agree by construction. This is deliberately NOT `SharedLogic.Pricing.getDistanceBin` (2km bins for pricing Redis keys — that granularity would blow up metric cardinality).
- **`pooling_logic_version` + `pooling_config_version` labels** only on allocation-side counters (`sent_to_driver`, `expired`, `driver_search_request_response_count`) — where `ensurePoolingLogicVersion` has already run. Deliberately NOT on `search_try`: INITIAL tries are created before version assignment, so the label would encode try order, not pooling.
- **Driver response counter**: Reject/Pulled paths now load the search request so labels are consistent across Accept/Reject/Pulled — without this, only accepts would carry version labels and every per-version accept rate would be biased upward. The lookup is **non-throwing** (missing record degrades labels to "unknown") and **forked off the respond hot path** — which also moves the previously-synchronous metrics-label lookups off it, so the reject path is net lighter than before.

## Notes for reviewers

- Label9 on the response counter is the prometheus-client maximum — any future label needs a metric split (documented in-code).
- `BPP_search_request_count` buckets on the BAP-sent `routeDistance` (pre-serviceability); downstream stages bucket on persisted `estimatedDistance`. Per-bucket funnel ratios should start from `search_try`.
- Optional follow-up if even a forked KV read is unwanted: stamp the three label values onto `search_request_for_driver` at ping creation.

## Validation

- All 10 counter label-tuple arities machine-checked against their `P.vector` registrations.
- Pooling-version assignment ordering verified against `ensurePoolingLogicVersion` call flow in the allocator.
- After integ deploy: confirm `pooling_*_version != "unknown"` on batch-0 `sent_to_driver`, and watch VM series growth (~×4–5 expected from distance buckets).