### PR TITLE
Revert "backend/feat: adopt person_pt_stats rows keyed on personId, enabling …"

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/PersonPTStats.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/PersonPTStats.yaml
@@ -41,29 +41,20 @@ PersonPTStats:
 
   constraints:
     id: PrimaryKey
-    personId: "!SecondaryKey"
     staticPersonId: "!SecondaryKey"
 
   extraIndexes:
     - columns: [staticPersonId, vehicleType, vehicleServiceTierType, productType, passTypeId]
     - columns: [staticPersonId]
-    - columns: [personId]
 
   queries:
     findAllByStaticPersonId:
       kvFunction: findAllWithKV
       where: staticPersonId
-    findAllByPersonId:
-      kvFunction: findAllWithKV
-      where: personId
     findByDimensions:
       kvFunction: findOneWithKV
       where:
         and: [staticPersonId, vehicleType, vehicleServiceTierType, productType, passTypeId]
-    findByPersonIdAndDimensions:
-      kvFunction: findOneWithKV
-      where:
-        and: [personId, vehicleType, vehicleServiceTierType, productType, passTypeId]
     updateCounts:
       kvFunction: updateOneWithKV
       params: [ticketCount, purchaseCount, lastPurchasedAt, personId]
@@ -71,10 +62,6 @@ PersonPTStats:
     updatePersonIdById:
       kvFunction: updateOneWithKV
       params: [personId]
-      where: id
-    updateStaticPersonIdById:
-      kvFunction: updateOneWithKV
-      params: [staticPersonId]
       where: id
 
   extraOperations:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/PersonPTStats.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/PersonPTStats.hs
@@ -36,6 +36,6 @@ instance B.Table PersonPTStatsT where
 
 type PersonPTStats = PersonPTStatsT Identity
 
-$(enableKVPG ''PersonPTStatsT ['id] [['personId], ['staticPersonId]])
+$(enableKVPG ''PersonPTStatsT ['id] [['staticPersonId]])
 
 $(mkTableInstances ''PersonPTStatsT "person_pt_stats")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/PersonPTStats.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/PersonPTStats.hs
@@ -24,9 +24,6 @@ create = createWithKV
 createMany :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => ([Domain.Types.PersonPTStats.PersonPTStats] -> m ())
 createMany = traverse_ create
 
-findAllByPersonId :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Types.Id.Id Domain.Types.Person.Person -> m [Domain.Types.PersonPTStats.PersonPTStats])
-findAllByPersonId personId = do findAllWithKV [Se.Is Beam.personId $ Se.Eq (Kernel.Types.Id.getId personId)]
-
 findAllByStaticPersonId :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Prelude.Text -> m [Domain.Types.PersonPTStats.PersonPTStats])
 findAllByStaticPersonId staticPersonId = do findAllWithKV [Se.Is Beam.staticPersonId $ Se.Eq staticPersonId]
 
@@ -37,20 +34,6 @@ findByDimensions staticPersonId vehicleType vehicleServiceTierType productType p
   findOneWithKV
     [ Se.And
         [ Se.Is Beam.staticPersonId $ Se.Eq staticPersonId,
-          Se.Is Beam.vehicleType $ Se.Eq vehicleType,
-          Se.Is Beam.vehicleServiceTierType $ Se.Eq vehicleServiceTierType,
-          Se.Is Beam.productType $ Se.Eq productType,
-          Se.Is Beam.passTypeId $ Se.Eq (Kernel.Types.Id.getId <$> passTypeId)
-        ]
-    ]
-
-findByPersonIdAndDimensions ::
-  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
-  (Kernel.Types.Id.Id Domain.Types.Person.Person -> Kernel.Prelude.Maybe BecknV2.FRFS.Enums.VehicleCategory -> Kernel.Prelude.Maybe BecknV2.FRFS.Enums.ServiceTierType -> Domain.Types.PersonPTStats.FRFSProductType -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.PassType.PassType) -> m (Maybe Domain.Types.PersonPTStats.PersonPTStats))
-findByPersonIdAndDimensions personId vehicleType vehicleServiceTierType productType passTypeId = do
-  findOneWithKV
-    [ Se.And
-        [ Se.Is Beam.personId $ Se.Eq (Kernel.Types.Id.getId personId),
           Se.Is Beam.vehicleType $ Se.Eq vehicleType,
           Se.Is Beam.vehicleServiceTierType $ Se.Eq vehicleServiceTierType,
           Se.Is Beam.productType $ Se.Eq productType,
@@ -76,11 +59,6 @@ updatePersonIdById :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Typ
 updatePersonIdById personId id = do
   _now <- getCurrentTime
   updateOneWithKV [Se.Set Beam.personId (Kernel.Types.Id.getId personId), Se.Set Beam.updatedAt _now] [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]
-
-updateStaticPersonIdById :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Prelude.Text -> Kernel.Types.Id.Id Domain.Types.PersonPTStats.PersonPTStats -> m ())
-updateStaticPersonIdById staticPersonId id = do
-  _now <- getCurrentTime
-  updateOneWithKV [Se.Set Beam.staticPersonId staticPersonId, Se.Set Beam.updatedAt _now] [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]
 
 findByPrimaryKey :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Types.Id.Id Domain.Types.PersonPTStats.PersonPTStats -> m (Maybe Domain.Types.PersonPTStats.PersonPTStats))
 findByPrimaryKey id = do findOneWithKV [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]]

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/OfferSegment.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/OfferSegment.hs
@@ -140,26 +140,18 @@ fetchUsageRows ::
   Person.Person ->
   m [DPUS.PersonPTStats]
 fetchUsageRows person = do
