### PR TITLE
backend/enh: normal block enhanced for airport block

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/QueueRank.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/QueueRank.hs
@@ -28,7 +28,7 @@ getQueuePosition (driverId, _merchantId, _merchantOpCityId) specialLocationId ve
   driverInfo <- QDI.findById driverId >>= fromMaybeM DriverInfoNotFound
   now <- getCurrentTime
   enableForAirport <- QDI.resolveAirportRestriction now driverInfo
-  if enableForAirport == DI.BLOCKED
+  if enableForAirport == DI.BLOCKED || driverInfo.blocked
     then
       pure $
         QueueRankResponse

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SpecialZoneDriverDemand.hs
@@ -1127,6 +1127,12 @@ filterEligibleDrivers merchantId specialLocationId vehicleType gateId mbFilterAi
             | info <- driverInfos,
               info.onRide || info.mode == Just DTC.OFFLINE
           ]
+      blockedDrivers =
+        Set.fromList
+          [ info.driverId
+            | info <- driverInfos,
+              info.blocked
+          ]
       airportIneligibleDrivers =
         Set.fromList
           [ did
@@ -1156,17 +1162,19 @@ filterEligibleDrivers merchantId specialLocationId vehicleType gateId mbFilterAi
               not (Set.member (cooldownKeyFor d) inCooldownKeys)
                 && not (Set.member d busyDrivers)
                 && not (Set.member d onRideDriversOrOfflineDrivers)
+                && not (Set.member d blockedDrivers)
                 && not (Set.member d airportIneligibleDrivers)
           )
           vehicleEligibleDriverIds
       -- Drivers with no business sitting in the special-zone queue — on a ride,
-      -- offline, or not airport-eligible — are evicted in the background. Cooldown /
-      -- pending-Active drivers are only *temporarily* ineligible and stay in place.
-      -- Scoped to this batch's input set so we never touch drivers we didn't fetch
-      -- info for; dedup by driverId (on-ride/offline reason wins) so each driver is
-      -- removed at most once even when it matches both conditions.
+      -- offline, blocked, or not airport-eligible — are evicted in the background.
+      -- Cooldown / pending-Active drivers are only *temporarily* ineligible and stay
+      -- in place. Scoped to this batch's input set so we never touch drivers we didn't
+      -- fetch info for; dedup by driverId (first matching reason wins) so each driver
+      -- is removed at most once even when it matches several conditions.
       reasonForQueueRemoval d
         | Set.member d onRideDriversOrOfflineDrivers = Just ("on_ride_or_offline" :: Text)
+        | Set.member d blockedDrivers = Just "driver_blocked"
         | Set.member d airportIneligibleDrivers = Just "cannot_switch_to_airport"
         | otherwise = Nothing
       toRemoveWithReason = mapMaybe (\d -> (,) d <$> reasonForQueueRemoval d) driverIds


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Extended checks of PermanentBlock to disable the driver from the airport queue and PickupRequests


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked drivers can no longer access airport queues.
  * Blocked drivers are excluded from offer notifications.
  * Blocked drivers are removed from the long-term supply queue with an appropriate reason.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->