### PR TITLE
fix: reallocate pickup-stalled rides regardless of driver-cancellatio…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/PickupProgress/CheckDriverPickupProgress.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/PickupProgress/CheckDriverPickupProgress.hs
@@ -156,9 +156,9 @@ checkDriverPickupProgress Job {id, jobInfo} = withLogTag ("JobId-" <> id.getId) 
                               Just stage | stallDuration >= fromIntegral stage.afterStallSec -> do
                                 let situation = rideSituation booking
                                 sendStallOverlay ride.merchantOperatingCityId driverId (stage.overlayKey <> "_" <> situation)
-                                -- REALLOCATE_RIDE acts only on non-cancellable rides; for cancellable
-                                -- situations the driver always had the cancel exit, so we only record.
-                                let shouldReallocate = stage.terminalAction == Just DTC.REALLOCATE_RIDE && situation == situationNonCancellable
+                                -- REALLOCATE_RIDE is controlled purely by pickupStallMonitoringConfig's
+                                -- terminalAction; the ride's cancellation situation no longer gates it.
+                                let shouldReallocate = stage.terminalAction == Just DTC.REALLOCATE_RIDE
                                 if isJust stage.terminalAction
                                   then do
                                     stampPickupStallTag ride activeCase'


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pickup progress handling by ensuring driver reallocation follows the configured terminal action.
  * Reallocation is no longer prevented solely because a ride may be cancellable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->