### PR TITLE
backend/refactor: table-driven JV dispatch for SAP posting jobs

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Settlement/SAPDispatchCommon.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Settlement/SAPDispatchCommon.hs
@@ -34,6 +34,15 @@ module SharedLogic.Allocator.Jobs.Settlement.SAPDispatchCommon
     saveSapJournalEntries,
     formatSAPDate,
     formatSAPTime,
+
+    -- * Declarative JV posting
+    JVLeg (..),
+    JVSpec (..),
+    postJV,
+
+    -- * Journal entry transaction writer
+    JournalTxnRowFields (..),
+    saveJournalEntryTransactions,
   )
 where
 
@@ -60,10 +69,12 @@ import Kernel.Types.Id (Id (..))
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
 import qualified Lib.Finance.Core.Types as Finance
+import qualified Lib.Finance.Domain.Types.JournalEntryTransaction as JET
 import qualified Lib.Finance.Domain.Types.SapJournalEntry as SJE
 import Lib.Finance.SapJournalEntry.Interface (SapJournalEntryInput (..))
 import qualified Lib.Finance.SapJournalEntry.Service as SapJournalEntryService
 import Lib.Finance.Storage.Beam.BeamFlow (BeamFlow)
+import qualified Lib.Finance.Storage.Queries.JournalEntryTransaction as QJETExtra
 import qualified Lib.Finance.Storage.Queries.SapJournalEntry as QSJE
 import Lib.Scheduler
 import Lib.Scheduler.JobStorageType.DB.Table (SchedulerJobT)
@@ -632,3 +643,117 @@ handleSAPResponse label req result txnType txnCount mId mocid periodStart period
         (sapEntryId, sapBatchId) <- saveSapJournalEntries req (Just resp) SJE.SUCCESS txnType txnCount mId mocid periodStart periodEnd Nothing currency
         saveTransactionAction sapEntryId sapBatchId
         pure True
+
+-- ---------------------------------------------------------------------------
+-- Declarative JV posting
+-- ---------------------------------------------------------------------------
+
+-- | One GL leg of a journal voucher.
+data JVLeg = JVLeg
+  { accountKey :: Text,
+    direction :: PostingDirection,
+    amount :: HighPrecMoney
+  }
+
+-- | One JV event: legs + label + txn count + success callback.
+data JVSpec m = JVSpec
+  { label :: Text,
+    legs :: [JVLeg],
+    txnCount :: Int,
+    saveRows :: Id SJE.SapJournalEntry -> Text -> m () -- called on SUCCESS with (sapEntryId, batchId)
+  }
+
+-- | Build items for each leg, skip if all zero, post to SAP and persist.
+postJV ::
+  ( BeamFlow m r,
+    EncFlow m r,
+    CacheFlow m r,
+    CoreMetrics m,
+    Finance.HasActorInfo m r,
+    HasRequestId r,
+    MonadReader r m
+  ) =>
+  SAPConfig.SAPServiceConfig ->
+  Text ->
+  SAPDispatchJobParams ->
+  Currency ->
+  SJE.TransactionType ->
+  JVSpec m ->
+  m Bool
+postJV sapCfg token params currency txnType spec = do
+  let SAPDispatchJobParams
+        { merchantId = mId,
+          merchantOperatingCityId = mocid,
+          maxApiRetries = maxRetries,
+          startTime = fromTime,
+          endTime = toTime
+        } = params
+  bId <- getNextBatchId
+  items <-
+    forM (zip [1 :: Int ..] spec.legs) $ \(itemNum, leg) ->
+      mkItem bId (show itemNum) leg.accountKey sapCfg.accountMapping leg.direction leg.amount currency
+  let filtered = filterZeroItems items
+  if null filtered
+    then do
+      logInfo $ "No non-zero items for " <> spec.label <> ", skipping"
+      pure True
+    else do
+      logInfo $ "Dispatching " <> spec.label <> " to SAP, txnCount=" <> show spec.txnCount
+      req <- buildJournalRequestFromItems sapCfg spec.label fromTime filtered
+      logInfo $ "SAP journal entry request body = " <> show req
+      result <- callSAPWithRetry sapCfg token req spec.label maxRetries
+      handleSAPResponse spec.label req result txnType spec.txnCount mId mocid fromTime toTime currency spec.saveRows
+
+-- ---------------------------------------------------------------------------
+-- Journal Entry Transaction persistence (individual source transactions)
+-- ---------------------------------------------------------------------------
+
+-- | Per-row fields that vary between journal_entry_transaction writers.
+data JournalTxnRowFields = JournalTxnRowFields
+  { debitAmount :: HighPrecMoney,
+    creditAmount :: HighPrecMoney,
+    description :: Text,
+    referenceId :: Maybe Text,
+    referenceType :: Maybe JET.ReferenceType,
+    transactionType :: SJE.TransactionType,
+    status :: Text
+  }
+
+saveJournalEntryTransactions ::
+  (BeamFlow m r, Finance.HasActorInfo m r) =>
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
+  Id SJE.SapJournalEntry ->
+  Text ->
+  Currency ->
+  (row -> JournalTxnRowFields) ->
+  [row] ->
+  m ()
+saveJournalEntryTransactions mId mocId sapEntryId batchId currency projectRow rows = do
+  now <- getCurrentTime
+  aInfo <- asks (.actorInfo)
+  forM_ rows $ \row -> do
+    let fields = projectRow row
+    txnId <- generateGUID
+    QJETExtra.create
+      JET.JournalEntryTransaction
+        { id = Id txnId,
+          debitAmount = fields.debitAmount,
+          creditAmount = fields.creditAmount,
+          currency,
+          description = fields.description,
+          referenceId = fields.referenceId,
+          referenceType = fields.referenceType,
+          sapJournalEntryId = sapEntryId,
+          sapBatchId = batchId,
+          transactionType = fields.transactionType,
+          status = fields.status,
+          merchantId = mId.getId,
+          merchantOperatingCityId = mocId.getId,
+          createdAt = now,
+          updatedAt = now,
+          createdBy = aInfo.actorType,
+          createdById = aInfo.actorId,
+          updatedBy = aInfo.actorType,
+          updatedById = aInfo.actorId
+        }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Settlement/SAPReportDispatch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Settlement/SAPReportDispatch.hs
@@ -24,7 +24,7 @@ import qualified Domain.Types.MerchantOperatingCity as DMOC
 import Kernel.Beam.Lib.UtilsTH (HasSchemaName)
 import Kernel.External.Encryption ()
 import qualified Kernel.External.SAP.Config as SAPConfig
