### PR TITLE
backend/fix: apply pass override when a booking is reconfirmed at a new quantity

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
@@ -312,20 +312,108 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
       maybeM
         (buildAndCreateBooking rider quote fareParameters mbIsMockPayment mbHoldCtxForAll firstTripId mbSeatSelectionType isSpotBooking' mbPurchasedPassPaymentId)
         ( \booking -> do
+            booking' <- reapplyPassOverride isMultiInitAllowed firstTripId rider fareParameters booking
             updatedBooking <-
               if isMultiInitAllowed
                 then do
                   let mBookAuthCode = crisSdkResponse <&> (.bookAuthCode)
                       totalPrice = fareParameters.totalPrice
                       mbNewServiceTierType = FRFSUtils.getServiceTierTypeFromRouteStationsJson quote.routeStationsJson
-                  void $ QFRFSTicketBooking.updateBookingAuthCodeById mBookAuthCode booking.id
-                  void $ QFRFSTicketBooking.updateQuoteBppItemIdRouteStationsAndServiceTierById quote.id quote.bppItemId quote.routeStationsJson mbNewServiceTierType booking.id
-                  void $ QFRFSTicketBooking.updateIsFareChangedById Nothing booking.id
-                  return $ booking {DFRFSTicketBooking.quoteId = quote.id, DFRFSTicketBooking.bppItemId = quote.bppItemId, DFRFSTicketBooking.bookingAuthCode = mBookAuthCode, DFRFSTicketBooking.totalPrice = totalPrice, DFRFSTicketBooking.serviceTierType = mbNewServiceTierType}
-                else return booking
+                  void $ QFRFSTicketBooking.updateBookingAuthCodeById mBookAuthCode booking'.id
+                  void $ QFRFSTicketBooking.updateQuoteBppItemIdRouteStationsAndServiceTierById quote.id quote.bppItemId quote.routeStationsJson mbNewServiceTierType booking'.id
+                  void $ QFRFSTicketBooking.updateIsFareChangedById Nothing booking'.id
+                  void $ QFRFSTicketBooking.updateTotalPriceById totalPrice booking'.id
+                  return $ booking' {DFRFSTicketBooking.quoteId = quote.id, DFRFSTicketBooking.bppItemId = quote.bppItemId, DFRFSTicketBooking.bookingAuthCode = mBookAuthCode, DFRFSTicketBooking.totalPrice = totalPrice, DFRFSTicketBooking.serviceTierType = mbNewServiceTierType}
+                else return booking'
             pure (rider, updatedBooking)
         )
         (pure mbBooking)
+
+    reapplyPassOverride :: (CallExternalBPP.FRFSConfirmFlow m r c) => Bool -> Maybe Text -> Domain.Types.Person.Person -> FRFSUtils.FRFSFareParameters -> DFRFSTicketBooking.FRFSTicketBooking -> m DFRFSTicketBooking.FRFSTicketBooking
+    reapplyPassOverride isMultiInitAllowed' mbFirstTripId rider fareParameters booking = do
+      let repriceable = booking.status == DFRFSTicketBooking.NEW || isMultiInitAllowed'
+      case mbPurchasedPassPaymentId of
+        Nothing -> dropOverride repriceable
+        Just paymentId
+          | not repriceable && booking.overrideAppliedEntityId == Just paymentId.getId -> pure booking
+          | otherwise -> do
+            now <- getCurrentTime
+            let mbAdultUnitPriceForOverride =
+                  find (\priceItem -> priceItem.categoryType == ADULT) fareParameters.priceItems <&> (.unitPrice)
+                mbServiceTierType = FRFSUtils.getServiceTierTypeFromRouteStationsJson quote.routeStationsJson
+            adultUnitPriceForOverride <-
+              mbAdultUnitPriceForOverride
+                & fromMaybeM (InvalidRequest $ "Selected pass is not applicable to this booking, purchasedPassPaymentId=" <> paymentId.getId)
+            tripTime <- resolvedTripTime now
+            mbResolved <-
+              FRFSPassOverride.resolvePassOverride
+                integratedBppConfig
+                rider
+                quote.vehicleType
+                tripTime
+                mbServiceTierType
+                adultUnitPriceForOverride
+                (map (\priceItem -> (priceItem.unitPrice, priceItem.quantity)) fareParameters.priceItems)
+                paymentId
+            passOption <-
+              (snd <$> mbResolved)
+                & fromMaybeM (InvalidRequest $ "Selected pass is not applicable to this booking, purchasedPassPaymentId=" <> paymentId.getId)
+            let overriddenAmount = passOption.overriddenTotalPrice.amount
+                overrideEntityId = passOption.purchasedPassPaymentId.getId
+                alreadyApplied =
+                  booking.overrideAppliedEntityId == Just overrideEntityId
+                    && booking.overriddenAmount == Just overriddenAmount
+            if alreadyApplied
+              then pure booking
+              else do
+                unless repriceable $ do
+                  logInfo $
+                    "FRFSConfirm:reapplyPassOverride booking past NEW with no multi-init, refusing to re-price bookingId="
+                      <> booking.id.getId
+                      <> " status="
+                      <> show booking.status
+                      <> " purchasedPassPaymentId="
+                      <> paymentId.getId
+                  throwError (InvalidRequest $ "Selected pass is not applicable to this booking, purchasedPassPaymentId=" <> paymentId.getId)
+                QFRFSTicketBooking.updatePassOverrideById (Just DFRFSTicketBooking.PassOverride) (Just overriddenAmount) (Just overrideEntityId) booking.id
+                when (booking.status /= DFRFSTicketBooking.NEW) $
+                  void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.NEW booking.id
+                logInfo $
+                  "FRFSConfirm:reapplyPassOverride applied on existing booking bookingId="
+                    <> booking.id.getId
+                    <> " purchasedPassPaymentId="
+                    <> paymentId.getId
+                    <> " overriddenAmount="
+                    <> show overriddenAmount
+                pure
+                  booking
+                    { DFRFSTicketBooking.overrideType = Just DFRFSTicketBooking.PassOverride,
+                      DFRFSTicketBooking.overriddenAmount = Just overriddenAmount,
+                      DFRFSTicketBooking.overrideAppliedEntityId = Just overrideEntityId,
+                      DFRFSTicketBooking.status = DFRFSTicketBooking.NEW
+                    }
+      where
+        dropOverride repriceable = case booking.overrideAppliedEntityId of
+          Nothing -> pure booking
+          Just _
+            | not repriceable -> pure booking
+            | otherwise -> do
+              logInfo $ "FRFSConfirm:reapplyPassOverride no pass on this confirm, dropping the stamped override bookingId=" <> booking.id.getId
+              QFRFSTicketBooking.updatePassOverrideById Nothing Nothing Nothing booking.id
+              pure
+                booking
+                  { DFRFSTicketBooking.overrideType = Nothing,
+                    DFRFSTicketBooking.overriddenAmount = Nothing,
+                    DFRFSTicketBooking.overrideAppliedEntityId = Nothing
+                  }
+
+        resolvedTripTime now = do
+          let routeStations :: Maybe [FRFSRouteStationsAPI] = decodeFromText =<< quote.routeStationsJson
+              mbRouteCode = listToMaybe (fromMaybe [] routeStations) <&> (.code)
+          mbScheduled <- case (mbFirstTripId, mbRouteCode) of
+            (Just tripId, Just routeCode) -> getScheduledTripStartTime tripId routeCode quote.fromStationCode integratedBppConfig
+            _ -> pure Nothing
+          pure $ fromMaybe now (mbScheduled <|> booking.startTime)
 
     validateQuota :: Int -> Int -> Maybe Seat.Seat -> Either GenericError ()
     validateQuota fromIdx toIdx mbSeat =


### PR DESCRIPTION
Ticket quantity is a confirm-time input on a reused quote, so lowering it re-enters
`confirmAndUpsertBooking` through the "booking already exists" branch — which resolved the override
only in `buildAndCreateBooking` and silently dropped `purchasedPassPaymentId`.

Repro: confirm 4 tickets (no pass covers 4) → booking parks at `PAYMENT_PENDING`; go back, drop to 2
and pick the pass → fare re-priced 276 → 138 but `overrideType` stayed null, so the rider was billed
in full after being shown full coverage.

`reapplyPassOverride` now re-resolves against this confirm's `fareParameters`, stamps `overrideType`
/ `overriddenAmount` / `overrideAppliedEntityId`, and resets the booking to `NEW` so the same confirm
reaches the fully-covered branch — the same reset the multi-init path already performs on a fare
change.

Verified black-box with `scripts/testing/pass/test_reprice_on_quantity_change.py`: green locally
(`overriddenTotalPrice` 0, override stamped), red on sandbox against the unpatched build.


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of passes during booking updates.
  * Prevented missing or inapplicable passes from being applied.
  * Preserved bookings when pass pricing already matches.
  * Prevented repricing bookings that are no longer eligible for initialization.
  * Ensured eligible bookings are repriced and reset for continued processing.
  * Removed outdated pass overrides when no pass is supplied.
  * Updated multi-init processing and booking details with the latest pricing adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->