### PR TITLE
provider-platform/feat: add BPP_rider_acceptance_count funnel counter

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
@@ -51,6 +51,7 @@ import SharedLogic.Cancel
 import SharedLogic.External.LocationTrackingService.Types (HasLocationService)
 import qualified SharedLogic.FareCalculator as FC
 import qualified SharedLogic.FarePolicy as SFP
+import qualified SharedLogic.MetricsLabels as SML
 import qualified SharedLogic.RiderDetails as SRD
 import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
 import qualified SharedLogic.Type as SLT
@@ -71,6 +72,7 @@ import qualified Storage.Queries.SearchTry as QST
 import Tools.Error
 import Tools.Event
 import qualified Tools.Maps as Maps
+import qualified Tools.Metrics.ARDUBPPMetrics as BPPMetrics
 
 data FulfillmentId = QuoteId (Id DQ.Quote) | DriverQuoteId (Id DDQ.DriverQuote)
 
@@ -130,6 +132,7 @@ handler ::
     EventStreamFlow m r,
     EncFlow m r,
     HasLocationService m r,
+    BPPMetrics.HasBPPMetrics m r,
     HasShortDurationRetryCfg r c,
     HasRequestId r,
     HasFlowEnv m r '["maxNotificationShards" ::: Int],
@@ -161,6 +164,13 @@ handler merchantId req validatedReq = do
       ValidatedQuote quote -> do
         booking <- buildBooking searchRequest quote SLT.PERSONAL quote.id.getId quote.tripCategory now mbPaymentMethod paymentUrl Nothing req.initReqDetails searchRequest.configInExperimentVersions Nothing Nothing Nothing Nothing Nothing Nothing Nothing
         QRB.createBooking booking
+        cityLabel <- SML.getCityLabel searchRequest.merchantOperatingCityId
+        distanceEdges <- SML.getDistanceBucketEdges searchRequest.merchantOperatingCityId
+        BPPMetrics.incrementRiderAcceptanceCount
+          transporter.shortId.getShortId
+          cityLabel
+          (show booking.vehicleServiceTier)
+          (SML.distanceBucketLabel distanceEdges booking.estimatedDistance)
         when booking.isScheduled $ void $ addScheduledBookingInRedis booking
         return (booking, Nothing, Nothing)
   -- Special zone driver demand pipeline: fires for BOTH estimate-based (normal Select → Init)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Select.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Select.hs
