### PR TITLE
backend/fix: allow admin force-enable for unlinked fleet drivers and …

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/wmb.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/wmb.yaml
@@ -213,6 +213,12 @@ apis:
       response:
         type: APISuccess
 
+  - POST: # Decline a pending fleet invitation, ending the driver-fleet association.
+      endpoint: /fleet/consent/decline
+      auth: TokenAuth PROVIDER_TYPE
+      response:
+        type: APISuccess
+
   - GET: # Retrieve the fleet config information
       endpoint: /fleet/config
       auth: TokenAuth PROVIDER_TYPE

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/UI/WMB.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/UI/WMB.hs
@@ -157,6 +157,13 @@ type API =
            Kernel.Types.APISuccess.APISuccess
       :<|> TokenAuth
       :> "fleet"
+      :> "consent"
+      :> "decline"
+      :> Post
+           '[JSON]
+           Kernel.Types.APISuccess.APISuccess
+      :<|> TokenAuth
+      :> "fleet"
       :> "config"
       :> Get
            '[JSON]
@@ -164,7 +171,7 @@ type API =
   )
 
 handler :: Environment.FlowServer API
-handler = getWmbFleetBadges :<|> postWmbAvailableRoutes :<|> postWmbQrStart :<|> getWmbTripActive :<|> getWmbRouteDetails :<|> getWmbTripList :<|> postWmbTripStart :<|> postWmbTripEnd :<|> postWmbTripRequest :<|> getWmbRequestsStatus :<|> postWmbRequestsCancel :<|> postFleetConsent :<|> getFleetConfig
+handler = getWmbFleetBadges :<|> postWmbAvailableRoutes :<|> postWmbQrStart :<|> getWmbTripActive :<|> getWmbRouteDetails :<|> getWmbTripList :<|> postWmbTripStart :<|> postWmbTripEnd :<|> postWmbTripRequest :<|> getWmbRequestsStatus :<|> postWmbRequestsCancel :<|> postFleetConsent :<|> postFleetConsentDecline :<|> getFleetConfig
 
 getWmbFleetBadges ::
   ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
@@ -291,6 +298,15 @@ postFleetConsent ::
     Environment.FlowHandler Kernel.Types.APISuccess.APISuccess
   )
 postFleetConsent a1 = withFlowHandlerAPI $ Domain.Action.UI.WMB.postFleetConsent (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a1)
+
+postFleetConsentDecline ::
+  ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
+      Kernel.Types.Id.Id Domain.Types.Merchant.Merchant,
+      Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity
+    ) ->
+    Environment.FlowHandler Kernel.Types.APISuccess.APISuccess
+  )
+postFleetConsentDecline a1 = withFlowHandlerAPI $ Domain.Action.UI.WMB.postFleetConsentDecline (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a1)
 
 getFleetConfig ::
   ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/WMB.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/WMB.hs
@@ -10,6 +10,7 @@ module Domain.Action.UI.WMB
     postWmbTripEnd,
     getWmbTripList,
     postFleetConsent,
+    postFleetConsentDecline,
     getFleetConfig,
     getWmbRouteDetails,
     getWmbFleetBadges,
@@ -467,6 +468,20 @@ postWmbTripRequest (_, merchantId, merchantOperatingCityId) tripTransactionId re
           appletId = maybeAppId
         }
   pure $ AlertReqResp {requestId = alertRequestId.getId}