-import Kernel.External.SAP.Types (SAPJournalHeader (..), SAPJournalItem (..), SAPJournalRequest (..))
+import Kernel.External.SAP.Types (SAPJournalItem, SAPJournalRequest)
 import Kernel.Prelude
 import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
 import Kernel.Types.Id
@@ -34,7 +34,6 @@ import qualified Lib.Finance.Domain.Types.JournalEntryTransaction as JET
 import qualified Lib.Finance.Domain.Types.PgPaymentSettlementReport as PgDom
 import qualified Lib.Finance.Domain.Types.SapJournalEntry as SJE
 import Lib.Finance.Storage.Beam.BeamFlow (BeamFlow)
-import qualified Lib.Finance.Storage.Queries.JournalEntryTransaction as QJETExtra
 import Lib.Scheduler
 import Lib.Scheduler.JobStorageType.DB.Table (SchedulerJobT)
 import qualified Lib.Scheduler.JobStorageType.SchedulerType as JC
@@ -208,40 +207,10 @@ buildJournalRequest ::
   Currency ->
   m SAPJournalRequest
 buildJournalRequest sapCfg entryType amount fromTime currency = do
-  now <- getCurrentTime
-  let reqDate = formatSAPDate now
-      reqTime = formatSAPTime now
-      postingDate = formatSAPDate fromTime
-      acctMap = sapCfg.accountMapping
+  let acctMap = sapCfg.accountMapping
   bId <- getNextBatchId
-  items <- filterZeroItems <$> buildItems entryType acctMap bId currency amount
-  let header =
-        SAPJournalHeader
-          { msgtyp = Nothing,
-            batchId = bId,
-            requestDate = reqDate,
-            requestTime = reqTime,
-            headerdesc = show entryType,
-            bukrs = sapCfg.bukrs,
-            blart = sapCfg.blart,
-            budat = postingDate,
-            bldat = postingDate,
-            attrName1 = Nothing,
-            attrValue1 = Nothing,
-            attrName2 = Nothing,
-            attrValue2 = Nothing,
-            attrName3 = Nothing,
-            attrValue3 = Nothing,
-            attrName4 = Nothing,
-            attrValue4 = Nothing,
-            attrName5 = Nothing,
-            attrValue5 = Nothing,
-            belnr = Nothing,
-            gjahr = Nothing,
-            message = Nothing,
-            items = items
-          }
-  pure SAPJournalRequest {headers = [header]}
+  items <- buildItems entryType acctMap bId currency amount
+  buildJournalRequestFromItems sapCfg (show entryType) fromTime items
 
 -- ---------------------------------------------------------------------------
 -- Item builders per entry type
@@ -326,51 +295,17 @@ buildSubscriptionJournalRequest ::
   Currency ->
   m SAPJournalRequest
 buildSubscriptionJournalRequest sapCfg fromTime totals entryType currency = do
-  now <- getCurrentTime
-  let reqDate = formatSAPDate now
-      reqTime = formatSAPTime now
-      postingDate = formatSAPDate fromTime
-      acctMap = sapCfg.accountMapping
+  let acctMap = sapCfg.accountMapping
   bId <- getNextBatchId
