### PR TITLE
feat(bpp-metrics): driver supply gauges — online, receiving, accepting, on-ride

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -556,6 +556,7 @@ library
       SharedLogic.DriverPool.DriverPoolMigrations
       SharedLogic.DriverPool.LTSDataSync
       SharedLogic.DriverPool.Types
+      SharedLogic.DriverSupplyCounter
       SharedLogic.DriverSupplyMetrics
       SharedLogic.DynamicPricing
       SharedLogic.EventTracking

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -556,6 +556,7 @@ library
       SharedLogic.DriverPool.DriverPoolMigrations
       SharedLogic.DriverPool.LTSDataSync
       SharedLogic.DriverPool.Types
+      SharedLogic.DriverSupplyMetrics
       SharedLogic.DynamicPricing
       SharedLogic.EventTracking
       SharedLogic.External.LocationTrackingService.API.DriverBlockTill
@@ -1008,6 +1009,7 @@ library
       Tools.Metrics.ARDUBPPMetrics.Types
       Tools.Metrics.DriverSearchRequestResponseMetrics
       Tools.Metrics.DriverSearchRequestResponseMetrics.Types
+      Tools.Metrics.DriverSupplyMetrics.Types
       Tools.Metrics.SendSearchRequestToDriverMetrics
       Tools.Metrics.SendSearchRequestToDriverMetrics.Types
       Tools.Notifications

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/App.hs
@@ -66,6 +66,7 @@ import Network.Wai.Handler.Warp
     setInstallShutdownHandler,
     setPort,
   )
+import qualified SharedLogic.DriverSupplyMetrics as DSM
 import Storage.Beam.SystemConfigs ()
 import qualified Storage.CachedQueries.Merchant as Storage
 import System.Environment (lookupEnv)
@@ -139,6 +140,7 @@ runDynamicOfferDriverApp' appCfg = do
         L.setOption KBT.Tables kvConfigs
         _ <- liftIO $ createCAC appCfg
         initCityMaps
+        fork "driver supply metrics publisher" DSM.runDriverSupplyMetricsPublisher
         allProviders <-
           try Storage.loadAllProviders
             >>= handleLeft @SomeException exitLoadAllProvidersFailure "Exception thrown: "

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/DriverMode.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/DriverMode.hs
@@ -31,6 +31,7 @@ import Kernel.Types.Id
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import qualified SharedLogic.DriverFlowStatus as SDF
+import qualified SharedLogic.DriverSupplyCounter as DSC
 import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions (..))
 import qualified Storage.Queries.DriverInformation as QDriverInformation
 import qualified Storage.Queries.DriverOperatorAssociationExtra as QDriverOperatorAssociationExtra
@@ -270,5 +271,7 @@ updateDriverModeAndFlowStatus driverId transporterConfig isActive mbNewMode newF
       QDriverInformation.updateActivityWithDriverFlowStatus isActive mbNewMode (Just newFlowStatus) mbHasRideStarted lastOfflineTime driverId
       updateFleetOperatorStatusKeyForDriver driverId newFlowStatus oldDriverInfo
     else QDriverInformation.updateActivityWithDriverFlowStatus isActive mbNewMode Nothing mbHasRideStarted lastOfflineTime driverId
+  -- Shared doorway for eligibility changes; after the write so a failed write can't move it.
+  DSC.recordDriverActiveChange oldDriverInfo.merchantOperatingCityId oldDriverInfo.active isActive
   fork "update driver online duration" $
     processingChangeOnline driverId transporterConfig mbNewMode oldDriverInfo.mode

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -271,6 +271,7 @@ import SharedLogic.DriverOnboarding.OnboardingFlags.Types (OnboardingFlow)
 import qualified SharedLogic.DriverOnboarding.OnboardingFlags.Types as SOnboardingFlags
 import qualified SharedLogic.DriverOnboarding.Status as SStatus
 import SharedLogic.DriverPool as DP
+import qualified SharedLogic.DriverSupplyCounter as DSC
 import qualified SharedLogic.DriverSupplyMetrics as DSM
 import qualified SharedLogic.EventTracking as ET
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTF
@@ -1448,7 +1449,12 @@ deleteDriver admin driverId = do
   unless (driver.merchantId == admin.merchantId || driver.role == SP.DRIVER) $ throwError Unauthorized
   -- this function uses tokens from db, so should be called before transaction
   Auth.clearDriverSession driverId
+  -- Deleting the row drops the driver out of the supply count without ever clearing
+  -- `active`, so the count is corrected here.
+  mbDriverInfo <- QDriverInformation.findById (cast driverId)
   QDriverInformation.deleteById (cast driverId)
+  whenJust mbDriverInfo $ \driverInfo ->
+    DSC.recordDriverActiveChange driverInfo.merchantOperatingCityId driverInfo.active False
   QDriverStats.deleteById (cast driverId)
   QR.deleteByPersonId driverId.getId
   QVehicle.deleteById driverId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -1968,7 +1968,7 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
               DTC.QuoteBased _ -> acceptStaticOfferDriverRequest (Just searchTry) driver (fromMaybe searchTry.estimateId sReqFD.estimateId) reqOfferedValue merchant clientId transporterConfig Nothing
             when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False True False False
             QSRD.updateDriverResponse (Just Accept) Inactive req.notificationSource req.renderedAt req.respondedAt sReqFD.id
-            DSM.recordDriverAccepted merchantOpCityId driverId
+            DSM.recordDriverAccepted merchantOpCityId (show sReqFD.vehicleServiceTier) driverId
             cityLabel <- SML.getCityLabel merchantOpCityId
             Metrics.incrementDriverResponseCounter merchant.shortId.getShortId cityLabel (show sReqFD.vehicleServiceTier) (show sReqFD.batchNumber) (show req.response)
             DS.driverScoreEventHandler merchantOpCityId $ buildDriverRespondEventPayload searchTry.id searchTry.requestId driverFCMPulledList

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -271,6 +271,7 @@ import SharedLogic.DriverOnboarding.OnboardingFlags.Types (OnboardingFlow)
 import qualified SharedLogic.DriverOnboarding.OnboardingFlags.Types as SOnboardingFlags
 import qualified SharedLogic.DriverOnboarding.Status as SStatus
 import SharedLogic.DriverPool as DP
+import qualified SharedLogic.DriverSupplyMetrics as DSM
 import qualified SharedLogic.EventTracking as ET
 import qualified SharedLogic.External.LocationTrackingService.Flow as LTF
 import qualified SharedLogic.External.LocationTrackingService.Types as LT
