### PR TITLE
[WIP] fix: reapply pass override and confirm on quantity-change reconfirm, refund superseded orders

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
@@ -257,7 +257,15 @@ onConfirm merchant booking' quoteCategories dOrder = do
   -- dedupes for passMarkerTtl. Debit strictly on the transition into CONFIRMED.
   -- Reschedule staging bookings (parentBookingId set) carry the parent's already-spent trip over, so skip
   -- the debit here (completeReschedule migrates the parent's TripConsumed marker onto the staging search).
-  unless (booking.status == Booking.CONFIRMED || isJust booking.parentBookingId) $
+  -- frfsTicketBookingPaymentIdForTicketGeneration excludes the case where a PAYMENT generated this
+  -- ticket. The debit keyed only off the override being present, never off who actually paid, so a
+  -- payment webhook that reached the booking while the pass confirm was mid-flight -- override
+  -- already stamped, status not yet CONFIRMING -- issued the ticket AND left the trip to be spent
+  -- here. The rider was charged the fare and lost a pass trip for one ride, and the stamp then
+  -- disarmed the refund gate (ticketBookingPaymentIdMatched). Reproduced 6/6 with the confirm and
+  -- webhook ~250ms apart. A genuinely pass-covered booking has no payment row, so this cannot
+  -- suppress a legitimate debit; reschedule staging is already excluded via parentBookingId.
+  unless (booking.status == Booking.CONFIRMED || isJust booking.parentBookingId || isJust booking.frfsTicketBookingPaymentIdForTicketGeneration) $
     void $ withTryCatch "onConfirm:spendTripForBooking" (FRFSPassOverride.spendTripForBooking person booking {Booking.status = Booking.CONFIRMED})
   mRiderNumber <- mapM ENC.decrypt person.mobileNumber
   integratedBPPConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
@@ -284,7 +292,15 @@ onConfirm merchant booking' quoteCategories dOrder = do
   -- which marks the booking FAILED, and a journey must not read as paid with a failed leg.
   when (FRFSPassOverride.fullyCoveredByPass booking) $
     whenJust mbJourneyId $ \journeyId ->
-      void $ withTryCatch "onConfirm:markJourneyPaid" (QJourney.updateIsPaymentSuccessIfNoOrder (Just True) journeyId Nothing)
+      void $
+        withTryCatch "onConfirm:markJourneyPaid" $ do
+          QJourney.updateIsPaymentSuccessIfNoOrder (Just True) journeyId Nothing
+          mbJourney <- QJourney.findByPrimaryKey journeyId
+          whenJust mbJourney $ \journey ->
+            when (isJust journey.paymentOrderShortId && journey.isPaymentSuccess /= Just True) $ do
+              (_, _, allCovered) <- FRFSUtils.journeyFullyPassCovered booking
+              when allCovered $
+                QJourney.updatePaymentOrderShortId journey.paymentOrderShortId (Just True) journeyId
   return ()
   where
     sendTicketBookedSMS mRiderNumber mRiderMobileCountryCode fareParameters =

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnSelect.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnSelect.hs
@@ -59,4 +59,4 @@ onSelect onSelectReq merchant quote isSingleMode mbEnableOffer crisSdkResponse i
                 <&> (\category' -> (FRFSCategorySelectionReq {quantity = category.quantity, quoteCategoryId = category'.id, seatIds = category'.seatIds}))
           )
           onSelectReq.categories
-  void $ postFrfsQuoteV2ConfirmUtil (Just quote.riderId, merchant.id) quote categorySelectionReq crisSdkResponse isSingleMode mbEnableOffer Nothing integratedBppConfig Nothing Nothing Nothing Nothing Nothing
+  void $ postFrfsQuoteV2ConfirmUtil (Just quote.riderId, merchant.id) quote categorySelectionReq crisSdkResponse isSingleMode mbEnableOffer Nothing integratedBppConfig Nothing Nothing Nothing Nothing Nothing False

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -923,11 +923,11 @@ postFrfsQuoteV2ConfirmWithActor (mbPersonId, merchantId) quoteId mbIsMockPayment
       merchant <- CQM.findById merchantId >>= fromMaybeM (MerchantDoesNotExist merchantId.getId)
       merchantOperatingCity <- CQMOC.findById quote.merchantOperatingCityId >>= fromMaybeM (MerchantOperatingCityNotFound quote.merchantOperatingCityId.getId)
       bapConfig <- getOneConfig (BecknConfigDimensions {merchantOperatingCityId = merchantOperatingCity.id.getId, merchantId = merchant.id.getId, domain = Just (show Spec.FRFS), vehicleCategory = Just (frfsVehicleCategoryToBecknVehicleCategory quote.vehicleType), becknProtocol = Nothing}) (Just (maybeToList <$> CQBC.findByMerchantIdDomainVehicleAndMerchantOperatingCityIdWithFallback merchantOperatingCity.id merchant.id (show Spec.FRFS) (frfsVehicleCategoryToBecknVehicleCategory quote.vehicleType))) >>= fromMaybeM (InternalError "Beckn Config not found")
-      (_, booking, _, _, _) <- confirmAndUpsertBooking personId quote selectedQuoteCategories req.crisSdkResponse (Just True) mbIsMockPayment integratedBppConfig Nothing req.isSpotBooking Nothing Nothing req.purchasedPassPaymentId
+      (_, booking, _, _, _) <- confirmAndUpsertBooking personId quote selectedQuoteCategories req.crisSdkResponse (Just True) mbIsMockPayment integratedBppConfig Nothing req.isSpotBooking Nothing Nothing req.purchasedPassPaymentId True
       select merchant merchantOperatingCity bapConfig quote selectedQuoteCategories req.crisSdkResponse (Just True) req.enableOffer
       getFrfsBookingStatusWithActor (Just personId, merchantId) booking.id
     _ -> do
-      postFrfsQuoteV2ConfirmUtil (Just personId, merchantId) quote selectedQuoteCategories req.crisSdkResponse (Just True) req.enableOffer mbIsMockPayment integratedBppConfig req.tripId req.isSpotBooking Nothing Nothing req.purchasedPassPaymentId
+      postFrfsQuoteV2ConfirmUtil (Just personId, merchantId) quote selectedQuoteCategories req.crisSdkResponse (Just True) req.enableOffer mbIsMockPayment integratedBppConfig req.tripId req.isSpotBooking Nothing Nothing req.purchasedPassPaymentId True
   where
     rateLimitKey :: Text -> Text -> Text
     rateLimitKey personId' tripId' = "BAP:FRFS_CONFIRM_RATE_LIMIT:" <> personId' <> ":" <> tripId'
@@ -1276,7 +1276,7 @@ postFrfsBookingReschedule (mbPersonId, merchantId) oldBookingId req = do
                 )
                 freshCategories
         -- Staging booking is created + confirmed; if confirmation fails the old booking is left untouched.
-        eStatusRes <- withTryCatch "FRFSReschedule:confirm" (postFrfsQuoteV2ConfirmUtil (Just personId, merchantId) stagingQuote selectedQuoteCategories Nothing (Just True) (Just False) Nothing integratedBppConfig (Just req.tripId) Nothing Nothing (Just (RescheduleCtx oldBooking.id (mbOldPayment <&> (.id)))) Nothing)
+        eStatusRes <- withTryCatch "FRFSReschedule:confirm" (postFrfsQuoteV2ConfirmUtil (Just personId, merchantId) stagingQuote selectedQuoteCategories Nothing (Just True) (Just False) Nothing integratedBppConfig (Just req.tripId) Nothing Nothing (Just (RescheduleCtx oldBooking.id (mbOldPayment <&> (.id)))) Nothing False)
         statusRes <- case eStatusRes of
           Right r -> pure r
           Left err -> do

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerOrganizationFRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/PartnerOrganizationFRFS.hs
@@ -846,7 +846,7 @@ createNewBookingAndTriggerInit partnerOrg req regPOCfg = do
               ( \quoteCategory -> FRFSTypes.FRFSCategorySelectionReq {quoteCategoryId = quoteCategory.id, quantity = quoteCategory.selectedQuantity, seatIds = Nothing}
               )
               updatedQuoteCategories
-      bookingRes <- postFrfsQuoteV2ConfirmUtil (Just personId, fromStation.merchantId) quote selectedQuoteCategories Nothing Nothing Nothing (Just False) integratedBPPConfig Nothing Nothing Nothing Nothing Nothing
+      bookingRes <- postFrfsQuoteV2ConfirmUtil (Just personId, fromStation.merchantId) quote selectedQuoteCategories Nothing Nothing Nothing (Just False) integratedBPPConfig Nothing Nothing Nothing Nothing Nothing False
       let body = UpsertPersonAndQuoteConfirmResBody {bookingInfo = bookingRes, token}
       Redis.unlockRedis lockKey
       return

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
@@ -463,7 +463,7 @@ confirm personId merchantId mbQuoteId bookLater bookingAllowed crisSdkResponse v
         bapConfig <- getOneConfig (BecknConfigDimensions {merchantOperatingCityId = merchantOperatingCity.id.getId, merchantId = merchant.id.getId, domain = Just (show Spec.FRFS), vehicleCategory = Just (frfsVehicleCategoryToBecknVehicleCategory vehicleType), becknProtocol = Nothing}) (Just (maybeToList <$> CQBC.findByMerchantIdDomainVehicleAndMerchantOperatingCityIdWithFallback merchantOperatingCity.id merchant.id (show Spec.FRFS) (frfsVehicleCategoryToBecknVehicleCategory vehicleType))) >>= fromMaybeM (InternalError "Beckn Config not found")
         FRFSTicketService.select merchant merchantOperatingCity bapConfig quote categorySelectionReq crisSdkResponse isSingleMode mbEnableOffer
       _ -> do
