### PR TITLE
backend/chore: add db index on search_request.parent_search_request_id

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/SearchRequest.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/SearchRequest.yaml
@@ -284,8 +284,13 @@ SearchRequest:
     # forced form is required for the KV secondary-key list to include it.
     parentSearchRequestId: "!SecondaryKey"
 
+  extraIndexes:
+    - columns: [parentSearchRequestId]
+
   extraOperations:
     - EXTRA_QUERY_FILE
+    - GENERATE_INDEXES
+    - NO_DEFAULT_INDEXES
 
 SearchRequestPartiesLink:
   fields:

--- a/Backend/dev/migrations-read-only/rider-app/search_request.sql
+++ b/Backend/dev/migrations-read-only/rider-app/search_request.sql
@@ -501,3 +501,8 @@ ALTER TABLE atlas_app.search_request ADD COLUMN parent_search_request_id charact
 ALTER TABLE atlas_app.search_request ADD COLUMN better_point_walk_to_pickup integer ;
 ALTER TABLE atlas_app.search_request ADD COLUMN better_point_walk_from_drop integer ;
 ALTER TABLE atlas_app.search_request ADD COLUMN better_point_ride_distance_saved integer ;
+
+
+------- SQL updates -------
+
+CREATE INDEX CONCURRENTLY search_request_idx_parent_search_request_id ON atlas_app.search_request USING btree (parent_search_request_id);


### PR DESCRIPTION
## Why

`search_request.parent_search_request_id` (added in 9ecdf4fa6c for better route point suggestions) is read back by `findByParentSearchRequestId` in `Storage.Queries.SearchRequestExtra`, but had no Postgres index — only the KV secondary key. The DB-side fallback was a sequential scan on `search_request`.

## What

Declared the index in the storage spec rather than hand-rolled SQL:

```yaml
  extraIndexes:
    - columns: [parentSearchRequestId]

  extraOperations:
    - EXTRA_QUERY_FILE
    - GENERATE_INDEXES
    - NO_DEFAULT_INDEXES
```

Generated by `, run-generator --apply-hint`:

```sql
CREATE INDEX CONCURRENTLY search_request_idx_parent_search_request_id
  ON atlas_app.search_request USING btree (parent_search_request_id);
```

`NO_DEFAULT_INDEXES` is set deliberately: `GENERATE_INDEXES` alone emits an index for every `SecondaryKey`, which would have created `search_request_idx_rider_id` — a duplicate of the existing `idx_search_req_rider_id` (`ddl-migrations/rider-app/1046-optimize-tables.sql`) and `idx_16386_requestor` (`0000-db-init.sql`). On a table this size that second btree is pure cost.

## Notes

- No Haskell regenerated — the domain/beam/query files already carried the field, so `enableKVPG` is unchanged and there is nothing new to compile.
- Index is `CONCURRENTLY`, so it can be applied without locking writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved search request lookup performance when filtering by a parent search request.
  * Added a database index to support faster related search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->