### PR TITLE
fix: frfs gtfs fulfillment id as route code

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnSearch.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnSearch.hs
@@ -43,7 +43,7 @@ import Domain.Types.MerchantOperatingCity
 import qualified Domain.Types.StationType as Station
 import qualified Domain.Types.StopFare as StopFare
 import qualified Domain.Types.Trip as DTripTypes
-import EulerHS.Prelude (comparing, toStrict)
+import EulerHS.Prelude (comparing, toStrict, (<|>))
 import Kernel.Beam.Functions
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto.Config
@@ -798,23 +798,24 @@ extractGtfsPage req =
       let desc = loc.locationDescriptor
           (lat, lon) = parseGtfsGps loc.locationGps
       pure API.FRFSGtfsStopAPI {code = code, name = desc >>= (.descriptorName), lat = lat, lon = lon}
-    routeCodeOf f = do
-      let tags = fromMaybe [] f.fulfillmentTags
-      rid <- SpecUtils.getTag "ROUTE_INFO" "ROUTE_ID" tags
-      pure $ T.strip rid <> maybe "" ("_" <>) (SpecUtils.getTag "ROUTE_INFO" "ROUTE_DIRECTION" tags)
+    routeIdTag f = T.strip <$> SpecUtils.getTag "ROUTE_INFO" "ROUTE_ID" (fromMaybe [] f.fulfillmentTags)
+    routeIdTagWithDirection f =
+      (\rid -> rid <> maybe "" ("_" <>) (SpecUtils.getTag "ROUTE_INFO" "ROUTE_DIRECTION" (fromMaybe [] f.fulfillmentTags))) <$> routeIdTag f
+    routeCodeFor f
+      | f.fulfillmentType == Just "ROUTE" = f.fulfillmentId <|> routeIdTagWithDirection f
+      | otherwise = routeIdTagWithDirection f
     toRoute f = do
-      let tags = fromMaybe [] f.fulfillmentTags
-      rid <- SpecUtils.getTag "ROUTE_INFO" "ROUTE_ID" tags
-      code <- routeCodeOf f
+      code <- routeCodeFor f
+      let shortName = fromMaybe code (routeIdTag f)
       pure
         API.FRFSGtfsRouteAPI
           { code = code,
-            shortName = T.strip rid,
+            shortName = shortName,
             vehicleType = f.fulfillmentVehicle >>= (.vehicleCategory),
             variant = f.fulfillmentVehicle >>= (.vehicleVariant)
           }
     toRouteStops f =
-      case routeCodeOf f of
+      case routeCodeFor f of
         Nothing -> []
         Just code ->
           mapMaybe


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved route identification during transit search.
  - Route IDs now consistently incorporate available direction information.
  - Prioritizes fulfillment-based route identifiers while retaining a fallback option.
  - Standardized route and stop details using the same route-code logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->