-        void $ postFrfsQuoteV2ConfirmUtil (Just personId, merchantId) quote categorySelectionReq crisSdkResponse isSingleMode mbEnableOffer mbIsMockPayment integratedBppConfig mbTripId Nothing mbVehicleNumber Nothing mbPurchasedPassPaymentId
+        void $ postFrfsQuoteV2ConfirmUtil (Just personId, merchantId) quote categorySelectionReq crisSdkResponse isSingleMode mbEnableOffer mbIsMockPayment integratedBppConfig mbTripId Nothing mbVehicleNumber Nothing mbPurchasedPassPaymentId True
 
 cancel :: JT.CancelFlow m r c => Id FRFSSearch -> Spec.CancellationType -> m ()
 cancel searchId cancellationType = do

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
@@ -53,6 +53,7 @@ import qualified Lib.Payment.Domain.Action as DPayment
 import qualified Lib.Payment.Domain.Types.PaymentOrder as DPaymentOrder
 import Lib.Payment.Storage.Beam.BeamFlow
 import qualified Lib.Payment.Storage.Queries.PaymentOrder as QPaymentOrder
+import qualified SharedLogic.FRFSPassConfirm as FRFSPassConfirm
 import qualified SharedLogic.FRFSPassOverride as FRFSPassOverride
 import qualified SharedLogic.FRFSReschedule as FRFSReschedule
 import qualified SharedLogic.FRFSSeatBooking as SeatBooking
@@ -96,8 +97,8 @@ data RescheduleCtx = RescheduleCtx
     oldFrfsPaymentId :: Maybe (Id DFRFSTicketBookingPayment.FRFSTicketBookingPayment)
   }
 
-confirmAndUpsertBooking :: (CallExternalBPP.FRFSConfirmFlow m r c, HasField "cloudType" r (Maybe CloudType)) => Id Domain.Types.Person.Person -> DFRFSQuote.FRFSQuote -> [API.Types.UI.FRFSTicketService.FRFSCategorySelectionReq] -> Maybe CrisSdkResponse -> Maybe Bool -> Maybe Bool -> DIBC.IntegratedBPPConfig -> Maybe Text -> Maybe Bool -> Maybe Text -> Maybe RescheduleCtx -> Maybe (Id DPPP.PurchasedPassPayment) -> m (Domain.Types.Person.Person, DFRFSTicketBooking.FRFSTicketBooking, FRFSUtils.FRFSFareParameters, [FRFSQuoteCategory.FRFSQuoteCategory], Bool)
-confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse isSingleMode mbIsMockPayment integratedBppConfig mbTripId isSpotBooking mbVehicleNumber mbRescheduleCtx mbPurchasedPassPaymentId = do
+confirmAndUpsertBooking :: (CallExternalBPP.FRFSConfirmFlow m r c, HasField "cloudType" r (Maybe CloudType)) => Id Domain.Types.Person.Person -> DFRFSQuote.FRFSQuote -> [API.Types.UI.FRFSTicketService.FRFSCategorySelectionReq] -> Maybe CrisSdkResponse -> Maybe Bool -> Maybe Bool -> DIBC.IntegratedBPPConfig -> Maybe Text -> Maybe Bool -> Maybe Text -> Maybe RescheduleCtx -> Maybe (Id DPPP.PurchasedPassPayment) -> Bool -> m (Domain.Types.Person.Person, DFRFSTicketBooking.FRFSTicketBooking, FRFSUtils.FRFSFareParameters, [FRFSQuoteCategory.FRFSQuoteCategory], Bool)
+confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse isSingleMode mbIsMockPayment integratedBppConfig mbTripId isSpotBooking mbVehicleNumber mbRescheduleCtx mbPurchasedPassPaymentId passSelectionAuthoritative = do
   Hedis.withWaitAndLockMasterCloudCrossAppRedis (mkConfirmLockKey quote.searchId.getId) confirmLockTtlSec confirmLockRetryDelayMicros $ do
     quoteCategories <- QFRFSQuoteCategory.findAllByQuoteId quote.id
     mbBooking <- QFRFSTicketBooking.findBySearchId quote.searchId
@@ -318,14 +319,76 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
                   let mBookAuthCode = crisSdkResponse <&> (.bookAuthCode)
                       totalPrice = fareParameters.totalPrice
                       mbNewServiceTierType = FRFSUtils.getServiceTierTypeFromRouteStationsJson quote.routeStationsJson
+                  mbResolved <- resolvePassForFare rider quote.vehicleType (fromMaybe now booking.startTime) mbNewServiceTierType fareParameters mbPurchasedPassPaymentId
                   void $ QFRFSTicketBooking.updateBookingAuthCodeById mBookAuthCode booking.id
                   void $ QFRFSTicketBooking.updateQuoteBppItemIdRouteStationsAndServiceTierById quote.id quote.bppItemId quote.routeStationsJson mbNewServiceTierType booking.id
                   void $ QFRFSTicketBooking.updateIsFareChangedById Nothing booking.id
