### PR TITLE
refactor: move quote to top by routeData.serviceTierType from OTPRest

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/BecknConfig.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/BecknConfig.yaml
@@ -116,6 +116,7 @@ IntegratedBPPConfig:
     providerName: Maybe Text
     isTicketValidOnMultipleRoutes: Maybe Bool
     passOverrideApplicable: Maybe Bool
+    sortQuotesByRouteServiceTiers: Maybe Bool
 
   beamFields:
     providerConfig:
@@ -124,6 +125,7 @@ IntegratedBPPConfig:
   default:
     isTicketValidOnMultipleRoutes: "true"
     passOverrideApplicable: "false"
+    sortQuotesByRouteServiceTiers: "false"
 
   types:
     PlatformType:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/IntegratedBPPConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/IntegratedBPPConfig.hs
@@ -28,6 +28,7 @@ data IntegratedBPPConfig = IntegratedBPPConfig
     platformType :: Domain.Types.IntegratedBPPConfig.PlatformType,
     providerConfig :: Domain.Types.IntegratedBPPConfig.ProviderConfig,
     providerName :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    sortQuotesByRouteServiceTiers :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
     vehicleCategory :: BecknV2.OnDemand.Enums.VehicleCategory,
     createdAt :: Kernel.Prelude.UTCTime,
     updatedAt :: Kernel.Prelude.UTCTime

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/IntegratedBPPConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/IntegratedBPPConfig.hs
@@ -25,6 +25,7 @@ data IntegratedBPPConfigT f = IntegratedBPPConfigT
     platformType :: B.C f Domain.Types.IntegratedBPPConfig.PlatformType,
     configJSON :: B.C f Data.Aeson.Value,
     providerName :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    sortQuotesByRouteServiceTiers :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Bool),
     vehicleCategory :: B.C f BecknV2.OnDemand.Enums.VehicleCategory,
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     updatedAt :: B.C f Kernel.Prelude.UTCTime

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/IntegratedBPPConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/IntegratedBPPConfig.hs
@@ -48,6 +48,7 @@ updateByPrimaryKey (Domain.Types.IntegratedBPPConfig.IntegratedBPPConfig {..}) =
       Se.Set Beam.platformType platformType,
       Se.Set Beam.configJSON (Storage.Queries.Transformers.IntegratedBPPConfig.getProviderConfigJson providerConfig),
       Se.Set Beam.providerName providerName,
+      Se.Set Beam.sortQuotesByRouteServiceTiers sortQuotesByRouteServiceTiers,
       Se.Set Beam.vehicleCategory vehicleCategory,
       Se.Set Beam.updatedAt _now
     ]

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/IntegratedBPPConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/OrphanInstances/IntegratedBPPConfig.hs
@@ -30,6 +30,7 @@ instance FromTType' Beam.IntegratedBPPConfig Domain.Types.IntegratedBPPConfig.In
             platformType = platformType,
             providerConfig = providerConfig',
             providerName = providerName,
+            sortQuotesByRouteServiceTiers = sortQuotesByRouteServiceTiers,
             vehicleCategory = vehicleCategory,
             createdAt = createdAt,
             updatedAt = updatedAt
@@ -49,6 +50,7 @@ instance ToTType' Beam.IntegratedBPPConfig Domain.Types.IntegratedBPPConfig.Inte
         Beam.platformType = platformType,
         Beam.configJSON = Storage.Queries.Transformers.IntegratedBPPConfig.getProviderConfigJson providerConfig,
         Beam.providerName = providerName,
+        Beam.sortQuotesByRouteServiceTiers = sortQuotesByRouteServiceTiers,
         Beam.vehicleCategory = vehicleCategory,
         Beam.createdAt = createdAt,
         Beam.updatedAt = updatedAt

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -10,7 +10,7 @@ import BecknV2.FRFS.Utils
 import qualified BecknV2.OnDemand.Enums as Enums
 import Control.Monad.Extra hiding (fromMaybeM)
 import qualified Data.HashMap.Strict as HashMap
-import Data.List (groupBy, nub, nubBy)
+import Data.List (groupBy, nub, nubBy, partition)
 import qualified Data.List.NonEmpty as NonEmpty hiding (groupBy, map, nub, nubBy)
 import Data.List.Split (chunksOf)
 import qualified Data.Map.Strict as Map
@@ -797,54 +797,75 @@ getFrfsSearchQuote (mbPersonId, merchantId_) searchId_ mbHasPasses mbTripTime = 
               Left _ -> pure Nothing
               Right mbResp -> pure mbResp
   applicablePassesForSearch <- enrichQuotesWithPassOverride integratedBppConfig personId search mbHasPasses mbTripTime
