### PR TITLE
backend/fix: gate PhotoPending on the pass actually requiring a photo

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Pass.hs
@@ -509,6 +509,17 @@ validateRequiredDocuments mbProfilePicture mbPassPhotoMediaId person requiredDoc
     let missingDocNames = show missingDocs
     throwError $ InvalidRequest $ "Missing required documents: " <> missingDocNames
 
+passRequiresDocument ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  DPass.PassDocumentType ->
+  DPurchasedPassPayment.PurchasedPassPayment ->
+  m Bool
+passRequiresDocument docType purchasedPassPayment =
+  maybe
+    (pure True)
+    (fmap (maybe True (elem docType . (.documentsRequired))) . CQPass.findById)
+    purchasedPassPayment.passId
+
 -- Check if person has a specific document
 hasDocument :: Maybe Text -> Maybe (Id.Id DMF.MediaFile) -> DP.Person -> DPass.PassDocumentType -> Bool
 hasDocument mbProfilePicture mbPassPhotoMediaId person docType = case docType of
@@ -1037,7 +1048,8 @@ passOrderStatusHandler paymentOrderId _merchantId status = do
     (Just purchasedPassPayment, Just purchasedPass) -> do
       let isDashboard = fromMaybe False purchasedPassPayment.isDashboard
       let hasProfilePicture = isJust purchasedPass.profilePicture || isJust purchasedPass.passPhotoMediaId
-      let mbPassStatus = convertPaymentStatusToPurchasedPassStatus hasProfilePicture (purchasedPassPayment.startDate > DT.utctDay istTime) status
+      photoRequired <- passRequiresDocument DPass.ProfilePicture purchasedPassPayment
+      let mbPassStatus = convertPaymentStatusToPurchasedPassStatus (hasProfilePicture || not photoRequired) (purchasedPassPayment.startDate > DT.utctDay istTime) status
       let activeLikeStatuses = [DPurchasedPass.Active, DPurchasedPass.PreBooked, DPurchasedPass.PhotoPending]
       let refundStatuses = [DPurchasedPass.RefundPending, DPurchasedPass.RefundInitiated, DPurchasedPass.RefundFailed, DPurchasedPass.Refunded]
       mbDuplicateActivePayment <-
@@ -1139,8 +1151,8 @@ passOrderStatusHandler paymentOrderId _merchantId status = do
       logError $ "Purchased pass not found for paymentOrderId: " <> paymentOrderId.getId
       return (DPayment.FulfillmentPending, Nothing, Nothing)
   where
-    convertPaymentStatusToPurchasedPassStatus hasProfilePicture futureDatePass = \case
-      Payment.CHARGED -> if hasProfilePicture then if futureDatePass then Just DPurchasedPass.PreBooked else Just DPurchasedPass.Active else Just DPurchasedPass.PhotoPending
+    convertPaymentStatusToPurchasedPassStatus photoSatisfied futureDatePass = \case
+      Payment.CHARGED -> if photoSatisfied then if futureDatePass then Just DPurchasedPass.PreBooked else Just DPurchasedPass.Active else Just DPurchasedPass.PhotoPending
       -- There can be a CHARGED transaction for Same Order even on Failure, so we should not mark the Pass as FAILED.
       -- Payment.AUTHENTICATION_FAILED -> Just DPurchasedPass.Failed
       -- Payment.AUTHORIZATION_FAILED -> Just DPurchasedPass.Failed
@@ -1190,6 +1202,8 @@ updatePurchasedPass mbClientSdkVersion purchasedPass today now = do
       [DPurchasedPass.PreBooked, DPurchasedPass.Active, DPurchasedPass.PhotoPending]
       today
 
+  photoRequired <- maybe (pure True) (passRequiresDocument DPass.ProfilePicture) (listToMaybe latestPayments)
+
   case listToMaybe latestPayments of
     Just firstPayment ->
       let newProfilePicture = firstPayment.profilePicture <|> mbRefilledPhoto <|> purchasedPass.profilePicture
@@ -1203,7 +1217,7 @@ updatePurchasedPass mbClientSdkVersion purchasedPass today now = do
 
           newStatus
             | firstPayment.endDate < today = DPurchasedPass.Expired
-            | not hasPhoto = DPurchasedPass.PhotoPending
+            | not hasPhoto && photoRequired = DPurchasedPass.PhotoPending
             | firstPayment.startDate <= today = DPurchasedPass.Active
             | otherwise = DPurchasedPass.PreBooked
 

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/DailyPassStatusUpdate.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/DailyPassStatusUpdate.hs
@@ -1,8 +1,10 @@
 module SharedLogic.Scheduler.Jobs.DailyPassStatusUpdate where
 
