### PR TITLE
backend/enh: fixed PerMinRate fare param

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FullFarePolicyProgressiveDetailsPerMinRateSection.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/FullFarePolicyProgressiveDetailsPerMinRateSection.yaml
@@ -17,7 +17,7 @@ FullFarePolicyProgressiveDetailsPerMinRateSection:
     currency: "'INR'"
 
   constraints:
-    farePolicyId: PrimaryKey
+    farePolicyId: "PrimaryKey | SecondaryKey"
     rideDurationInMin: PrimaryKey
 
   excludedFields:

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FullFarePolicyProgressiveDetailsPerMinRateSection.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Storage/Beam/FullFarePolicyProgressiveDetailsPerMinRateSection.hs
@@ -29,6 +29,6 @@ instance B.Table FullFarePolicyProgressiveDetailsPerMinRateSectionT where
 
 type FullFarePolicyProgressiveDetailsPerMinRateSection = FullFarePolicyProgressiveDetailsPerMinRateSectionT Identity
 
-$(enableKVPG ''FullFarePolicyProgressiveDetailsPerMinRateSectionT ['farePolicyId, 'rideDurationInMin] [])
+$(enableKVPG ''FullFarePolicyProgressiveDetailsPerMinRateSectionT ['farePolicyId, 'rideDurationInMin] [['farePolicyId]])
 
 $(mkTableInstances ''FullFarePolicyProgressiveDetailsPerMinRateSectionT "fare_policy_progressive_details_per_min_rate_section")


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
FullFarePolicyProgressiveDetailsPerMinRateSectionT didn't have the fare-policy id as key in redis
it is query based on that falling back to DB and hence not able to find



### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fare policy data handling by allowing `farePolicyId` to be used as either a primary or secondary key.
  * Updated fare policy lookups to recognize `farePolicyId` as a unique identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->