@@ -1967,6 +1968,7 @@ respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion m
               DTC.QuoteBased _ -> acceptStaticOfferDriverRequest (Just searchTry) driver (fromMaybe searchTry.estimateId sReqFD.estimateId) reqOfferedValue merchant clientId transporterConfig Nothing
             when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.updateOperatorAnalyticsAcceptationTotalRequestAndPassedCount driverId transporterConfig False True False False
             QSRD.updateDriverResponse (Just Accept) Inactive req.notificationSource req.renderedAt req.respondedAt sReqFD.id
+            DSM.recordDriverAccepted merchantOpCityId driverId
             cityLabel <- SML.getCityLabel merchantOpCityId
             Metrics.incrementDriverResponseCounter merchant.shortId.getShortId cityLabel (show sReqFD.vehicleServiceTier) (show sReqFD.batchNumber) (show req.response)
             DS.driverScoreEventHandler merchantOpCityId $ buildDriverRespondEventPayload searchTry.id searchTry.requestId driverFCMPulledList

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/VehicleRegistrationCertificate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboarding/VehicleRegistrationCertificate.hs
@@ -91,6 +91,7 @@ import qualified SharedLogic.Analytics as Analytics
 import SharedLogic.DriverOnboarding
 import SharedLogic.DriverOnboarding.OnboardingFlags.Types (OnboardingFlow)
 import qualified SharedLogic.DriverOnboarding.VehicleDocs as SStatus
+import qualified SharedLogic.DriverSupplyCounter as DSC
 import SharedLogic.Reminder.Helper (createReminder)
 import qualified Storage.CachedQueries.Driver.OnBoarding as CQO
 import qualified Storage.CachedQueries.VehicleServiceTier as CQVST
@@ -781,7 +782,11 @@ deactivateRC isTaxiBoothRequest transporterConfig rc driverId = do
   removeVehicle isTaxiBoothRequest driverId
   DAQuery.deactivateRCForDriver False driverId rc.id
   now <- getCurrentTime
+  -- Bypasses updateDriverModeAndFlowStatus, so the supply count is maintained here too.
+  mbDriverInfo <- DIQuery.findById (cast driverId)
   DIQuery.updateActivityWithDriverFlowStatus False (Just DCommon.OFFLINE) (Just DDFS.OFFLINE) Nothing (Just now) (cast driverId)
+  whenJust mbDriverInfo $ \driverInfo ->
+    DSC.recordDriverActiveChange driverInfo.merchantOperatingCityId driverInfo.active False
   when transporterConfig.analyticsConfig.enableFleetOperatorDashboardAnalytics $ Analytics.decrementFleetOwnerAnalyticsActiveVehicleCount transporterConfig rc.fleetOwnerId driverId
   return ()
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Environment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Environment.hs
@@ -252,6 +252,7 @@ data AppEnv = AppEnv
     bppMetrics :: BPPMetricsContainer,
     ssrMetrics :: SendSearchRequestToDriverMetricsContainer,
     driverSearchRequestResponseMetrics :: DriverSearchRequestResponseMetricsContainer,
+    driverSupplyMetrics :: DriverSupplyMetricsContainer,
     searchRequestExpirationSeconds :: NominalDiffTime,
     searchRequestExpirationSecondsForMultimodal :: NominalDiffTime,
     driverQuoteExpirationSeconds :: NominalDiffTime,
