### PR TITLE
backend/fix: sending duplicate fare-breakup to BAP side fixed

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Confirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Confirm.hs
@@ -105,7 +105,7 @@ confirm transporterId (SignatureAuthResult _ subscriber) reqV2 = withFlowHandler
             Nothing -> do
               fork "on_confirm on-us" $ do
                 handle (errHandler dConfirmRes transporter Nothing) $ do
-                  callOnConfirm dConfirmRes msgId txnId bapId callbackUrl bppId bppUri city country
+                  callOnConfirm dConfirmRes msgId txnId bapId callbackUrl bppId bppUri city country isValueAddNP
     pure Ack
   where
     isMeterRide = \case
@@ -117,7 +117,7 @@ confirm transporterId (SignatureAuthResult _ subscriber) reqV2 = withFlowHandler
       | Just ExternalAPICallError {} <- fromException @ExternalAPICallError exc = SBooking.cancelBooking dConfirmRes.booking mbDriver transporter
       | otherwise = throwM exc
 
-    callOnConfirm dConfirmRes msgId txnId bapId callbackUrl bppId bppUri city country = do
+    callOnConfirm dConfirmRes msgId txnId bapId callbackUrl bppId bppUri city country isValueAddNP = do
       context <- ContextV2.buildContextV2 Context.CONFIRM Context.MOBILITY msgId txnId bapId callbackUrl bppId bppUri city country (Just "PT2M")
       let vehicleCategory = Utils.mapServiceTierToCategory dConfirmRes.booking.vehicleServiceTier
       becknConfig <- QBC.findByMerchantIdDomainAndVehicle dConfirmRes.transporter.id (show Context.MOBILITY) vehicleCategory >>= fromMaybeM (InternalError "Beckn Config not found")
@@ -125,7 +125,7 @@ confirm transporterId (SignatureAuthResult _ subscriber) reqV2 = withFlowHandler
       vehicleServiceTierItem <- CQVST.findByServiceTierTypeAndCityIdInRideFlow dConfirmRes.booking.vehicleServiceTier dConfirmRes.booking.merchantOperatingCityId (dConfirmRes.booking.area >>= SL.pickupSpecialZoneIdFromArea) >>= fromMaybeM (VehicleServiceTierNotFound (show dConfirmRes.booking.vehicleServiceTier))
       let pricing = Utils.convertBookingToPricing vehicleServiceTierItem dConfirmRes.booking
       bppInvoiceInfo <- ACL.resolveBPPInvoiceInfo dConfirmRes
-      let onConfirmMessage = ACL.buildOnConfirmMessageV2 dConfirmRes pricing becknConfig mbFarePolicy bppInvoiceInfo
+      let onConfirmMessage = ACL.buildOnConfirmMessageV2 isValueAddNP dConfirmRes pricing becknConfig mbFarePolicy bppInvoiceInfo
       void $ BP.callOnConfirmV2 dConfirmRes.transporter context onConfirmMessage becknConfig
 
 confirmProcessingLockKey :: Text -> Text

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Init.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Beckn/Init.hs
@@ -66,7 +66,7 @@ init transporterId (SignatureAuthResult _ subscriber) reqV2 = withFlowHandlerBec
   L.setOptionLocal TxnIdKey transactionId
   Utils.withTransactionIdLogTag transactionId $ do
     logTagInfo "Init APIV2 Flow" "Reached"
-    (dInitReq, bapUri, bapId, msgId, city, country, bppId, bppUri) <- do
+    (dInitReq, bapUri, bapId, msgId, city, country, bppId, bppUri, isValueAddNP) <- do
       let context = reqV2.initReqContext
       callbackUrl <- Utils.getContextBapUri context
       bppUri <- Utils.getContextBppUri context
@@ -76,7 +76,7 @@ init transporterId (SignatureAuthResult _ subscriber) reqV2 = withFlowHandlerBec
       country <- Utils.getContextCountry context
       isValueAddNP <- CQVAN.isValueAddNP bapId
       dInitReq <- ACL.buildInitReqV2 subscriber reqV2 isValueAddNP
-      pure (dInitReq, callbackUrl, bapId, messageId, city, country, context.contextBppId, bppUri)
+      pure (dInitReq, callbackUrl, bapId, messageId, city, country, context.contextBppId, bppUri, isValueAddNP)
 
     let txnId = Just transactionId
         initFulfillmentId =
@@ -103,7 +103,7 @@ init transporterId (SignatureAuthResult _ subscriber) reqV2 = withFlowHandlerBec
             void . handle (errHandler dInitRes.booking dInitRes.transporter) $
               Callback.withCallback dInitRes.transporter "on_init" OnInit.onInitAPIV2 bapUri internalEndPointHashMap (errHandlerV2 context) $ do
                 mbFarePolicy <- SFP.getFarePolicyByEstOrQuoteIdWithoutFallback dInitRes.booking.quoteId
-                let onInitMessage = ACL.mkOnInitMessageV2 dInitRes bppConfig mbFarePolicy
+                let onInitMessage = ACL.mkOnInitMessageV2 isValueAddNP dInitRes bppConfig mbFarePolicy
                 pure $
                   Spec.OnInitReq
                     { onInitReqContext = context,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Common/Order.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/Common/Order.hs
@@ -63,6 +63,7 @@ import Kernel.Types.Common
 import Kernel.Utils.Common
 import SharedLogic.Beckn.Common as Common
 import qualified SharedLogic.FareCalculator as Fare
+import qualified Storage.CachedQueries.ValueAddNP as CQVAN
 import Tools.Error
 import qualified Tools.Utils as Tools
 
@@ -212,8 +213,8 @@ mkArrivalTimeTagGroup arrivalTime =
       }
   ]
 
