### PR TITLE
Backend/feat: add in mem cache for asset manifests

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/AssetReleaseInternal.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/AssetReleaseInternal.hs
@@ -35,7 +35,8 @@ postAssetReleasePublish mbToken req = do
   mbLatest <- findLatest req.assetType merchantId merchantOperatingCityId
   case mbLatest of
     Just latest
-      | latest.sha256 == sha256 && latest.url == req.url && latest.version == req.version ->
+      | latest.sha256 == sha256 && latest.url == req.url && latest.version == req.version -> do
+        reconcileCache latest
         pure $
           API.Types.UI.AssetReleaseInternal.AssetPublishResp
             { releaseId = latest.id.getId,
@@ -129,6 +130,12 @@ getAssetRelease mbAssetType mbCity mbMerchantShortId mbToken = do
   (merchantId, merchantOperatingCityId) <- resolveCity merchantShortId city
   mbRelease <- findLatest assetType merchantId merchantOperatingCityId
   pure $ toResp <$> mbRelease
+
+reconcileCache :: Domain.Types.AssetRelease.AssetRelease -> Environment.Flow ()
+reconcileCache latest = do
+  mbCached <- CQAssetRelease.findLatest latest.assetType latest.merchantId latest.merchantOperatingCityId
+  unless (((.id) <$> mbCached) == Just latest.id) $
+    CQAssetRelease.clearCache latest.assetType latest.merchantId latest.merchantOperatingCityId
 
 findLatest ::
   Domain.Types.AssetRelease.AssetType ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/AssetReleaseExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/AssetReleaseExtra.hs
@@ -21,6 +21,7 @@ import Domain.Types.Merchant (Merchant)
 import Domain.Types.MerchantOperatingCity (MerchantOperatingCity)
 import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Hedis
+import qualified Kernel.Storage.InMem as IM
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import qualified Storage.Queries.AssetRelease as Queries
@@ -31,13 +32,16 @@ findLatest ::
   Id Merchant ->
   Id MerchantOperatingCity ->
   m (Maybe AssetRelease)
-findLatest assetType merchantId merchantOperatingCityId = do
-  Hedis.safeGet (makeLatestKey assetType merchantId merchantOperatingCityId) >>= \case
-    Just release -> return $ Just release
-    Nothing -> do
-      mbRelease <- Queries.findLatestByAssetTypeAndCity (Just 1) Nothing assetType merchantId merchantOperatingCityId <&> listToMaybe
-      whenJust mbRelease cacheLatest
-      return mbRelease
+findLatest assetType merchantId merchantOperatingCityId =
+  IM.withInMemCache [cacheKey] inMemCacheExpTime $ do
+    Hedis.safeGet cacheKey >>= \case
+      Just release -> return $ Just release
+      Nothing -> do
+        mbRelease <- Queries.findLatestByAssetTypeAndCity (Just 1) Nothing assetType merchantId merchantOperatingCityId <&> listToMaybe
+        whenJust mbRelease cacheLatest
+        return mbRelease
+  where
+    cacheKey = makeLatestKey assetType merchantId merchantOperatingCityId
 
 findAllLatest ::
   (CacheFlow m r, EsqDBFlow m r) =>
@@ -60,6 +64,11 @@ makeLatestKey :: AssetType -> Id Merchant -> Id MerchantOperatingCity -> Text
 makeLatestKey assetType merchantId merchantOperatingCityId =
   "rider-app:CachedQueries:AssetRelease:Latest-" <> show assetType <> "-" <> merchantId.getId <> "-" <> merchantOperatingCityId.getId
 
-clearCache :: Hedis.HedisFlow m r => AssetType -> Id Merchant -> Id MerchantOperatingCity -> m ()
-clearCache assetType merchantId merchantOperatingCityId =
-  Hedis.runInMultiCloudRedisWrite $ Hedis.del (makeLatestKey assetType merchantId merchantOperatingCityId)
+clearCache :: (CacheFlow m r, MonadFlow m) => AssetType -> Id Merchant -> Id MerchantOperatingCity -> m ()
+clearCache assetType merchantId merchantOperatingCityId = do
+  let cacheKey = makeLatestKey assetType merchantId merchantOperatingCityId
+  Hedis.runInMultiCloudRedisWrite $ Hedis.del cacheKey
+  IM.refreshInMem cacheKey
+
+inMemCacheExpTime :: Seconds
+inMemCacheExpTime = 3600


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
add in mem cache for asset manifest api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset release publishing when the latest release is unchanged.
  * Fixed stale release information by reconciling cached data with the latest available release.
  * Improved cache refresh behavior to provide more reliable release retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->