### PR TITLE
backend/fix:- Passing exact FCM type or if not sending default Trigge…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/BehaviourManagement/ConsequenceDispatcher.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/BehaviourManagement/ConsequenceDispatcher.hs
@@ -22,6 +22,7 @@ where
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Key as AK
 import qualified Data.Aeson.KeyMap as AKM
+import qualified Data.Text as T
 import qualified Domain.Types.Common as DriverInfo
 import qualified Domain.Types.DriverBlockTransactions as DTDBT
 import qualified Domain.Types.DriverInformation as DI
@@ -302,9 +303,12 @@ dispatchCommunicationAction ctx driverId = \case
   CMT.FcmNotification params -> do
     let title = fromMaybe params.templateKey (textFromParams "title" params.templateParams)
         body = fromMaybe "" (textFromParams "body" params.templateParams)
+        notifType =
+          fromMaybe FCM.TRIGGER_FCM $
+            textFromParams "notificationType" params.templateParams >>= readMaybe . T.unpack
     withDriver $ \driver -> do
-      logInfo $ "FCM notification for driver " <> driverId.getId <> ": " <> params.templateKey
-      Notify.notifyDriver ctx.merchantOperatingCityId FCM.DRIVER_NOTIFY title body driver driver.deviceToken
+      logInfo $ "FCM notification for driver " <> driverId.getId <> ": " <> params.templateKey <> " as " <> show notifType
+      Notify.notifyDriver ctx.merchantOperatingCityId notifType title body driver driver.deviceToken
   CMT.InAppOverlay params ->
     withDriver $ \driver -> do
       logInfo $ "In-app overlay for driver " <> driverId.getId <> ": " <> params.overlayKey


### PR DESCRIPTION
…r_FCM

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FCM notification types can now be configured through communication template parameters.
  * Notifications default to the standard trigger type when no notification type is specified.
* **Bug Fixes**
  * Notification dispatching now uses the configured notification type instead of always applying a fixed type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->