-buildRideCompletedQuote :: MonadFlow m => DRide.Ride -> DFParams.FareParameters -> m Quote.RideCompletedQuote
-buildRideCompletedQuote ride fareParams = do
+buildRideCompletedQuote :: MonadFlow m => Bool -> DRide.Ride -> DFParams.FareParameters -> m Quote.RideCompletedQuote
+buildRideCompletedQuote isValueAddNP ride fareParams = do
   fare <- ride.fare & fromMaybeM (InternalError "Ride fare is not present.")
   let value = Quote.DecimalValue $ fare.getHighPrecMoney
       currency = show ride.currency
@@ -224,7 +225,7 @@ buildRideCompletedQuote ride fareParams = do
             computed_value = value
           }
       breakup =
-        Fare.mkFareParamsBreakups (Breakup.BreakupItemPrice currency . DecimalValue.DecimalValue . getHighPrecMoney) Breakup.BreakupItem fareParams
+        Fare.mkFareParamsBreakups isValueAddNP (Breakup.BreakupItemPrice currency . DecimalValue.DecimalValue . getHighPrecMoney) Breakup.BreakupItem fareParams
           & filter (ACLCommon.filterRequiredBreakups $ DFParams.getFareParametersType fareParams) -- TODO: Remove after roll out
   pure
     Quote.RideCompletedQuote
@@ -255,7 +256,7 @@ tfAssignedReqToOrder Common.DRideAssignedReq {..} mbFarePolicy becknConfig fulfi
       isSafetyPlusTagGroup = if isValueAddNP then Utils.mkIsSafetyPlusTagGroupV2 isSafetyPlus else Nothing
       tierUpgradeTagGroup = if isValueAddNP then Utils.mkTierUpgradeTagGroupV2 isTierUpgrade assignedServiceTierType assignedServiceTierName else Nothing
       tagGroups = currentRideDropLocation <> arrivalTimeTagGroup <> vehicleAgeTagGroup <> isSafetyPlusTagGroup <> tierUpgradeTagGroup
-      quote = Utils.tfQuotation booking
+      quote = Utils.tfQuotation isValueAddNP booking
       farePolicy = FarePolicyD.fullFarePolicyToFarePolicy <$> mbFarePolicy
       items = UtilsOU.tfItems ride booking merchant.shortId.getShortId Nothing farePolicy booking.paymentId
       payment = UtilsOU.mkPaymentParams paymentMethodInfo paymentUrl merchant bppConfig booking
@@ -287,7 +288,7 @@ tfStartReqToOrder Common.DRideStartedReq {..} mbFarePolicy becknConfig = do
       arrivalTimeTagGroup = if isValueAddNP then Utils.mkArrivalTimeTagGroupV2 ride.driverArrivalTime else Nothing
       estimatedEndTimeRangeTagGroup = if isValueAddNP then Utils.mkEstimatedEndTimeRangeTagGroupV2 ride.estimatedEndTimeRange else Nothing
       payment = UtilsOU.mkPaymentParams paymentMethodInfo paymentUrl merchant bppConfig booking
-      quote = Utils.tfQuotation booking
+      quote = Utils.tfQuotation isValueAddNP booking
       farePolicy = FarePolicyD.fullFarePolicyToFarePolicy <$> mbFarePolicy
       items = UtilsOU.tfItems ride booking merchant.shortId.getShortId Nothing farePolicy booking.paymentId
   let orderSettlementTags = mkOrderSettlementTags bppConfig merchant
@@ -319,7 +320,7 @@ tfCompleteReqToOrder Common.DRideCompletedReq {..} mbFarePolicy becknConfig = do
       rideTagGroup = if isValueAddNP then Utils.mkRideDetailsTagGroup (Just isValidRide) else Nothing
   distanceTagGroup <- if isValueAddNP then UtilsOU.mkDistanceTagGroup ride else return Nothing
   fulfillment <- Utils.mkFulfillmentV2 (Just driver) (Just driverStats) ride booking (Just vehicle) Nothing (arrivalTimeTagGroup <> distanceTagGroup <> tollConfidence <> rideTagGroup) personTag False False Nothing (Just $ show EventEnum.RIDE_ENDED) isValueAddNP riderPhone False 0
-  quote <- UtilsOU.mkRideCompletedQuote ride fareParams
+  quote <- UtilsOU.mkRideCompletedQuote isValueAddNP ride fareParams
   let farePolicy = FarePolicyD.fullFarePolicyToFarePolicy <$> mbFarePolicy
   let items = UtilsOU.tfItems ride booking merchant.shortId.getShortId Nothing farePolicy booking.paymentId
   let payment = UtilsOU.mkPaymentParams paymentMethodInfo paymentUrl merchant bppConfig booking
@@ -357,9 +358,10 @@ tfCompleteReqToOrder Common.DRideCompletedReq {..} mbFarePolicy becknConfig = do
         orderUpdatedAt = Just booking.updatedAt
       }
 
-tfCancelReqToOrder :: (MonadFlow m, EncFlow m r) => Common.DBookingCancelledReq -> DBC.BecknConfig -> m Spec.Order
+tfCancelReqToOrder :: (MonadFlow m, EncFlow m r, CacheFlow m r, EsqDBFlow m r) => Common.DBookingCancelledReq -> DBC.BecknConfig -> m Spec.Order
 tfCancelReqToOrder Common.DBookingCancelledReq {..} becknConfig = do