-  filteredItems <-
-    filterZeroItems
-      <$> sequence
-        [ mkItem bId "1" "PG_CLEARING A/C" acctMap Debit totals.grossAmount currency,
-          mkItem bId "2" "DEFERRED_REVENUE A/C" acctMap Credit totals.netAmount currency,
-          mkItem bId "3" "CGST_PAYABLE A/C" acctMap Credit totals.cgst currency,
-          mkItem bId "4" "SGST_PAYABLE A/C" acctMap Credit totals.sgst currency,
-          mkItem bId "5" "IGST_PAYABLE A/C" acctMap Credit totals.igst currency
-        ]
-  let header =
-        SAPJournalHeader
-          { msgtyp = Nothing,
-            batchId = bId,
-            requestDate = reqDate,
-            requestTime = reqTime,
-            headerdesc = show entryType,
-            bukrs = sapCfg.bukrs,
-            blart = sapCfg.blart,
-            budat = postingDate,
-            bldat = postingDate,
-            attrName1 = Nothing,
-            attrValue1 = Nothing,
-            attrName2 = Nothing,
-            attrValue2 = Nothing,
-            attrName3 = Nothing,
-            attrValue3 = Nothing,
-            attrName4 = Nothing,
-            attrValue4 = Nothing,
-            attrName5 = Nothing,
-            attrValue5 = Nothing,
-            belnr = Nothing,
-            gjahr = Nothing,
-            message = Nothing,
-            items = filteredItems
-          }
-      debit = totals.grossAmount
-      credit = totals.netAmount + totals.cgst + totals.sgst + totals.igst
-  assertDebitEqualsCredit "SubscriptionPurchase" bId debit credit
-  pure SAPJournalRequest {headers = [header]}
+  items <-
+    sequence
+      [ mkItem bId "1" "PG_CLEARING A/C" acctMap Debit totals.grossAmount currency,
+        mkItem bId "2" "DEFERRED_REVENUE A/C" acctMap Credit totals.netAmount currency,
+        mkItem bId "3" "CGST_PAYABLE A/C" acctMap Credit totals.cgst currency,
+        mkItem bId "4" "SGST_PAYABLE A/C" acctMap Credit totals.sgst currency,
+        mkItem bId "5" "IGST_PAYABLE A/C" acctMap Credit totals.igst currency
+      ]
+  buildJournalRequestFromItems sapCfg (show entryType) fromTime items
 
 -- ---------------------------------------------------------------------------
 -- SAP Journal Entry persistence
@@ -411,33 +346,17 @@ saveSubscriptionTransactions ::
   Currency ->
   [SubscriptionTransactionRow] ->
   m ()
-saveSubscriptionTransactions mId mocId sapEntryId batchId currency rows = do
-  now <- getCurrentTime
-  aInfo <- asks (.actorInfo)
-  forM_ rows $ \row -> do
-    txnId <- generateGUID
-    QJETExtra.create
-      JET.JournalEntryTransaction
-        { id = Id txnId,
-          debitAmount = row.debitAmount,
-          creditAmount = row.creditAmount,
-          currency,
-          description = "Subscription Purchase",
-          referenceId = Just row.subscriptionId,
-          referenceType = Just JET.SubscriptionPurchase,
-          sapJournalEntryId = sapEntryId,
-          sapBatchId = batchId,
-          transactionType = SJE.SubscriptionPurchase,
-          status = row.status,
-          merchantId = mId.getId,
-          merchantOperatingCityId = mocId.getId,
-          createdAt = now,
-          updatedAt = now,
-          createdBy = aInfo.actorType,
-          createdById = aInfo.actorId,
-          updatedBy = aInfo.actorType,
-          updatedById = aInfo.actorId
-        }
+saveSubscriptionTransactions mId mocId sapEntryId batchId currency =
+  saveJournalEntryTransactions mId mocId sapEntryId batchId currency $ \row ->
+    JournalTxnRowFields
+      { debitAmount = row.debitAmount,
+        creditAmount = row.creditAmount,
+        description = "Subscription Purchase",
+        referenceId = Just row.subscriptionId,
+        referenceType = Just JET.SubscriptionPurchase,
+        transactionType = SJE.SubscriptionPurchase,
+        status = row.status
+      }
 
 savePGSettlementTransactions ::
   (BeamFlow m r, Finance.HasActorInfo m r) =>
@@ -448,33 +367,17 @@ savePGSettlementTransactions ::
   Currency ->
   [PGSettlementTransactionRow] ->
   m ()
-savePGSettlementTransactions mId mocId sapEntryId batchId currency rows = do
-  now <- getCurrentTime
-  aInfo <- asks (.actorInfo)
-  forM_ rows $ \row -> do
-    txnId <- generateGUID
-    QJETExtra.create
-      JET.JournalEntryTransaction
-        { id = Id txnId,
-          debitAmount = row.amount,
-          creditAmount = row.amount,
-          currency,
-          description = show row.txnType,
-          referenceId = row.subscriptionPurchaseId,
-          referenceType = JET.SubscriptionPurchase <$ row.subscriptionPurchaseId,
-          sapJournalEntryId = sapEntryId,
-          sapBatchId = batchId,
-          transactionType = pgTxnTypeToSJE row.txnType,
-          status = row.txnStatus,
-          merchantId = mId.getId,
-          merchantOperatingCityId = mocId.getId,
-          createdAt = now,
-          updatedAt = now,
-          createdBy = aInfo.actorType,
-          createdById = aInfo.actorId,
-          updatedBy = aInfo.actorType,
-          updatedById = aInfo.actorId
-        }
+savePGSettlementTransactions mId mocId sapEntryId batchId currency =
+  saveJournalEntryTransactions mId mocId sapEntryId batchId currency $ \row ->
+    JournalTxnRowFields
+      { debitAmount = row.amount,
+        creditAmount = row.amount,
+        description = show row.txnType,
+        referenceId = row.subscriptionPurchaseId,
+        referenceType = JET.SubscriptionPurchase <$ row.subscriptionPurchaseId,
+        transactionType = pgTxnTypeToSJE row.txnType,
+        status = row.txnStatus
+      }
 
 pgTxnTypeToSJE :: PgDom.TxnType -> SJE.TransactionType
 pgTxnTypeToSJE t = case t of

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Settlement/SAPRideRevenueDispatch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Settlement/SAPRideRevenueDispatch.hs
@@ -19,7 +19,6 @@ import qualified Domain.Types.MerchantOperatingCity as DMOC
 import Kernel.Beam.Lib.UtilsTH (HasSchemaName)
 import Kernel.External.Encryption ()
 import qualified Kernel.External.SAP.Config as SAPConfig