@@ -404,6 +405,7 @@ buildAppEnv cfg@AppCfg {searchRequestExpirationSeconds = _searchRequestExpiratio
   bppMetrics <- registerBPPMetricsContainer metricsSearchDurationTimeout
   ssrMetrics <- registerSendSearchRequestToDriverMetricsContainer
   driverSearchRequestResponseMetrics <- registerDriverSearchRequestResponseMetricsContainer
+  driverSupplyMetrics <- registerDriverSupplyMetricsContainer
   coreMetrics <- Metrics.registerCoreMetricsContainer
   kafkaClickhouseEnv <- createConn kafkaClickhouseCfg
   serviceClickhouseEnv <- createConn driverClickhouseCfg

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
@@ -67,6 +67,7 @@ import qualified SharedLogic.Analytics as Analytics
 import qualified SharedLogic.CallInternalMLPricing as ML
 import qualified SharedLogic.DriverIdleTime as DriverIdleTime
 import qualified SharedLogic.DriverPool as SDP
+import qualified SharedLogic.DriverSupplyMetrics as DSM
 import qualified SharedLogic.External.LocationTrackingService.Types as LT
 import qualified SharedLogic.FareCalculator as Fare
 import SharedLogic.FarePolicy
@@ -187,6 +188,7 @@ sendSearchRequestToDrivers isAllocatorBatch tripQuoteDetails oldSearchReq search
   -- Batch size on record, so the respond API can recognise a *fully* rejected batch
   -- (rejects == sent) and advance the batch chain early instead of idling out the timer.
   SDP.setBatchSentCount searchTry.id batchNumber (length searchRequestsForDrivers)
+  DSM.recordDriversPinged searchReq.merchantOperatingCityId (map (.driverId) searchRequestsForDrivers)
   forM_ (M.toList $ M.fromListWith (+) $ map (\srfd -> (srfd.vehicleServiceTier, 1 :: Int)) searchRequestsForDrivers) $ \(serviceTier, sentCount) ->
     TM.addSearchRequestSentToDriverCount merchantLabel cityLabel (show serviceTier) sentCount
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
@@ -188,7 +188,7 @@ sendSearchRequestToDrivers isAllocatorBatch tripQuoteDetails oldSearchReq search
   -- Batch size on record, so the respond API can recognise a *fully* rejected batch
   -- (rejects == sent) and advance the batch chain early instead of idling out the timer.
   SDP.setBatchSentCount searchTry.id batchNumber (length searchRequestsForDrivers)
-  DSM.recordDriversPinged searchReq.merchantOperatingCityId (map (.driverId) searchRequestsForDrivers)
+  DSM.recordDriversPinged searchReq.merchantOperatingCityId (map (\srfd -> (show srfd.vehicleServiceTier, srfd.driverId)) searchRequestsForDrivers)
   forM_ (M.toList $ M.fromListWith (+) $ map (\srfd -> (srfd.vehicleServiceTier, 1 :: Int)) searchRequestsForDrivers) $ \(serviceTier, sentCount) ->
     TM.addSearchRequestSentToDriverCount merchantLabel cityLabel (show serviceTier) sentCount
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverSupplyCounter.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverSupplyCounter.hs
@@ -1,0 +1,45 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+-- | Dispatch-eligible driver count per operating city, held in Redis.
+-- Kept a leaf module on purpose: moving it into DriverSupplyMetrics would make
+-- DriverInformationExtra -> DriverSupplyMetrics -> DriverInformation an import cycle.
+module SharedLogic.DriverSupplyCounter
+  ( onlineCountKey,
+    recordDriverActiveChange,
+  )
+where
+
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import Kernel.Prelude
+import qualified Kernel.Storage.Hedis as Redis
+import Kernel.Types.Id
+import Kernel.Utils.Common
+
+onlineCountKey :: Text -> Text
+onlineCountKey cityId = "driverSupply:onlineCount:" <> cityId
+
+-- | Only moves on a real change: updateDriverModeAndFlowStatus is called on every ride
+-- start and end with `active` unchanged, so an unguarded incr/decr would track ride
+-- volume, not supply. incr/decr throw (unlike sAddExp), hence withTryCatch.
+recordDriverActiveChange ::
+  (Redis.HedisFlow m r, MonadFlow m) =>
+  Maybe (Id DMOC.MerchantOperatingCity) ->
+  Bool ->
+  Bool ->
+  m ()
+recordDriverActiveChange mbCityId wasActive nowActive =
+  when (wasActive /= nowActive) $
+    whenJust mbCityId $ \cityId ->
+      void $ withTryCatch "driverSupplyCounter" $ (if nowActive then Redis.incr else Redis.decr) (onlineCountKey cityId.getId)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverSupplyMetrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverSupplyMetrics.hs
@@ -22,13 +22,14 @@
 --     10-minute window (TTL 2.5 windows); the kernel's sAddExp already catches and
 --     logs Redis errors, so recording can never break a business flow.
 --   * publishing: a single forked loop (started at app boot) sets the gauges —
---     drivers-online every tick from driver_information on the read replica, and
+--     drivers-online every tick from the Redis counter in SharedLogic.DriverSupplyCounter
+--     (recounted from driver_information on a cache miss or the 10-minute reconcile), and
 --     the three windowed uniques once per COMPLETED window (the kernel exposes no
 --     SCARD, so cardinality = length of sMembers; publishing once per window keeps
 --     that to 3 set-reads per city per 10 minutes).
 --
--- Every pod runs the publisher; all pods compute the same values from shared
--- sources of truth, so concurrent publishes are benign.
+-- Every pod runs the publisher; the online recount is single-flighted behind a per-window
+-- lock so only one pod queries Postgres.
 module SharedLogic.DriverSupplyMetrics
   ( recordDriversPinged,
     recordDriverAccepted,
@@ -48,6 +49,7 @@ import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Types.Id
 import Kernel.Utils.Common
+import SharedLogic.DriverSupplyCounter (onlineCountKey)
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import qualified Storage.Queries.DriverInformation as QDI
@@ -72,6 +74,12 @@ currentBucket now = floor (utcTimeToPOSIXSeconds now) `div` windowSecs
 -- distinct counts — no extra Redis reads, and no need to enumerate service tiers.
 supplyMember :: (Text, Id DP.Person) -> Text
 supplyMember (tier, driverId) = tier <> "|" <> driverId.getId
+
+reconcileLockKey :: Int -> Text
+reconcileLockKey bucket = "driverSupply:onlineCount:reconcile:" <> show bucket
+
+reconcileSecs :: Int
+reconcileSecs = 600
 
 recordSupplyEvent :: (Redis.HedisFlow m r, MonadFlow m) => Text -> Id DMOC.MerchantOperatingCity -> [(Text, Id DP.Person)] -> m ()
 recordSupplyEvent kind cityId entries =
@@ -101,6 +109,33 @@ countWindowByTier kind cityId bucket = do
       let (tier, rest) = T.breakOn "|" m
        in if T.null rest then Nothing else Just (tier, T.drop 1 rest)
 
+-- | Authoritative recount for one city, straight from driver_information. Only ever
+-- called on a cache miss or on the periodic reconcile -- never per tick.
+-- | Absolute recount. `set` not a read-then-incrby delta: a delta is not idempotent
+-- across pods, so a cache miss would leave the key at (pods x online).
+rebuildOnlineCount :: (CacheFlow m r, EsqDBFlow m r, Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> m Int
+rebuildOnlineCount cityId = do
+  online <- QDI.countOnlineByCity cityId
+  Redis.set (onlineCountKey cityId.getId) online
+  pure online
+
+-- | Redis is the fast path; Postgres only on a cache miss or when this pod won the reconcile lock.
+currentOnlineCount ::
+  (CacheFlow m r, EsqDBFlow m r, Redis.HedisFlow m r, MonadFlow m) =>
+  Bool ->
+  Id DMOC.MerchantOperatingCity ->
+  m Int
+currentOnlineCount shouldReconcile cityId
+  | shouldReconcile = rebuildOnlineCount cityId
+  | otherwise = do
+    mbCount <- Redis.get (onlineCountKey cityId.getId)
+    case mbCount of
+      -- DECR on a missing key creates it at -1, so "exists" is not enough.
+      Just count | count >= 0 -> pure count
+      _ -> do
+        logWarning $ "online count missing or negative for city " <> cityId.getId <> ", rebuilding from driver_information"
+        rebuildOnlineCount cityId
+
 -- | Forked once at app boot; must never die, so each tick is exception-guarded.
 runDriverSupplyMetricsPublisher ::
   ( CacheFlow m r,
@@ -110,21 +145,28 @@ runDriverSupplyMetricsPublisher ::
     MonadFlow m
   ) =>
   m ()
-runDriverSupplyMetricsPublisher = withLogTag "DriverSupplyMetrics" $ go (-1)
+runDriverSupplyMetricsPublisher = withLogTag "DriverSupplyMetrics" $ go (-1) (-1)
   where
-    go lastPublishedBucket = do
-      res <- try @_ @SomeException (publishTick lastPublishedBucket)
-      newLast <- case res of
+    go lastPublishedBucket lastReconciledBucket = do
+      res <- try @_ @SomeException (publishTick lastPublishedBucket lastReconciledBucket)
+      (newLast, newReconciled) <- case res of
         Left err -> do
           logError $ "publish tick failed: " <> show err
-          pure lastPublishedBucket
+          pure (lastPublishedBucket, lastReconciledBucket)
         Right published -> pure published
       liftIO $ threadDelay (publishTickSecs * 1000000)
-      go newLast
+      go newLast newReconciled
 
-    publishTick lastPublishedBucket = do
+    publishTick lastPublishedBucket lastReconciledBucket = do
       supplyMetrics <- asks (.driverSupplyMetrics)
       now <- getCurrentTime
+      -- One pod per window recounts from Postgres so drift cannot accumulate.
+      let reconcileBucket = floor (utcTimeToPOSIXSeconds now) `div` reconcileSecs
+      shouldReconcile <-
+        if reconcileBucket == lastReconciledBucket
+          then pure False
+          else Redis.setNxExpire (reconcileLockKey reconcileBucket) reconcileSecs True
+      when shouldReconcile $ logInfo "won reconcile lock, recounting online drivers from driver_information"
       let prevBucket = currentBucket now - 1
           -- Publish every completed-but-unpublished window, ascending so gauges end
           -- on the newest. Capped at 3 windows back (beyond the Redis TTL the sets
@@ -135,19 +177,27 @@ runDriverSupplyMetricsPublisher = withLogTag "DriverSupplyMetrics" $ go (-1)
             | otherwise = [max (lastPublishedBucket + 1) (prevBucket - 2) .. prevBucket]
       when (length bucketsToPublish > 1) $
         logWarning $ "publishing " <> show (length bucketsToPublish) <> " windows at once - earlier ticks were missed"
-      providers <- CQM.loadAllProviders
-      forM_ providers $ \merchant -> do
-        cities <- CQMOC.findAllByMerchantId merchant.id
-        forM_ cities $ \city -> do
-          let merchantLabel = merchant.shortId.getShortId
-              cityLabel = show city.city
-          online <- QDI.countOnlineByCity city.id
-          setDriverSupplyGauge supplyMetrics.driversOnlineGauge merchantLabel cityLabel online
-          forM_ bucketsToPublish $ \bucket -> do
-            publishTierGauge supplyMetrics.driversReceivingGauge "pinged" merchantLabel cityLabel city.id bucket
-            publishTierGauge supplyMetrics.driversAcceptingGauge "accepted" merchantLabel cityLabel city.id bucket
-            publishTierGauge supplyMetrics.driversOnRideGauge "onride" merchantLabel cityLabel city.id bucket
-      pure $ max lastPublishedBucket prevBucket
+      -- Release the lock if this tick dies partway, so the next one can retry.
+      res <- try @_ @SomeException $ do
+        providers <- CQM.loadAllProviders
+        forM_ providers $ \merchant -> do
+          cities <- CQMOC.findAllByMerchantId merchant.id
+          forM_ cities $ \city -> do
+            let merchantLabel = merchant.shortId.getShortId
+                cityLabel = show city.city
+            online <- currentOnlineCount shouldReconcile city.id
+            setDriverSupplyGauge supplyMetrics.driversOnlineGauge merchantLabel cityLabel online
+            forM_ bucketsToPublish $ \bucket -> do
+              publishTierGauge supplyMetrics.driversReceivingGauge "pinged" merchantLabel cityLabel city.id bucket
+              publishTierGauge supplyMetrics.driversAcceptingGauge "accepted" merchantLabel cityLabel city.id bucket
+              publishTierGauge supplyMetrics.driversOnRideGauge "onride" merchantLabel cityLabel city.id bucket
+        pure (max lastPublishedBucket prevBucket, if shouldReconcile then reconcileBucket else lastReconciledBucket)
+      case res of
+        Right published -> pure published
+        Left err -> do
+          logError $ "publish tick failed mid-publish: " <> show err
+          when shouldReconcile $ Redis.del (reconcileLockKey reconcileBucket)
+          pure (lastPublishedBucket, lastReconciledBucket)
 
     publishTierGauge gaugeVec kind merchantLabel cityLabel cityId bucket = do
       perTier <- countWindowByTier kind cityId bucket

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverSupplyMetrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverSupplyMetrics.hs
@@ -1,0 +1,136 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+-- | Driver-supply metrics: how many drivers are online, receiving search requests,
+-- accepting them, and taking rides — per merchant × operating city.
+--
+-- These are DISTINCT-DRIVER counts, which Prometheus counters cannot express
+-- (counters count events; the same driver pinged 40 times must count once). So:
+--
+--   * recording: event call sites SADD the driver id into a Redis set keyed by a
+--     10-minute window (TTL 2.5 windows); the kernel's sAddExp already catches and
+--     logs Redis errors, so recording can never break a business flow.
+--   * publishing: a single forked loop (started at app boot) sets the gauges —
+--     drivers-online every tick from driver_information on the read replica, and
+--     the three windowed uniques once per COMPLETED window (the kernel exposes no
+--     SCARD, so cardinality = length of sMembers; publishing once per window keeps
+--     that to 3 set-reads per city per 10 minutes).
+--
+-- Every pod runs the publisher; all pods compute the same values from shared
+-- sources of truth, so concurrent publishes are benign.
+module SharedLogic.DriverSupplyMetrics
+  ( recordDriversPinged,
+    recordDriverAccepted,
+    recordDriverOnRide,
+    runDriverSupplyMetricsPublisher,
+  )
+where
+
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Person as DP
+import Kernel.Prelude
+import qualified Kernel.Storage.Hedis as Redis
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import qualified Storage.CachedQueries.Merchant as CQM
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import qualified Storage.Queries.DriverInformation as QDI
+import Tools.Metrics.DriverSupplyMetrics.Types
+
+windowSecs :: Int
+windowSecs = 600
+
+windowTtlSecs :: Int
+windowTtlSecs = 1500 -- 2.5 windows: previous window must survive until published
+
+publishTickSecs :: Int
+publishTickSecs = 60
+
+supplyKey :: Text -> Text -> Int -> Text
+supplyKey kind cityId bucket = "driverSupply:" <> kind <> ":" <> cityId <> ":" <> show bucket
+
+currentBucket :: UTCTime -> Int
+currentBucket now = floor (utcTimeToPOSIXSeconds now) `div` windowSecs
+
+recordSupplyEvent :: (Redis.HedisFlow m r, MonadFlow m) => Text -> Id DMOC.MerchantOperatingCity -> [Id DP.Person] -> m ()
+recordSupplyEvent kind cityId driverIds =
+  unless (null driverIds) $ do
+    now <- getCurrentTime
+    Redis.sAddExp (supplyKey kind cityId.getId (currentBucket now)) (map (.getId) driverIds) windowTtlSecs
+
+recordDriversPinged :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> [Id DP.Person] -> m ()
+recordDriversPinged = recordSupplyEvent "pinged"
+
+recordDriverAccepted :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> Id DP.Person -> m ()
+recordDriverAccepted cityId driverId = recordSupplyEvent "accepted" cityId [driverId]
+
+recordDriverOnRide :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> Id DP.Person -> m ()
+recordDriverOnRide cityId driverId = recordSupplyEvent "onride" cityId [driverId]
+
+countWindow :: (Redis.HedisFlow m r, MonadFlow m) => Text -> Id DMOC.MerchantOperatingCity -> Int -> m Int
+countWindow kind cityId bucket = do
+  (members :: [Text]) <- Redis.sMembers (supplyKey kind cityId.getId bucket)
+  pure $ length members
+
+-- | Forked once at app boot; must never die, so each tick is exception-guarded.
+runDriverSupplyMetricsPublisher ::
+  ( CacheFlow m r,
+    EsqDBFlow m r,
+    Redis.HedisFlow m r,
+    HasDriverSupplyMetrics m r,
+    MonadFlow m
+  ) =>
+  m ()
+runDriverSupplyMetricsPublisher = withLogTag "DriverSupplyMetrics" $ go (-1)
+  where
+    go lastPublishedBucket = do
+      res <- try @_ @SomeException (publishTick lastPublishedBucket)
+      newLast <- case res of
+        Left err -> do
+          logError $ "publish tick failed: " <> show err
+          pure lastPublishedBucket
+        Right published -> pure published
+      liftIO $ threadDelay (publishTickSecs * 1000000)
+      go newLast
+
+    publishTick lastPublishedBucket = do
+      supplyMetrics <- asks (.driverSupplyMetrics)
+      now <- getCurrentTime
+      let prevBucket = currentBucket now - 1
+          -- Publish every completed-but-unpublished window, ascending so gauges end
+          -- on the newest. Capped at 3 windows back (beyond the Redis TTL the sets
+          -- are empty anyway); the strictly-increasing range also guards against a
+          -- backward clock step republishing an already-expired bucket as 0.
+          bucketsToPublish
+            | lastPublishedBucket < 0 = [prevBucket]
+            | otherwise = [max (lastPublishedBucket + 1) (prevBucket - 2) .. prevBucket]
+      when (length bucketsToPublish > 1) $
+        logWarning $ "publishing " <> show (length bucketsToPublish) <> " windows at once - earlier ticks were missed"
+      providers <- CQM.loadAllProviders
+      forM_ providers $ \merchant -> do
+        cities <- CQMOC.findAllByMerchantId merchant.id
+        forM_ cities $ \city -> do
+          let merchantLabel = merchant.shortId.getShortId
+              cityLabel = show city.city
+          online <- QDI.countOnlineByCity city.id
+          setDriverSupplyGauge supplyMetrics.driversOnlineGauge merchantLabel cityLabel online
+          forM_ bucketsToPublish $ \bucket -> do
+            pinged <- countWindow "pinged" city.id bucket
+            accepted <- countWindow "accepted" city.id bucket
+            onRide <- countWindow "onride" city.id bucket
+            setDriverSupplyGauge supplyMetrics.driversReceivingGauge merchantLabel cityLabel pinged
+            setDriverSupplyGauge supplyMetrics.driversAcceptingGauge merchantLabel cityLabel accepted
+            setDriverSupplyGauge supplyMetrics.driversOnRideGauge merchantLabel cityLabel onRide
+      pure $ max lastPublishedBucket prevBucket

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverSupplyMetrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverSupplyMetrics.hs
@@ -37,6 +37,10 @@ module SharedLogic.DriverSupplyMetrics
   )
 where
 
+import Data.Bifunctor (second)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.Person as DP
@@ -64,25 +68,38 @@ supplyKey kind cityId bucket = "driverSupply:" <> kind <> ":" <> cityId <> ":" <
 currentBucket :: UTCTime -> Int
 currentBucket now = floor (utcTimeToPOSIXSeconds now) `div` windowSecs
 
-recordSupplyEvent :: (Redis.HedisFlow m r, MonadFlow m) => Text -> Id DMOC.MerchantOperatingCity -> [Id DP.Person] -> m ()
-recordSupplyEvent kind cityId driverIds =
-  unless (null driverIds) $ do
-    now <- getCurrentTime
-    Redis.sAddExp (supplyKey kind cityId.getId (currentBucket now)) (map (.getId) driverIds) windowTtlSecs
+-- Members are "&lt;tier&gt;|&lt;driverId&gt;" so one set per (city, window) still yields per-tier
+-- distinct counts — no extra Redis reads, and no need to enumerate service tiers.
+supplyMember :: (Text, Id DP.Person) -> Text
+supplyMember (tier, driverId) = tier <> "|" <> driverId.getId
 
-recordDriversPinged :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> [Id DP.Person] -> m ()
+recordSupplyEvent :: (Redis.HedisFlow m r, MonadFlow m) => Text -> Id DMOC.MerchantOperatingCity -> [(Text, Id DP.Person)] -> m ()
+recordSupplyEvent kind cityId entries =
+  unless (null entries) $ do
+    now <- getCurrentTime
+    Redis.sAddExp (supplyKey kind cityId.getId (currentBucket now)) (map supplyMember entries) windowTtlSecs
+
+recordDriversPinged :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> [(Text, Id DP.Person)] -> m ()
 recordDriversPinged = recordSupplyEvent "pinged"
 
-recordDriverAccepted :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> Id DP.Person -> m ()
-recordDriverAccepted cityId driverId = recordSupplyEvent "accepted" cityId [driverId]
+recordDriverAccepted :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> Text -> Id DP.Person -> m ()
+recordDriverAccepted cityId tier driverId = recordSupplyEvent "accepted" cityId [(tier, driverId)]
 
-recordDriverOnRide :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> Id DP.Person -> m ()
-recordDriverOnRide cityId driverId = recordSupplyEvent "onride" cityId [driverId]
+recordDriverOnRide :: (Redis.HedisFlow m r, MonadFlow m) => Id DMOC.MerchantOperatingCity -> Text -> Id DP.Person -> m ()
+recordDriverOnRide cityId tier driverId = recordSupplyEvent "onride" cityId [(tier, driverId)]
 
-countWindow :: (Redis.HedisFlow m r, MonadFlow m) => Text -> Id DMOC.MerchantOperatingCity -> Int -> m Int
-countWindow kind cityId bucket = do
+-- | Distinct drivers per tier for one window. Malformed members (no separator) are
+-- dropped rather than counted under a bogus tier.
+countWindowByTier :: (Redis.HedisFlow m r, MonadFlow m) => Text -> Id DMOC.MerchantOperatingCity -> Int -> m [(Text, Int)]
+countWindowByTier kind cityId bucket = do
   (members :: [Text]) <- Redis.sMembers (supplyKey kind cityId.getId bucket)
-  pure $ length members
+  let parsed = mapMaybe parseMember members
+      byTier = Map.fromListWith Set.union [(tier, Set.singleton driverId) | (tier, driverId) <- parsed]
+  pure $ map (second Set.size) (Map.toList byTier)
+  where
+    parseMember m =
+      let (tier, rest) = T.breakOn "|" m
+       in if T.null rest then Nothing else Just (tier, T.drop 1 rest)
 
 -- | Forked once at app boot; must never die, so each tick is exception-guarded.
 runDriverSupplyMetricsPublisher ::
@@ -127,10 +144,11 @@ runDriverSupplyMetricsPublisher = withLogTag "DriverSupplyMetrics" $ go (-1)
           online <- QDI.countOnlineByCity city.id
           setDriverSupplyGauge supplyMetrics.driversOnlineGauge merchantLabel cityLabel online
           forM_ bucketsToPublish $ \bucket -> do
-            pinged <- countWindow "pinged" city.id bucket
-            accepted <- countWindow "accepted" city.id bucket
-            onRide <- countWindow "onride" city.id bucket
-            setDriverSupplyGauge supplyMetrics.driversReceivingGauge merchantLabel cityLabel pinged
-            setDriverSupplyGauge supplyMetrics.driversAcceptingGauge merchantLabel cityLabel accepted
-            setDriverSupplyGauge supplyMetrics.driversOnRideGauge merchantLabel cityLabel onRide
+            publishTierGauge supplyMetrics.driversReceivingGauge "pinged" merchantLabel cityLabel city.id bucket
+            publishTierGauge supplyMetrics.driversAcceptingGauge "accepted" merchantLabel cityLabel city.id bucket
+            publishTierGauge supplyMetrics.driversOnRideGauge "onride" merchantLabel cityLabel city.id bucket
       pure $ max lastPublishedBucket prevBucket
+
+    publishTierGauge gaugeVec kind merchantLabel cityLabel cityId bucket = do
+      perTier <- countWindowByTier kind cityId bucket
+      forM_ perTier $ \(tier, n) -> setDriverSupplyTierGauge gaugeVec merchantLabel cityLabel tier n

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
@@ -60,6 +60,7 @@ import SharedLogic.Allocator (AllocatorJobType (..), CheckDriverPickupProgressJo
 import qualified SharedLogic.Analytics as Analytics
 import qualified SharedLogic.CallBAPInternal as CallBAPInternal
 import qualified SharedLogic.DriverPool as DP
+import qualified SharedLogic.DriverSupplyMetrics as DSM
 import qualified SharedLogic.External.LocationTrackingService.Flow as LF
 import qualified SharedLogic.External.LocationTrackingService.Types as LT
 import qualified SharedLogic.FareCalculator as FC
@@ -184,6 +185,8 @@ initializeRide merchant driver booking mbOtpCode enableFrequentLocationUpdates m
   rideDetails <- buildRideDetails booking ride driver vehicle
   QRB.updateStatus booking.id DBooking.TRIP_ASSIGNED
   QRide.createRide ride
+  -- scheduled bookings assign a driver hours before the trip - not on-ride supply
+  when (not booking.isScheduled) $ DSM.recordDriverOnRide booking.merchantOperatingCityId ride.driverId
   cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
   Metrics.incrementRideCreatedCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier)
   QRideD.create rideDetails

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
@@ -186,7 +186,7 @@ initializeRide merchant driver booking mbOtpCode enableFrequentLocationUpdates m
   QRB.updateStatus booking.id DBooking.TRIP_ASSIGNED
   QRide.createRide ride
   -- scheduled bookings assign a driver hours before the trip - not on-ride supply
-  when (not booking.isScheduled) $ DSM.recordDriverOnRide booking.merchantOperatingCityId ride.driverId
+  when (not booking.isScheduled) $ DSM.recordDriverOnRide booking.merchantOperatingCityId (show booking.vehicleServiceTier) ride.driverId
   cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
   Metrics.incrementRideCreatedCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier)
   QRideD.create rideDetails

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverInformationExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverInformationExtra.hs
@@ -26,6 +26,7 @@ import Kernel.Utils.Common
 import qualified Lib.Types.SpecialLocation as SL
 import qualified Sequelize as Se
 import qualified SharedLogic.DriverPool.LTSDataSync as LTSSync
+import qualified SharedLogic.DriverSupplyCounter as DSC
 import qualified Storage.Beam.Common as BeamCommon
 import qualified Storage.Beam.Common as SBC
 import qualified Storage.Beam.DriverInformation as BeamDI
@@ -283,6 +284,9 @@ updateDynamicBlockedStateWithActivity driverId blockedReason blockedExpiryTime d
         <> ([Se.Set BeamDI.numOfLocks (numOfLocks' + 1) | isBlocked])
     )
     [Se.Is BeamDI.driverId (Se.Eq (getId driverId))]
+  -- Blocking writes `active` too. Keyed on the driver's own city, which is what countOnlineByCity buckets on.
+  whenJust driverInfo $ \di ->
+    DSC.recordDriverActiveChange di.merchantOperatingCityId di.active (fromMaybe True (mbActive <|> activeState))
   LTSSync.syncDriverPoolDataToLTS (cast driverId) $
     LTSSync.emptyUpdate
       { LTSSync.blocked = LTSSync.Set isBlocked,
@@ -577,12 +581,18 @@ countEnabledByDriverIds driverIds =
 updateMerchantIdAndCityIdByDriverId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id Person.Person -> Id Merchant -> Id DMOC.MerchantOperatingCity -> m ()
 updateMerchantIdAndCityIdByDriverId driverId merchantId merchantOperatingCityId = do
   now <- getCurrentTime
+  -- A city move relocates an online driver between supply buckets without touching `active`.
+  mbDriverInfo <- findById (cast driverId)
   updateOneWithKV
     [ Se.Set BeamDI.merchantId (Just $ getId merchantId),
       Se.Set BeamDI.merchantOperatingCityId (Just $ getId merchantOperatingCityId),
       Se.Set BeamDI.updatedAt now
     ]
     [Se.Is BeamDI.driverId (Se.Eq $ getId driverId)]
+  whenJust mbDriverInfo $ \di ->
+    when di.active $ do
+      DSC.recordDriverActiveChange di.merchantOperatingCityId True False
+      DSC.recordDriverActiveChange (Just merchantOperatingCityId) False True
 
 findEligibleForScheduledPayout ::
   (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverInformationExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverInformationExtra.hs
@@ -528,6 +528,33 @@ updateOnlineDurationRefreshedAt (Id driverId) onlineDurationRefreshedAt = do
 findAllByDriverIds :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => [Text] -> m [DriverInformation]
 findAllByDriverIds driverIds = findAllWithKV [Se.Is BeamDI.driverId $ Se.In driverIds]
 
+-- | Per-city count of currently-active drivers, for the driver-supply metrics
+-- publisher. Runs on the read replica; requires the partial index
+-- idx_driver_information_city_active (ddl-migration 0854).
+-- Assumes driver_information stays KV-DISABLED (Postgres-direct writes, per
+-- kv_configs) — if it is ever KV-enabled this count becomes drainer-stale.
+-- Legacy rows with NULL merchant_operating_city_id (pre-city-column) are
+-- deliberately excluded, matching the plain-equality convention of most
+-- per-city queries in this file. Errors PROPAGATE by design: the metrics
+-- publisher catches per-tick and holds the last good gauge value — coercing
+-- to 0 here would fake a supply collapse during a replica blip.
+countOnlineByCity :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> m Int
+countOnlineByCity merchantOpCityId = do
+  dbConf <- getReplicaBeamConfig
+  res <-
+    L.runDB dbConf $
+      L.findRows $
+        B.select $
+          B.aggregate_ (\_ -> B.as_ @Int B.countAll_) $
+            B.filter_'
+              ( \driverInfo ->
+                  driverInfo.active B.==?. B.val_ True
+                    B.&&?. driverInfo.merchantOperatingCityId B.==?. B.val_ (Just $ getId merchantOpCityId)
+              )
+              $ B.all_ (SBC.driverInformation SBC.atlasDB)
+  rows <- either (\err -> throwError $ InternalError $ "countOnlineByCity failed: " <> show err) pure res
+  pure $ fromMaybe 0 (listToMaybe rows)
+
 countEnabledByDriverIds :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => [Text] -> m Int
 countEnabledByDriverIds driverIds =
   if null driverIds

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics.hs
@@ -17,4 +17,5 @@ module Tools.Metrics (module Reexport) where
 import Kernel.Tools.Metrics.CoreMetrics as Reexport
 import Tools.Metrics.ARDUBPPMetrics as Reexport
 import Tools.Metrics.DriverSearchRequestResponseMetrics as Reexport
+import Tools.Metrics.DriverSupplyMetrics.Types as Reexport
 import Tools.Metrics.SendSearchRequestToDriverMetrics as Reexport

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSupplyMetrics/Types.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSupplyMetrics/Types.hs
@@ -1,0 +1,65 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Tools.Metrics.DriverSupplyMetrics.Types
+  ( HasDriverSupplyMetrics,
+    DriverSupplyMetricsContainer (..),
+    registerDriverSupplyMetricsContainer,
+    setDriverSupplyGauge,
+  )
+where
+
+import EulerHS.Prelude
+import Kernel.Utils.Common
+import Prometheus as P
+
+type HasDriverSupplyMetrics m r =
+  HasFlowEnv m r '["driverSupplyMetrics" ::: DriverSupplyMetricsContainer]
+
+-- Driver-supply gauges: ABSOLUTE values set periodically from a source of truth,
+-- never incremented/decremented on events (event-driven gauges drift on pod
+-- restarts and split across pods).
+--
+-- Labels are (merchant, city) ONLY — deliberately no backend_version: gauges are
+-- published concurrently by every pod, and during a rollout two deployment
+-- versions would publish the same truth under different label sets, so any sum()
+-- would double-count supply. Concurrent same-value writes without the version
+-- label are benign (last-writer-wins on identical numbers).
+-- merchant = merchant shortId, city = operating city name.
+-- DASHBOARDS: every pod exports its own series — always aggregate with
+-- max by (merchant, city), NEVER sum across instances.
+type DriverSupplyGauge = P.Vector P.Label2 P.Gauge
+
+data DriverSupplyMetricsContainer = DriverSupplyMetricsContainer
+  { driversOnlineGauge :: DriverSupplyGauge,
+    driversReceivingGauge :: DriverSupplyGauge,
+    driversAcceptingGauge :: DriverSupplyGauge,
+    driversOnRideGauge :: DriverSupplyGauge
+  }
+
+registerDriverSupplyMetricsContainer :: IO DriverSupplyMetricsContainer
+registerDriverSupplyMetricsContainer = do
+  driversOnlineGauge <- reg "BPP_drivers_online" "Current on-duty drivers (active: ONLINE or SILENT mode, including on-ride) per driver_information, refreshed periodically from the read replica"
+  driversReceivingGauge <- reg "BPP_drivers_receiving_searches" "Distinct drivers sent at least one search request in the last completed 10-minute window"
+  driversAcceptingGauge <- reg "BPP_drivers_accepting_searches" "Distinct drivers who accepted at least one search request in the last completed 10-minute window"
+  driversOnRideGauge <- reg "BPP_drivers_on_ride" "Distinct drivers assigned to at least one ride in the last completed 10-minute window"
+  return $ DriverSupplyMetricsContainer {..}
+  where
+    reg name description = P.register . P.vector ("merchant", "city") . P.gauge $ P.Info name description
+
+-- (param is gaugeVec, not "gauge": Prometheus is imported unqualified too, and a
+-- local named gauge shadows P.gauge — fatal under this package's -Wall -Werror)
+setDriverSupplyGauge :: MonadIO m => DriverSupplyGauge -> Text -> Text -> Int -> m ()
+setDriverSupplyGauge gaugeVec merchantLabel cityLabel value =
+  liftIO $ P.withLabel gaugeVec (merchantLabel, cityLabel) (`P.setGauge` fromIntegral value)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSupplyMetrics/Types.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/DriverSupplyMetrics/Types.hs
@@ -17,6 +17,7 @@ module Tools.Metrics.DriverSupplyMetrics.Types
     DriverSupplyMetricsContainer (..),
     registerDriverSupplyMetricsContainer,
     setDriverSupplyGauge,
+    setDriverSupplyTierGauge,
   )
 where
 
@@ -38,28 +39,46 @@ type HasDriverSupplyMetrics m r =
 -- label are benign (last-writer-wins on identical numbers).
 -- merchant = merchant shortId, city = operating city name.
 -- DASHBOARDS: every pod exports its own series — always aggregate with
--- max by (merchant, city), NEVER sum across instances.
+-- max by (...), NEVER sum across instances.
 type DriverSupplyGauge = P.Vector P.Label2 P.Gauge
+
+-- The windowed metrics additionally carry vehicle_service_tier, matching every other
+-- BPP funnel counter — supply shortages are tier-specific, and a city total blends
+-- auto/cab/bike so a collapse in one tier can hide behind a flat line.
+-- NOTE: summing across tiers OVER-counts a driver who serves several tiers; each
+-- series is "distinct drivers for that (city, tier)". Use a specific tier, or
+-- BPP_drivers_online for the city-wide figure.
+type DriverSupplyTierGauge = P.Vector P.Label3 P.Gauge
 
 data DriverSupplyMetricsContainer = DriverSupplyMetricsContainer
   { driversOnlineGauge :: DriverSupplyGauge,
-    driversReceivingGauge :: DriverSupplyGauge,
-    driversAcceptingGauge :: DriverSupplyGauge,
-    driversOnRideGauge :: DriverSupplyGauge
+    driversReceivingGauge :: DriverSupplyTierGauge,
+    driversAcceptingGauge :: DriverSupplyTierGauge,
+    driversOnRideGauge :: DriverSupplyTierGauge
   }
 
 registerDriverSupplyMetricsContainer :: IO DriverSupplyMetricsContainer
 registerDriverSupplyMetricsContainer = do
-  driversOnlineGauge <- reg "BPP_drivers_online" "Current on-duty drivers (active: ONLINE or SILENT mode, including on-ride) per driver_information, refreshed periodically from the read replica"
-  driversReceivingGauge <- reg "BPP_drivers_receiving_searches" "Distinct drivers sent at least one search request in the last completed 10-minute window"
-  driversAcceptingGauge <- reg "BPP_drivers_accepting_searches" "Distinct drivers who accepted at least one search request in the last completed 10-minute window"
-  driversOnRideGauge <- reg "BPP_drivers_on_ride" "Distinct drivers assigned to at least one ride in the last completed 10-minute window"
+  -- No vehicle_service_tier here: driver_information carries no tier (a driver's tiers
+  -- come from their vehicle and preferences), so this gauge is city-wide by necessity.
+  -- "active" is the same predicate the dispatch filter uses — dispatch-eligible drivers,
+  -- which spans ONLINE and SILENT mode and includes drivers currently on a ride.
+  -- Subtract BPP_drivers_on_ride for a free-supply view.
+  driversOnlineGauge <- reg "BPP_drivers_online" "Current dispatch-eligible drivers (driver_information.active, spans ONLINE/SILENT and includes on-ride), refreshed periodically from the read replica"
+  driversReceivingGauge <- regTier "BPP_drivers_receiving_searches" "Distinct drivers sent at least one search request in the last completed 10-minute window, per vehicle service tier"
+  driversAcceptingGauge <- regTier "BPP_drivers_accepting_searches" "Distinct drivers who accepted at least one search request in the last completed 10-minute window, per vehicle service tier"
+  driversOnRideGauge <- regTier "BPP_drivers_on_ride" "Distinct drivers assigned to at least one ride in the last completed 10-minute window, per vehicle service tier"
   return $ DriverSupplyMetricsContainer {..}
   where
     reg name description = P.register . P.vector ("merchant", "city") . P.gauge $ P.Info name description
+    regTier name description = P.register . P.vector ("merchant", "city", "vehicle_service_tier") . P.gauge $ P.Info name description
 
 -- (param is gaugeVec, not "gauge": Prometheus is imported unqualified too, and a
 -- local named gauge shadows P.gauge — fatal under this package's -Wall -Werror)
 setDriverSupplyGauge :: MonadIO m => DriverSupplyGauge -> Text -> Text -> Int -> m ()
 setDriverSupplyGauge gaugeVec merchantLabel cityLabel value =
   liftIO $ P.withLabel gaugeVec (merchantLabel, cityLabel) (`P.setGauge` fromIntegral value)
+
+setDriverSupplyTierGauge :: MonadIO m => DriverSupplyTierGauge -> Text -> Text -> Text -> Int -> m ()
+setDriverSupplyTierGauge gaugeVec merchantLabel cityLabel tierLabel value =
+  liftIO $ P.withLabel gaugeVec (merchantLabel, cityLabel, tierLabel) (`P.setGauge` fromIntegral value)

--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-driver-supply-metrics-index.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0854-driver-supply-metrics-index.sql
@@ -1,0 +1,8 @@
+-- Partial index for the driver-supply metrics publisher: per-city count of active drivers,
+-- executed on the read replica every 60s per operating city.
+-- CONCURRENTLY: driver_information is one of the hottest write tables (every online/offline
+-- toggle); a plain build would block all writes for the duration. The runner applies these
+-- files via plain psql (autocommit), so CONCURRENTLY is valid here — house style per
+-- migrations 0822/0830/0839/0847. If a concurrent build fails it leaves an INVALID index:
+-- drop and re-run.
+create index concurrently if not exists idx_driver_information_city_active on atlas_driver_offer_bpp.driver_information (merchant_operating_city_id) where active = true;


### PR DESCRIPTION
Supersedes #16277 (re-raised from the correct account).

## What

Four **distinct-driver** supply metrics per merchant × operating city, filling the gap that no supply-side signal exists in VictoriaMetrics today:

| Metric | Meaning | Freshness |
|---|---|---|
| `BPP_drivers_online` | on-duty drivers (`active` = ONLINE/SILENT mode, incl. on-ride — same population the dispatch filter uses) | 60s, from read replica |
| `BPP_drivers_receiving_searches` | distinct drivers sent ≥1 search request | per completed 10-min window |
| `BPP_drivers_accepting_searches` | distinct drivers accepting ≥1 request | per completed 10-min window |
| `BPP_drivers_on_ride` | distinct drivers assigned ≥1 ride (scheduled bookings excluded) | per completed 10-min window |

The driver-grain ratio (accepting ÷ receiving) is a new signal: it distinguishes "all drivers accept less" from "fewer drivers do all the accepting", which ping-grain accept rates cannot see.

## Why gauges + Redis sets (not counters)

These are **entity counts, not event counts** — Prometheus counters count events and cannot dedup the same driver across 40 pings. Call sites `sAddExp` the driver id into a 10-min-bucketed Redis set (TTL 2.5 windows, reset per event); a publisher loop forked at app boot (same pattern as kafka-consumers' startup loops) sets the gauges. Gauges are **set from source of truth, never inc/dec on events** — event-driven gauges drift on pod restarts and split across pods.

## Robustness properties (each verified against kernel/source precedent)

- **Recording can never break a business flow** — kernel `sAddExp` catches and logs all Redis errors internally.
- **Count-query errors propagate** — the publisher's per-tick exception guard holds the last good gauge value; coercing to 0 would fake a supply collapse during a replica blip.
- **Missed ticks lose no windows** — the publisher emits every completed-but-unpublished window (capped 3 back, with a warning log); the strictly-increasing bucket range also guards against backward clock steps.
- **No deployment-version label on gauges** — every pod publishes; a version label would double-count supply during rollouts.
- **Scheduled bookings excluded from on-ride** — mirrors the `updateOnRide` guard in the same function.

## Dashboards

Every pod exports its own series: **always aggregate `max by (merchant, city)` — never `sum` across instances.**

## Ops note — migration 0854

Partial index `idx_driver_information_city_active ON driver_information (merchant_operating_city_id) WHERE active = true`, created **CONCURRENTLY** (hot write table; runner applies via autocommit psql, per existing migrations 0822/0830/0847). If a concurrent build fails it leaves an INVALID index — drop and re-run. Pre-creating manually on prod is safe (`IF NOT EXISTS`).

Known limitation (documented in-code): legacy `driver_information` rows with NULL `merchant_operating_city_id` are excluded from the online count, consistent with most per-city queries.

## Validation after integ deploy

- `BPP_drivers_online` appears within ~60s of boot and roughly tracks known supply
- windowed gauges appear after the first full 10-min window
- `max by (merchant, city)` of accepting ÷ receiving produces a sane driver-grain accept ratio
- follow-up candidate: add `sCard` to shared-kernel to make window reads O(1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added driver supply metrics for online, receiving requests, accepting rides, and on-ride drivers.
  * Metrics are tracked by merchant and operating city in rolling time windows.
  * Added monitoring support for driver activity and supply levels.
* **Performance**
  * Improved active-driver lookups by operating city to support metric reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->