### PR TITLE
frfs/fix: use live journey-leg bus number for trip-start notification

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -1743,7 +1743,7 @@ notifyBusTripStartedForTrip tripId = do
           when isShuttle $ do
             -- Send trip start notification sequentially
             let routeName = fromMaybe "" booking.routeName
-            let vehicleNo = fromMaybe "" booking.vehicleNumber
+            let vehicleNo = fromMaybe "" (mbJourneyLeg >>= (.finalBoardedBusNumber))
             logInfo $ "Notifying passenger " <> person.id.getId <> " that bus trip has started on route " <> routeName <> "for journeyId" <> show mbJourneyId
             -- Sends push (primary) + opt-in WhatsApp (secondary), both handled inside notifyBusTripStarted.
             -- The WhatsApp `trip_tracking_enabled` template carries a static deep link, so no URL variable is passed.


### PR DESCRIPTION
## Summary
- `notifyBusTripStartedForTrip` now reads the vehicle number from `journeyLeg.finalBoardedBusNumber` instead of `booking.vehicleNumber`, which is frozen at booking-confirm time and goes stale after an operator bus swap.
- `applyWaybillMetadataToTicket` (the operator waybill-details fan-out) now also refreshes `booking.vehicleNumber` alongside the driver fields and the leg's `finalBoardedBusNumber`, whenever either the driver or the bus changes — so the booking's vehicle number tracks the currently-assigned bus rather than only the originally-booked one.
- `updateFRFSTicketBookingVehicleDataById` gained a `vehicleNumber` parameter; the other two callers (`FRFSConfirm.hs`, `MultimodalConfirm.hs`) pass `booking.vehicleNumber` through unchanged to preserve existing behavior there.

## Test plan
- [ ] `cabal build all` (rider-app)
- [ ] Trigger a GIMS trip-start on a waybill with a confirmed shuttle/premium-tier booking; confirm the push/WhatsApp notification carries the correct current vehicle number
- [ ] Trigger an operator waybill fleet reassignment (bus swap, no driver change) via `transitOperatorUpdateWaybillDetailsUtil`; confirm `booking.vehicleNumber` and `journeyLeg.finalBoardedBusNumber` both update, and the customer notification fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trip-start notifications to use the confirmed boarded bus number.
  * Kept booking vehicle details synchronized when bus or driver information changes.
  * Ensured updated vehicle numbers are saved and reflected across booking records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->