### PR TITLE
backend/feat: gate scheduler consumer-maintenance threads behind runConsumerCleanupThreads

### DIFF
--- a/Backend/dhall-configs/dev/driver-offer-allocator.dhall
+++ b/Backend/dhall-configs/dev/driver-offer-allocator.dhall
@@ -53,6 +53,7 @@ let schedulerConfig =
       , reclaimBatch = +200
       , heartbeatIntervalSec = +60
       , deadConsumerThresholdSec = +1200
+      , runConsumerCleanupThreads = True
       }
 
 in  { appCfg =

--- a/Backend/dhall-configs/dev/rider-app-scheduler.dhall
+++ b/Backend/dhall-configs/dev/rider-app-scheduler.dhall
@@ -51,6 +51,7 @@ let schedulerConfig =
       , reclaimBatch = +200
       , heartbeatIntervalSec = +60
       , deadConsumerThresholdSec = +1200
+      , runConsumerCleanupThreads = True
       }
 
 in  { appCfg =

--- a/Backend/lib/scheduler/src/Lib/Scheduler/Environment.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/Environment.hs
@@ -86,7 +86,8 @@ data SchedulerConfig = SchedulerConfig
     -- | How often (seconds) each pod heartbeats its consumer into the liveness registry.
     heartbeatIntervalSec :: Seconds,
     -- | A consumer whose last heartbeat is older than this (seconds) is considered dead and pruned.
-    deadConsumerThresholdSec :: Integer
+    deadConsumerThresholdSec :: Integer,
+    runConsumerCleanupThreads :: Bool
   }
   deriving (Generic, FromDhall)
 
@@ -125,6 +126,7 @@ data SchedulerEnv = SchedulerEnv
     reclaimBatch :: Integer,
     heartbeatIntervalSec :: Seconds,
     deadConsumerThresholdSec :: Integer,
+    runConsumerCleanupThreads :: Bool,
     port :: Int,
     isShuttingDown :: Shutdown,
     version :: Metrics.DeploymentVersion,

--- a/Backend/lib/scheduler/src/Lib/Scheduler/Handler.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/Handler.hs
@@ -65,11 +65,14 @@ handler :: forall t. (HasSchemaName BeamSC.SystemConfigsT, JobProcessor t, FromJ
 handler hnd = do
   schedulerType <- asks (.schedulerType)
   maxThreads <- asks (.maxThreads)
+  runConsumerCleanupThreads <- asks (.runConsumerCleanupThreads)
   case schedulerType of
-    RedisBased ->
+    RedisBased -> do
+      let consumerCleanupThreads = if runConsumerCleanupThreads then [heartbeatLoop, reclaimerLoop hnd, sweeperLoop hnd] else []
+      unless runConsumerCleanupThreads $ logInfo "CONSUMER_CLEANUP_THREADS_DISABLED: skipping heartbeat, reclaimer and sweeper loops"
       loopGracefully $
         replicate maxThreads (runnerIterationRedis hnd runTask)
-          <> [heartbeatLoop, reclaimerLoop hnd, sweeperLoop hnd]
+          <> consumerCleanupThreads
     DbBased -> loopGracefully $ replicate maxThreads (dbBasedHandlerLoop hnd runTask)
   where
     runTask :: AnyJob t -> SchedulerM ()


### PR DESCRIPTION
## What

Adds a `runConsumerCleanupThreads :: Bool` kill switch to `SchedulerConfig` / `SchedulerEnv`, driven from dhall.

The three auxiliary Redis-stream consumer threads started alongside the job runners in `Lib.Scheduler.Handler.handler` —

1. `heartbeatLoop` — per-pod liveness heartbeat into the `Scheduler:LiveConsumers:*` registry ZSET
2. `reclaimerLoop` — periodic PEL scan + `XCLAIM` of idle pending entries
3. `sweeperLoop` — dead-consumer sweeper (`XGROUP DELCONSUMER` + drain, under a cross-pod lock)

— are now only started when the flag is `True`. When `False`, only `replicate maxThreads runnerIterationRedis` is passed to `loopGracefully`, and a single `CONSUMER_CLEANUP_THREADS_DISABLED` line is logged at startup so it's verifiable from logs which mode a pod is in.

`DbBased` schedulers are unaffected (they never started these threads).

## Why

Gives us a config-level switch to turn the stream consumer-maintenance machinery off per environment without a code rollback, in case reclaim/sweep behaviour needs to be disabled in prod.

## Changes

- `Backend/lib/scheduler/src/Lib/Scheduler/Environment.hs` — new `runConsumerCleanupThreads :: Bool` on both `SchedulerConfig` (`FromDhall`) and `SchedulerEnv`. Wiring is automatic via the existing `SchedulerEnv {cacheConfig, esqDBReplicaEnv, ..}` record-wildcard in `Lib/Scheduler/App.hs`.
- `Backend/lib/scheduler/src/Lib/Scheduler/Handler.hs` — gate the three loops on the flag.
- `Backend/dhall-configs/dev/rider-app-scheduler.dhall`, `Backend/dhall-configs/dev/driver-offer-allocator.dhall` — `runConsumerCleanupThreads = True` (preserves current behaviour). These are the only two dhall configs that build a `SchedulerConfig`.

Note: `gracefulConsumerCleanup` (the SIGTERM shutdown hook) is deliberately left unconditional — it is a shutdown-path drain of the pod's own PEL, not one of the background threads, and is safe/useful independently of the flag.

## Notes

- Base is `prodHotPush-BPP`; the scheduler + dhall files are identical between `main` and `prodHotPush-BPP`, so this applies cleanly to `main` as well.
- Not compiled locally (no nix toolchain in this shell) — relying on CI for the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