-  let quote = Utils.tfQuotation booking
+  bapIsValueAddNP <- maybe (CQVAN.isValueAddNP booking.bapId) (pure . (.isValueAddNP)) bookingDetails
+  let quote = Utils.tfQuotation bapIsValueAddNP booking
   fulfillment <- forM bookingDetails $ \bookingDetails' -> do
     let Common.BookingDetails {driver, driverStats, vehicle, ride, isValueAddNP, riderPhone} = bookingDetails'
     let image = Nothing
@@ -391,7 +393,7 @@ tfCancelReqToOrder Common.DBookingCancelledReq {..} becknConfig = do
 tfArrivedReqToOrder :: (MonadFlow m, EncFlow m r) => Common.DDriverArrivedReq -> Maybe FarePolicyD.FullFarePolicy -> DBC.BecknConfig -> m Spec.Order
 tfArrivedReqToOrder Common.DDriverArrivedReq {..} mbFarePolicy becknConfig = do
   let BookingDetails {..} = bookingDetails
-      quote = Utils.tfQuotation booking
+      quote = Utils.tfQuotation isValueAddNP booking
       payment = UtilsOU.mkPaymentParams paymentMethodInfo paymentUrl merchant bppConfig booking
       driverArrivedInfoTags = if isValueAddNP then Utils.mkArrivalTimeTagGroupV2 arrivalTime else Nothing
       farePolicy = FarePolicyD.fullFarePolicyToFarePolicy <$> mbFarePolicy

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnConfirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnConfirm.hs
@@ -118,14 +118,14 @@ bookingStatusCode :: DConfirm.ValidatedQuote -> Maybe Enum.FulfillmentState
 bookingStatusCode (DConfirm.DriverQuote _ _) = Just Enum.RIDE_ASSIGNED -- ONDC v2.1.0: phased confirmation, driver details sent via on_update RIDE_ASSIGNED
 bookingStatusCode _ = Just Enum.NEW
 
-buildOnConfirmMessageV2 :: DConfirm.DConfirmResp -> Utils.Pricing -> DBC.BecknConfig -> Maybe FarePolicyD.FullFarePolicy -> BPPInvoiceInfo -> Spec.ConfirmReqMessage
-buildOnConfirmMessageV2 res pricing becknConfig mbFarePolicy bppInvoiceInfo =
+buildOnConfirmMessageV2 :: Utils.IsValueAddNP -> DConfirm.DConfirmResp -> Utils.Pricing -> DBC.BecknConfig -> Maybe FarePolicyD.FullFarePolicy -> BPPInvoiceInfo -> Spec.ConfirmReqMessage
+buildOnConfirmMessageV2 isValueAddNP res pricing becknConfig mbFarePolicy bppInvoiceInfo =
   Spec.ConfirmReqMessage
