### PR TITLE
fix: make quantity Maybe for manifest

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/FRFSFleetOperator.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/FRFSFleetOperator.yaml
@@ -86,7 +86,7 @@ types:
     phone: Text
     bookingId: Text
     checkedIn: Bool
-    quantity: Int
+    quantity: Maybe Int
     derive: "Show"
 
   PassengerStopManifest:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/FRFSFleetOperator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/FRFSFleetOperator.hs
@@ -120,7 +120,14 @@ data OperatorTripInfo = OperatorTripInfo
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data PassengerInfo = PassengerInfo {bookingId :: Data.Text.Text, checkedIn :: Kernel.Prelude.Bool, name :: Data.Text.Text, personId :: Data.Text.Text, phone :: Data.Text.Text, quantity :: Kernel.Prelude.Int}
+data PassengerInfo = PassengerInfo
+  { bookingId :: Data.Text.Text,
+    checkedIn :: Kernel.Prelude.Bool,
+    name :: Data.Text.Text,
+    personId :: Data.Text.Text,
+    phone :: Data.Text.Text,
+    quantity :: Kernel.Prelude.Maybe Kernel.Prelude.Int
+  }
   deriving stock (Generic, Show)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Passenger quantity is now optional when providing passenger information.
  - Improved compatibility for requests where quantity is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->