### PR TITLE
backend/chore: index purchased_pass_payment secondary keys

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/PurchasedPass.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/PurchasedPass.yaml
@@ -312,6 +312,7 @@ PurchasedPassPayment:
 
   extraOperations:
     - EXTRA_QUERY_FILE
+    - GENERATE_INDEXES
 
 PassVerifyTransaction:
   tableName: pass_verify_transaction

--- a/Backend/dev/migrations-read-only/rider-app/purchased_pass_payment.sql
+++ b/Backend/dev/migrations-read-only/rider-app/purchased_pass_payment.sql
@@ -69,3 +69,9 @@ ALTER TABLE atlas_app.purchased_pass_payment ADD COLUMN pass_photo_change_count 
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.purchased_pass_payment ADD COLUMN activated_at timestamp with time zone ;
+
+
+------- SQL updates -------
+
+CREATE INDEX CONCURRENTLY purchased_pass_payment_idx_order_id ON atlas_app.purchased_pass_payment USING btree (order_id);
+CREATE INDEX CONCURRENTLY purchased_pass_payment_idx_purchased_pass_id ON atlas_app.purchased_pass_payment USING btree (purchased_pass_id);


### PR DESCRIPTION
## What

Enables `GENERATE_INDEXES` on `PurchasedPassPayment`, producing btree indexes for its declared secondary keys:

```sql
CREATE INDEX CONCURRENTLY purchased_pass_payment_idx_order_id
  ON atlas_app.purchased_pass_payment USING btree (order_id);
CREATE INDEX CONCURRENTLY purchased_pass_payment_idx_purchased_pass_id
  ON atlas_app.purchased_pass_payment USING btree (purchased_pass_id);
```

## Why

The table had no indexes beyond its primary key, yet every query filters on one of these two:

| column | queries |
|---|---|
| `order_id` | `findOneByPaymentOrderId`, `updateStatusByOrderId`, `updateSdkVersionByOrderId` |
| `purchased_pass_id` | `findAllByPurchasedPassId`, `findAllByPurchasedPassIdAndStatus`, `updatePersonIdByPurchasedPassId`, `expireOlderPaymentsByPurchasedPassId`, `activatePreBookedPaymentsByPurchasedPassIds`, `updateStatusToPhotoPendingByPurchasedPassIds` |

`findAllByPurchasedPassIdAndStatus` runs once per pass on every pass-list load, and `findOneByPaymentOrderId` is the payment webhook's first lookup.

Both indexes are `CONCURRENTLY`, so no table lock on deploy.

## Note

`personId` is declared `"!SecondaryKey"` and did **not** get an index — `GENERATE_INDEXES` appears to emit only for plain `SecondaryKey`. Several queries filter on `person_id`, so that may be worth a follow-up; leaving it out of this PR rather than hand-writing a migration the generator would not reproduce.

Generated output only — the SQL was produced by `run-generator`, not written by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved purchased pass payment data access by adding indexes for order and purchased pass lookups.
* **Maintenance**
  * Enabled automatic index generation for purchased pass payment records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->