+
+postFleetConsentDecline ::
+  ( ( Maybe (Id Person),
+      Id Merchant,
+      Id MerchantOperatingCity
+    ) ->
+    Flow APISuccess
+  )
+postFleetConsentDecline (mbDriverId, _merchantId, _merchantOperatingCityId) = do
+  driverId <- fromMaybeM (DriverNotFoundWithId) mbDriverId
+  fleetDriverAssociation <- FDV.findByDriverId driverId False >>= fromMaybeM (InactiveFleetDriverAssociationNotFound driverId.getId)
+  when (isJust fleetDriverAssociation.requestReason) $ throwError $ InvalidRequest "Cannot decline a driver-initiated request"
+  FDV.endFleetDriverAssociation fleetDriverAssociation.fleetOwnerId driverId
+  pure Success
 
 postFleetConsent ::
   ( ( Maybe (Id Person),

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/OnboardingFlags/Flow.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverOnboarding/OnboardingFlags/Flow.hs
@@ -250,7 +250,7 @@ recomputeDriverFlagsArm merchantOpCityId merchantId person allDocVerificationCon
       else pure driverInfo.enabledReasonFlag
   let approvedGateOk = if useUnifiedOnboardingFlagsRecompute then approvedToWrite == Just True else driverInfo.approved == Just True
       bypassDocGates = effectiveEnabledReasonFlag == Just DI.AdminEnabled
-      derivedShouldEnable = consentGateOk && (bypassDocGates || (verifiedToWrite && allEnablingDocsValid && approvedGateOk))
+      derivedShouldEnable = bypassDocGates || (consentGateOk && verifiedToWrite && allEnablingDocsValid && approvedGateOk)
       shouldEnable = derivedShouldEnable || (driverInfo.enabled && not mutationAllowed)
   let justEnabled = shouldEnable && not driverInfo.enabled
   -- The association is read once and reused for both the onboardingAs reconciliation and the


### PR DESCRIPTION
## Description

Two independent driver-onboarding changes.

**1. Force-enable fix** — `SharedLogic/DriverOnboarding/OnboardingFlags/Flow.hs:253`

`recomputeDriverFlagsArm` derives the driver `enabled` flag on every recompute. `consentGateOk` (fleet driver has an active fleet association) was ANDed *outside* the bracket, so it also gated the `bypassDocGates` admin override:

```haskell
-- before
derivedShouldEnable = consentGateOk && (bypassDocGates || (verifiedToWrite && allEnablingDocsValid && approvedGateOk))
-- after
derivedShouldEnable = bypassDocGates || (consentGateOk && verifiedToWrite && allEnablingDocsValid && approvedGateOk)
```

Moving `consentGateOk` inside the bracket makes the admin override a real bypass while leaving the normal document path unchanged — an ordinary fleet driver still needs an active fleet, valid mandatory docs, valid enabling docs and `approved = true`.

Behaviour matrix — only the last row changes:

| Driver | `consentGateOk` | `bypassDocGates` | Before | After |
|---|---|---|---|---|
| Self-employed, docs done | True | False | True | True |
| Self-employed, docs pending, force-enabled | True | True | True | True |
| Fleet driver in fleet, docs done | True | False | True | True |
| Fleet driver in fleet, docs pending | True | False | False | False |
| Fleet driver not in fleet, docs done, no force-enable | False | False | False | False |
| **Fleet driver not in fleet, force-enabled** | False | True | **False** | **True** |

Self-employed drivers cannot be affected — `consentGateOk` is `True` by construction for them (line 219). `bypassDocGates` is true only when `enabledReasonFlag == AdminEnabled`, which is written solely by the admin force-enable path, so no driver can set it on himself. The existing revoke path (lines 242–249, `forceEnabledBypassingDocsUponDisableTakesToOnboarding`) still clears the flag on disable and is untouched.

**2. Decline fleet invitation** — new `POST /fleet/consent/decline`

A driver could only *accept* an invitation via `POST /fleet/consent`; there was no way to decline, so an unwanted pending invitation stayed on the account indefinitely and kept the driver on the waiting screen. (`/driver/consent/respond` only writes `nyClubConsent` and is unrelated to fleets.)

The handler mirrors `postFleetConsent` exactly:
- Looks up the caller's pending association via the same `FDV.findByDriverId driverId False` query (`is_active = false`, `associated_till > now`)
- Rejects driver-initiated rows with the same guard accept uses (`requestReason` set)
- Ends it via the existing `FDV.endFleetDriverAssociation`, which stamps `associatedTill = now`, sets `isActive = false` and clears `fleetOwnerId` in LTS

Driver id comes from `TokenAuth` only — no id in the request body, so a driver can only act on his own invitation. Decline intentionally skips accept's heavy work (ending other associations, active-ride checks, analytics counters): nothing was joined, so there is nothing to unwind.

`src-read-only/API/Action/UI/WMB.hs` is generator output from the `spec/API/wmb.yaml` change, not hand-written.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

No schema change — `fleet_driver_association` already has every column used. New endpoint is purely additive; no existing request/response shape changes.

## Motivation and Context

1. An admin cannot enable a fleet driver who is not currently linked to a fleet — the dashboard action appears to succeed but `enabled` is reset to `false` on the next recompute. This blocks the flow where a driver is unlinked from a fleet, gets his documents approved, and needs to be let into the app before any new fleet invites him.
2. A driver has no way to refuse a fleet invitation. The pending invitation persists forever, blocking him from receiving a new one from another fleet (a driver can belong to only one fleet at a time).

## How did you test it?

- `cabal build dynamic-offer-driver-app` compiles clean under `-Werror` (all 1907 modules, executable links)
- Pre-commit hooks pass: `hpack`, `treefmt`, `trailing-ws`
- Force-enable change verified by case analysis against every combination of `consentGateOk` / `bypassDocGates` (table above); the two expressions differ in exactly one case
- No automated tests added — the force-enable change is a boolean-precedence fix inside a function with no existing test harness, and the decline endpoint reuses query functions already exercised by the accept path

## Screenshot of test results

N/A

## Checklist

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option for drivers to decline pending fleet invitations.
  * Declining an eligible invitation ends the driver–fleet association and confirms success.

* **Bug Fixes**
  * Drivers marked for administrative enablement can now be enabled without being blocked by document or consent validation gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->