### PR TITLE
Return 4xx for dummy searchTryId in driver respondQuote instead of 500

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -1924,6 +1924,7 @@ offerQuote (driverId, merchantId, merchantOpCityId) clientId DriverOfferReq {..}
 respondQuote :: (Id SP.Person, Id DM.Merchant, Id DMOC.MerchantOperatingCity) -> Maybe Text -> Maybe Version -> Maybe Version -> Maybe Version -> Maybe Text -> Maybe Text -> DriverRespondReq -> Flow APISuccess
 respondQuote (driverId, merchantId, merchantOpCityId) clientId mbBundleVersion mbClientVersion mbConfigVersion mbReactBundleVersion mbDevice req = do
   searchTryId <- req.searchRequestId <|> req.searchTryId & fromMaybeM (InvalidRequest "searchTryId field is not present.")
+  when (searchTryId.getId == DLoc.dummyFromLocationData.dummyId) $ throwError (InvalidRequest "Invalid searchTryId")
   searchTry <- QST.findById searchTryId >>= fromMaybeM (SearchTryNotFound searchTryId.getId)
   mSReqFD <- QSRD.findByDriverAndSearchTryId driverId searchTry.id
   sReqFD <-


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/1l)

### Root cause
The driver respondQuote handler threw SearchTryNotFound (mapped to E500) whenever the sentinel dummy searchTryId "dummyFromLocation" was received. The handler now rejects that sentinel id with InvalidRequest before the DB lookup, eliminating the chronic 500.

### Evidence
_see RCA_

### Rollback
Revert the added guard in Domain/Action/UI/Driver.hs respondQuote so the dummy id falls through to the original SearchTryNotFound 500 path.

---
_Draft PR — review and merge manually. Generated by Argus._