### PR TITLE
backend/refactor: remove dead city-name fallback from GST jurisdiction logic

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Finance/GstBreakdown.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Finance/GstBreakdown.hs
@@ -45,14 +45,11 @@ computeGstBreakdownForRideOwner gstBreakup fromLocation ride mbFleetInfoCached m
       "GST breakdown: missing counterparty addressState for pickupLocationId="
         <> fromLocation.id.getId
         <> "; falling back to intra-state CGST/SGST"
-  let pickupAddress = fromLocation.address
   pure $
-    computeGstBreakdownByPlace
+    computeGstBreakdownByState
       gstBreakup
       mbResidenceState
-      pickupAddress.state
-      Nothing
-      pickupAddress.city
+      fromLocation.address.state
       totalGst
 
 -- | Subscription / prepaid GST: counterparty residence proof vs platform PoB (merchant operating city).
@@ -77,33 +74,29 @@ computeGstBreakdownForPerson gstBreakup merchantOperatingCity personId isFleetOw
       "GST breakdown: missing counterparty addressState for merchantOpCityId="
         <> merchantOperatingCity.id.getId
         <> "; falling back to intra-state CGST/SGST"
-  let (supplierState, supplierCity) = (Just $ show merchantOperatingCity.state, Just $ show merchantOperatingCity.city)
+  let supplierState = Just $ show merchantOperatingCity.state
   pure $
-    computeGstBreakdownByPlace
+    computeGstBreakdownByState
       gstBreakup
       supplierState
       mbReceiverState
-      supplierCity
-      Nothing
       totalGst
 
--- | Determine GST jurisdiction by comparing supplier vs receiver place
---   (state first; city fallback when either state is missing), then split the total GST.
---   Falls back to intra-state CGST/SGST when place cannot be compared.
-computeGstBreakdownByPlace ::
+-- | Determine GST jurisdiction by comparing supplier vs receiver state,
+--   then split the total GST.
+--   Falls back to intra-state CGST/SGST when states cannot be compared.
+computeGstBreakdownByState ::
   DTC.GstBreakup ->
   Maybe Text -> -- supplier state
   Maybe Text -> -- receiver state
-  Maybe Text -> -- supplier city
-  Maybe Text -> -- receiver city
   HighPrecMoney -> -- totalGst
   Maybe Finance.GstAmountBreakdown
-computeGstBreakdownByPlace gstBreakup supplierState receiverState supplierCity receiverCity =
+computeGstBreakdownByState gstBreakup supplierState receiverState =
   Finance.computeGstBreakdownFromRates (toGstRateBreakup jurisdiction gstBreakup)
   where
     jurisdiction =
       fromMaybe Finance.IntraState $
-        Finance.compareIndianPlace supplierState receiverState supplierCity receiverCity
+        Finance.compareIndianState supplierState receiverState
 
 -- | Determine GST jurisdiction by comparing the first 2 characters (state code)
 --   of the seller and buyer GSTINs, then split the total GST accordingly.

--- a/Backend/lib/finance-kernel/src/Lib/Finance/Utils/GstBreakdown.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Utils/GstBreakdown.hs
@@ -5,7 +5,7 @@ module Lib.Finance.Utils.GstBreakdown
     GstRateBreakup (..),
     GstRateIntraStateBreakup (..),
     GstRateInterStateBreakup (..),
-    compareIndianPlace,
+    compareIndianState,
     compareIndianGstinStateCode,
     computeGstBreakdownFromRates,
     defaultIntraStateGstBreakdown,
@@ -44,6 +44,8 @@ normalizeGeoComponent mbText =
     _ -> Nothing
 
 -- | Compare two Indian state names (case-insensitive).
+--   Returns Nothing (unknown jurisdiction) when either state is missing;
+--   state resolution must happen upstream.
 compareIndianState :: Maybe Text -> Maybe Text -> Maybe GstJurisdiction
 compareIndianState supplierState receiverState =
   case (normalizeGeoComponent supplierState, normalizeGeoComponent receiverState) of
@@ -53,25 +55,6 @@ compareIndianState supplierState receiverState =
           then IntraState
           else InterState
     _ -> Nothing
-
--- | Compare states first; fall back to city names when either state is missing.
-compareIndianPlace ::
-  Maybe Text ->
-  Maybe Text ->
-  Maybe Text ->
-  Maybe Text ->
-  Maybe GstJurisdiction
-compareIndianPlace supplierState receiverState supplierCity receiverCity =
-  case compareIndianState supplierState receiverState of
-    Just jurisdiction -> Just jurisdiction
-    Nothing ->
-      case (normalizeGeoComponent supplierCity, normalizeGeoComponent receiverCity) of
-        (Just leftCity, Just rightCity) ->
-          Just $
-            if leftCity == rightCity
-              then IntraState
-              else InterState
-        _ -> Nothing
 
 normaliseGstin :: Maybe Text -> Maybe Text
 normaliseGstin mbGstin = do


### PR DESCRIPTION
Stacked on #15756.

## Description

Removes the city-name comparison fallback from the GST jurisdiction logic (`compareIndianPlace`) and determines jurisdiction by state comparison only (`compareIndianState`), returning unknown jurisdiction when state information is unavailable.

The city fallback was verified to be dead code: it only fires when **both** supplier and receiver cities are present, but `computeGstBreakdownForRideOwner` always passes `supplierCity = Nothing` and `computeGstBreakdownForPerson` always passes `receiverCity = Nothing`. Zero behavior change.

- `Lib.Finance.Utils.GstBreakdown`: drop `compareIndianPlace`, export `compareIndianState` instead (returns `Nothing` when either state is missing; state resolution must happen upstream)
- `SharedLogic.Finance.GstBreakdown`: `computeGstBreakdownByPlace` → `computeGstBreakdownByState`, city parameters removed, both call sites updated

The existing upstream fallback (unknown jurisdiction → intra-state CGST/SGST split + `logWarning`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)