### PR TITLE
backend/fix: don't park passes in PhotoPending when no photo is required

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -1035,7 +1035,8 @@ passOrderStatusHandler paymentOrderId _merchantId status = do
     (Just purchasedPassPayment, Just purchasedPass) -> do
       let isDashboard = fromMaybe False purchasedPassPayment.isDashboard
       let hasProfilePicture = isJust purchasedPass.profilePicture || isJust purchasedPass.passPhotoMediaId
-      let mbPassStatus = convertPaymentStatusToPurchasedPassStatus hasProfilePicture (purchasedPassPayment.startDate > DT.utctDay istTime) status
+      photoRequired <- isPhotoRequired purchasedPassPayment
+      let mbPassStatus = convertPaymentStatusToPurchasedPassStatus (hasProfilePicture || not photoRequired) (purchasedPassPayment.startDate > DT.utctDay istTime) status
       let activeLikeStatuses = [DPurchasedPass.Active, DPurchasedPass.PreBooked, DPurchasedPass.PhotoPending]
       let refundStatuses = [DPurchasedPass.RefundPending, DPurchasedPass.RefundInitiated, DPurchasedPass.RefundFailed, DPurchasedPass.Refunded]
       mbDuplicateActivePayment <-
@@ -1159,6 +1160,20 @@ passOrderStatusHandler paymentOrderId _merchantId status = do
           Sms.sendSMS merchantId merchantOpCityId (buildSmsReq phoneNumberWithCountryCode)
             >>= Sms.checkSmsResult
 
+-- A pass that asks for no documents must never park in PhotoPending: the pass list hides
+-- non-Active tourist passes, so such a pass goes invisible and the rider can never reach
+-- the screen that would attach the photo releasing it. Unknown pass row (or a legacy
+-- payment with no passId) keeps the old behaviour.
+isPhotoRequired ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  DPurchasedPassPayment.PurchasedPassPayment ->
+  m Bool
+isPhotoRequired purchasedPassPayment =
+  maybe
+    (pure True)
+    (fmap (maybe True (elem DPass.ProfilePicture . (.documentsRequired))) . CQPass.findById)
+    purchasedPassPayment.passId
+
 updatePurchasedPass ::
   ( MonadFlow m,
     EsqDBFlow m r,
@@ -1188,6 +1203,8 @@ updatePurchasedPass mbClientSdkVersion purchasedPass today now = do
       [DPurchasedPass.PreBooked, DPurchasedPass.Active, DPurchasedPass.PhotoPending]
       today
 
+  photoRequired <- maybe (pure True) isPhotoRequired (listToMaybe latestPayments)
+
   case listToMaybe latestPayments of
     Just firstPayment ->
       let newProfilePicture = firstPayment.profilePicture <|> mbRefilledPhoto <|> purchasedPass.profilePicture
@@ -1201,7 +1218,7 @@ updatePurchasedPass mbClientSdkVersion purchasedPass today now = do
 
           newStatus
             | firstPayment.endDate < today = DPurchasedPass.Expired
-            | not hasPhoto = DPurchasedPass.PhotoPending
+            | not hasPhoto && photoRequired = DPurchasedPass.PhotoPending
             | firstPayment.startDate <= today = DPurchasedPass.Active
             | otherwise = DPurchasedPass.PreBooked
 


### PR DESCRIPTION
## Problem

Riders buy an **ULLA1DAY** pass, the payment succeeds, and the pass never appears in the app.

Observed on UAT:

```
ULLA1DAY  PhotoPending  start/end 2026-08-25  created 08:28:17  updated 08:28:32
ULLA1DAY  PhotoPending  start/end 2026-08-25  created 08:22:26  updated 08:22:44
```

Created, then updated ~15s later — the payment webhook landing. The money is fine.

## Root cause

Two rules that are individually reasonable combine into a dead end:

1. **Status is decided purely on "is a photo attached"**, never on whether the pass wants one:
   ```haskell
   Payment.CHARGED -> if hasProfilePicture then … else Just DPurchasedPass.PhotoPending
   ```
   Same in `updatePurchasedPass`: `| not hasPhoto = DPurchasedPass.PhotoPending`.
   `ULLA1DAY` has `documentsRequired = []` — `/availablePasses` reports no documents, and `validateRequiredDocuments` lets the purchase through without a photo. Only this path disagrees.

2. **The pass list hides non-Active tourist passes**:
   ```haskell
   isInactiveTouristPass p = p.passEntity.passType.passEnum == Just TouristPass && p.status /= Active
   ```

So a paid ULLA pass goes to `PhotoPending`, gets filtered out of `getMultimodalPassList`, and the rider cannot see it. The screen that would attach a photo is reached *through* that list, and `PhotoPending -> Active` only happens once a photo exists — so it can never resolve on its own. Even `?status=PhotoPending` can't surface it, because the filter is applied after the status query.

## Fix

Gate both status decisions on the pass actually requiring a `ProfilePicture`, via `purchased_pass_payment.pass_id` → `CQPass.findById` (in-mem + Redis cached, 1h, so no meaningful cost in the list loop).

**Existing stuck rows self-heal.** The reconcile runs on every pass-list load, before the filter, so an in-date `PhotoPending` pass flips to `Active` the next time the rider opens the app — no backfill. Passes already past their end date fall to `Expired` instead; for a 1-day pass that means today's rows recover only if opened today.

Conservative on unknowns: no pass row found, or a legacy payment with no `passId`, keeps the current behaviour.

## Verification

- Reproduced on UAT: bought `ulla-unlimited-1day`, then `/v2/multimodal/pass/list` returned `[]` for every `status` filter (`Pending`, `PhotoPending`, `Active`, `Expired`, `Failed`)
- Control: the same flow with `mtc-frfs-executive-100` (a `RegularPass`) **does** appear in the list — isolating the tourist filter as the thing hiding it
- DB confirms the rows exist as `PhotoPending` with the webhook timestamps above

Not built locally — no `dist-newstyle` in this checkout; leaving the typecheck to CI.

## Note

Worth deciding separately whether hiding a **paid** pass from its owner is ever right. A `PhotoPending` pass arguably belongs in the list with an "upload photo" affordance rather than being invisible — that would have made this self-evident instead of looking like a lost payment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Passes that do not require a profile photo now activate or pre-book directly after payment.
  * Passes requiring a photo continue to enter photo-pending status when the photo is missing.
  * Legacy or incomplete payment records continue to be handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->