@@ -42,6 +42,7 @@ import qualified Lib.Yudhishthira.Tools.DebugLog as LYDL
 import qualified Lib.Yudhishthira.Types as Yudhishthira
 import SharedLogic.Allocator.Jobs.SendSearchRequestToDrivers (sendSearchRequestToDrivers')
 import SharedLogic.DriverPool
+import qualified SharedLogic.MetricsLabels as SML
 import qualified SharedLogic.RiderDetails as SRD
 import SharedLogic.SearchTry
 import qualified SharedLogic.Type as SLT
@@ -51,6 +52,7 @@ import qualified Storage.Queries.Estimate as QEst
 import qualified Storage.Queries.RiderDetails as QRD
 import qualified Storage.Queries.SearchRequest as QSR
 import Tools.Error
+import qualified Tools.Metrics.ARDUBPPMetrics as BPPMetrics
 
 data DSelectReq = DSelectReq
   { messageId :: Text,
@@ -80,6 +82,14 @@ data DSelectReq = DSelectReq
 handler :: DM.Merchant -> DSelectReq -> DSR.SearchRequest -> [DEst.Estimate] -> Flow ()
 handler merchant sReq searchReq estimates = do
   logDebug $ "DSelectReq: select request billingCategory: " <> show sReq.billingCategory <> "transactionId: " <> sReq.transactionId
+  whenJust (listToMaybe estimates) $ \primaryEstimate -> do
+    cityLabel <- SML.getCityLabel searchReq.merchantOperatingCityId
+    distanceEdges <- SML.getDistanceBucketEdges searchReq.merchantOperatingCityId
+    BPPMetrics.incrementRiderAcceptanceCount
+      merchant.shortId.getShortId
+      cityLabel
+      (show primaryEstimate.vehicleServiceTier)
+      (SML.distanceBucketLabel distanceEdges primaryEstimate.estimatedDistance)
   now <- getCurrentTime
   riderId <- case sReq.customerPhoneNum of
     Just number -> do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics.hs
@@ -57,6 +57,12 @@ addSearchRequestExpiredCount merchantId merchantOpCityId vehicleServiceTier (dis
   version <- asks (.version)
   liftIO $ P.withLabel bmContainer.searchRequestExpiredCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, poolingLogicV, poolingConfigV, version.getDeploymentVersion) (void . (`P.addCounter` fromIntegral count))
 
+incrementRiderAcceptanceCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
+incrementRiderAcceptanceCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
+  bmContainer <- asks (.bppMetrics)
+  version <- asks (.version)
+  liftIO $ P.withLabel bmContainer.riderAcceptanceCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
+
 incrementBookingCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
 incrementBookingCreatedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
   bmContainer <- asks (.bppMetrics)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics/Types.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics/Types.hs
@@ -63,6 +63,7 @@ data BPPMetricsContainer = BPPMetricsContainer
     searchTryCounter :: SearchTryCounterMetric,
     searchRequestSentToDriverCounter :: AllocationFunnelCounterMetric,
     searchRequestExpiredCounter :: AllocationFunnelCounterMetric,
+    riderAcceptanceCounter :: RideFunnelCounterMetric,
     bookingCreatedCounter :: RideFunnelCounterMetric,
     rideCreatedCounter :: RideFunnelCounterMetric,
     rideStartedCounter :: RideFunnelCounterMetric,
@@ -83,6 +84,7 @@ registerBPPMetricsContainer searchDurationTimeout = do
   searchTryCounter <- registerSearchTryCounter
   searchRequestSentToDriverCounter <- registerAllocationFunnelCounter "BPP_search_request_sent_to_driver_count" "Count of search requests fanned out to drivers, batched per driver"
   searchRequestExpiredCounter <- registerAllocationFunnelCounter "BPP_search_request_expired_count" "Count of driver search requests retracted without any driver response"
+  riderAcceptanceCounter <- registerRideFunnelCounter "BPP_rider_acceptance_count" "Count of rider fare acceptances (Beckn select; normal flow only, OTP/special-zone rides skip select)"
   bookingCreatedCounter <- registerRideFunnelCounter "BPP_booking_created_count" "Count of bookings confirmed on the BPP"
   rideCreatedCounter <- registerRideFunnelCounter "BPP_ride_created_count" "Count of rides created (driver assigned to booking)"
   rideStartedCounter <- registerRideFunnelCounter "BPP_ride_started_count" "Count of rides started"


### PR DESCRIPTION
Adds BPP_rider_acceptance_count, a new Prometheus counter for the rider-acceptance step of the BPP ride funnel.

Every other stage of the funnel is already instrumented, but nothing fires when a rider accepts a fare. That value is the numerator of Rider Acceptance and the denominator of Driver Acceptance, so without it RA cannot be computed at all and DA has to fall back on ride_created / booking_created, which is ~100% by construction and measures nothing.

The counter is incremented at both acceptance points: Beckn/Select.hs for the normal flow, and the ValidatedQuote branch of Beckn/Init.hs for OTP and special-zone rides, which confirm a quote directly from on_search and never pass through Select. The two Init branches are mutually exclusive, so no acceptance is counted twice. It is registered through the existing registerRideFunnelCounter helper, so it carries the same labels as the other funnel counters — {merchant, city, vehicle_service_tier, distance_bucket, backend_version} — and needs no new handling in Grafana.

With this in place RA (rider_acceptance / search_request) and DA (ride_created / rider_acceptance) become exact rather than proxies. The change is purely additive: one new counter and two increments, with no change to any existing metric, query, or behaviour.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for rider acceptance during fare selection and quote-confirmed booking flows.
  * Acceptance metrics are categorized by vehicle service tier, travel distance, operating city, merchant, and deployment version.
  * Metrics now cover standard fare acceptances and eligible special-zone OTP bookings.
  * This provides more detailed visibility into acceptance patterns across supported booking scenarios and service areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->