+import Data.List (nub)
 import qualified Data.Time as Time
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Pass as DPass
 import qualified Domain.Types.PurchasedPass as DPurchasedPass
 import Kernel.External.Types (SchedulerFlow)
 import Kernel.Prelude
@@ -14,6 +16,7 @@ import Lib.Scheduler
 import Lib.Scheduler.JobStorageType.SchedulerType (createJobIn)
 import SharedLogic.JobScheduler
 import Storage.Beam.SchedulerJob ()
+import qualified Storage.CachedQueries.Pass as CQPass
 import Storage.ConfigPilot.Config.RiderConfig (RiderConfigDimensions (..))
 import qualified Storage.Queries.PurchasedPass as QPurchasedPass
 import qualified Storage.Queries.PurchasedPassPayment as QPurchasedPassPayment
@@ -104,9 +107,29 @@ activateBatch merchantOpCityId today budget = do
   let passIds = map (.id) passes
   QPurchasedPass.updateStatusByIds DPurchasedPass.Active passIds
   QPurchasedPassPayment.activatePreBookedPaymentsByPurchasedPassIds passIds today
-  QPurchasedPass.updateStatusToPhotoPendingByIds passIds today
-  QPurchasedPassPayment.updateStatusToPhotoPendingByPurchasedPassIds passIds today
+  photoPassCodes <- passCodesRequiringPhoto passes
+  QPurchasedPass.updateStatusToPhotoPendingByIds passIds photoPassCodes today
+  QPurchasedPassPayment.updateStatusToPhotoPendingByPurchasedPassIds passIds photoPassCodes today
   pure (length passes)
