### PR TITLE
Made hasAlternate field Maybe

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/API/UI/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/API/UI/Search.hs
@@ -154,7 +154,7 @@ data SearchResp = SearchResp
     --
     -- Counts every shape that endpoint serves: when the city prices one inline this is the
     -- shapes beside it, and when it loads them asynchronously it includes the default too.
-    hasAlternates :: Bool
+    hasAlternates :: Maybe Bool
   }
   deriving (Generic, FromJSON, ToJSON, Show, ToSchema)
 
@@ -325,7 +325,7 @@ search' (personId, merchantId) req mbBundleVersion mbClientVersion mbClientConfi
           searchExpiry = dSearchRes.searchRequestExpiry,
           routeInfo = dSearchRes.shortestRouteInfo,
           results = dispatchRes.inlineResults,
-          hasAlternates = dispatchRes.hasAlternates
+          hasAlternates = Just dispatchRes.hasAlternates
         }
   where
     -- TODO : remove this code after multiple search req issue get fixed from frontend
@@ -1314,7 +1314,7 @@ searchTrigger' (personId, merchantId) req mbBundleVersion mbClientVersion mbClie
         results = Nothing,
         -- A reserved ride never gets a walk-and-save shape: its pickup is one the customer
         -- already committed to, and this path does not dispatch suggestions at all.
-        hasAlternates = False
+        hasAlternates = Just False
       }
   where
     -- TODO : remove this code after multiple search req issue get fixed from frontend


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search responses so the alternates indicator can be omitted or returned as a nullable value.
  * Standard search results continue to report whether alternate options are available.
  * Search-trigger responses now explicitly indicate that no alternates are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->