-  mapM
-    ( \(quote, quoteCategories) -> do
-        let decodedRouteStations :: Maybe [FRFSRouteStationsAPI] = decodeFromText =<< quote.routeStationsJson
-            mbFirstRouteStation = decodedRouteStations >>= listToMaybe
-            mbVehicleServiceTier = mbFirstRouteStation >>= (.vehicleServiceTier)
-            serviceTierType = mbVehicleServiceTier <&> (._type)
-            serviceTierName = mbVehicleServiceTier <&> (.shortName)
-            routeCode = mbFirstRouteStation <&> (.code)
-        let (routeStations :: Maybe [FRFSRouteStationsAPI], stations :: Maybe [FRFSStationAPI]) =
-              if integratedBppConfig.platformType == DIBC.MULTIMODAL
-                then (Nothing, Nothing)
-                else (decodedRouteStations, decodeFromText quote.stationsJson)
-        -- Per-sub-leg transit route details for interchange journeys. These rows are persisted
-        -- alongside the Journey/JourneyLeg during the discovery flow (buildInterchangeJourney), so
-        -- here we simply read them back off the leg tied to this quote's search. Only the MULTIMODAL
-        -- platform builds interchange journeys, so we skip the lookup otherwise.
-        routeDetails <-
-          if integratedBppConfig.platformType == DIBC.MULTIMODAL
-            then do
-              mbLeg <- QJourneyLeg.findByLegSearchId (Just quote.searchId.getId)
-              pure $ (map mkRouteDetail . (.routeDetails)) <$> mbLeg
-            else pure Nothing
-        let fareParameters = FRFSUtils.mkFareParameters (FRFSUtils.mkCategoryPriceItemFromQuoteCategories quoteCategories)
-            categories = map mkCategoryInfoResponse quoteCategories
-        singleAdultTicketPrice <- (find (\category -> category.categoryType == ADULT) fareParameters.priceItems <&> (.unitPrice)) & fromMaybeM (InternalError "Adult Ticket Unit Price not found.")
-        adultQuantity <- (find (\category -> category.categoryType == ADULT) fareParameters.priceItems <&> (.quantity)) & fromMaybeM (InternalError "Adult Ticket Quantity not found.")
-        return $
-          FRFSTicketService.FRFSQuoteAPIRes
-            { quoteId = quote.id,
-              _type = quote._type,
-              applicablePasses =
-                map FRFSPassOverride.mkPassOptionAPIEntity $
-                  FRFSPassOverride.passOptionsForQuote integratedBppConfig applicablePassesForSearch serviceTierType singleAdultTicketPrice (map (\priceItem -> (priceItem.unitPrice, priceItem.quantity)) fareParameters.priceItems),
-              price = singleAdultTicketPrice.amount,
-              priceWithCurrency = mkPriceAPIEntity singleAdultTicketPrice,
-              quantity = adultQuantity,
-              validTill = quote.validTill,
-              vehicleType = quote.vehicleType,
-              discountedTickets = quote.discountedTickets,
-              eventDiscountAmount = quote.eventDiscountAmount,
-              integratedBppConfigId = quote.integratedBppConfigId,
-              stations = fromMaybe [] stations,
-              observingFailures = Just observingFailures,
-              offer = mbOffer,
-              ..
-            }
-    )
-    sortedQuotesWithCategories
+  quotesRes <-
+    mapM
+      ( \(quote, quoteCategories) -> do
+          let decodedRouteStations :: Maybe [FRFSRouteStationsAPI] = decodeFromText =<< quote.routeStationsJson
+              mbFirstRouteStation = decodedRouteStations >>= listToMaybe
+              mbVehicleServiceTier = mbFirstRouteStation >>= (.vehicleServiceTier)
+              serviceTierType = mbVehicleServiceTier <&> (._type)
+              serviceTierName = mbVehicleServiceTier <&> (.shortName)
+              routeCode = mbFirstRouteStation <&> (.code)
+          let (routeStations :: Maybe [FRFSRouteStationsAPI], stations :: Maybe [FRFSStationAPI]) =
+                if integratedBppConfig.platformType == DIBC.MULTIMODAL
+                  then (Nothing, Nothing)
+                  else (decodedRouteStations, decodeFromText quote.stationsJson)
+          -- Per-sub-leg transit route details for interchange journeys. These rows are persisted
+          -- alongside the Journey/JourneyLeg during the discovery flow (buildInterchangeJourney), so
+          -- here we simply read them back off the leg tied to this quote's search. Only the MULTIMODAL
+          -- platform builds interchange journeys, so we skip the lookup otherwise.
+          routeDetails <-
+            if integratedBppConfig.platformType == DIBC.MULTIMODAL
+              then do
+                mbLeg <- QJourneyLeg.findByLegSearchId (Just quote.searchId.getId)
+                pure $ (map mkRouteDetail . (.routeDetails)) <$> mbLeg
+              else pure Nothing
+          let fareParameters = FRFSUtils.mkFareParameters (FRFSUtils.mkCategoryPriceItemFromQuoteCategories quoteCategories)
+              categories = map mkCategoryInfoResponse quoteCategories
+          singleAdultTicketPrice <- (find (\category -> category.categoryType == ADULT) fareParameters.priceItems <&> (.unitPrice)) & fromMaybeM (InternalError "Adult Ticket Unit Price not found.")
+          adultQuantity <- (find (\category -> category.categoryType == ADULT) fareParameters.priceItems <&> (.quantity)) & fromMaybeM (InternalError "Adult Ticket Quantity not found.")
+          return $
+            FRFSTicketService.FRFSQuoteAPIRes
+              { quoteId = quote.id,
+                _type = quote._type,
+                applicablePasses =
+                  map FRFSPassOverride.mkPassOptionAPIEntity $
+                    FRFSPassOverride.passOptionsForQuote integratedBppConfig applicablePassesForSearch serviceTierType singleAdultTicketPrice (map (\priceItem -> (priceItem.unitPrice, priceItem.quantity)) fareParameters.priceItems),
+                price = singleAdultTicketPrice.amount,
+                priceWithCurrency = mkPriceAPIEntity singleAdultTicketPrice,
+                quantity = adultQuantity,
+                validTill = quote.validTill,
+                vehicleType = quote.vehicleType,
+                discountedTickets = quote.discountedTickets,
+                eventDiscountAmount = quote.eventDiscountAmount,
+                integratedBppConfigId = quote.integratedBppConfigId,
+                stations = fromMaybe [] stations,
+                observingFailures = Just observingFailures,
+                offer = mbOffer,
+                ..
+              }
+      )
+      sortedQuotesWithCategories
+
+  routeTierByRouteCode <-
+    if integratedBppConfig.sortQuotesByRouteServiceTiers /= Just True || length quotesRes < 2
+      then pure Map.empty
+      else do
+        let quoteRouteCodes = nub $ mapMaybe (.routeCode) quotesRes
+        routeTiers <- forM quoteRouteCodes $ \quoteRouteCode -> do
+          mbTier <-
+            withTryCatch "getFrfsSearchQuote:routeTier" (OTPRest.getRouteByRouteId integratedBppConfig quoteRouteCode) <&> \case
+              Right (Just route) -> route.serviceTierType
+              _ -> Nothing
+          pure $ (quoteRouteCode,) <$> mbTier
+        pure $ Map.fromList (catMaybes routeTiers)
+  if Map.null routeTierByRouteCode
+    then return quotesRes
+    else do
+      let isRouteTierQuote quoteRes = isJust quoteRes.serviceTierType && (quoteRes.routeCode >>= (`Map.lookup` routeTierByRouteCode)) == quoteRes.serviceTierType
+          (matchingRouteTier, otherTiers) = partition isRouteTierQuote quotesRes
+      logInfo $ "getFrfsSearchQuote routeTiers=" <> show (Map.toList routeTierByRouteCode) <> " quotesAtRouteTier=" <> show (length matchingRouteTier)
+      return $ matchingRouteTier <> otherTiers
 
 postFrfsQuoteV2Confirm :: (CallExternalBPP.FRFSConfirmFlow m r c, HasField "blackListedJobs" r [Text], HasFlowEnv m r '["seatBookingConfirmAPIRateLimitOptions" ::: APIRateLimitOptions], HasField "cloudType" r (Maybe CloudType), HasMasterCloudForwarder r) => (Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Person.Person), Kernel.Types.Id.Id Domain.Types.Merchant.Merchant) -> Kernel.Types.Id.Id DFRFSQuote.FRFSQuote -> Maybe Bool -> API.Types.UI.FRFSTicketService.FRFSQuoteConfirmReq -> m API.Types.UI.FRFSTicketService.FRFSTicketBookingStatusAPIRes
 postFrfsQuoteV2Confirm (mbPersonId, merchantId) quoteId mbIsMockPayment req =

--- a/Backend/dev/migrations-read-only/rider-app/integrated_bpp_config.sql
+++ b/Backend/dev/migrations-read-only/rider-app/integrated_bpp_config.sql
@@ -39,3 +39,8 @@ ALTER TABLE atlas_app.integrated_bpp_config DROP CONSTRAINT integrated_bpp_confi
 ------- SQL updates -------
 
 ALTER TABLE atlas_app.integrated_bpp_config ADD COLUMN pass_override_applicable boolean ;
+
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.integrated_bpp_config ADD COLUMN sort_quotes_by_route_service_tiers boolean ;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Search quote results can now be prioritized according to the route’s service tier.
  * Quotes matching the route’s service tier appear first, followed by other available quotes.
  * If route-tier information is unavailable, quotes continue to appear without disruption.
  * This behavior can be enabled or disabled through the applicable configuration setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->