### PR TITLE
Sending std code to registry instead of name

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
@@ -3836,12 +3836,15 @@ postMerchantConfigOperatingCityCreate merchantShortId city req = do
             logError $ "No entry found for subscriberId: " <> subscriberId <> ", uniqueKeyId: " <> uniqueKeyId <> " in NY registry"
             return Nothing
           Just sub | req.city `elem` sub.city -> return Nothing
-          Just _ -> Just <$> RegistryT.buildAddCityNyReq (req.city :| []) newUniqueId newSubscriberId subType domain
+          Just _ -> do
+            cityStdCode <- getCityStdCode req.city req.cityStdCode >>= fromMaybeM (InvalidRequest "City std code not found")
+            Just <$> RegistryT.buildAddCityNyReq (Context.City cityStdCode :| []) newUniqueId newSubscriberId subType domain
 
   whenJust mbNewOperatingCity $ \newOperatingCity ->
     whenJust newOperatingCity.stdCode $ \stdCode -> do
       let (Context.City cityText) = newOperatingCity.city
-      void $ City.validateAndAppendCityStdCodeMapping cityText stdCode
+      mbMappingError <- City.validateAndAppendCityStdCodeMapping cityText stdCode
+      whenJust mbMappingError $ \mappingError -> throwError $ InvalidRequest mappingError
 
   -- Reject before any DB write if the requested exophone number is already in use by another operating city
   existingExophones <- CQExophone.findAllByPhone req.exophone


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * City additions to existing NY registry subscriptions now use the correct standardized city code.
  * Invalid city-code mappings are now reported as invalid requests instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->