-import Kernel.External.SAP.Types (SAPJournalItem (..))
 import Kernel.Prelude
 import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
 import Kernel.Types.Id (Id (..))
@@ -28,7 +27,6 @@ import qualified Lib.Finance.Core.Types as Finance
 import qualified Lib.Finance.Domain.Types.JournalEntryTransaction as JET
 import qualified Lib.Finance.Domain.Types.SapJournalEntry as SJE
 import Lib.Finance.Storage.Beam.BeamFlow (BeamFlow)
-import qualified Lib.Finance.Storage.Queries.JournalEntryTransaction as QJETExtra
 import Lib.Scheduler
 import Lib.Scheduler.JobStorageType.DB.Table (SchedulerJobT)
 import qualified Lib.Scheduler.JobStorageType.SchedulerType as JC
@@ -158,294 +156,76 @@ dispatchRideRevenue ::
 dispatchRideRevenue sapCfg token params totals = do
   merchantOperatingCity <- CQMOC.findById params.merchantOperatingCityId >>= fromMaybeM (MerchantOperatingCityNotFound params.merchantOperatingCityId.getId)
   let currency = merchantOperatingCity.currency
-  onlineOk <-
-    uncurry
-      (dispatchRideFareRevRec sapCfg token params onlineRideRevRecLabel buyerAppReceivableAcct currency)
-      totals.onlineRideRevRec
-  settleOk <- uncurry (dispatchBuyerAppSettlement sapCfg token params currency) totals.buyerAppSettlement
-  offlineOk <-
-    uncurry
-      (dispatchRideFareRevRec sapCfg token params offlineCashRideLabel driverBalanceAcct currency)
-      totals.offlineCashRide
-  accrualOk <- uncurry (dispatchDriverEarningAccrual sapCfg token params currency) totals.driverEarningAccrual
-  payoutOk <- uncurry (dispatchPayout sapCfg token params currency) totals.payout
-  tdsOk <-
-    let (tdsTotals, deductionRows, reimbursementRows) = totals.tds
-     in dispatchTds sapCfg token params currency tdsTotals deductionRows reimbursementRows
-  rideSubOk <- uncurry (dispatchSubscriptionRevenue sapCfg token params subscriptionRideRevenueLabel currency) totals.subscriptionRideRevenue
-  expirySubOk <- uncurry (dispatchSubscriptionRevenue sapCfg token params subscriptionExpiryRevenueLabel currency) totals.subscriptionExpiryRevenue
-  pure $ onlineOk && settleOk && offlineOk && accrualOk && payoutOk && tdsOk && rideSubOk && expirySubOk
+  results <-
+    forM (mkJVSpecs params.merchantId params.merchantOperatingCityId currency totals) $
+      postJV sapCfg token params currency SJE.RevenueRecognition
+  pure $ and results
 
-postRevenueRecognitionJV ::
-  ( BeamFlow m r,
-    EncFlow m r,
-    CacheFlow m r,
-    CoreMetrics m,
-    Finance.HasActorInfo m r,
-    HasRequestId r,
-    MonadReader r m
-  ) =>
-  SAPConfig.SAPServiceConfig ->
-  Text ->
-  SAPDispatchJobParams ->
-  Text ->
-  JET.ReferenceType ->
-  Int ->
-  [SAPJournalItem] ->
+-- | One JVSpec per matrix event, in dispatch order.
+mkJVSpecs ::
+  (BeamFlow m r, Finance.HasActorInfo m r) =>
+  Id DM.Merchant ->
+  Id DMOC.MerchantOperatingCity ->
   Currency ->
