### PR TITLE
frfs/fix: use live journey-leg bus number for trip-start notification (prodHotPush-BAP)

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -1750,7 +1750,7 @@ notifyBusTripStartedForTrip tripId = do
           when isShuttle $ do
             -- Send trip start notification sequentially
             let routeName = fromMaybe "" booking.routeName
-            let vehicleNo = fromMaybe "" booking.vehicleNumber
+            let vehicleNo = fromMaybe "" (mbJourneyLeg >>= (.finalBoardedBusNumber))
             logInfo $ "Notifying passenger " <> person.id.getId <> " that bus trip has started on route " <> routeName <> "for journeyId" <> show mbJourneyId
             -- Sends push (primary) + opt-in WhatsApp (secondary), both handled inside notifyBusTripStarted.
             -- The WhatsApp `trip_tracking_enabled` template carries a static deep link, so no URL variable is passed.


### PR DESCRIPTION
## Summary
- Same fix as #16319, targeted at `prodHotPush-BAP`.
- `notifyBusTripStartedForTrip` now reads the vehicle number from `journeyLeg.finalBoardedBusNumber` instead of `booking.vehicleNumber`, which is frozen at booking-confirm time and goes stale after an operator bus swap.
- `finalBoardedBusNumber` is seeded at leg creation from `booking.vehicleNumber` and kept fresh independently by the waybill-details fan-out and the QR-boarding-confirm flow, so no other files need to change for this to work correctly.

## Test plan
- [ ] `cabal build all` (rider-app)
- [ ] Trigger a GIMS trip-start on a waybill with a confirmed shuttle/premium-tier booking; confirm the push/WhatsApp notification carries the correct current vehicle number