### PR TITLE
Map zero-amount clear-dues error to 4xx instead of 500

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs
@@ -143,7 +143,7 @@ createOrder (driverId, merchantId, opCity) serviceName (driverFees, driverFeesTo
           else vendorFees
   splitSettlementDetails <- if splitEnabled then mkSplitSettlementDetails currentVendorFees amount else pure Nothing
   logInfo $ "split details: " <> show splitSettlementDetails
-  when (amount <= 0) $ throwError (InternalError "Invalid Amount :- should be greater than 0")
+  when (amount <= 0) $ throwError (InvalidRequest "Invalid Amount :- should be greater than 0")
   unless (isJust existingInvoice) $ QIN.createMany invoices
   nwAddress <- asks (.nwAddress)
   paymentServiceName <- TPayment.decidePaymentService serviceName driver.clientSdkVersion driver.merchantOperatingCityId


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/2l)

### Root cause
The GCP ELB 5xx alert was breached primarily by POST /ui/driver/cleardues/ on beckn-driver-offer-bpp-production. SharedLogic.Payment.createOrder throws InternalError "Invalid Amount :- should be greater than 0" when the summed overdue driver-fee amount is <= 0 (no dues to clear). InternalError maps to HTTP 500, turning a routine business condition into a server error and inflating the ELB 5xx rate. Changing it to InvalidRequest maps it to 4xx and removes the false 5xx.

### Evidence
_see RCA_

### Rollback
Revert the single-line change in Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Payment.hs line 146 from InvalidRequest back to InternalError.

---
_Draft PR — review and merge manually. Generated by Argus._