+
+-- Codes of the passes in this batch that actually ask for a photo. Enabled and disabled
+-- passes both count: retiring a product must not stop collecting photos from the riders
+-- still holding it.
+passCodesRequiringPhoto ::
+  ( EsqDBFlow m r,
+    CacheFlow m r,
+    MonadFlow m
+  ) =>
+  [DPurchasedPass.PurchasedPass] ->
+  m [Text]
+passCodesRequiringPhoto purchasedPasses = do
+  let passTypeIds = nub $ map (.passTypeId) purchasedPasses
+  passes <-
+    concat
+      <$> mapM
+        (\passTypeId -> (<>) <$> CQPass.findAllByPassTypeIdAndEnabled passTypeId True <*> CQPass.findAllByPassTypeIdAndEnabled passTypeId False)
+        passTypeIds
+  pure [pass.code | pass <- passes, DPass.ProfilePicture `elem` pass.documentsRequired]
 
 scheduleTomorrow ::
   ( EsqDBFlow m r,

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassExtra.hs
@@ -154,15 +154,18 @@ updateStatusByIds status purchasedPassIds = do
 updateStatusToPhotoPendingByIds ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
   [Id DPurchasedPass.PurchasedPass] ->
+  [Text] ->
   Day ->
   m ()
-updateStatusToPhotoPendingByIds [] _ = pure ()
-updateStatusToPhotoPendingByIds purchasedPassIds today = do
+updateStatusToPhotoPendingByIds [] _ _ = pure ()
+updateStatusToPhotoPendingByIds _ [] _ = pure ()
+updateStatusToPhotoPendingByIds purchasedPassIds photoPassCodes today = do
   now <- getCurrentTime
   updateWithKV
     [Se.Set Beam.status DPurchasedPass.PhotoPending, Se.Set Beam.updatedAt now]
     [ Se.And
         [ Se.Is Beam.id $ Se.In (map getId purchasedPassIds),
+          Se.Is Beam.passCode $ Se.In photoPassCodes,
           Se.Is Beam.startDate $ Se.LessThanOrEq today,
           Se.Is Beam.endDate $ Se.GreaterThanOrEq today,
           Se.Is Beam.passPhotoMediaId $ Se.Eq Nothing,

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassPaymentExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PurchasedPassPaymentExtra.hs
@@ -53,15 +53,18 @@ expireOlderPaymentsByPurchasedPassIds purchasedPassIds endDate = do
 updateStatusToPhotoPendingByPurchasedPassIds ::
   (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
   [Id DPurchasedPass.PurchasedPass] ->
+  [Text] ->
   Day ->
   m ()
-updateStatusToPhotoPendingByPurchasedPassIds [] _ = pure ()
-updateStatusToPhotoPendingByPurchasedPassIds purchasedPassIds today = do
+updateStatusToPhotoPendingByPurchasedPassIds [] _ _ = pure ()
+updateStatusToPhotoPendingByPurchasedPassIds _ [] _ = pure ()
+updateStatusToPhotoPendingByPurchasedPassIds purchasedPassIds photoPassCodes today = do
   now <- getCurrentTime
   updateWithKV
     [Se.Set Beam.status DPurchasedPass.PhotoPending, Se.Set Beam.updatedAt now]
     [ Se.And
         [ Se.Is Beam.purchasedPassId $ Se.In (map getId purchasedPassIds),
+          Se.Is Beam.passCode $ Se.In photoPassCodes,
           Se.Is Beam.status $ Se.In [DPurchasedPass.PreBooked, DPurchasedPass.Active],
           Se.Is Beam.startDate $ Se.LessThanOrEq today,
           Se.Is Beam.endDate $ Se.GreaterThanOrEq today,


### PR DESCRIPTION
Replaces #16424, reworked per review: the photo condition is gated rather than bypassed, so `PreBooked` / `Expired` still win where they should.

## Problem

Riders buy **ULLA1DAY**, payment succeeds, and the pass never appears in the app. Observed on UAT — created, then updated ~15s later by the payment webhook:

```
ULLA1DAY  PhotoPending  start/end 2026-08-25  created 08:28:17  updated 08:28:32
ULLA1DAY  PhotoPending  start/end 2026-08-25  created 08:22:26  updated 08:22:44
```

The money is fine. The status is wrong, and the wrong status makes the pass unreachable.

## Root cause

Status is decided purely on whether a photo is attached, never on whether the pass asks for one — in both the payment webhook and the pass-list reconcile:

```haskell
Payment.CHARGED -> if hasProfilePicture then … else Just PhotoPending
| not hasPhoto  = DPurchasedPass.PhotoPending
```

`ULLA1DAY` has `documentsRequired = []`. `/availablePasses` reports no documents, and `validateRequiredDocuments` lets the purchase through without a photo. Only this path disagrees.

For a `TouristPass` that is a dead end: `getMultimodalPassList` drops every non-Active tourist pass (`isInactiveTouristPass`), so the pass is hidden from the rider who paid for it — and the screen that would attach a photo is reached *through* that list. `PhotoPending -> Active` only fires once a photo exists, so it never resolves. Even `?status=PhotoPending` can't surface it, because the filter runs after the status query.

## Fix

Gate both decisions on `ProfilePicture ∈ pass.documentsRequired`, reached via `purchased_pass_payment.pass_id`.

Both sites are required — the reconcile re-derives status on every list load and would silently undo a webhook-only fix.

The `Expired / PhotoPending / Active / PreBooked` ladder is untouched; only the photo condition moves. A pass with no photo requirement now follows the same future-date branching as one that has its photo, instead of short-circuiting to `Active` and losing `PreBooked`.

`CQPass.findById` is in-mem + Redis cached (1h), so this costs nothing meaningful in the list loop. Unknown pass row, or a legacy payment with no `passId`, keeps current behaviour.

**Existing stuck rows self-heal**: the reconcile runs on every pass-list load, ahead of the filter, so an in-date `PhotoPending` pass flips to `Active` next time the rider opens the app — no backfill. Passes already past their end date go to `Expired` instead, so for a 1-day pass only same-day rows recover.

## Verification

- Reproduced on UAT: bought `ulla-unlimited-1day`, then `/v2/multimodal/pass/list` returned `[]` for **every** status filter (`Pending`, `PhotoPending`, `Active`, `Expired`, `Failed`)
- Control: same flow with `mtc-frfs-executive-100` (a `RegularPass`) **does** appear — isolating the tourist filter as what hides it
- DB confirms the rows exist as `PhotoPending` with the webhook timestamps above

Not built locally — no `dist-newstyle` in this checkout; leaving the typecheck to CI.

## Related, deliberately not in this PR

1. **A paid pass being hidden at all.** Even a legitimately `PhotoPending` pass — one that genuinely requires a photo — is invisible to its owner, with the upload screen behind that same list. Showing it with an "upload photo" affordance is a product call, and shouldn't block this fix.
2. **`isJust` treats `Just ""` as a photo.** Confirmed on UAT: a rider with `length(profile_picture) = 0` and `pass_photo_media_id = NULL` is `Active`. Empty-string vs `NULL` is the only difference between the rider whose pass works and the two who are stuck. Tightening that check **must not ship before this PR** — on its own it would flip every ULLA pass currently Active on `''` into `PhotoPending`, where they'd vanish behind the same filter. Better fixed at the write, so one place stops it rather than every reader remembering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pass photo statuses now accurately reflect whether the purchased pass requires a profile photo.
  * Prevented unnecessary photo requests for passes that do not require one.
  * Preserved existing behavior for unknown passes and legacy payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->