-    { confirmReqMessageOrder = tfOrder res pricing becknConfig mbFarePolicy bppInvoiceInfo
+    { confirmReqMessageOrder = tfOrder isValueAddNP res pricing becknConfig mbFarePolicy bppInvoiceInfo
     }
 
-tfOrder :: DConfirm.DConfirmResp -> Utils.Pricing -> DBC.BecknConfig -> Maybe FarePolicyD.FullFarePolicy -> BPPInvoiceInfo -> Spec.Order
-tfOrder res pricing bppConfig mbFarePolicy bppInvoiceInfo = do
+tfOrder :: Utils.IsValueAddNP -> DConfirm.DConfirmResp -> Utils.Pricing -> DBC.BecknConfig -> Maybe FarePolicyD.FullFarePolicy -> BPPInvoiceInfo -> Spec.Order
+tfOrder isValueAddNP res pricing bppConfig mbFarePolicy bppInvoiceInfo = do
   let farePolicy = case mbFarePolicy of
         Nothing -> Nothing
         Just fullFarePolicy -> Just $ FarePolicyD.fullFarePolicyToFarePolicy fullFarePolicy
@@ -138,7 +138,7 @@ tfOrder res pricing bppConfig mbFarePolicy bppInvoiceInfo = do
       orderItems = Utils.tfItems res.booking res.transporter.shortId.getShortId pricing.estimatedDistance farePolicy res.paymentId,
       orderPayments = tfPayments res bppConfig,
       orderProvider = Utils.tfProvider bppConfig,
-      orderQuote = Utils.tfQuotation res.booking,
+      orderQuote = Utils.tfQuotation isValueAddNP res.booking,
       orderTags = mkBPPInvoiceInfoTagGroup bppInvoiceInfo,
       orderStatus = Just "ACTIVE",
       orderCreatedAt = Just res.booking.createdAt,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnInit.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnInit.hs
@@ -30,14 +30,14 @@ import Kernel.Prelude
 import qualified Kernel.Types.Common as Common
 import Kernel.Utils.Common
 
-mkOnInitMessageV2 :: DInit.InitRes -> DBC.BecknConfig -> Maybe FarePolicyD.FullFarePolicy -> Spec.ConfirmReqMessage
-mkOnInitMessageV2 res becknConfig mbFarePolicy =
+mkOnInitMessageV2 :: Utils.IsValueAddNP -> DInit.InitRes -> DBC.BecknConfig -> Maybe FarePolicyD.FullFarePolicy -> Spec.ConfirmReqMessage
+mkOnInitMessageV2 isValueAddNP res becknConfig mbFarePolicy =
   Spec.ConfirmReqMessage
-    { confirmReqMessageOrder = tfOrder res becknConfig mbFarePolicy
+    { confirmReqMessageOrder = tfOrder isValueAddNP res becknConfig mbFarePolicy
     }
 
-tfOrder :: DInit.InitRes -> DBC.BecknConfig -> Maybe FarePolicyD.FullFarePolicy -> Spec.Order
-tfOrder res becknConfig mbFarePolicy = do
+tfOrder :: Utils.IsValueAddNP -> DInit.InitRes -> DBC.BecknConfig -> Maybe FarePolicyD.FullFarePolicy -> Spec.Order
+tfOrder isValueAddNP res becknConfig mbFarePolicy = do
   let farePolicy = case mbFarePolicy of
         Nothing -> Nothing
         Just fullFarePolicy -> Just $ FarePolicyD.fullFarePolicyToFarePolicy fullFarePolicy
@@ -50,7 +50,7 @@ tfOrder res becknConfig mbFarePolicy = do
       orderItems = Utils.tfItems res.booking res.transporter.shortId.getShortId Nothing farePolicy (Just res.paymentId),
       orderPayments = tfPayments res becknConfig,
       orderProvider = Utils.tfProvider becknConfig,
-      orderQuote = Utils.tfQuotation res.booking,
+      orderQuote = Utils.tfQuotation isValueAddNP res.booking,
       orderTags = Nothing,
       orderStatus = Nothing,
       orderCreatedAt = Just res.booking.createdAt,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnSelect.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnSelect.hs
@@ -74,7 +74,7 @@ mkOnSelectMessageV2 isValueAddNP bppConfig merchant mbFarePolicy req@DOnSelectRe
       emptyOrder
         { Spec.orderFulfillments = Just fulfillments,
           Spec.orderItems = Just $ map (\fulf -> mkItemV2 fulf vehicleServiceTierItem driverQuote mbFarePolicy taggings (not $ null searchRequest.stops)) fulfillments,
-          Spec.orderQuote = Just $ mkQuoteV2 driverQuote req.now,
+          Spec.orderQuote = Just $ mkQuoteV2 isValueAddNP driverQuote req.now,
           Spec.orderPayments = Just [paymentV2],
           Spec.orderProvider = mkProvider bppConfig
         }
@@ -160,18 +160,18 @@ mkItemTagsV2 estimatedFare mbCancellationCharge congestionChargeViaDp mbFarePoli
   let farePolicyTag = Utils.mkRateCardTag Nothing mbCancellationCharge Nothing estimatedFare congestionChargeViaDp (Just . FarePolicyD.fullFarePolicyToFarePolicy =<< mbFarePolicy) Nothing Nothing Nothing hasStops
   Tags.convertToTagGroup taggings.itemTags <> farePolicyTag
 
-mkQuoteV2 :: DQuote.DriverQuote -> UTCTime -> Spec.Quotation
-mkQuoteV2 quote now = do
+mkQuoteV2 :: Bool -> DQuote.DriverQuote -> UTCTime -> Spec.Quotation
+mkQuoteV2 isValueAddNP quote now = do
   let nominalDifferenceTime = diffUTCTime quote.validTill now
   Spec.Quotation
-    { quotationBreakup = Just $ mkQuoteBreakupInner quote,
+    { quotationBreakup = Just $ mkQuoteBreakupInner isValueAddNP quote,
       quotationPrice = mkQuotationPrice quote,
       quotationTtl = Just $ formatTimeDifference nominalDifferenceTime
     }
 
-mkQuoteBreakupInner :: DQuote.DriverQuote -> [Spec.QuotationBreakupInner]
-mkQuoteBreakupInner quote = do
-  let fareParams = mkFareParamsBreakups mkBreakupPrice mkQuotationBreakupInner quote.fareParams
+mkQuoteBreakupInner :: Bool -> DQuote.DriverQuote -> [Spec.QuotationBreakupInner]
+mkQuoteBreakupInner isValueAddNP quote = do
+  let fareParams = mkFareParamsBreakups isValueAddNP mkBreakupPrice mkQuotationBreakupInner quote.fareParams
    in filter filterRequiredBreakups fareParams
   where
     mkBreakupPrice money =

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnStatus.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/ACL/OnStatus.hs
@@ -102,7 +102,7 @@ buildOnStatusMessage (DStatus.RideCompletedReq Common.DRideCompletedReq {..}) = 
   let arrivalTimeTagGroup = Common.mkArrivalTimeTagGroup ride.driverArrivalTime
   distanceTagGroup <- Common.buildDistanceTagGroup ride
   fulfillment <- Common.mkFulfillment (Just driver) (Just driverStats) ride booking (Just vehicle) image (Just $ Tags.TG (distanceTagGroup <> arrivalTimeTagGroup)) Nothing False False False 0 booking.isSafetyPlus
-  quote <- Common.buildRideCompletedQuote ride fareParams
+  quote <- Common.buildRideCompletedQuote isValueAddNP ride fareParams
   return $
     OnStatus.OnStatusMessage
       { order =
@@ -199,7 +199,7 @@ buildOnStatusReqV2' action domain messageId bppSubscriberId bppUri city country 
       }
 
 mkOnStatusMessageV2 ::
-  (MonadFlow m, EncFlow m r) =>
+  (MonadFlow m, EncFlow m r, CacheFlow m r, EsqDBFlow m r) =>
   DStatus.OnStatusBuildReq ->
   Maybe FarePolicyD.FullFarePolicy ->
   DBC.BecknConfig ->
@@ -211,7 +211,7 @@ mkOnStatusMessageV2 res mbFarePolicy bppConfig = do
       { confirmReqMessageOrder = order
       }
 
-tfOrder :: (MonadFlow m, EncFlow m r) => DStatus.OnStatusBuildReq -> Maybe FarePolicyD.FullFarePolicy -> DBC.BecknConfig -> m Spec.Order
+tfOrder :: (MonadFlow m, EncFlow m r, CacheFlow m r, EsqDBFlow m r) => DStatus.OnStatusBuildReq -> Maybe FarePolicyD.FullFarePolicy -> DBC.BecknConfig -> m Spec.Order
 tfOrder (DStatus.NewBookingBuildReq DNewBookingBuildReq {bookingId}) _ becknConfig =
   pure
     Spec.Order

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Transformer/OnUpdate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Transformer/OnUpdate.hs
@@ -41,6 +41,7 @@ import Kernel.Utils.Common
 import SharedLogic.Beckn.Common
 import qualified SharedLogic.FarePolicy as SFP
 import qualified Storage.CachedQueries.BecknConfig as QBC
+import qualified Storage.CachedQueries.ValueAddNP as CQVAN
 import qualified Storage.Queries.FareParameters as QFP
 
 buildOnUpdateReqV2 ::
@@ -240,12 +241,12 @@ buildOnUpdateReqOrderV2 outerBooking req' mbFarePolicy becknConfig = case req' o
         let (items, quote, payment) = case updateType of
               OU.SOFT_UPDATE -> do
                 let items' = Utils.tfItemsSoftUpdate booking merchant.shortId.getShortId bookingUpdateReqDetails.estimatedDistance farePolicy Nothing bookingUpdateReqDetails ride.id.getId
-                    quote' = Utils.tfQuotationSU fareParameters bookingUpdateReqDetails.estimatedFare
+                    quote' = Utils.tfQuotationSU isValueAddNP fareParameters bookingUpdateReqDetails.estimatedFare
                     payment' = UtilsOU.mkPaymentParamsSoftUpdate paymentMethodInfo paymentUrl merchant bppConfig bookingUpdateReqDetails.estimatedFare fareParameters.currency
                 (items', quote', payment')
               OU.CONFIRM_UPDATE -> do
                 let items' = Utils.tfItems booking merchant.shortId.getShortId booking.estimatedDistance farePolicy Nothing
-                    quote' = Utils.tfQuotation booking
+                    quote' = Utils.tfQuotation isValueAddNP booking
                     payment' = UtilsOU.mkPaymentParams paymentMethodInfo paymentUrl merchant bppConfig booking
                 (items', quote', payment')
         fulfillment <- case updateType of
@@ -272,10 +273,11 @@ buildOnUpdateReqOrderV2 outerBooking req' mbFarePolicy becknConfig = case req' o
               orderUpdatedAt = Just booking.updatedAt
             }
       Nothing -> do
+        isValueAddNP <- CQVAN.isValueAddNP booking.bapId
         let distanceTagGroups = case updateType of
               OU.SOFT_UPDATE -> UtilsOU.mkUpdatedDistanceTags bookingUpdateReqDetails.estimatedDistance
               OU.CONFIRM_UPDATE -> Nothing
-            quote = Utils.tfQuotationSU fareParameters bookingUpdateReqDetails.estimatedFare
+            quote = Utils.tfQuotationSU isValueAddNP fareParameters bookingUpdateReqDetails.estimatedFare
             fulfillment =
               Spec.Fulfillment
                 { fulfillmentId = Nothing,
@@ -482,6 +484,7 @@ buildOnUpdateReqOrderV2 outerBooking req' mbFarePolicy becknConfig = case req' o
           orderUpdatedAt = Nothing
         }
   OU.AddBaggageBuildReq OU.DAddBaggageReq {..} -> do
+    isValueAddNP <- CQVAN.isValueAddNP outerBooking.bapId
     let addBaggageTags =
           [ Tag.getFullTagGroup
               Tag.SEARCH_REQUEST_INFO
@@ -524,7 +527,7 @@ buildOnUpdateReqOrderV2 outerBooking req' mbFarePolicy becknConfig = case req' o
           orderQuote =
             Just $
               Spec.Quotation
-                { quotationBreakup = Utils.mkQuotationBreakup fareParams,
+                { quotationBreakup = Utils.mkQuotationBreakup isValueAddNP fareParams,
                   quotationPrice =
                     Just $
                       Spec.Price

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/Common.hs
@@ -793,19 +793,19 @@ tfCancellationFee (Just price) = do
 tfFulfillmentState :: Enums.FulfillmentState -> Maybe Spec.FulfillmentState
 tfFulfillmentState = Just . mkFulfillmentState
 
-tfQuotation :: DBooking.Booking -> Maybe Spec.Quotation
-tfQuotation booking =
+tfQuotation :: IsValueAddNP -> DBooking.Booking -> Maybe Spec.Quotation
+tfQuotation isValueAddNP booking =
   Just
     emptyQuotation
-      { Spec.quotationBreakup = mkQuotationBreakup booking.fareParams,
+      { Spec.quotationBreakup = mkQuotationBreakup isValueAddNP booking.fareParams,
         Spec.quotationPrice = tfQuotationPrice (HighPrecMoney $ toRational booking.estimatedFare) booking.currency
       }
 
-tfQuotationSU :: DFParams.FareParameters -> HighPrecMoney -> Maybe Spec.Quotation
-tfQuotationSU fareParams estimatedFare =
+tfQuotationSU :: IsValueAddNP -> DFParams.FareParameters -> HighPrecMoney -> Maybe Spec.Quotation
+tfQuotationSU isValueAddNP fareParams estimatedFare =
   Just
     emptyQuotation
-      { Spec.quotationBreakup = mkQuotationBreakup fareParams,
+      { Spec.quotationBreakup = mkQuotationBreakup isValueAddNP fareParams,
         Spec.quotationPrice = tfQuotationPrice estimatedFare fareParams.currency
       }
 
@@ -818,9 +818,9 @@ tfQuotationPrice estimatedFare currency =
         Spec.priceValue = Just $ encodeToText estimatedFare
       }
 
-mkQuotationBreakup :: DFParams.FareParameters -> Maybe [Spec.QuotationBreakupInner]
-mkQuotationBreakup fareParams =
-  let fareParameters = mkFareParamsBreakups mkPrice mkQuotationBreakupInner fareParams
+mkQuotationBreakup :: IsValueAddNP -> DFParams.FareParameters -> Maybe [Spec.QuotationBreakupInner]
+mkQuotationBreakup isValueAddNP fareParams =
+  let fareParameters = mkFareParamsBreakups isValueAddNP mkPrice mkQuotationBreakupInner fareParams
    in Just $ filter (filterRequiredBreakups $ DFParams.getFareParametersType fareParams) fareParameters -- TODO: Remove after roll out
   where
     mkPrice :: HighPrecMoney -> Maybe Spec.Price
@@ -1115,15 +1115,15 @@ mkGeneralInfoTagGroup pricing isValueAddNP =
             estimatedTimeTakenInSeconds :: Int = ceiling $ (distanceInMeters / avgSpeedInMetersPerSec)
         Just $ show estimatedTimeTakenInSeconds
 
-mkRateCardTag :: Maybe Meters -> Maybe HighPrecMoney -> Maybe HighPrecMoney -> HighPrecMoney -> Maybe HighPrecMoney -> Maybe FarePolicyD.FarePolicy -> Maybe Bool -> Maybe Params.FareParameters -> Maybe Double -> Bool -> Maybe [Spec.TagGroup]
-mkRateCardTag estimatedDistance mbCancellationCharge tollCharges estimatedFare congestionChargeViaDp farePolicy fareParametersInRateCard fareParams mbGovtChargesRate hasStops = do
+mkRateCardTag :: Maybe Meters -> Maybe HighPrecMoney -> Maybe HighPrecMoney -> HighPrecMoney -> Maybe HighPrecMoney -> Maybe FarePolicyD.FarePolicy -> Maybe Bool -> Maybe (IsValueAddNP, Params.FareParameters) -> Maybe Double -> Bool -> Maybe [Spec.TagGroup]
+mkRateCardTag estimatedDistance mbCancellationCharge tollCharges estimatedFare congestionChargeViaDp farePolicy fareParametersInRateCard mbFareParams mbGovtChargesRate hasStops = do
   let farePolicyBreakups = maybe [] (mkFarePolicyBreakups Prelude.id mkRateCardBreakupItem estimatedDistance mbCancellationCharge tollCharges estimatedFare congestionChargeViaDp mbGovtChargesRate hasStops) farePolicy
       displayFareParamsBreakups =
-        case fareParametersInRateCard of
-          Just True -> maybe [] (mkFareParamsDisplayBreakups (\price -> show price) mkRateCardFareParamsBreakupItem) fareParams
+        case (fareParametersInRateCard, mbFareParams) of
+          (Just True, Just (isValueAddNP, fareParams)) -> mkFareParamsDisplayBreakups isValueAddNP (\price -> show price) mkRateCardFareParamsBreakupItem fareParams
           _ -> []
       filteredDisplayBreakups = filter (not . findDup farePolicyBreakups) displayFareParamsBreakups
-      summaryBreakups = maybe [] (mkProjectFareParamsTagBreakupItems (\price -> show price) mkRateCardBreakupItem) fareParams
+      summaryBreakups = maybe [] (mkProjectFareParamsTagBreakupItems (\price -> show price) mkRateCardBreakupItem . snd) mbFareParams
       combainedParams = farePolicyBreakups <> filteredDisplayBreakups <> summaryBreakups
       farePolicyBreakupsTags = buildRateCardTags <$> combainedParams
   Just [Tags.getFullTagGroup Tags.FARE_POLICY farePolicyBreakupsTags]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/OnSearch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/OnSearch.hs
@@ -93,7 +93,7 @@ mkPayment merchant bppConfig mbPaymentId = do
 
 mkItemTags :: CUtils.Pricing -> Bool -> Maybe Bool -> Bool -> Maybe [Spec.TagGroup]
 mkItemTags pricing isValueAddNP fareParametersInRateCard hasStops = do
-  let rateCardTag = CUtils.mkRateCardTag pricing.estimatedDistance (pricing.fareParams >>= (.customerCancellationDues)) (pricing.fareParams >>= (.tollCharges)) pricing.pricingMaxFare (pricing.fareParams >>= (.congestionChargeViaDp)) pricing.farePolicy fareParametersInRateCard pricing.fareParams Nothing hasStops
+  let rateCardTag = CUtils.mkRateCardTag pricing.estimatedDistance (pricing.fareParams >>= (.customerCancellationDues)) (pricing.fareParams >>= (.tollCharges)) pricing.pricingMaxFare (pricing.fareParams >>= (.congestionChargeViaDp)) pricing.farePolicy fareParametersInRateCard ((isValueAddNP,) <$> pricing.fareParams) Nothing hasStops
   let vehicleIconTag = CUtils.mkVehicleIconTag pricing.vehicleIconUrl
   let featureListTag = mkFeatureListTags pricing.isAirConditioned
   vehicleIconTag <> rateCardTag <> CUtils.mkGeneralInfoTagGroup pricing isValueAddNP <> featureListTag

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/OnUpdate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Beckn/OnDemand/Utils/OnUpdate.hs
@@ -49,8 +49,8 @@ mkRideCompletedPaymentType = show . maybe OnUpdate.ON_FULFILLMENT (Common.castDP
 showPaymentCollectedBy :: Maybe DMPM.PaymentMethodInfo -> Text
 showPaymentCollectedBy = show . maybe OnUpdate.BPP (Common.castDPaymentCollector . (.collectedBy))
 
-mkRideCompletedQuote :: MonadFlow m => DRide.Ride -> DFParams.FareParameters -> m Spec.Quotation
-mkRideCompletedQuote ride fareParams = do
+mkRideCompletedQuote :: MonadFlow m => Utils.IsValueAddNP -> DRide.Ride -> DFParams.FareParameters -> m Spec.Quotation
+mkRideCompletedQuote isValueAddNP ride fareParams = do
   fare' <- ride.fare & fromMaybeM (InternalError "Ride fare is not present in RideCompletedReq ride.")
   let fare = highPrecMoneyToText fare'
   let currency = show ride.currency
@@ -64,7 +64,7 @@ mkRideCompletedQuote ride fareParams = do
             priceOfferedValue = Nothing
           }
       fareBreakup =
-        Fare.mkFareParamsBreakups (mkPrice' currency) mkBreakupItem fareParams
+        Fare.mkFareParamsBreakups isValueAddNP (mkPrice' currency) mkBreakupItem fareParams
           & filter (filterRequiredBreakups $ DFParams.getFareParametersType fareParams)
       tipBreakup = mkTipBreakup currency ride.tipAmount
       breakup = fareBreakup <> tipBreakup

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareCalculator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FareCalculator.hs
@@ -84,9 +84,9 @@ import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions
 --   the canonical eight-tag summary. Callers who want finer control can
 --   use 'mkFareParamsDisplayBreakups' and 'mkProjectFareParamsTagBreakupItems'
 --   separately.
-mkFareParamsBreakups :: (HighPrecMoney -> breakupItemPrice) -> (Text -> breakupItemPrice -> breakupItem) -> FareParameters -> [breakupItem]
-mkFareParamsBreakups mkPrice mkBreakupItem fareParams =
-  mkFareParamsDisplayBreakups mkPrice mkBreakupItem fareParams
+mkFareParamsBreakups :: Bool -> (HighPrecMoney -> breakupItemPrice) -> (Text -> breakupItemPrice -> breakupItem) -> FareParameters -> [breakupItem]
+mkFareParamsBreakups isValueAddNP mkPrice mkBreakupItem fareParams =
+  mkFareParamsDisplayBreakups isValueAddNP mkPrice mkBreakupItem fareParams
     <> mkProjectFareParamsTagBreakupItems mkPrice mkBreakupItem fareParams
 
 -- | Canonical ten-tag summary only. Exposed so callers (e.g. rate-card
@@ -133,8 +133,14 @@ mkProjectFareParamsTagBreakupItemsForCancellation mkPrice mkBreakupItem cancella
 -- | Display-tag portion of the quotation.breakup (BASE_FARE,
 --   DISTANCE_FARE, PARKING_CHARGE, TOLL_CHARGES, …). Does NOT include
 --   the canonical eight-tag summary — 'mkFareParamsBreakups' concats both.
-mkFareParamsDisplayBreakups :: (HighPrecMoney -> breakupItemPrice) -> (Text -> breakupItemPrice -> breakupItem) -> FareParameters -> [breakupItem]
-mkFareParamsDisplayBreakups mkPrice mkBreakupItem fareParams = do
+--
+--   Three components carry an extra copy under their ONDC v2.1.0 spec title
+--   (@PARKING_CHARGES@, @NIGHT_CHARGES@, @WAITING_CHARGES@). Those exist purely
+--   for external NPs that validate against the spec vocabulary, so they are
+--   emitted only when the BAP is not a value-add NP — our own apps read the
+--   legacy titles, and sending both would show the component twice.
+mkFareParamsDisplayBreakups :: Bool -> (HighPrecMoney -> breakupItemPrice) -> (Text -> breakupItemPrice -> breakupItem) -> FareParameters -> [breakupItem]
+mkFareParamsDisplayBreakups isValueAddNP mkPrice mkBreakupItem fareParams = do
   -- let dayPartRate = fromMaybe 1.0 fareParams.nightShiftRateIfApplies -- Temp fix :: have to fix properly
   let baseFareFinal = HighPrecMoney $ fareParams.baseFare.getHighPrecMoney -- Temp fix :: have to fix properly
       baseFareCaption = show Enums.BASE_FARE
@@ -165,23 +171,23 @@ mkFareParamsDisplayBreakups mkPrice mkBreakupItem fareParams = do
       nightShiftCaption = show Enums.NIGHT_SHIFT_CHARGE
       mbNightShiftChargeItem = fmap (mkBreakupItem nightShiftCaption) (mkPrice <$> fareParams.nightShiftCharge)
 
-      -- ONDC v2.1.0: duplicate with new title for spec compliance
+      -- ONDC v2.1.0: duplicate with new title for spec compliance, external NPs only
       nightChargesCaption = show Enums.NIGHT_CHARGES
-      mbNightChargesItem = fmap (mkBreakupItem nightChargesCaption) (mkPrice <$> fareParams.nightShiftCharge)
+      mbNightChargesItem = mkV2SpecAliasItem nightChargesCaption fareParams.nightShiftCharge
 
       parkingChargeCaption = show Enums.PARKING_CHARGE
       mbParkingChargeItem = mkBreakupItem parkingChargeCaption . mkPrice <$> fareParams.parkingCharge
 
-      -- ONDC v2.1.0: duplicate with new title for spec compliance
+      -- ONDC v2.1.0: duplicate with new title for spec compliance, external NPs only
       parkingChargesCaption = show Enums.PARKING_CHARGES
-      mbParkingChargesItem = mkBreakupItem parkingChargesCaption . mkPrice <$> fareParams.parkingCharge
+      mbParkingChargesItem = mkV2SpecAliasItem parkingChargesCaption fareParams.parkingCharge
 
       waitingChargesCaption = show Enums.WAITING_OR_PICKUP_CHARGES
       mbWaitingChargesItem = mkBreakupItem waitingChargesCaption . mkPrice <$> fareParams.waitingCharge
 
-      -- ONDC v2.1.0: duplicate with new title for spec compliance
+      -- ONDC v2.1.0: duplicate with new title for spec compliance, external NPs only
       waitingChargesCaption2 = show Enums.WAITING_CHARGES
-      mbWaitingChargesItem2 = mkBreakupItem waitingChargesCaption2 . mkPrice <$> fareParams.waitingCharge
+      mbWaitingChargesItem2 = mkV2SpecAliasItem waitingChargesCaption2 fareParams.waitingCharge
 
       mbFixedGovtRateCaption = show Enums.FIXED_GOVERNMENT_RATE
       mbFixedGovtRateItem = mkBreakupItem mbFixedGovtRateCaption . mkPrice <$> fareParams.govtCharges
@@ -285,6 +291,13 @@ mkFareParamsDisplayBreakups mkPrice mkBreakupItem fareParams = do
     <> detailsBreakups
     <> additionalChargesBreakup
   where
+    -- The ONDC v2.1.0 spec title for a component we already emit under its legacy
+    -- title. Only external NPs need it; for our own apps it would be a duplicate.
+    mkV2SpecAliasItem caption mbAmount =
+      if isValueAddNP
+        then Nothing
+        else mkBreakupItem caption . mkPrice <$> mbAmount
+
     castAdditionalChargeCategoriesToEnum = \case
       DAC.SAFETY_PLUS_CHARGES -> Enums.SAFETY_PLUS_CHARGES
       DAC.NYREGULAR_SUBSCRIPTION_CHARGE -> Enums.NYREGULAR_SUBSCRIPTION_CHARGE

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/CachedQueries/ValueAddNP.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/CachedQueries/ValueAddNP.hs
@@ -20,17 +20,25 @@ where
 
 import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Hedis
+import qualified Kernel.Storage.InMem as IM
 import Kernel.Utils.Common
 import qualified Storage.Queries.ValueAddNP as Queries
 
+inMemCacheTtl :: Seconds
+inMemCacheTtl = 3600
+
 isValueAddNP :: (CacheFlow m r, EsqDBFlow m r, MonadFlow m) => Text -> m Bool
-isValueAddNP subscriberId =
-  Hedis.safeGet lookupKey >>= \case
-    Just subscriberIds -> return $ checkIfValueAddNP subscriberId subscriberIds
-    Nothing -> do
-      subscriberIds <- Queries.findAll True <&> map (.subscriberId)
-      cacheValueAddNPList subscriberIds
-      return $ checkIfValueAddNP subscriberId subscriberIds
+isValueAddNP subscriberId = checkIfValueAddNP subscriberId <$> getValueAddNPList
+
+getValueAddNPList :: (CacheFlow m r, EsqDBFlow m r, MonadFlow m) => m [Text]
+getValueAddNPList =
+  IM.withInMemCache [lookupKey] inMemCacheTtl $
+    Hedis.safeGet lookupKey >>= \case
+      Just subscriberIds -> return subscriberIds
+      Nothing -> do
+        subscriberIds <- Queries.findAll True <&> map (.subscriberId)
+        cacheValueAddNPList subscriberIds
+        return subscriberIds
 
 checkIfValueAddNP :: Text -> [Text] -> Bool
 checkIfValueAddNP subscriberId subscriberIds = subscriberId `elem` subscriberIds

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/ValueAddNP.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/ValueAddNP.hs
@@ -20,17 +20,25 @@ where
 
 import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Hedis
+import qualified Kernel.Storage.InMem as IM
 import Kernel.Utils.Common
 import qualified Storage.Queries.ValueAddNP as Queries
 
+inMemCacheTtl :: Seconds
+inMemCacheTtl = 3600
+
 isValueAddNP :: (CacheFlow m r, EsqDBFlow m r, MonadFlow m) => Text -> m Bool
-isValueAddNP subscriberId =
-  Hedis.safeGet lookupKey >>= \case
-    Just subscriberIds -> return $ checkIfValueAddNP subscriberId subscriberIds
-    Nothing -> do
-      subscriberIds <- Queries.findAll True <&> map (.subscriberId)
-      cacheValueAddNPList subscriberIds
-      return $ checkIfValueAddNP subscriberId subscriberIds
+isValueAddNP subscriberId = checkIfValueAddNP subscriberId <$> getValueAddNPList
+
+getValueAddNPList :: (CacheFlow m r, EsqDBFlow m r, MonadFlow m) => m [Text]
+getValueAddNPList =
+  IM.withInMemCache [lookupKey] inMemCacheTtl $
+    Hedis.safeGet lookupKey >>= \case
+      Just subscriberIds -> return subscriberIds
+      Nothing -> do
+        subscriberIds <- Queries.findAll True <&> map (.subscriberId)
+        cacheValueAddNPList subscriberIds
+        return subscriberIds
 
 checkIfValueAddNP :: Text -> [Text] -> Bool
 checkIfValueAddNP subscriberId subscriberIds = subscriberId `elem` subscriberIds


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Basically getting PARKING_CHARGE and PARKING_CHARGES, the later one due to some ONDC update we did
added check is our BAP (isValueAddedNP) then no need to send otherwise send these field to BAP


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pricing and fare-breakup handling for value-added network partners across booking, confirmation, updates, and ride completion flows.
  * Value-added partner transactions now receive tailored quotation details and fare labels.
* **Performance**
  * Added in-memory caching for value-added partner information, reducing repeated data lookups.
* **Bug Fixes**
  * Ensured value-added partner status is consistently preserved across order and callback workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->