-  mbStaticPersonId <-
-    forM person.mobileNumber $ \encPhone ->
-      SLUtils.getPureStaticCustomerId person <$> decrypt encPhone
-  case mbStaticPersonId of
-    Nothing -> QPersonPTStats.findAllByPersonId person.id
-    Just staticPersonId -> do
-      byStaticPersonId <- QPersonPTStats.findAllByStaticPersonId staticPersonId
-      byPersonId <- QPersonPTStats.findAllByPersonId person.id
-      let adoptedIds = map (.id) byStaticPersonId
-          rows = byStaticPersonId <> filter (\row -> row.id `notElem` adoptedIds) byPersonId
-      reconcileKeys staticPersonId rows
-      pure rows
-  where
-    reconcileKeys staticPersonId rows = do
-      let needsAdopting = filter (\row -> row.staticPersonId /= staticPersonId) rows
-          needsRepointing = filter (\row -> row.personId /= person.id) rows
-      unless (null needsAdopting && null needsRepointing) $
-        fork "reconcile person pt stats keys" $ do
-          forM_ needsAdopting $ \row -> QPersonPTStats.updateStaticPersonIdById staticPersonId row.id
-          forM_ needsRepointing $ \row -> QPersonPTStats.updatePersonIdById person.id row.id
+  -- Same fallback as the write path, so reads and writes agree on the key.
+  staticPersonId <-
+    maybe
+      (pure person.id.getId)
+      (\encPhone -> SLUtils.getPureStaticCustomerId person <$> decrypt encPhone)
+      person.mobileNumber
+  rows <- QPersonPTStats.findAllByStaticPersonId staticPersonId
+  let staleRows = filter (\row -> row.personId /= person.id) rows
+  unless (null staleRows) $
+    fork "repoint person usage stats" $
+      forM_ staleRows $ \row -> QPersonPTStats.updatePersonIdById person.id row.id
+  pure rows
 
 mkInput :: UTCTime -> [DPUS.PersonPTStats] -> OfferSegmentContext -> OfferSegmentInput
 mkInput now rows ctx =

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/PersonPTStats.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/PersonPTStats.hs
@@ -135,19 +135,6 @@ findRow ev =
     ev.vehicleServiceTierType
     ev.productType
     ev.passTypeId
-    >>= \case
-      Just row -> pure (Just row)
-      Nothing -> do
-        mbLegacyRow <-
-          QPersonPTStats.findByPersonIdAndDimensions
-            ev.personId
-            ev.vehicleType
-            ev.vehicleServiceTierType
-            ev.productType
-            ev.passTypeId
-        forM mbLegacyRow $ \row -> do
-          QPersonPTStats.updateStaticPersonIdById ev.staticPersonId row.id
-          pure row
 
 -- | Keyed on staticPersonId, the same identity findRow reads by. Locking on
 -- personId instead would let two accounts sharing a phone update one row under

--- a/Backend/dev/migrations-read-only/rider-app/person_pt_stats.sql
+++ b/Backend/dev/migrations-read-only/rider-app/person_pt_stats.sql
@@ -17,8 +17,3 @@ ALTER TABLE atlas_app.person_pt_stats ADD COLUMN vehicle_type text ;
 ALTER TABLE atlas_app.person_pt_stats ADD PRIMARY KEY ( id);
 CREATE INDEX CONCURRENTLY person_pt_stats_idx_pass_type_id_product_type_static_person_id_vehicle_service_tier_type_vehicle_type ON atlas_app.person_pt_stats USING btree (pass_type_id, product_type, static_person_id, vehicle_service_tier_type, vehicle_type);
 CREATE INDEX CONCURRENTLY person_pt_stats_idx_static_person_id ON atlas_app.person_pt_stats USING btree (static_person_id);
-
-
-------- SQL updates -------
-
-CREATE INDEX CONCURRENTLY person_pt_stats_idx_person_id ON atlas_app.person_pt_stats USING btree (person_id);


### PR DESCRIPTION
Reverts nammayatri/nammayatri#16340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined person statistics lookups to use a single static person identifier.
  * Removed legacy fallback searches and automatic identifier migration during offer and usage processing.
  * Retained dimension-based and static-person statistics retrieval.
  * Removed outdated person-based lookup and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->