### PR TITLE
backend/fix: mark job status Pending when a job is rescheduled

### DIFF
--- a/Backend/lib/scheduler/src/Lib/Scheduler/JobStorageType/DB/Queries.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/JobStorageType/DB/Queries.hs
@@ -237,7 +237,8 @@ reSchedule (Id jobId) newScheduleTime = do
   now <- getCurrentTime
   updateWithKVScheduler
     [ Se.Set BeamST.updatedAt (T.utcToLocalTime T.utc now),
-      Se.Set BeamST.scheduledAt (T.utcToLocalTime T.utc newScheduleTime)
+      Se.Set BeamST.scheduledAt (T.utcToLocalTime T.utc newScheduleTime),
+      Se.Set BeamST.status Pending
     ]
     [Se.Is BeamST.id (Se.Eq jobId)]
 
@@ -256,6 +257,7 @@ reScheduleOnError (Id jobId) newCountValue newScheduleTime = do
   updateWithKVScheduler
     [ Se.Set BeamST.scheduledAt (T.utcToLocalTime T.utc newScheduleTime),
       Se.Set BeamST.currErrors newCountValue,
-      Se.Set BeamST.updatedAt (T.utcToLocalTime T.utc now)
+      Se.Set BeamST.updatedAt (T.utcToLocalTime T.utc now),
+      Se.Set BeamST.status Pending
     ]
     [Se.Is BeamST.id (Se.Eq jobId)]

--- a/Backend/lib/scheduler/src/Lib/Scheduler/JobStorageType/Redis/Queries.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/JobStorageType/Redis/Queries.hs
@@ -187,7 +187,7 @@ reSchedule j byTime = do
   key <- getShardKey
   case toJSON byTime of
     A.String newScheduleTime -> do
-      let newJOB = updateKey "scheduledAt" newScheduleTime jobJson
+      let newJOB = updateKey "status" "Pending" $ updateKey "scheduledAt" newScheduleTime jobJson
       Hedis.withNonCriticalCrossAppRedis $ Hedis.zAdd key [(utcToMilliseconds byTime, newJOB)]
     jsonTime -> logError $ "got unsupported scheduleTime type: " <> show jsonTime
 


### PR DESCRIPTION
## Problem

`DBQ.reSchedule` (and `DBQ.reScheduleOnError`) only set `scheduledAt` / `updatedAt` / `currErrors` — they never touched `status`.

But every pickup path filters on `status = Pending`:

- `getReadyTasks` — the DbBased runner (`DB/Queries.hs:200`)
- `getPendingStuckJobs` — the producer's reviver (`DB/Queries.hs:147`)
- the `executeTask` duplicate guard — `if scheduledAt latestState > scheduledAt job || status latestState /= Pending then pure DuplicateExecution` (`Handler.hs:230`)

So once a row's status drifts off `Pending`, a reschedule pushes `scheduledAt` into the future and the row becomes **invisible to both the runner and the reviver**. The reschedule is silently dropped and the job never runs again.

## How the drift happens

The producer's reviver (`lib/producer/src/Producer/Flow.hs:105`) marks the old row `Revived` and inserts a fresh `Pending` row. Meanwhile, for long-running jobs `SchedulerType.reSchedule` writes to *both* stores:

```haskell
bool (RQ.reSchedule job time)
     (do DBQ.reSchedule id time; RQ.reSchedule job time)
     =<< isLongRunning jobType
```

and RedisBased `executeTask` skips the status check entirely (`RedisBased -> pure [AnyJob job]`).

Net effect: the revived-away row keeps executing off the Redis sorted set indefinitely while its DB row sits at `Revived` — permanently invisible to the reviver, permanently duplicating the fresh row's work. That is a same-`jobData` duplicate, which is one way jobs end up contending on their own app-level locks (e.g. `CalculateDriverFeesScheduler:Lock:<hash>`, whose loser reschedules a flat 600s).

## Fix

- `DB/Queries.hs` — add `Se.Set BeamST.status Pending` to `reSchedule` and `reScheduleOnError`.
- `Redis/Queries.hs` — `RQ.reSchedule` also patches the payload so the re-added sorted-set entry doesn't carry a stale status:
  ```haskell
  let newJOB = updateKey "status" "Pending" $ updateKey "scheduledAt" newScheduleTime jobJson
  ```
  This is inert today (RedisBased never reads status back), but without it the DB row and the sorted-set payload disagree, and the `Handler.hs:230` guard would reject the entry the moment that check is extended to RedisBased.

## Scope / notes

- `reScheduleOnError` (the `Retry` path) is included alongside `reSchedule` — same bug, and fixing only one would be a half-fix.
- This is `lib/scheduler`, so it affects **every** job type across rider-app-scheduler and driver-offer-allocator, not one job.
- No schema change; `Pending` is already in scope in both files.
- Not compiled locally (no nix toolchain in this shell) — relying on CI for the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rescheduled jobs are now correctly returned to a **Pending** status.
  * Jobs rescheduled after an error also return to **Pending**, ensuring they can be processed again as expected.
  * This behavior is consistent across database and Redis-backed job storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->