### PR TITLE
backend/fix: driver cancellation charges popup shows GST-exclusive amount

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Penalty.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Penalty.hs
@@ -18,6 +18,7 @@ import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import qualified SharedLogic.CancellationConsequence as CancellationConsequence
 import qualified SharedLogic.CancellationFault as CancellationFault
 import qualified SharedLogic.CancellationOrchestrator as Orchestrator
+import SharedLogic.DriverCancellationPenalty (applyCancellationPenaltyGst)
 import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions (..))
 import qualified Storage.Queries.Booking as QBooking
 import qualified Storage.Queries.CallStatus as QCallStatus
@@ -51,7 +52,14 @@ postPenaltyCheck (mbPersonId, _merchantId, _merchantOpCityId) req = do
   -- matrix row), via the orchestrator's dry-run entry: no Redis caches, no ride-row
   -- persistence — the cancellation may never happen.
   decision <- Orchestrator.previewCancellationConsequences booking ride transporterConfig SBCR.ByDriver Nothing mbDriverDistToPickup
-  let penaltyAmount = (\row -> CancellationConsequence.driverMoneyDeduction row booking.estimatedFare) =<< decision.consequenceRow
+  let rawPenaltyAmount = (\row -> CancellationConsequence.driverMoneyDeduction row booking.estimatedFare) =<< decision.consequenceRow
+      -- The matrix stores the driver penalty GST-exclusive; the real charge
+      -- (SharedLogic.DriverCancellationPenalty.applyCancellationPenaltyGst, applied once the
+      -- DriverFee moves to PAYMENT_PENDING) grosses it up. Apply the same multiplier here so
+      -- this preview matches what the driver is actually charged. Only positive amounts (an
+      -- actual charge) are grossed up — a negative amount is compensation credited via the
+      -- wallet, which never carries GST.
+      penaltyAmount = rawPenaltyAmount <&> \amt -> if amt > 0 then applyCancellationPenaltyGst amt else amt
       isApplicable = isJust penaltyAmount
       -- Verdict-based validity (the RideCancel tag rules are retired). "Valid" follows
       -- the legacy DriverCancellation#Valid convention: the cancellation VALIDLY COUNTS

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
@@ -64,6 +64,7 @@ import Lib.Scheduler.JobStorageType.SchedulerType (createJobIn)
 import qualified SharedLogic.ActiveDriversList as ADL
 import SharedLogic.Allocator
 import qualified SharedLogic.Allocator.Jobs.Overlay.SendOverlay as SLOSO
+import SharedLogic.DriverCancellationPenalty (applyCancellationPenaltyGst)
 import SharedLogic.DriverFee (calcNumRides, calculatePlatformFeeAttr, getPaymentModeAndVehicleCategoryKey, jobDuplicationPreventionKey, roundToHalf, setCoinToCashUsedAmount, setCreateDriverFeeForServiceInSchedulerKey, toCreateDriverFeeForService)
 import qualified SharedLogic.Merchant as SMerchant
 import qualified SharedLogic.Payment as SPayment
@@ -1039,7 +1040,7 @@ updateCancellationPenaltyAccumulationFees serviceName transporterConfig merchant
     let disputeEndTime = addUTCTime disputeWindowSeconds penalty.endTime
     when (now >= disputeEndTime) $ do
       let penaltyAmount = fromMaybe 0.0 penalty.cancellationPenaltyAmount
-          amountWithGst = penaltyAmount * 1.18
+          amountWithGst = applyCancellationPenaltyGst penaltyAmount
       QDF.moveCancellationPenaltyToPaymentPending penalty.id amountWithGst
   logInfo $ "updateCancellationPenaltyAccumulationFees: Processed cancellation penalty status changes for service: " <> show serviceName <> " merchant: " <> merchantId.getId <> " operatingCity: " <> merchantOperatingCityId.getId
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverCancellationPenalty.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverCancellationPenalty.hs
@@ -16,6 +16,7 @@ module SharedLogic.DriverCancellationPenalty
   ( mkCancellationPenaltyFee,
     accumulateCancellationPenalty,
     chargeDriverPenaltyFee,
+    applyCancellationPenaltyGst,
   )
 where
 