-                  return $ booking {DFRFSTicketBooking.quoteId = quote.id, DFRFSTicketBooking.bppItemId = quote.bppItemId, DFRFSTicketBooking.bookingAuthCode = mBookAuthCode, DFRFSTicketBooking.totalPrice = totalPrice, DFRFSTicketBooking.serviceTierType = mbNewServiceTierType}
+                  -- Persist the re-priced total, not just carry it on the returned record: the status
+                  -- response is built from a re-read of this row, and on_init -- the only other writer
+                  -- of totalPrice -- is an async callback that has not landed yet, so the row would
+                  -- otherwise still hold the previous quantity's fare.
+                  void $ QFRFSTicketBooking.updateTotalPriceById totalPrice booking.id
+                  let mbPassOption = snd <$> mbResolved
+                      resolvedType = DFRFSTicketBooking.PassOverride <$ mbPassOption
+                      resolvedAmount = (.overriddenTotalPrice.amount) <$> mbPassOption
+                      resolvedEntityId = (.purchasedPassPaymentId.getId) <$> mbPassOption
+                      -- A pass resolved -> stamp it. No pass and the caller is authoritative (the rider's
+                      -- own confirm) -> clear a now-stale override. No pass and NOT authoritative (on_select
+                      -- and other internal re-entries call with Nothing) -> keep the existing override, so a
+                      -- partial-pass booking is not silently stripped and billed full fare.
+                      (overrideType', overriddenAmount', overrideAppliedEntityId') =
+                        if isJust mbPassOption || passSelectionAuthoritative
+                          then (resolvedType, resolvedAmount, resolvedEntityId)
+                          else (booking.overrideType, booking.overriddenAmount, booking.overrideAppliedEntityId)
+                  when (overrideType' /= booking.overrideType || overriddenAmount' /= booking.overriddenAmount || overrideAppliedEntityId' /= booking.overrideAppliedEntityId) $
+                    QFRFSTicketBooking.updatePassOverrideById overrideType' overriddenAmount' overrideAppliedEntityId' booking.id
+                  return $
+                    booking
+                      { DFRFSTicketBooking.quoteId = quote.id,
+                        DFRFSTicketBooking.bppItemId = quote.bppItemId,
+                        DFRFSTicketBooking.bookingAuthCode = mBookAuthCode,
+                        DFRFSTicketBooking.totalPrice = totalPrice,
+                        DFRFSTicketBooking.serviceTierType = mbNewServiceTierType,
+                        DFRFSTicketBooking.overrideType = overrideType',
+                        DFRFSTicketBooking.overriddenAmount = overriddenAmount',
+                        DFRFSTicketBooking.overrideAppliedEntityId = overrideAppliedEntityId'
+                      }
                 else return booking
             pure (rider, updatedBooking)
         )
         (pure mbBooking)
+
+    resolvePassForFare ::
+      (CallExternalBPP.FRFSConfirmFlow m r c) =>
+      Domain.Types.Person.Person ->
+      Spec.VehicleCategory ->
+      UTCTime ->
+      Maybe Spec.ServiceTierType ->
+      FRFSUtils.FRFSFareParameters ->
+      Maybe (Id DPPP.PurchasedPassPayment) ->
+      m (Maybe (FRFSPassOverride.ApplicablePass, FRFSPassOverride.PassOption))
+    resolvePassForFare rider vehicleType bookingStartTime mbServiceTierType fareParameters mbPassPaymentId = do
+      let mbAdultUnitPriceForOverride =
+            find (\priceItem -> priceItem.categoryType == ADULT) fareParameters.priceItems <&> (.unitPrice)
+      case (mbPassPaymentId, mbAdultUnitPriceForOverride) of
+        (Just paymentId, Nothing) -> do
+          logWarning $ "FRFSConfirm: pass selected but no ADULT price item to price the override against purchasedPassPaymentId=" <> paymentId.getId
+          throwError (InvalidRequest $ "Selected pass is not applicable to this booking, purchasedPassPaymentId=" <> paymentId.getId)
+        (Nothing, _) -> pure Nothing
+        (Just paymentId, Just adultUnitPriceForOverride) -> do
+          resolved <-
+            FRFSPassOverride.resolvePassOverride
+              integratedBppConfig
+              rider
+              vehicleType
+              bookingStartTime
+              mbServiceTierType
+              adultUnitPriceForOverride
+              (map (\priceItem -> (priceItem.unitPrice, priceItem.quantity)) fareParameters.priceItems)
+              paymentId
+          when (isNothing resolved) $
+            throwError (InvalidRequest $ "Selected pass is not applicable to this booking, purchasedPassPaymentId=" <> paymentId.getId)
+          pure resolved
 
     validateQuota :: Int -> Int -> Maybe Seat.Seat -> Either GenericError ()
     validateQuota fromIdx toIdx mbSeat =
@@ -375,35 +438,7 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
                 pure (fromMaybe now mbLegDepartureTime)
           _ -> pure (fromMaybe now mbLegDepartureTime)
 
-      -- No fallback to totalPrice: that is the quantity-multiplied order total, and handing it to
-      -- resolvePassOverride as a UNIT price mis-values the override. The offer side
-      -- (Lib.JourneyModule.Types) offers no pass at all when there is no ADULT item, so treating it
-      -- as "no override applicable" here is what keeps the two sides agreeing.
-      let mbAdultUnitPriceForOverride =
-            find (\priceItem -> priceItem.categoryType == ADULT) fareParameters.priceItems <&> (.unitPrice)
-      mbResolved <-
-        case (mbPurchasedPassPaymentId', mbAdultUnitPriceForOverride) of
-          (Just paymentId, Nothing) -> do
-            -- Rejected rather than silently ignored, matching the "not applicable" throw below:
-            -- honouring the request without the override would charge the rider the full fare
-            -- having been told a pass applied.
-            logWarning $ "FRFSConfirm: pass selected but no ADULT price item to price the override against purchasedPassPaymentId=" <> paymentId.getId
-            throwError (InvalidRequest $ "Selected pass is not applicable to this booking, purchasedPassPaymentId=" <> paymentId.getId)
-          (Nothing, _) -> pure Nothing
-          (Just paymentId, Just adultUnitPriceForOverride) -> do
-            resolved <-
-              FRFSPassOverride.resolvePassOverride
-                integratedBppConfig
-                rider
-                quote'.vehicleType
-                bookingStartTime
-                mbServiceTierType
-                adultUnitPriceForOverride
-                (map (\priceItem -> (priceItem.unitPrice, priceItem.quantity)) fareParameters.priceItems)
-                paymentId
-            when (isNothing resolved) $
-              throwError (InvalidRequest $ "Selected pass is not applicable to this booking, purchasedPassPaymentId=" <> paymentId.getId)
-            pure resolved
+      mbResolved <- resolvePassForFare rider quote'.vehicleType bookingStartTime mbServiceTierType fareParameters mbPurchasedPassPaymentId'
 
       -- Stamped on the insert, not patched in afterwards: a status read hitting the replica in
       -- between would see a booking that is neither payable nor pass-covered and reject it.
@@ -568,12 +603,12 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
                   chosenEta = fromMaybe (minimumBy (comparing (.arrivalTimeUnix)) allEtas) mbBoardingEta
               pure $ Just (unixToUTC chosenEta.arrivalTimeUnix)
 
-postFrfsQuoteV2ConfirmUtil :: (CallExternalBPP.FRFSConfirmFlow m r c, HasField "blackListedJobs" r [Text], HasField "cloudType" r (Maybe CloudType), HasMasterCloudForwarder r) => (Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant) -> DFRFSQuote.FRFSQuote -> [API.Types.UI.FRFSTicketService.FRFSCategorySelectionReq] -> Maybe CrisSdkResponse -> Maybe Bool -> Maybe Bool -> Maybe Bool -> DIBC.IntegratedBPPConfig -> Maybe Text -> Maybe Bool -> Maybe Text -> Maybe RescheduleCtx -> Maybe (Id DPPP.PurchasedPassPayment) -> m API.Types.UI.FRFSTicketService.FRFSTicketBookingStatusAPIRes
-postFrfsQuoteV2ConfirmUtil (mbPersonId, merchantId_) quote selectedQuoteCategories crisSdkResponse isSingleMode mbEnableOffer mbIsMockPayment integratedBppConfig mbTripId isSpotBooking mbVehicleNumber mbRescheduleCtx mbPurchasedPassPaymentId = do
+postFrfsQuoteV2ConfirmUtil :: (CallExternalBPP.FRFSConfirmFlow m r c, HasField "blackListedJobs" r [Text], HasField "cloudType" r (Maybe CloudType), HasMasterCloudForwarder r) => (Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant) -> DFRFSQuote.FRFSQuote -> [API.Types.UI.FRFSTicketService.FRFSCategorySelectionReq] -> Maybe CrisSdkResponse -> Maybe Bool -> Maybe Bool -> Maybe Bool -> DIBC.IntegratedBPPConfig -> Maybe Text -> Maybe Bool -> Maybe Text -> Maybe RescheduleCtx -> Maybe (Id DPPP.PurchasedPassPayment) -> Bool -> m API.Types.UI.FRFSTicketService.FRFSTicketBookingStatusAPIRes
+postFrfsQuoteV2ConfirmUtil (mbPersonId, merchantId_) quote selectedQuoteCategories crisSdkResponse isSingleMode mbEnableOffer mbIsMockPayment integratedBppConfig mbTripId isSpotBooking mbVehicleNumber mbRescheduleCtx mbPurchasedPassPaymentId passSelectionAuthoritative = do
   when (null selectedQuoteCategories) $ throwError $ NoSelectedCategoryFound quote.id.getId
   personId <- fromMaybeM (InvalidRequest "Invalid person id") mbPersonId
   merchant <- CQM.findById merchantId_ >>= fromMaybeM (InvalidRequest "Invalid merchant id")
-  (rider, dConfirmRes, fareParameters, updatedQuoteCategories, isMultiInitAllowed) <- confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse isSingleMode mbIsMockPayment integratedBppConfig mbTripId isSpotBooking mbVehicleNumber mbRescheduleCtx mbPurchasedPassPaymentId
+  (rider, dConfirmRes, fareParameters, updatedQuoteCategories, isMultiInitAllowed) <- confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse isSingleMode mbIsMockPayment integratedBppConfig mbTripId isSpotBooking mbVehicleNumber mbRescheduleCtx mbPurchasedPassPaymentId passSelectionAuthoritative
   (mbJourneyId, _) <- getAllJourneyFrfsBookings dConfirmRes
   when (isNothing mbJourneyId) $ do
     when (isNothing mbRescheduleCtx) $ do
@@ -592,7 +627,7 @@ postFrfsQuoteV2ConfirmUtil (mbPersonId, merchantId_) quote selectedQuoteCategori
   -- SharedLogic.FRFSPassConfirm, driven either by the journey's payment success or -- when no leg is
   -- payable at all -- by Lib.JourneyModule.Base once every leg is confirmed. Confirming a leg here
   -- would issue a ticket and spend a pass trip before the rider has paid for the journey's other legs.
-  if isFullyPassCovered && dConfirmRes.status == DFRFSTicketBooking.NEW && isNothing mbJourneyId
+  if isFullyPassCovered && dConfirmRes.status `elem` [DFRFSTicketBooking.NEW, DFRFSTicketBooking.PAYMENT_PENDING, DFRFSTicketBooking.APPROVED] && isNothing mbJourneyId
     then do
       bapConfig <-
         getOneConfig
@@ -602,54 +637,90 @@ postFrfsQuoteV2ConfirmUtil (mbPersonId, merchantId_) quote selectedQuoteCategori
       let validTillPass = addUTCTime (maybe 60 intToNominalDiffTime bapConfig.confirmTTLSec) now
           mRiderNamePass = rider.firstName <&> (\fName -> rider.lastName & maybe fName (\lName -> fName <> " " <> lName))
       mRiderNumberPass <- mapM decrypt rider.mobileNumber
-      -- dConfirmRes.status in the guard above is a snapshot taken before confirmAndUpsertBooking's
-      -- lock was released, so it cannot decide this on its own: two concurrent confirms for one
-      -- searchId would both read NEW and both call the BPP, issuing two tickets and debiting the
-      -- pass twice at on_confirm. claimBookingForConfirm re-reads under a lock and is the only
-      -- thing allowed to make the NEW -> CONFIRMING transition -- the same claim the journey path
-      -- uses, so the two cannot drift.
       mbClaimed <- FRFSUtils.claimBookingForConfirm dConfirmRes.id validTillPass
       case mbClaimed of
-        Nothing -> logInfo $ "FRFSConfirm: pass-covered booking no longer NEW, skipping inline confirm bookingId=" <> dConfirmRes.id.getId
+        Nothing -> logInfo $ "FRFSConfirm: not claiming for inline confirm (already confirming, or a payment webhook holds the booking) bookingId=" <> dConfirmRes.id.getId
         Just claimedBooking -> do
-          void $ QFRFSTicketBooking.updateOnInitDone (Just True) claimedBooking.id
-          -- The booking is CONFIRMING by now. CallExternalBPP.confirm returns Left for an error it
-          -- handled but THROWS on a transport or decode failure, and a throw here skips both writes
-          -- below and escapes as a 5xx, leaving the booking CONFIRMING with an empty
-          -- failure_reason. Nothing sweeps that: this branch requires isNothing mbJourneyId, so no
-          -- CheckMultimodalConfirmFail job is scheduled, and with no payment row none of the
-          -- payment-driven paths touch it either -- only the rider polling status past validTill
-          -- would ever resolve it. Fold a throw into the same Left path instead.
-          confirmResp <-
-            withTryCatch "FRFSConfirm:passCoveredBppConfirm" (CallExternalBPP.confirm merchant merchantOperatingCity bapConfig (mRiderNamePass, mRiderNumberPass) claimedBooking updatedQuoteCategories isSingleMode) >>= \case
-              Right resp -> pure resp
-              Left err -> pure (Left ("BPP confirm threw: " <> show err))
-          case confirmResp of
+          -- Everything past the claim runs under this: the booking is already CONFIRMING, so a throw
+          -- from any write or lookup below would leave it CONFIRMING with an empty failure_reason and
+          -- nothing to resolve it -- no payment row, and CheckMultimodalConfirmFail is only scheduled
+          -- on payment success, which never comes for a fully covered booking. Same wrapper the
+          -- journey path uses in FRFSPassConfirm.
+          afterClaim <- withTryCatch "FRFSConfirm:passCoveredAfterClaim" $ do
+            -- Carried on the record too, not just written: the CRIS confirm builds chargeableAmount
+            -- from booking.totalPrice, so the pre-update record would quote the operator the
+            -- previous quantity's fare.
+            let repricedBooking = claimedBooking {DFRFSTicketBooking.totalPrice = fareParameters.totalPrice}
+            void $ QFRFSTicketBooking.updateTotalPriceById fareParameters.totalPrice claimedBooking.id
+            void $ QFRFSTicketBooking.updateOnInitDone (Just True) claimedBooking.id
+            confirmResp <-
+              withTryCatch "FRFSConfirm:passCoveredBppConfirm" (CallExternalBPP.confirm merchant merchantOperatingCity bapConfig (mRiderNamePass, mRiderNumberPass) repricedBooking updatedQuoteCategories isSingleMode) >>= \case
+                Right resp -> pure resp
+                Left err -> pure (Left ("BPP confirm threw: " <> show err))
+            case confirmResp of
+              Left err -> do
+                void $ QFRFSTicketBooking.updateFailureReasonById (Just err) claimedBooking.id
+                void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.FAILED claimedBooking.id
+              Right _ -> pure ()
+          case afterClaim of
+            Right () -> pure ()
             Left err -> do
-              void $ QFRFSTicketBooking.updateFailureReasonById (Just err) claimedBooking.id
+              logError $ "FRFSConfirm: pass-covered confirm failed after the claim bookingId=" <> claimedBooking.id.getId <> " err=" <> show err
+              void $ QFRFSTicketBooking.updateFailureReasonById (Just ("Pass confirm failed: " <> show err)) claimedBooking.id
               void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.FAILED claimedBooking.id
-            Right _ -> pure ()
-    else when isMultiInitAllowed $ do
-      case mbRescheduleCtx of
-        Just ctx -> do
-          -- Load-bearing: rewrite the reused payment's categories to the new seats BEFORE the staging
-          -- confirm reads them (confirm resolves seats from findAllByPaymentId first). A fully pass-covered
-          -- reschedule has no reused payment (oldFrfsPaymentId = Nothing) and confirms via the pass path,
-          -- so there is nothing to sync — only APPROVED still applies as the multi-init marker.
-          whenJust ctx.oldFrfsPaymentId $ \oldFrfsPaymentId ->
-            FRFSReschedule.syncPaymentCategories oldFrfsPaymentId updatedQuoteCategories
-          void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.APPROVED dConfirmRes.id
-        Nothing -> do
-          bapConfig <- getOneConfig (BecknConfigDimensions {merchantOperatingCityId = merchantOperatingCity.id.getId, merchantId = merchant.id.getId, domain = Just (show Spec.FRFS), vehicleCategory = Just (frfsVehicleCategoryToBecknVehicleCategory dConfirmRes.vehicleType), becknProtocol = Nothing}) (Just (maybeToList <$> CQBC.findByMerchantIdDomainVehicleAndMerchantOperatingCityIdWithFallback merchantOperatingCity.id merchant.id (show Spec.FRFS) (frfsVehicleCategoryToBecknVehicleCategory dConfirmRes.vehicleType))) >>= fromMaybeM (InternalError "Beckn Config not found")
-          let mRiderName = rider.firstName <&> (\fName -> rider.lastName & maybe fName (\lName -> fName <> " " <> lName))
-          mRiderNumber <- mapM decrypt rider.mobileNumber
-          let validTill = addUTCTime (maybe 30 intToNominalDiffTime bapConfig.initTTLSec) now
-          void $ QFRFSTicketBooking.updateValidTillById validTill dConfirmRes.id
-          let dConfirmRes' = dConfirmRes {DFRFSTicketBooking.validTill = validTill}
-          when (dConfirmRes.status /= DFRFSTicketBooking.NEW) $ do
-            void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.NEW dConfirmRes.id
-          CallExternalBPP.init merchant merchantOperatingCity bapConfig (mRiderName, mRiderNumber) dConfirmRes' updatedQuoteCategories mbEnableOffer
-  frfsBookingStatus (dConfirmRes.riderId, merchantId_) (integratedBppConfig.platformType == DIBC.MULTIMODAL) (withPaymentStatusResponseHandler dConfirmRes updatedQuoteCategories fareParameters routeStations stations merchantOperatingCity) dConfirmRes rider (\_ _ -> pure ())
+          FRFSUtils.releasePaymentSuccessLock claimedBooking.id
+    else do
+      -- Only the standalone reprice case: a single-leg journey (the synthetic journey buildJourneyAndLeg
+      -- creates for a lone FRFS booking) whose sole leg is fully pass-covered, and which is still in a
+      -- confirmable state. A genuine multimodal journey has >1 leg, or a leg with no booking row yet
+      -- (a deferred, still-payable leg dropped by getAllJourneyFrfsBookings' mapMaybeM), and is left to
+      -- the existing deferred path (Base.hs / FRFSStatus on payment success) exactly as before. The
+      -- status guard mirrors the sibling branch's isMultiInitAllowed set and stops a re-confirm of an
+      -- already CONFIRMING/CONFIRMED/terminal booking from being reset to NEW and ticketed twice.
+      journeyFullyCovered <-
+        if isFullyPassCovered
+          && dConfirmRes.status `elem` [DFRFSTicketBooking.NEW, DFRFSTicketBooking.PAYMENT_PENDING, DFRFSTicketBooking.APPROVED]
+          && isNothing mbRescheduleCtx
+          then case mbJourneyId of
+            Nothing -> pure False
+            Just journeyId -> do
+              legs <- QJourneyLeg.getJourneyLegs journeyId
+              (_, allJourneyBookings) <- getAllJourneyFrfsBookings dConfirmRes
+              pure $
+                length legs == 1
+                  && length allJourneyBookings == 1
+                  && all (FRFSPassOverride.isFullyPassCovered . (.overriddenAmount)) allJourneyBookings
+          else pure False
+      if journeyFullyCovered
+        then do
+          logInfo $ "FRFSConfirm: single pass-covered leg, confirming inline bookingId=" <> dConfirmRes.id.getId
+          -- confirmOne claims first and does every write inside its own guarded section, so a claim
+          -- that loses to a payment webhook leaves the row untouched. Going through it directly also
+          -- avoids the PAYMENT_PENDING -> NEW reset that confirmPassCoveredLegs' status == NEW filter
+          -- would otherwise require -- a transition a concurrent poll can observe.
+          FRFSPassConfirm.confirmOne dConfirmRes
+        else when isMultiInitAllowed $ do
+          case mbRescheduleCtx of
+            Just ctx -> do
+              -- Load-bearing: rewrite the reused payment's categories to the new seats BEFORE the staging
+              -- confirm reads them (confirm resolves seats from findAllByPaymentId first). A fully pass-covered
+              -- reschedule has no reused payment (oldFrfsPaymentId = Nothing) and confirms via the pass path,
+              -- so there is nothing to sync — only APPROVED still applies as the multi-init marker.
+              whenJust ctx.oldFrfsPaymentId $ \oldFrfsPaymentId ->
+                FRFSReschedule.syncPaymentCategories oldFrfsPaymentId updatedQuoteCategories
+              void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.APPROVED dConfirmRes.id
+            Nothing -> do
+              bapConfig <- getOneConfig (BecknConfigDimensions {merchantOperatingCityId = merchantOperatingCity.id.getId, merchantId = merchant.id.getId, domain = Just (show Spec.FRFS), vehicleCategory = Just (frfsVehicleCategoryToBecknVehicleCategory dConfirmRes.vehicleType), becknProtocol = Nothing}) (Just (maybeToList <$> CQBC.findByMerchantIdDomainVehicleAndMerchantOperatingCityIdWithFallback merchantOperatingCity.id merchant.id (show Spec.FRFS) (frfsVehicleCategoryToBecknVehicleCategory dConfirmRes.vehicleType))) >>= fromMaybeM (InternalError "Beckn Config not found")
+              let mRiderName = rider.firstName <&> (\fName -> rider.lastName & maybe fName (\lName -> fName <> " " <> lName))
+              mRiderNumber <- mapM decrypt rider.mobileNumber
+              let validTill = addUTCTime (maybe 30 intToNominalDiffTime bapConfig.initTTLSec) now
+              void $ QFRFSTicketBooking.updateValidTillById validTill dConfirmRes.id
+              let dConfirmRes' = dConfirmRes {DFRFSTicketBooking.validTill = validTill}
+              when (dConfirmRes.status /= DFRFSTicketBooking.NEW) $ do
+                void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.NEW dConfirmRes.id
+              CallExternalBPP.init merchant merchantOperatingCity bapConfig (mRiderName, mRiderNumber) dConfirmRes' updatedQuoteCategories mbEnableOffer
+  latestConfirmRes <- QFRFSTicketBooking.findById dConfirmRes.id >>= fromMaybeM (InvalidRequest $ "Invalid booking id " <> dConfirmRes.id.getId)
+  frfsBookingStatus (latestConfirmRes.riderId, merchantId_) (integratedBppConfig.platformType == DIBC.MULTIMODAL) (withPaymentStatusResponseHandler latestConfirmRes updatedQuoteCategories fareParameters routeStations stations merchantOperatingCity) latestConfirmRes rider (\_ _ -> pure ())
   where
     withPaymentStatusResponseHandler ::
       CallExternalBPP.FRFSConfirmFlow m r c =>

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSConfirm.hs
@@ -182,7 +182,26 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
     (rider, dConfirmRes) <- case confirmResult of
       Right res -> pure res
       Left err -> do
-        when (isJust mbPurchasedPassPaymentId) $
+        when (isJust mbPurchasedPassPaymentId) $ do
+          -- The selections were already persisted above, and resolvePassForFare throws AFTER that
+          -- write. Without this the rejected quantity sticks: the quote categories sit at the
+          -- refused quantity while the booking keeps the overrideType stamped by the previous,
+          -- covered confirm -- a booking marked pass-covered at a quantity the pass just refused,
+          -- which is the one thing the cap exists to prevent. Put the prior selections back so the
+          -- rejection leaves no trace.
+          void $
+            withTryCatch "FRFSConfirm:restoreQuoteCategoriesOnFailure" $
+              FRFSUtils.updateQuoteCategoriesWithSelections
+                -- Nothing, not mbHoldId: the hold is released immediately below, so stamping it
+                -- back onto the restored categories would leave them pointing at a dead hold.
+                Nothing
+                -- Seats carried over from the ORIGINAL categories, not zeroed. seatIds/seatLabels
+                -- are written straight through by updateQuoteCategoriesWithSelections, so passing
+                -- Nothing here would clear the rider's seat selection as a side effect of
+                -- rejecting their pass -- on a seat-selection flow that is a worse bug than the
+                -- one this restore exists to fix.
+                (quoteCategories <&> (\qc -> FRFSUtils.QuoteCategorySelection qc.id qc.selectedQuantity qc.seatIds qc.seatLabels))
+                updatedQuoteCategories
           whenJust ((,) <$> mbTripId <*> mbHoldId) $ \(tripId, holdId) -> do
             logWarning $ "FRFSConfirm:confirmAndUpsertBooking releasing hold after a pass failure holdId=" <> holdId <> " tripId=" <> tripId <> " err=" <> show err
             void $ withTryCatch "FRFSConfirm:releaseHoldOnFailure" (SeatBooking.releaseHold tripId holdId)
@@ -319,27 +338,38 @@ confirmAndUpsertBooking personId quote selectedQuoteCategories crisSdkResponse i
                   let mBookAuthCode = crisSdkResponse <&> (.bookAuthCode)
                       totalPrice = fareParameters.totalPrice
                       mbNewServiceTierType = FRFSUtils.getServiceTierTypeFromRouteStationsJson quote.routeStationsJson
-                  mbResolved <- resolvePassForFare rider quote.vehicleType (fromMaybe now booking.startTime) mbNewServiceTierType fareParameters mbPurchasedPassPaymentId
+                  -- booking.startTime was stamped at the ORIGINAL confirm, and
+                  -- filterCandidatesForLeg gates a pass on startDate <= tripDay <= endDate. A
+                  -- reconfirm the next day would still be priced against yesterday and could accept
+                  -- a pass that no longer covers the trip. A start time still in the future is a
+                  -- real scheduled departure and stays authoritative; anything past means the
+                  -- reconfirm is the trip being booked, so price against now.
+                  let passResolutionTime = case booking.startTime of
+                        Just startTime | startTime > now -> startTime
+                        _ -> now
+                  mbResolved <- resolvePassForFare rider quote.vehicleType passResolutionTime mbNewServiceTierType fareParameters mbPurchasedPassPaymentId
                   void $ QFRFSTicketBooking.updateBookingAuthCodeById mBookAuthCode booking.id
                   void $ QFRFSTicketBooking.updateQuoteBppItemIdRouteStationsAndServiceTierById quote.id quote.bppItemId quote.routeStationsJson mbNewServiceTierType booking.id
                   void $ QFRFSTicketBooking.updateIsFareChangedById Nothing booking.id
-                  -- Persist the re-priced total, not just carry it on the returned record: the status
-                  -- response is built from a re-read of this row, and on_init -- the only other writer
-                  -- of totalPrice -- is an async callback that has not landed yet, so the row would
-                  -- otherwise still hold the previous quantity's fare.
                   void $ QFRFSTicketBooking.updateTotalPriceById totalPrice booking.id
                   let mbPassOption = snd <$> mbResolved
                       resolvedType = DFRFSTicketBooking.PassOverride <$ mbPassOption
                       resolvedAmount = (.overriddenTotalPrice.amount) <$> mbPassOption
                       resolvedEntityId = (.purchasedPassPaymentId.getId) <$> mbPassOption
-                      -- A pass resolved -> stamp it. No pass and the caller is authoritative (the rider's
-                      -- own confirm) -> clear a now-stale override. No pass and NOT authoritative (on_select
-                      -- and other internal re-entries call with Nothing) -> keep the existing override, so a
-                      -- partial-pass booking is not silently stripped and billed full fare.
                       (overrideType', overriddenAmount', overrideAppliedEntityId') =
                         if isJust mbPassOption || passSelectionAuthoritative
                           then (resolvedType, resolvedAmount, resolvedEntityId)
                           else (booking.overrideType, booking.overriddenAmount, booking.overrideAppliedEntityId)
+                  -- Clearing is the correct answer to a rider who deselected the pass, but it is
+                  -- indistinguishable from a client that simply retried without the id -- and the
+                  -- rider then silently lands on a full-fare PAYMENT_PENDING with a 200. Log it so
+                  -- the transition is at least visible when a rider asks where their pass went.
+                  when (isJust booking.overrideType && isNothing overrideType') $
+                    logWarning $
+                      "FRFSConfirm: clearing pass override on reconfirm bookingId=" <> booking.id.getId
+                        <> " previousPass="
+                        <> show booking.overrideAppliedEntityId
+                        <> " (no purchasedPassPaymentId supplied by an authoritative caller)"
                   when (overrideType' /= booking.overrideType || overriddenAmount' /= booking.overriddenAmount || overrideAppliedEntityId' /= booking.overrideAppliedEntityId) $
                     QFRFSTicketBooking.updatePassOverrideById overrideType' overriddenAmount' overrideAppliedEntityId' booking.id
                   return $
@@ -641,15 +671,7 @@ postFrfsQuoteV2ConfirmUtil (mbPersonId, merchantId_) quote selectedQuoteCategori
       case mbClaimed of
         Nothing -> logInfo $ "FRFSConfirm: not claiming for inline confirm (already confirming, or a payment webhook holds the booking) bookingId=" <> dConfirmRes.id.getId
         Just claimedBooking -> do
-          -- Everything past the claim runs under this: the booking is already CONFIRMING, so a throw
-          -- from any write or lookup below would leave it CONFIRMING with an empty failure_reason and
-          -- nothing to resolve it -- no payment row, and CheckMultimodalConfirmFail is only scheduled
-          -- on payment success, which never comes for a fully covered booking. Same wrapper the
-          -- journey path uses in FRFSPassConfirm.
           afterClaim <- withTryCatch "FRFSConfirm:passCoveredAfterClaim" $ do
-            -- Carried on the record too, not just written: the CRIS confirm builds chargeableAmount
-            -- from booking.totalPrice, so the pre-update record would quote the operator the
-            -- previous quantity's fare.
             let repricedBooking = claimedBooking {DFRFSTicketBooking.totalPrice = fareParameters.totalPrice}
             void $ QFRFSTicketBooking.updateTotalPriceById fareParameters.totalPrice claimedBooking.id
             void $ QFRFSTicketBooking.updateOnInitDone (Just True) claimedBooking.id
@@ -670,42 +692,23 @@ postFrfsQuoteV2ConfirmUtil (mbPersonId, merchantId_) quote selectedQuoteCategori
               void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.FAILED claimedBooking.id
           FRFSUtils.releasePaymentSuccessLock claimedBooking.id
     else do
-      -- Only the standalone reprice case: a single-leg journey (the synthetic journey buildJourneyAndLeg
-      -- creates for a lone FRFS booking) whose sole leg is fully pass-covered, and which is still in a
-      -- confirmable state. A genuine multimodal journey has >1 leg, or a leg with no booking row yet
-      -- (a deferred, still-payable leg dropped by getAllJourneyFrfsBookings' mapMaybeM), and is left to
-      -- the existing deferred path (Base.hs / FRFSStatus on payment success) exactly as before. The
-      -- status guard mirrors the sibling branch's isMultiInitAllowed set and stops a re-confirm of an
-      -- already CONFIRMING/CONFIRMED/terminal booking from being reset to NEW and ticketed twice.
-      journeyFullyCovered <-
+      mbCoveredJourneyBookings <-
         if isFullyPassCovered
           && dConfirmRes.status `elem` [DFRFSTicketBooking.NEW, DFRFSTicketBooking.PAYMENT_PENDING, DFRFSTicketBooking.APPROVED]
           && isNothing mbRescheduleCtx
           then case mbJourneyId of
-            Nothing -> pure False
-            Just journeyId -> do
-              legs <- QJourneyLeg.getJourneyLegs journeyId
-              (_, allJourneyBookings) <- getAllJourneyFrfsBookings dConfirmRes
-              pure $
-                length legs == 1
-                  && length allJourneyBookings == 1
-                  && all (FRFSPassOverride.isFullyPassCovered . (.overriddenAmount)) allJourneyBookings
-          else pure False
-      if journeyFullyCovered
-        then do
-          logInfo $ "FRFSConfirm: single pass-covered leg, confirming inline bookingId=" <> dConfirmRes.id.getId
-          -- confirmOne claims first and does every write inside its own guarded section, so a claim
-          -- that loses to a payment webhook leaves the row untouched. Going through it directly also
-          -- avoids the PAYMENT_PENDING -> NEW reset that confirmPassCoveredLegs' status == NEW filter
-          -- would otherwise require -- a transition a concurrent poll can observe.
-          FRFSPassConfirm.confirmOne dConfirmRes
-        else when isMultiInitAllowed $ do
+            Nothing -> pure Nothing
+            Just _ -> do
+              (_, allJourneyBookings, covered) <- FRFSUtils.journeyFullyPassCovered dConfirmRes
+              pure $ if covered then Just allJourneyBookings else Nothing
+          else pure Nothing
+      case mbCoveredJourneyBookings of
+        Just coveredBookings -> do
+          logInfo $ "FRFSConfirm: journey fully pass-covered, confirming " <> show (length coveredBookings) <> " leg(s) inline bookingId=" <> dConfirmRes.id.getId
+          FRFSPassConfirm.confirmPassCoveredLegs coveredBookings
+        Nothing -> when isMultiInitAllowed $ do
           case mbRescheduleCtx of
             Just ctx -> do
-              -- Load-bearing: rewrite the reused payment's categories to the new seats BEFORE the staging
-              -- confirm reads them (confirm resolves seats from findAllByPaymentId first). A fully pass-covered
-              -- reschedule has no reused payment (oldFrfsPaymentId = Nothing) and confirms via the pass path,
-              -- so there is nothing to sync — only APPROVED still applies as the multi-init marker.
               whenJust ctx.oldFrfsPaymentId $ \oldFrfsPaymentId ->
                 FRFSReschedule.syncPaymentCategories oldFrfsPaymentId updatedQuoteCategories
               void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.APPROVED dConfirmRes.id

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSPassConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSPassConfirm.hs
@@ -1,17 +1,13 @@
 -- | Confirming FRFS legs whose fare is fully covered by a pass.
---
 -- A fully pass-covered leg has no payment order and no @FRFSTicketBookingPayment@ row, so nothing
 -- in the payment pipeline will ever drive it to confirm. A standalone booking is therefore confirmed
 -- inline at booking time (see @SharedLogic.FRFSConfirm.postFrfsQuoteV2ConfirmUtil@).
---
 -- A leg inside a multimodal journey must NOT be confirmed inline: its siblings may still be awaiting
 -- payment, and confirming early issues a real ticket (and spends a pass trip) for a journey the rider
 -- may abandon at the payment step. Journey legs are instead confirmed here, from exactly two places:
---
 --   * "Lib.JourneyModule.Base" — right after all legs are confirmed, when the journey has no payable
 --     leg at all (every leg pass-covered, so no payment will ever arrive to trigger anything).
 --   * "SharedLogic.FRFSStatus" — when the journey's payment succeeds.
---
 -- Both call sites are idempotent: only bookings still in 'NEW' are acted on, and the status flips to
 -- 'CONFIRMING' before the BPP call.
 module SharedLogic.FRFSPassConfirm
@@ -60,8 +56,6 @@ confirmPassCoveredLegsOfJourney booking = do
   (mbJourneyId, allJourneyBookings) <- getAllJourneyFrfsBookings booking
   whenJust mbJourneyId $ \_ -> confirmPassCoveredLegs allJourneyBookings
 
--- | Confirm the fully pass-covered bookings in the given set, skipping anything already past 'NEW'.
--- Each leg is confirmed independently; one leg failing does not abort the others.
 confirmPassCoveredLegs ::
   ( CallExternalBPP.FRFSConfirmFlow m r c,
     HasField "blackListedJobs" r [Text],
@@ -73,7 +67,10 @@ confirmPassCoveredLegs ::
 confirmPassCoveredLegs bookings = do
   let coveredLegs =
         filter
-          (\b -> FRFSPassOverride.isFullyPassCovered b.overriddenAmount && b.status == DFRFSTicketBooking.NEW)
+          ( \b ->
+              FRFSPassOverride.isFullyPassCovered b.overriddenAmount
+                && b.status `elem` [DFRFSTicketBooking.NEW, DFRFSTicketBooking.PAYMENT_PENDING, DFRFSTicketBooking.APPROVED]
+          )
           bookings
   forM_ coveredLegs $ \booking ->
     void $ withTryCatch "FRFSPassConfirm:confirmLeg" (confirmOne booking)
@@ -114,11 +111,6 @@ confirmOne booking = do
         let mRiderName = rider.firstName <&> (\fName -> rider.lastName & maybe fName (\lName -> fName <> " " <> lName))
         mRiderNumber <- mapM decrypt rider.mobileNumber
         void $ QFRFSTicketBooking.updateOnInitDone (Just True) latest.id
-        -- The pass path never calls init, and on_init is the only other writer of totalPrice, so a
-        -- reprice would otherwise leave the previous quantity's fare on the row for recon/settlement.
-        -- Carried on the record too, not just written: the CRIS confirm builds chargeableAmount from
-        -- booking.totalPrice (ExternalAPI/Subway/CRIS/BookJourney.hs:277), so passing the pre-update
-        -- record would quote the operator the previous quantity's fare.
         let repricedTotal = (mkFareParameters (mkCategoryPriceItemFromQuoteCategories quoteCategories)).totalPrice
             repriced = latest {DFRFSTicketBooking.totalPrice = repricedTotal}
         void $ QFRFSTicketBooking.updateTotalPriceById repricedTotal latest.id

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSPassConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSPassConfirm.hs
@@ -17,6 +17,7 @@
 module SharedLogic.FRFSPassConfirm
   ( confirmPassCoveredLegs,
     confirmPassCoveredLegsOfJourney,
+    confirmOne,
   )
 where
 
@@ -32,6 +33,7 @@ import Kernel.Prelude
 import Kernel.Types.Version (CloudType)
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
+import SharedLogic.FRFSFareCalculator (mkCategoryPriceItemFromQuoteCategories, mkFareParameters)
 import qualified SharedLogic.FRFSPassOverride as FRFSPassOverride
 import SharedLogic.FRFSUtils (getAllJourneyFrfsBookings)
 import qualified SharedLogic.FRFSUtils as FRFSUtils
@@ -99,7 +101,7 @@ confirmOne booking = do
   let validTill = addUTCTime (maybe 60 intToNominalDiffTime bapConfig.confirmTTLSec) now
   mbClaimed <- FRFSUtils.claimBookingForConfirm booking.id validTill
   case mbClaimed of
-    Nothing -> logInfo $ "FRFSPassConfirm: leg no longer NEW, skipping bookingId=" <> booking.id.getId
+    Nothing -> logInfo $ "FRFSPassConfirm: not claiming leg (already confirming, or a payment webhook holds the booking) bookingId=" <> booking.id.getId
     Just latest -> do
       -- Everything past the claim runs under this, because the claim has already moved the booking
       -- to CONFIRMING: a throw from any of the lookups below -- rider, quote categories, decrypt --
@@ -112,6 +114,14 @@ confirmOne booking = do
         let mRiderName = rider.firstName <&> (\fName -> rider.lastName & maybe fName (\lName -> fName <> " " <> lName))
         mRiderNumber <- mapM decrypt rider.mobileNumber
         void $ QFRFSTicketBooking.updateOnInitDone (Just True) latest.id
+        -- The pass path never calls init, and on_init is the only other writer of totalPrice, so a
+        -- reprice would otherwise leave the previous quantity's fare on the row for recon/settlement.
+        -- Carried on the record too, not just written: the CRIS confirm builds chargeableAmount from
+        -- booking.totalPrice (ExternalAPI/Subway/CRIS/BookJourney.hs:277), so passing the pre-update
+        -- record would quote the operator the previous quantity's fare.
+        let repricedTotal = (mkFareParameters (mkCategoryPriceItemFromQuoteCategories quoteCategories)).totalPrice
+            repriced = latest {DFRFSTicketBooking.totalPrice = repricedTotal}
+        void $ QFRFSTicketBooking.updateTotalPriceById repricedTotal latest.id
         logInfo $ "FRFSPassConfirm: confirming pass-covered leg bookingId=" <> latest.id.getId
         -- CallExternalBPP.confirm returns Left for an error it handled, but THROWS on a transport
         -- or decode failure -- and confirmLeg's withTryCatch swallows that, so the two writes below
@@ -123,7 +133,7 @@ confirmOne booking = do
         -- OnConfirm sets CONFIRMED unconditionally, so a late on_confirm still wins and debits the
         -- pass. The trip is only debited there, so nothing is lost on this path either way.
         confirmResp <-
-          withTryCatch "FRFSPassConfirm:bppConfirm" (CallExternalBPP.confirm merchant merchantOperatingCity bapConfig (mRiderName, mRiderNumber) latest quoteCategories Nothing) >>= \case
+          withTryCatch "FRFSPassConfirm:bppConfirm" (CallExternalBPP.confirm merchant merchantOperatingCity bapConfig (mRiderName, mRiderNumber) repriced quoteCategories repriced.isSingleMode) >>= \case
             Right resp -> pure resp
             Left err -> pure (Left ("BPP confirm threw: " <> show err))
         case confirmResp of
@@ -138,3 +148,4 @@ confirmOne booking = do
           logError $ "FRFSPassConfirm: leg failed after the claim bookingId=" <> latest.id.getId <> " err=" <> show err
           void $ QFRFSTicketBooking.updateFailureReasonById (Just ("Pass leg confirm failed: " <> show err)) latest.id
           void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.FAILED latest.id
+      FRFSUtils.releasePaymentSuccessLock latest.id

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStatus.hs
@@ -210,7 +210,7 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
                       let updatedTTL = addUTCTime (maybe 60 intToNominalDiffTime bapConfig.confirmTTLSec) now
                       transactions <- HQPaymentTransaction.findAllByOrderId paymentOrder.id
                       txnId <- getSuccessTransactionId transactions
-                      isLockAcquired <- Hedis.runInMasterCloudRedisCellWithCrossAppRedis $ Hedis.tryLockRedis (mkPaymentSuccessLockKey bookingId) 60
+                      isLockAcquired <- Hedis.runInMasterCloudRedisCellWithCrossAppRedis $ Hedis.tryLockRedis (FRFSUtils.frfsPaymentSuccessLockKey bookingId) FRFSUtils.paymentSuccessLockTtlSec
                       if isLockAcquired
                         then do
                           void $ QFRFSTicketBookingPayment.updateStatusById DFRFSTicketBookingPayment.SUCCESS paymentBooking.id
@@ -364,7 +364,10 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
       [FRFSQuoteCategory.FRFSQuoteCategory] ->
       m (Maybe FRFSTicketService.FRFSTicketBookingStatusAPIRes)
     buildRefundMoreThanOneChargedPaymentBookingStatusAPIRes paymentBooking paymentBookingStatus booking quoteCategories = do
-      if paymentBookingStatus == FRFSTicketService.SUCCESS && maybe False (/= paymentBooking.id.getId) booking.frfsTicketBookingPaymentIdForTicketGeneration
+      let ticketBookingPaymentIdMatched = booking.frfsTicketBookingPaymentIdForTicketGeneration == Just paymentBooking.id.getId
+          fulfilledByPass = isJust booking.overrideType && booking.status `elem` [DFRFSTicketBooking.CONFIRMING, DFRFSTicketBooking.CONFIRMED]
+          alreadyFulfilled = isJust booking.frfsTicketBookingPaymentIdForTicketGeneration || fulfilledByPass
+      if paymentBookingStatus == FRFSTicketService.SUCCESS && not ticketBookingPaymentIdMatched && alreadyFulfilled
         then do
           QFRFSTicketBookingPayment.updateStatusById DFRFSTicketBookingPayment.REFUND_PENDING paymentBooking.id
           response <-
@@ -381,8 +384,6 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
           return $ Just response
         else return Nothing
 
-    mkPaymentSuccessLockKey :: Kernel.Types.Id.Id DFRFSTicketBooking.FRFSTicketBooking -> Text
-    mkPaymentSuccessLockKey bookingId = "frfsPaymentSuccess:" <> bookingId.getId
 
     buildCreateOrderResp paymentOrder commonPersonId merchantOperatingCityId booking
       -- An external order has no session of ours behind it, so there is no payload to return and

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStatus.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSStatus.hs
@@ -365,7 +365,7 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
       m (Maybe FRFSTicketService.FRFSTicketBookingStatusAPIRes)
     buildRefundMoreThanOneChargedPaymentBookingStatusAPIRes paymentBooking paymentBookingStatus booking quoteCategories = do
       let ticketBookingPaymentIdMatched = booking.frfsTicketBookingPaymentIdForTicketGeneration == Just paymentBooking.id.getId
-          fulfilledByPass = isJust booking.overrideType && booking.status `elem` [DFRFSTicketBooking.CONFIRMING, DFRFSTicketBooking.CONFIRMED]
+          fulfilledByPass = FRFSPassOverride.fullyCoveredByPass booking && booking.status `elem` [DFRFSTicketBooking.CONFIRMING, DFRFSTicketBooking.CONFIRMED]
           alreadyFulfilled = isJust booking.frfsTicketBookingPaymentIdForTicketGeneration || fulfilledByPass
       if paymentBookingStatus == FRFSTicketService.SUCCESS && not ticketBookingPaymentIdMatched && alreadyFulfilled
         then do
@@ -383,7 +383,6 @@ frfsBookingStatus (personId, merchantId_) isMultiModalBooking withPaymentStatusR
               )
           return $ Just response
         else return Nothing
-
 
     buildCreateOrderResp paymentOrder commonPersonId merchantOperatingCityId booking
       -- An external order has no session of ours behind it, so there is no payload to return and

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
@@ -63,6 +63,7 @@ import qualified Domain.Types.RouteStopMapping as RouteStopMapping
 import qualified Domain.Types.RouteTripMapping as DRTM
 import qualified Domain.Types.Seat as DSeat
 import qualified Domain.Types.Station as Station
+import qualified Domain.Types.Trip as DTrip
 import qualified Domain.Types.VendorSplitDetails as VendorSplitDetails
 import EulerHS.Prelude (comparing, concatMapM, (+||), (<|>), (||+))
 import Kernel.Beam.Functions as B
@@ -852,6 +853,38 @@ getAllJourneyFrfsBookings booking = do
       return (Just leg.journeyId, bookings)
     Nothing -> pure (Nothing, [booking])
 
+journeyFullyPassCovered ::
+  ( EsqDBFlow m r,
+    CacheFlow m r,
+    MonadFlow m,
+    EsqDBReplicaFlow m r,
+    ServiceFlow m r,
+    EncFlow m r
+  ) =>
+  DFRFSTicketBooking.FRFSTicketBooking ->
+  m (Maybe (Id DJourney.Journey), [DFRFSTicketBooking.FRFSTicketBooking], Bool)
+journeyFullyPassCovered booking = do
+  mbJourneyLeg <- QJL.findByLegSearchId (Just booking.searchId.getId)
+  case mbJourneyLeg of
+    Nothing -> pure (Nothing, [booking], FRFSPassOverride.isFullyPassCovered booking.overriddenAmount)
+    Just leg -> do
+      legs <- QJL.getJourneyLegs leg.journeyId
+      bookings <- mapMaybeM (QFRFSTicketBooking.findBySearchId . Id) (mapMaybe (.legSearchId) legs)
+      let frfsLegs = filter (\l -> l.mode `elem` [DTrip.Bus, DTrip.Metro, DTrip.Subway]) legs
+          live b =
+            b.status
+              `notElem` [ DFRFSTicketBooking.FAILED,
+                          DFRFSTicketBooking.CANCELLED,
+                          DFRFSTicketBooking.COUNTER_CANCELLED,
+                          DFRFSTicketBooking.TECHNICAL_CANCEL_REJECTED
+                        ]
+          covered = case frfsLegs of
+            [] -> False
+            _ ->
+              length frfsLegs == length bookings
+                && all (\b -> live b && FRFSPassOverride.isFullyPassCovered b.overriddenAmount) bookings
+      pure (Just leg.journeyId, bookings, covered)
+
 getQuoteOfferSegment ::
   (EsqDBFlow m r, CacheFlow m r, EncFlow m r) =>
   Id DP.Person ->
@@ -1057,18 +1090,15 @@ data CancellationQuota = CancellationQuota
   }
 
 -- | Take a booking from NEW to CONFIRMING atomically, and return it as it was when claimed.
---
 -- Nothing means someone else already claimed it and the caller must not confirm. Every path that
 -- confirms with the BPP goes through this: the transition is a read then a write, so unguarded, two
 -- callers -- concurrent confirm requests for one searchId, or a retried payment webhook racing a
 -- status poll -- both see NEW, both call the BPP, and one booking gets two tickets and two debits
 -- at on_confirm.
---
 -- validTill is written inside the lock and BEFORE the status flip. Until it lands the booking is
 -- CONFIRMING while still carrying the validTill it had as NEW, and frfsBookingStatus fails a
 -- CONFIRMING booking whose validTill has passed -- so the other order lets a status poll kill a
 -- leg that is about to be confirmed.
---
 -- The lock covers ONLY the claim. Holding it across the BPP call would be worse than not locking:
 -- waiters spin on a microsecond retry delay, and a call slower than the lock TTL would let a second
 -- caller in while the first is still working, after which the first one's release deletes the
@@ -1090,9 +1120,6 @@ claimBookingForConfirm bookingId validTill =
           else do
             void $ QFRFSTicketBooking.updateValidTillById validTill latest.id
             void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.CONFIRMING latest.id
-            -- Carry the validTill we just wrote, not the stale one: ACL.buildConfirmReq falls back to
-            -- booking.validTill for the confirm TTL when bapConfig.confirmTTLSec is unset, so returning
-            -- the pre-update record would send the operator an expiry we have already replaced.
             pure (Just latest {DFRFSTicketBooking.validTill = validTill})
 
 confirmClaimLockKey :: Id DFRFSTicketBooking.FRFSTicketBooking -> Text

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSUtils.hs
@@ -1081,18 +1081,32 @@ claimBookingForConfirm ::
 claimBookingForConfirm bookingId validTill =
   Redis.withWaitAndLockRedis (confirmClaimLockKey bookingId) confirmClaimLockTtlSec confirmClaimLockRetryDelayMicros $ do
     latest <- QFRFSTicketBooking.findById bookingId >>= fromMaybeM (InvalidRequest $ "Invalid booking id " <> bookingId.getId)
-    if latest.status /= DFRFSTicketBooking.NEW
+    if latest.status `notElem` [DFRFSTicketBooking.NEW, DFRFSTicketBooking.PAYMENT_PENDING, DFRFSTicketBooking.APPROVED]
       then pure Nothing
       else do
-        void $ QFRFSTicketBooking.updateValidTillById validTill latest.id
-        void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.CONFIRMING latest.id
-        -- Carry the validTill we just wrote, not the stale one: ACL.buildConfirmReq falls back to
-        -- booking.validTill for the confirm TTL when bapConfig.confirmTTLSec is unset, so returning
-        -- the pre-update record would send the operator an expiry we have already replaced.
-        pure (Just latest {DFRFSTicketBooking.validTill = validTill})
+        gotPaymentLock <- Redis.runInMasterCloudRedisCellWithCrossAppRedis $ Redis.tryLockRedis (frfsPaymentSuccessLockKey bookingId) paymentSuccessLockTtlSec
+        if not gotPaymentLock
+          then pure Nothing
+          else do
+            void $ QFRFSTicketBooking.updateValidTillById validTill latest.id
+            void $ QFRFSTicketBooking.updateStatusById DFRFSTicketBooking.CONFIRMING latest.id
+            -- Carry the validTill we just wrote, not the stale one: ACL.buildConfirmReq falls back to
+            -- booking.validTill for the confirm TTL when bapConfig.confirmTTLSec is unset, so returning
+            -- the pre-update record would send the operator an expiry we have already replaced.
+            pure (Just latest {DFRFSTicketBooking.validTill = validTill})
 
 confirmClaimLockKey :: Id DFRFSTicketBooking.FRFSTicketBooking -> Text
 confirmClaimLockKey bookingId = "FRFSConfirm:claimBooking-" <> bookingId.getId
+
+frfsPaymentSuccessLockKey :: Id DFRFSTicketBooking.FRFSTicketBooking -> Text
+frfsPaymentSuccessLockKey bookingId = "frfsPaymentSuccess:" <> bookingId.getId
+
+paymentSuccessLockTtlSec :: Int
+paymentSuccessLockTtlSec = 60
+
+releasePaymentSuccessLock :: (CacheFlow m r, EsqDBFlow m r) => Id DFRFSTicketBooking.FRFSTicketBooking -> m ()
+releasePaymentSuccessLock bookingId =
+  Redis.runInMasterCloudRedisCellWithCrossAppRedis $ Redis.unlockRedis (frfsPaymentSuccessLockKey bookingId)
 
 -- The critical section is one read and two writes, so this only has to outlive a few KV round
 -- trips. Short on purpose: a TTL that can expire mid-section stops being a lock.


### PR DESCRIPTION
# backend/fix: apply pass override when a booking is reconfirmed at a new quantity

## Problem

Ticket quantity is a confirm-time input on a reused quote. Lowering it re-enters
`confirmAndUpsertBooking` through the "booking already exists" branch, which resolved the pass
override only in `buildAndCreateBooking` (the new-booking path). So a booking created without a
serviceable pass could never pick one up on a later reconfirm.

Repro (100% override pass, cap 2 tickets):

1. Search at qty 4 (no pass covers 4), confirm → booking parks at `PAYMENT_PENDING`, order raised,
   rider sent to the payment page.
2. Back out, drop to qty 2, pick the pass, confirm again on the same quote.
3. Expected: pass covers the fare, booking confirms, no payment. Actual: rider billed in full for a
   booking their pass now covers.

Two further defects surfaced from the same flow:

- **Reuse path never confirmed.** Even once the override was stamped, a standalone FRFS confirm
  gets a synthetic journey+leg on its first confirm, so every reconfirm carries `mbJourneyId` and
  the inline pass-confirm branch declined by design — the booking sat at `NEW`, no ticket, order
  still payable.
- **Stray order left payable.** The order raised before the pass applied is never invalidated
  (Juspay `abortOrder` is unimplemented), and a pass-covered booking never stamps
  `frfsTicketBookingPaymentIdForTicketGeneration`, so the duplicate-charge refund guard was dead
  for it — a charge on that order would sit in `CHARGED` forever.

## Change

`Backend/app/rider-platform/rider-app/Main/src/SharedLogic/`

- **FRFSConfirm.hs** — re-resolve the pass on the upsert branch and stamp
  `overrideType` / `overriddenAmount` / `overrideAppliedEntityId` (written unconditionally, so
  dropping the pass clears a now-stale override). When the whole journey is fully pass-covered,
  drive `confirmPassCoveredLegsOfJourney` inline so the reused booking confirms instead of stranding
  at `NEW`; guarded to exclude the reschedule path.
- **FRFSUtils.hs** — `claimBookingForConfirm` accepts `PAYMENT_PENDING` alongside `NEW`, so a
  booking a quantity change just made fully covered can confirm without paying. Everything from
  `CONFIRMING` on is still refused (the lock + re-read prevents a payment webhook and a pass confirm
  both issuing a ticket).
- **FRFSStatus.hs** — the duplicate-charge refund guard now also treats a pass-covered
  (`overrideType` set, `CONFIRMING`/`CONFIRMED`) booking as fulfilled, so a charge on the superseded
  order is refunded (`REFUND_PENDING`) instead of sitting in `CHARGED`.

## Verification

`scripts/testing/pass/test_reprice_on_quantity_change.py` — 172 assertions, black-box, against the
public API with DB reads for state the API does not expose. Requires
`seed_kolkata_metered_full_pass.sql` (a metered 100%-coverage pass, so the trip debit is
observable).

Covered:

- reprice on reuse — override stamped against the new quantity, cleared when the pass is dropped,
  tracked across alternating pass/no-pass quantity changes
- 100% pass on a booking already at `PAYMENT_PENDING` → `CONFIRMED`, `exactly 2 trips for 2 tickets`
  (the `NEW` reset must not double-debit)
- refused at an uncovered quantity (400, booking untouched), idempotent replay, pass switch
- stray order refunded via a real authenticated Juspay webhook (`payment row REFUND_PENDING`)

## Known limitations (not blocking)

- **Poll-path refund gap.** A rider who pays the superseded order and only polls booking status is
  not refunded — `findTicketBookingPayment` resolves the ticket-generation payment, which is null on
  a pass-covered booking, so the poll never reaches the stray order. The Juspay webhook is the
  backstop and is verified. Asserted in the suite so it cannot silently change.
- **Reschedule** of a pass booking is guarded out of the new branch but has no dedicated test.
- **Multi-leg journeys** are only exercised single-leg; a genuine multimodal all-covered journey
  reaches the new branch untested.

## Test tooling added

- `seed_kolkata_metered_full_pass.sql` — metered 100%-coverage pass fixture (re-run to reset the
  trip budget; also clear its Redis counter). A new `pass_category` needs an app restart + Redis
  clear to be visible.
- `auto_charge.py` — dev helper: polls `payment_order` and fires authenticated Juspay webhooks so
  stuck `PAYMENT_PENDING` bookings clear. Do NOT run it alongside the test suite (it charges the
  bookings the suite needs to stay pending). Each Juspay service config has its own
  username+password, city-scoped — the script resolves them per order.


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Eligible fare passes can be selected during booking confirmation.
  * Fully pass-covered, single-leg journeys can be confirmed without additional payment.
  * Pass-covered bookings awaiting payment can be completed inline.

* **Bug Fixes**
  * Improved confirmation handling for new, pending-payment, and approved bookings.
  * Prevented invalid or inapplicable pass selections.
  * Preserved valid pass overrides during booking updates.
  * Improved fare recalculation, refund handling, and failure recovery.
  * Prevented duplicate payment processing during confirmation.
  * Ensured payment locks are released after confirmation attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->