### PR TITLE
Backend:fix : fire fabric gateway based on V3 subscriberId

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/GatewayDispatch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/GatewayDispatch.hs
@@ -76,9 +76,9 @@ dispatchAction merchantId domain action mbPeerSubId req signedCall unsignedCall 
       base <- asks (.fabricGatewayBaseUrl)
       mbCfg <- QBC.findByMerchantIdDomainAndBecknProtocol (Just merchant.id) (show domain) (Just Domain.Beckn_V3)
       let mbNetworkId = mbCfg >>= (.networkId)
-          subId = merchant.subscriberId.getShortId
-          url = base {baseUrlPath = baseUrlPath base <> "/bpp/caller/" <> T.unpack subId}
-          bppReceiverUri = showBaseUrl $ base {baseUrlPath = baseUrlPath base <> "/bpp/receiver/" <> T.unpack subId}
+          fabricBppId = maybe (merchant.subscriberId.getShortId) (.subscriberId) mbCfg
+          url = base {baseUrlPath = baseUrlPath base <> "/bpp/caller/" <> T.unpack fabricBppId}
+          bppReceiverUri = showBaseUrl $ base {baseUrlPath = baseUrlPath base <> "/bpp/receiver/" <> T.unpack fabricBppId}
           mappedAction = BecknContext.fabricActionName action
           jsonReq = A.toJSON req
           mutated = case mbNetworkId of

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/GatewayLookup.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/GatewayLookup.hs
@@ -66,8 +66,9 @@ dispatchToGateway merchantId domain action req signedCall unsignedCall = do
       base <- asks (.fabricGatewayBaseUrl)
       mbCfg <- QBC.findByMerchantIdDomainAndBecknProtocol (Just merchant.id) (show domain) (Just Domain.Beckn_V3)
       let mbNetworkId = mbCfg >>= (.networkId)
-          url = base {baseUrlPath = baseUrlPath base <> "/bap/caller/" <> T.unpack merchant.bapId}
-          bapReceiverUri = showBaseUrl $ base {baseUrlPath = baseUrlPath base <> "/bap/receiver/" <> T.unpack merchant.bapId}
+          fabricBapId = maybe merchant.bapId (.subscriberId) mbCfg
+          url = base {baseUrlPath = baseUrlPath base <> "/bap/caller/" <> T.unpack fabricBapId}
+          bapReceiverUri = showBaseUrl $ base {baseUrlPath = baseUrlPath base <> "/bap/receiver/" <> T.unpack fabricBapId}
           mappedAction = BecknContext.fabricActionName action
           jsonReq = A.toJSON req
           mutated = case mbNetworkId of
@@ -120,8 +121,9 @@ dispatchAction merchantId domain action mbPeerSubId req signedCall unsignedCall 
       base <- asks (.fabricGatewayBaseUrl)
       mbCfg <- QBC.findByMerchantIdDomainAndBecknProtocol (Just merchant.id) (show domain) (Just Domain.Beckn_V3)
       let mbNetworkId = mbCfg >>= (.networkId)
-          url = base {baseUrlPath = baseUrlPath base <> "/bap/caller/" <> T.unpack merchant.bapId}
-          bapReceiverUri = showBaseUrl $ base {baseUrlPath = baseUrlPath base <> "/bap/receiver/" <> T.unpack merchant.bapId}
+          fabricBapId = maybe merchant.bapId (.subscriberId) mbCfg
+          url = base {baseUrlPath = baseUrlPath base <> "/bap/caller/" <> T.unpack fabricBapId}
+          bapReceiverUri = showBaseUrl $ base {baseUrlPath = baseUrlPath base <> "/bap/receiver/" <> T.unpack fabricBapId}
           mappedAction = BecknContext.fabricActionName action
           jsonReq = A.toJSON req
           mutated = case mbNetworkId of


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway dispatch routing by using the configured merchant subscriber identifier when available.
  * Added a fallback to the merchant’s default identifier when gateway configuration is unavailable.
  * Maintained existing dispatch behavior while ensuring caller and receiver URLs use the correct identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->