### PR TITLE
Fix CMRL V2 FRFS ticket status mapping and make getFare fareBeforeDiscount optional

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Metro/CMRL/V2/GetFare.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Metro/CMRL/V2/GetFare.hs
@@ -47,7 +47,7 @@ data EncryptedRes = EncryptedRes
 data GetFareItem = GetFareItem
   { fromStationId :: Maybe T.Text,
     toStationId :: Maybe T.Text,
-    fareBeforeDiscount :: Double,
+    fareBeforeDiscount :: Maybe Double,
     discountAmount :: Double,
     fareAfterDiscount :: Double,
     cgst :: Double,
@@ -122,7 +122,7 @@ getFare integrationBPPConfig config _riderId fareReq = do
     (fareItem : _) -> do
       if fareItem.returnCode == "0"
         then do
-          let originalPrice = HighPrecMoney $ toRational fareItem.fareBeforeDiscount
+          let originalPrice = HighPrecMoney $ toRational $ fromMaybe (fareItem.finalFare + fareItem.discountAmount) fareItem.fareBeforeDiscount
               offeredPrice = HighPrecMoney $ toRational fareItem.finalFare
           logDebug $ "[CMRLV2:GetFare] Using API values - fareBeforeDiscount: " <> T.pack (show fareItem.fareBeforeDiscount) <> ", finalFare: " <> T.pack (show fareItem.finalFare) <> ", discountAmount: " <> T.pack (show fareItem.discountAmount)
           return

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Metro/CMRL/V2/TicketStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/ExternalAPI/Metro/CMRL/V2/TicketStatus.hs
@@ -110,7 +110,8 @@ getTicketStatus config booking = do
                 { ticketNumber = ticketResp.qR_Tkt_Sl_No,
                   vehicleNumber = Nothing,
                   qrData = qrData,
-                  qrStatus = "ACTIVE",
+                  -- CMRL does not expose ticket scan state; treat an active QR as not-yet-used.
+                  qrStatus = "UNCLAIMED",
                   qrValidity = booking.validTill,
                   description = Nothing,
                   qrRefreshAt = Nothing,


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (2f/7l)

### Root cause
CMRL V2 ticket-status API hard-codes qrStatus = "ACTIVE", but castTicketStatus only understands UNCLAIMED/CLAIMED/CANCELLED/EXPIRED, causing every Chennai metro status poll to throw "Invalid ticket status" and kill the FRFS Booking Status thread, blocking payment completion. Additionally, CMRL V2 getFare now omits fareBeforeDiscount, causing fare decode failures.

### Evidence
_see RCA_

### Rollback
Revert the PR: restore qrStatus = "ACTIVE" in CMRL/V2/TicketStatus.hs and fareBeforeDiscount :: Double in CMRL/V2/GetFare.hs.

---
_Draft PR — review and merge manually. Generated by Argus._