-  [RevenueRecognitionTransactionRow] ->
-  m Bool
-postRevenueRecognitionJV sapCfg token params label refType txnCount items currency rows = do
-  let SAPDispatchJobParams
-        { merchantId = mId,
-          merchantOperatingCityId = mocid,
-          maxApiRetries = maxRetries,
-          startTime = fromTime,
-          endTime = toTime
-        } = params
-  let filtered = filterZeroItems items
-  if null filtered
-    then do
-      logInfo $ "No non-zero items for " <> label <> ", skipping"
-      pure True
-    else do
-      logInfo $ "Dispatching " <> label <> " to SAP, txnCount=" <> show txnCount
-      req <- buildJournalRequestFromItems sapCfg label fromTime filtered
-      logInfo $ "SAP journal entry request body = " <> show req
-      result <- callSAPWithRetry sapCfg token req label maxRetries
-      let saveTransactionAction sapEntryId sapBatchId =
-            saveRevenueRecognitionTransactions mId mocid sapEntryId sapBatchId label refType currency rows
-      handleSAPResponse label req result SJE.RevenueRecognition txnCount mId mocid fromTime toTime currency saveTransactionAction
+  RideRevenueTotals ->
+  [JVSpec m]
+mkJVSpecs mId mocid currency totals =
+  [ -- 1/3. Ride fare rev-rec (online or offline)
+    -- Online: Dr BUYER_APP_RECEIVABLE / Cr RIDE_FARE_REVENUE + GST
+    -- Online: Dr DRIVER_BALANCE / Cr RIDE_FARE_REVENUE + GST
+    mkSpec onlineRideRevRecLabel JET.Booking (rideFareRevRecLegs buyerAppReceivableAcct onlineTotals) onlineTotals.txnCount onlineRows,
+    -- 2. Buyer-app settlement: Dr BANK / Cr BUYER_APP_RECEIVABLE
+    mkSpec buyerAppSettlementLabel JET.Booking [JVLeg bankAcct Debit settleTotals.settledAmount, JVLeg buyerAppReceivableAcct Credit settleTotals.settledAmount] settleTotals.txnCount settleRows,
+    mkSpec offlineCashRideLabel JET.Booking (rideFareRevRecLegs driverBalanceAcct offlineTotals) offlineTotals.txnCount offlineRows,
+    -- 4. Driver earning accrual: Dr RIDE_FARE_REVENUE / Cr DRIVER_BALANCE
+    mkSpec driverEarningAccrualLabel JET.Booking [JVLeg rideFareRevenueAcct Debit accrualTotals.accrualAmount, JVLeg driverBalanceAcct Credit accrualTotals.accrualAmount] accrualTotals.txnCount accrualRows,
+    -- 5. Payout: two balanced JVs. Phase-1 both use the same WalletPayout total
+    --    (clearing is a same-day wash). Intended sources:
+    --      PayoutToClearing      = ledger WalletPayout (driver liability debit on SUCCESS)
+    --      PayoutClearingToBank  = pg_payout_settlement_report (PG/bank file; WS4 ingest, idealy separate scheduler job should be created)
+    mkSpec payoutToClearingLabel JET.Payout [JVLeg driverBalanceAcct Debit payoutTotals.payoutAmount, JVLeg payoutClearingAcct Credit payoutTotals.payoutAmount] payoutTotals.txnCount payoutRows,
+    -- Same amount as JV1 until WS4 wires pg_payout_settlement_report.
+    -- JV2: Dr PAYOUT_CLEARING / Cr BANK
+    mkSpec payoutClearingToBankLabel JET.Payout [JVLeg payoutClearingAcct Debit payoutTotals.payoutAmount, JVLeg bankAcct Credit payoutTotals.payoutAmount] payoutTotals.txnCount payoutRows,
+    -- 6. TDS: deduction Dr DRIVER_BALANCE / Cr TDS_PAYABLE; reimbursement Dr TDS_RECEIVABLE / Cr DRIVER_BALANCE
+    mkSpec tdsDeductionLabel JET.Booking [JVLeg driverBalanceAcct Debit tdsTotals.deductionAmount, JVLeg tdsPayableAcct Credit tdsTotals.deductionAmount] tdsTotals.deductionCount deductionRows,
+    mkSpec tdsReimbursementLabel JET.TdsReimbursementRequest [JVLeg tdsReceivableAcct Debit tdsTotals.reimbursementAmount, JVLeg driverBalanceAcct Credit tdsTotals.reimbursementAmount] tdsTotals.reimbursementCount reimbursementRows,
+    -- 7. Subscription revenue recognised: Dr DEFERRED_REVENUE / Cr SUBSCRIPTION_REVENUE
+    --    Ride vs expiry use the same legs, different description labels.
+    mkSpec subscriptionRideRevenueLabel JET.SubscriptionPurchase (subscriptionRevenueLegs rideSubTotals) rideSubTotals.txnCount rideSubRows,
+    mkSpec subscriptionExpiryRevenueLabel JET.SubscriptionPurchase (subscriptionRevenueLegs expirySubTotals) expirySubTotals.txnCount expirySubRows
+  ]
+  where
+    (onlineTotals, onlineRows) = totals.onlineRideRevRec
+    (settleTotals, settleRows) = totals.buyerAppSettlement
+    (offlineTotals, offlineRows) = totals.offlineCashRide
+    (accrualTotals, accrualRows) = totals.driverEarningAccrual
+    (payoutTotals, payoutRows) = totals.payout
+    (tdsTotals, deductionRows, reimbursementRows) = totals.tds
+    (rideSubTotals, rideSubRows) = totals.subscriptionRideRevenue
+    (expirySubTotals, expirySubRows) = totals.subscriptionExpiryRevenue
+    mkSpec label refType legs txnCount rows =
+      JVSpec
+        { label,
+          legs,
+          txnCount,
+          saveRows = \sapEntryId sapBatchId -> saveRevenueRecognitionTransactions mId mocid sapEntryId sapBatchId label refType currency rows
+        }
 