@@ -277,3 +278,17 @@ chargeDriverPenaltyFee merchantId merchantOpCityId driverId penaltyAmount curren
 
 cancellationPenaltyLockKey :: Text -> Text
 cancellationPenaltyLockKey id' = "Driver:Cancellation:Penalty:DriverFeeId-" <> id'
+
+-- | Cancellation-consequence-matrix amounts (and DriverFee.cancellationPenaltyAmount,
+-- while ONGOING/in its dispute window) are stored GST-EXCLUSIVE. The scheduler job that
+-- moves a penalty to PAYMENT_PENDING once its dispute window closes
+-- (SharedLogic.Allocator.Jobs.DriverFeeUpdates.DriverFee.updateCancellationPenaltyAccumulationFees)
+-- grosses the stored amount up by this multiplier to arrive at what is actually collected
+-- from the driver. Any place that previews the charge to the driver ahead of time (e.g.
+-- the pre-cancel warning popup) must apply the SAME multiplier, or it undershows the
+-- amount the driver will actually be charged.
+cancellationPenaltyGstMultiplier :: HighPrecMoney
+cancellationPenaltyGstMultiplier = 1.18
+
+applyCancellationPenaltyGst :: HighPrecMoney -> HighPrecMoney
+applyCancellationPenaltyGst = (* cancellationPenaltyGstMultiplier)


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

The driver-side pre-cancel warning popup (`CancelWarningBottomSheet` in `ny-react-native`, backed by `postPenaltyCheck`) was showing the cancellation penalty amount as GST-exclusive (e.g. ₹4.24, ₹6.78), while the amount actually deducted from the driver is GST-inclusive (₹5, ₹8).

Root cause: `CancellationConsequenceMatrix` rows store the driver penalty **GST-exclusive**. That raw amount is what `Domain.Action.UI.Penalty.postPenaltyCheck` returned to the popup, and it's also what gets persisted on `DriverFee.cancellationPenaltyAmount` when the cancellation actually happens. However, once that `DriverFee` moves from `ONGOING` to `PAYMENT_PENDING` (its dispute window elapses), `SharedLogic.Allocator.Jobs.DriverFeeUpdates.DriverFee.updateCancellationPenaltyAccumulationFees` grosses the stored amount up by 18% GST before it is actually billed/collected — so the popup and the real charge diverged by that same ~1.18x factor (₹4.24 × 1.18 ≈ ₹5, ₹6.78 × 1.18 ≈ ₹8).

### Fix

- Extracted the GST multiplier (previously an inline `* 1.18` literal in `updateCancellationPenaltyAccumulationFees`) into a single shared helper, `SharedLogic.DriverCancellationPenalty.applyCancellationPenaltyGst`.
- Applied that same helper in `Domain.Action.UI.Penalty.postPenaltyCheck` so the pre-cancel preview shown to the driver matches what will actually be charged.
- Only positive amounts (an actual penalty charge) are grossed up — a negative amount represents compensation credited via the wallet, which never carries GST, so it's left as-is.

This keeps both the preview and the real charge computation reading from one shared constant instead of a duplicated magic literal, so they can't drift apart again.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

## Motivation and Context

Reported issue: the driver cancellation charges pop-up displays the wrong (GST-exclusive) amount, e.g. ₹4.24 instead of ₹5, and ₹6.78 instead of ₹8, while the actual deduction correctly charges ₹5/₹8. The popup should show the correct final amount that will be charged.

## How did you test it?

Traced the two amount computations (`CancellationConsequence.driverMoneyDeduction` used by the preview, and `updateCancellationPenaltyAccumulationFees` used by the real billing job) and confirmed the ~1.18x ratio between the reported wrong/correct amounts matches the 18% GST gross-up applied only on the real-charge path. No local Haskell toolchain was available in this environment to run `cabal build`/tests; changes are confined to a small, well-typed refactor (extracting an existing expression into a named function) with no changes to the underlying `HighPrecMoney` arithmetic.

## Checklist

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uo2UDjhYwuTJfk6n7vftjc)_