--- 1/3. Ride fare rev-rec (online or offline)
--- Online: Dr BUYER_APP_RECEIVABLE / Cr RIDE_FARE_REVENUE + GST
--- Online: Dr DRIVER_BALANCE / Cr RIDE_FARE_REVENUE + GST
-dispatchRideFareRevRec ::
-  ( BeamFlow m r,
-    EncFlow m r,
-    CacheFlow m r,
-    CoreMetrics m,
-    Finance.HasActorInfo m r,
-    HasRequestId r,
-    MonadReader r m
-  ) =>
-  SAPConfig.SAPServiceConfig ->
-  Text ->
-  SAPDispatchJobParams ->
-  Text ->
-  Text ->
-  Currency ->
-  RideFareRevRecTotals ->
-  [RevenueRecognitionTransactionRow] ->
-  m Bool
-dispatchRideFareRevRec _sapCfg _token _params label _debitAcct _currency totals _rows
-  | totals.grossAmount == 0 && totals.netAmount == 0 = do
-    logInfo $ "No " <> label <> " totals, skipping"
-    pure True
-dispatchRideFareRevRec sapCfg token params label debitAcct currency totals rows = do
-  let acctMap = sapCfg.accountMapping
-  bId <- getNextBatchId
-  items <-
-    sequence
-      [ mkItem bId "1" debitAcct acctMap Debit totals.grossAmount currency,
-        mkItem bId "2" rideFareRevenueAcct acctMap Credit totals.netAmount currency,
-        mkItem bId "3" cgstPayableAcct acctMap Credit totals.cgst currency,
-        mkItem bId "4" sgstPayableAcct acctMap Credit totals.sgst currency,
-        mkItem bId "5" igstPayableAcct acctMap Credit totals.igst currency
-      ]
-  let debit = totals.grossAmount
-      credit = totals.netAmount + totals.cgst + totals.sgst + totals.igst
-  assertDebitEqualsCredit label bId debit credit
-  postRevenueRecognitionJV sapCfg token params label JET.Booking totals.txnCount items currency rows
+rideFareRevRecLegs :: Text -> RideFareRevRecTotals -> [JVLeg]
+rideFareRevRecLegs debitAcct totals =
+  [ JVLeg debitAcct Debit totals.grossAmount,
+    JVLeg rideFareRevenueAcct Credit totals.netAmount,
+    JVLeg cgstPayableAcct Credit totals.cgst,
+    JVLeg sgstPayableAcct Credit totals.sgst,
+    JVLeg igstPayableAcct Credit totals.igst
+  ]
 
--- 2. Buyer-app settlement: Dr BANK / Cr BUYER_APP_RECEIVABLE
-dispatchBuyerAppSettlement ::
-  ( BeamFlow m r,
-    EncFlow m r,
-    CacheFlow m r,
-    CoreMetrics m,
-    Finance.HasActorInfo m r,
-    HasRequestId r,
-    MonadReader r m
-  ) =>
-  SAPConfig.SAPServiceConfig ->
-  Text ->
-  SAPDispatchJobParams ->
-  Currency ->
-  BuyerAppSettlementTotals ->
-  [RevenueRecognitionTransactionRow] ->
-  m Bool
-dispatchBuyerAppSettlement _ _ _params _currency totals _rows
-  | totals.settledAmount == 0 = do
-    logInfo "No buyer-app settlement totals, skipping"
-    pure True
-dispatchBuyerAppSettlement sapCfg token params currency totals rows = do
-  let acctMap = sapCfg.accountMapping
-  bId <- getNextBatchId
-  items <-
-    sequence
-      [ mkItem bId "1" bankAcct acctMap Debit totals.settledAmount currency,
-        mkItem bId "2" buyerAppReceivableAcct acctMap Credit totals.settledAmount currency
-      ]
-  postRevenueRecognitionJV sapCfg token params buyerAppSettlementLabel JET.Booking totals.txnCount items currency rows
-
--- 4. Driver earning accrual: Dr RIDE_FARE_REVENUE / Cr DRIVER_BALANCE
-dispatchDriverEarningAccrual ::
-  ( BeamFlow m r,
-    EncFlow m r,
-    CacheFlow m r,
-    CoreMetrics m,
-    Finance.HasActorInfo m r,
-    HasRequestId r,
-    MonadReader r m
-  ) =>
-  SAPConfig.SAPServiceConfig ->
-  Text ->
-  SAPDispatchJobParams ->
-  Currency ->
-  DriverEarningAccrualTotals ->
-  [RevenueRecognitionTransactionRow] ->
-  m Bool
-dispatchDriverEarningAccrual _ _ _params _currency totals _rows
-  | totals.accrualAmount == 0 = do
-    logInfo "No driver earning accrual totals, skipping"
-    pure True
-dispatchDriverEarningAccrual sapCfg token params currency totals rows = do
-  let acctMap = sapCfg.accountMapping
-  bId <- getNextBatchId
-  items <-
-    sequence
-      [ mkItem bId "1" rideFareRevenueAcct acctMap Debit totals.accrualAmount currency,
-        mkItem bId "2" driverBalanceAcct acctMap Credit totals.accrualAmount currency
-      ]
-  postRevenueRecognitionJV sapCfg token params driverEarningAccrualLabel JET.Booking totals.txnCount items currency rows
-
--- 5. Payout: two balanced JVs. Phase-1 both use the same WalletPayout total
---    (clearing is a same-day wash). Intended sources:
---      PayoutToClearing      = ledger WalletPayout (driver liability debit on SUCCESS)
---      PayoutClearingToBank  = pg_payout_settlement_report (PG/bank file; WS4 ingest, idealy separate scheduler job should be created)
-dispatchPayout ::
-  ( BeamFlow m r,
-    EncFlow m r,
-    CacheFlow m r,
-    CoreMetrics m,
-    Finance.HasActorInfo m r,
-    HasRequestId r,
-    MonadReader r m
-  ) =>
-  SAPConfig.SAPServiceConfig ->
-  Text ->
-  SAPDispatchJobParams ->
-  Currency ->
-  PayoutTotals ->
-  [RevenueRecognitionTransactionRow] ->
-  m Bool
-dispatchPayout _ _ _params _currency totals _rows
-  | totals.payoutAmount == 0 = do
-    logInfo "No payout totals, skipping"
-    pure True
-dispatchPayout sapCfg token params currency totals rows = do
-  let acctMap = sapCfg.accountMapping
-      amount = totals.payoutAmount
-  bId1 <- getNextBatchId
-  items1 <-
-    sequence
-      [ mkItem bId1 "1" driverBalanceAcct acctMap Debit amount currency,
-        mkItem bId1 "2" payoutClearingAcct acctMap Credit amount currency
-      ]
-  ok1 <- postRevenueRecognitionJV sapCfg token params payoutToClearingLabel JET.Payout totals.txnCount items1 currency rows
-  -- Same amount as JV1 until WS4 wires pg_payout_settlement_report.
-  -- JV2: Dr PAYOUT_CLEARING / Cr BANK
-  bId2 <- getNextBatchId
-  items2 <-
-    sequence
-      [ mkItem bId2 "1" payoutClearingAcct acctMap Debit amount currency,
-        mkItem bId2 "2" bankAcct acctMap Credit amount currency
-      ]
-  ok2 <- postRevenueRecognitionJV sapCfg token params payoutClearingToBankLabel JET.Payout totals.txnCount items2 currency rows
-  pure $ ok1 && ok2
-
--- 6. TDS: deduction Dr DRIVER_BALANCE / Cr TDS_PAYABLE; reimbursement Dr TDS_RECEIVABLE / Cr DRIVER_BALANCE
-dispatchTds ::
-  ( BeamFlow m r,
-    EncFlow m r,
-    CacheFlow m r,
-    CoreMetrics m,
-    Finance.HasActorInfo m r,
-    HasRequestId r,
-    MonadReader r m
-  ) =>
-  SAPConfig.SAPServiceConfig ->
-  Text ->
-  SAPDispatchJobParams ->
-  Currency ->
-  TdsTotals ->
-  [RevenueRecognitionTransactionRow] ->
-  [RevenueRecognitionTransactionRow] ->
-  m Bool
-dispatchTds sapCfg token params currency totals deductionRows reimbursementRows = do
-  dedOk <-
-    if totals.deductionAmount == 0
-      then do
-        logInfo "No TDS deduction totals, skipping"
-        pure True
-      else do
-        let acctMap = sapCfg.accountMapping
-        bId <- getNextBatchId
-        items <-
-          sequence
-            [ mkItem bId "1" driverBalanceAcct acctMap Debit totals.deductionAmount currency,
-              mkItem bId "2" tdsPayableAcct acctMap Credit totals.deductionAmount currency
-            ]
-        postRevenueRecognitionJV sapCfg token params tdsDeductionLabel JET.Booking totals.deductionCount items currency deductionRows
-  reimbOk <-
-    if totals.reimbursementAmount == 0
-      then do
-        logInfo "No TDS reimbursement totals, skipping"
-        pure True
-      else do
-        let acctMap = sapCfg.accountMapping
-        bId <- getNextBatchId
-        items <-
-          sequence
-            [ mkItem bId "1" tdsReceivableAcct acctMap Debit totals.reimbursementAmount currency,
-              mkItem bId "2" driverBalanceAcct acctMap Credit totals.reimbursementAmount currency
-            ]
-        postRevenueRecognitionJV sapCfg token params tdsReimbursementLabel JET.TdsReimbursementRequest totals.reimbursementCount items currency reimbursementRows
-  pure $ dedOk && reimbOk
-
--- 7. Subscription revenue recognised: Dr DEFERRED_REVENUE / Cr SUBSCRIPTION_REVENUE
---    Ride vs expiry use the same legs, different description labels.
-dispatchSubscriptionRevenue ::
-  ( BeamFlow m r,
-    EncFlow m r,
-    CacheFlow m r,
-    CoreMetrics m,
-    Finance.HasActorInfo m r,
-    HasRequestId r,
-    MonadReader r m
-  ) =>
-  SAPConfig.SAPServiceConfig ->
-  Text ->
-  SAPDispatchJobParams ->
-  Text ->
-  Currency ->
-  SubscriptionRevenueTotals ->
-  [RevenueRecognitionTransactionRow] ->
-  m Bool
-dispatchSubscriptionRevenue _ _ _params label _currency totals _rows
-  | totals.recognizedAmount == 0 = do
-    logInfo $ "No " <> label <> " totals, skipping"
-    pure True
-dispatchSubscriptionRevenue sapCfg token params label currency totals rows = do
-  let acctMap = sapCfg.accountMapping
-  bId <- getNextBatchId
-  items <-
-    sequence
-      [ mkItem bId "1" deferredRevenueAcct acctMap Debit totals.recognizedAmount currency,
-        mkItem bId "2" subscriptionRevenueAcct acctMap Credit totals.recognizedAmount currency
-      ]
-  postRevenueRecognitionJV sapCfg token params label JET.SubscriptionPurchase totals.txnCount items currency rows
+subscriptionRevenueLegs :: SubscriptionRevenueTotals -> [JVLeg]
+subscriptionRevenueLegs totals =
+  [ JVLeg deferredRevenueAcct Debit totals.recognizedAmount,
+    JVLeg subscriptionRevenueAcct Credit totals.recognizedAmount
+  ]
 
 scheduleNextRideRevenueJob ::
   ( BeamFlow m r,
@@ -475,33 +255,17 @@ saveRevenueRecognitionTransactions ::
   Currency ->
   [RevenueRecognitionTransactionRow] ->
   m ()
-saveRevenueRecognitionTransactions mId mocId sapEntryId batchId label refType currency rows = do
-  now <- getCurrentTime
-  aInfo <- asks (.actorInfo)
-  forM_ rows $ \row -> do
-    txnId <- generateGUID
-    QJETExtra.create
-      JET.JournalEntryTransaction
-        { id = Id txnId,
-          debitAmount = row.amount,
-          creditAmount = row.amount,
-          currency,
-          description = label,
-          referenceId = Just row.referenceId,
-          referenceType = Just refType,
-          sapJournalEntryId = sapEntryId,
-          sapBatchId = batchId,
-          transactionType = SJE.RevenueRecognition,
-          status = row.txnStatus,
-          merchantId = mId.getId,
-          merchantOperatingCityId = mocId.getId,
-          createdAt = now,
-          updatedAt = now,
-          createdBy = aInfo.actorType,
-          createdById = aInfo.actorId,
-          updatedBy = aInfo.actorType,
-          updatedById = aInfo.actorId
-        }
+saveRevenueRecognitionTransactions mId mocId sapEntryId batchId label refType currency =
+  saveJournalEntryTransactions mId mocId sapEntryId batchId currency $ \row ->
+    JournalTxnRowFields
+      { debitAmount = row.amount,
+        creditAmount = row.amount,
+        description = label,
+        referenceId = Just row.referenceId,
+        referenceType = Just refType,
+        transactionType = SJE.RevenueRecognition,
+        status = row.txnStatus
+      }
 
 -- ---------------------------------------------------------------------------
 -- Helper functions


### PR DESCRIPTION
Stacked on #16049. Structural refactor of the SAP dispatch jobs; SAP calls, DB writes, amounts, labels, and account keys are unchanged.

## Changes (+236 / −447)

- **`JVSpec`/`postJV` in `SAPDispatchCommon`**: each journal voucher is now declared as data — `JVSpec {label, legs :: [JVLeg], txnCount, saveRows}` with `JVLeg {accountKey, direction, amount}` — and one generic `postJV` reproduces the previous per-event skeleton (batch id → items → zero-filter/skip → build+assert → SAP call with retry → response handling → drill-down rows).
- **`SAPRideRevenueDispatch`**: the seven `dispatch*` functions and `postRevenueRecognitionJV` are replaced by a pure `mkJVSpecs :: RideRevenueTotals -> ... -> [JVSpec]` table (payout contributes two specs, TDS two, the online/offline rev-rec variants are one parameterized entry) folded with `postJV`. Event order, labels, legs, amounts, txnCounts, and the all-events-attempted-then-ANDed semantics are identical. Adding a matrix event is now a data change.
- **`SAPReportDispatch`**: its two hand-rolled 25-field `SAPJournalHeader` builders now go through the shared `buildJournalRequestFromItems`; its two `journal_entry_transaction` writers and the ride job's writer now share one projection-parameterized `saveJournalEntryTransactions`. Its dispatch control flow is untouched (its guard/log semantics differ from the ride job's).

## Known behavior deltas (all edge-path, called out for review)

1. Zero-total ride-revenue events now log `postJV`'s "No non-zero items for <label>, skipping" instead of the seven bespoke "No <x> totals, skipping" lines.
2. Zero-total events consume a batch id and resolve account configs before skipping — batch-id gaps on zero days, and a missing SAP account config now fails even on a zero day (arguably a fail-fast improvement).
3. PG-settlement requests now pass through the shared debit=credit assert (previously unasserted; its two legs are always equal, so it cannot fire today).
4. A rev-rec event with gross==0, net==0 but non-zero GST would now throw a balance-mismatch error instead of silently skipping — this state is arithmetically impossible from `fetchRideRevenueTotals` (gross ≡ net+GST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)