### PR TITLE
feat: Add ride request stats

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -320,6 +320,7 @@ library
       Domain.Action.UI.DriverProfileQuestions
       Domain.Action.UI.DriverProfileSummary
       Domain.Action.UI.DriverReferral
+      Domain.Action.UI.DriverRideRequestStats
       Domain.Action.UI.DriverSafetySettings
       Domain.Action.UI.DriverWallet
       Domain.Action.UI.EditBooking
@@ -1119,6 +1120,7 @@ library
       API.Action.UI.DriverOnboardingV2
       API.Action.UI.DriverProfile
       API.Action.UI.DriverProfileQuestions
+      API.Action.UI.DriverRideRequestStats
       API.Action.UI.DriverSafetySettings
       API.Action.UI.DriverWallet
       API.Action.UI.EditBooking
@@ -1204,6 +1206,7 @@ library
       API.Types.UI.DriverOnboardingV2
       API.Types.UI.DriverProfile
       API.Types.UI.DriverProfileQuestions
+      API.Types.UI.DriverRideRequestStats
       API.Types.UI.DriverSafetySettings
       API.Types.UI.DriverWallet
       API.Types.UI.EditBooking

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/DriverRideRequestStats.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/DriverRideRequestStats.yaml
@@ -1,0 +1,19 @@
+module: DriverRideRequestStats
+
+types:
+  DriverRideRequestStatsRes:
+    totalRequests: Int
+    acceptedRequests: Int
+    rejectedRequests: Int
+    pulledRequests: Int
+    lastRequestAt: Maybe UTCTime
+    lastAcceptedRequestAt: Maybe UTCTime
+
+apis:
+  - GET: # DriverRideRequestStatsAPI
+      endpoint: /rideRequestStats
+      auth: TokenAuth PROVIDER_TYPE
+      query:
+        - durationInMinutes: Int
+      response:
+        type: DriverRideRequestStatsRes

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/DriverRideRequestStats.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/API/DriverRideRequestStats.yaml
@@ -11,7 +11,7 @@ types:
 
 apis:
   - GET: # DriverRideRequestStatsAPI
-      endpoint: /rideRequestStats
+      endpoint: /driver/rideRequestStats
       auth: TokenAuth PROVIDER_TYPE
       query:
         - durationInMinutes: Int

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/UI/DriverRideRequestStats.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Action/UI/DriverRideRequestStats.hs
@@ -1,0 +1,38 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module API.Action.UI.DriverRideRequestStats
+  ( API,
+    handler,
+  )
+where
+
+import qualified API.Types.UI.DriverRideRequestStats
+import qualified Control.Lens
+import qualified Domain.Action.UI.DriverRideRequestStats
+import qualified Domain.Types.Merchant
+import qualified Domain.Types.MerchantOperatingCity
+import qualified Domain.Types.Person
+import qualified Environment
+import EulerHS.Prelude
+import qualified Kernel.Prelude
+import qualified Kernel.Types.Id
+import Kernel.Utils.Common
+import Servant
+import Storage.Beam.SystemConfigs ()
+import Tools.Auth
+
+type API = (TokenAuth :> "rideRequestStats" :> QueryParam "durationInMinutes" Kernel.Prelude.Int :> Get ('[JSON]) API.Types.UI.DriverRideRequestStats.DriverRideRequestStatsRes)
+
+handler :: Environment.FlowServer API
+handler = getRideRequestStats
+
+getRideRequestStats ::
+  ( ( Kernel.Types.Id.Id Domain.Types.Person.Person,
+      Kernel.Types.Id.Id Domain.Types.Merchant.Merchant,
+      Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity
+    ) ->
+    Kernel.Prelude.Maybe (Kernel.Prelude.Int) ->
+    Environment.FlowHandler API.Types.UI.DriverRideRequestStats.DriverRideRequestStatsRes
+  )
+getRideRequestStats a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.DriverRideRequestStats.getRideRequestStats (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a2) a1

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/DriverRideRequestStats.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/API/Types/UI/DriverRideRequestStats.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module API.Types.UI.DriverRideRequestStats where
+
+import Data.OpenApi (ToSchema)
+import EulerHS.Prelude hiding (id)
+import qualified Kernel.Prelude
+import Servant
+import Tools.Auth
+
+data DriverRideRequestStatsRes = DriverRideRequestStatsRes
+  { acceptedRequests :: Kernel.Prelude.Int,
+    lastAcceptedRequestAt :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
+    lastRequestAt :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
+    pulledRequests :: Kernel.Prelude.Int,
+    rejectedRequests :: Kernel.Prelude.Int,
+    totalRequests :: Kernel.Prelude.Int
+  }
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI.hs
@@ -29,6 +29,7 @@ import qualified API.Action.UI.DriverIncentiveCoins as DriverIncentiveCoins
 import qualified API.Action.UI.DriverOnboardingV2 as DriverOnboardingV2
 import qualified API.Action.UI.DriverProfile as DriverProfile
 import qualified API.Action.UI.DriverProfileQuestions as DriverProfileQuestions
+import qualified API.Action.UI.DriverRideRequestStats as DriverRideRequestStats
 import qualified API.Action.UI.DriverSafetySettings as DriverSafetySettings
 import qualified API.Action.UI.DriverWallet as DriverWallet
 import qualified API.Action.UI.EditBooking as EditBooking
@@ -193,6 +194,7 @@ type API =
            :<|> FleetEngineToken.API
            :<|> DriverDocument.API
            :<|> DriverAreaPreference.API
+           :<|> DriverRideRequestStats.API
        )
 
 handler :: FlowServer API
@@ -276,3 +278,4 @@ handler =
     :<|> FleetEngineToken.handler
     :<|> DriverDocument.handler
     :<|> DriverAreaPreference.handler
+    :<|> DriverRideRequestStats.handler

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverRideRequestStats.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverRideRequestStats.hs
@@ -1,0 +1,36 @@
+module Domain.Action.UI.DriverRideRequestStats where
+
+import qualified API.Types.UI.DriverRideRequestStats
+import qualified Domain.Types.Merchant as DM
+import qualified Domain.Types.MerchantOperatingCity as DMOC
+import qualified Domain.Types.Person as SP
+import Environment
+import EulerHS.Prelude
+import Kernel.Types.Error
+import Kernel.Types.Id
+import Kernel.Utils.Common
+import qualified Storage.Queries.SearchRequestForDriverExtra as QSRFD
+
+getDriverRideRequestStats ::
+  ( ( Maybe (Id SP.Person),
+      Id DM.Merchant,
+      Id DMOC.MerchantOperatingCity
+    ) ->
+    Maybe Int ->
+    Flow API.Types.UI.DriverRideRequestStats.DriverRideRequestStatsRes
+  )
+getDriverRideRequestStats (mbPersonId, _merchantId, _merchantOpCityId) mbDurationInMinutes = do
+  driverId <- mbPersonId & fromMaybeM (PersonNotFound "No person id passed")
+  let durationInMinutes = fromMaybe (24 * 60) mbDurationInMinutes
+  now <- getCurrentTime
+  let since = addUTCTime (- fromIntegral (durationInMinutes * 60) :: NominalDiffTime) now
+  (totalRequests, acceptedRequests, rejectedRequests, pulledRequests, lastRequestAt, lastAcceptedRequestAt) <- QSRFD.getRideRequestStatsSince driverId since
+  pure
+    API.Types.UI.DriverRideRequestStats.DriverRideRequestStatsRes
+      { totalRequests = totalRequests,
+        acceptedRequests = acceptedRequests,
+        rejectedRequests = rejectedRequests,
+        pulledRequests = pulledRequests,
+        lastRequestAt = lastRequestAt,
+        lastAcceptedRequestAt = lastAcceptedRequestAt
+      }

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverRideRequestStats.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverRideRequestStats.hs
@@ -11,7 +11,7 @@ import Kernel.Types.Id
 import Kernel.Utils.Common
 import qualified Storage.Queries.SearchRequestForDriverExtra as QSRFD
 
-getDriverRideRequestStats ::
+getRideRequestStats ::
   ( ( Maybe (Id SP.Person),
       Id DM.Merchant,
       Id DMOC.MerchantOperatingCity
@@ -19,7 +19,7 @@ getDriverRideRequestStats ::
     Maybe Int ->
     Flow API.Types.UI.DriverRideRequestStats.DriverRideRequestStatsRes
   )
-getDriverRideRequestStats (mbPersonId, _merchantId, _merchantOpCityId) mbDurationInMinutes = do
+getRideRequestStats (mbPersonId, _merchantId, _merchantOpCityId) mbDurationInMinutes = do
   driverId <- mbPersonId & fromMaybeM (PersonNotFound "No person id passed")
   let durationInMinutes = fromMaybe (24 * 60) mbDurationInMinutes
   now <- getCurrentTime

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverRideRequestStats.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverRideRequestStats.hs
@@ -23,7 +23,7 @@ getRideRequestStats (mbPersonId, _merchantId, _merchantOpCityId) mbDurationInMin
   driverId <- mbPersonId & fromMaybeM (PersonNotFound "No person id passed")
   let durationInMinutes = fromMaybe (24 * 60) mbDurationInMinutes
   now <- getCurrentTime
-  let since = addUTCTime (- fromIntegral (durationInMinutes * 60) :: NominalDiffTime) now
+  let since = addUTCTime (fromIntegral (- (durationInMinutes * 60))) now
   (totalRequests, acceptedRequests, rejectedRequests, pulledRequests, lastRequestAt, lastAcceptedRequestAt) <- QSRFD.getRideRequestStatsSince driverId since
   pure
     API.Types.UI.DriverRideRequestStats.DriverRideRequestStatsRes

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SearchRequestForDriverExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SearchRequestForDriverExtra.hs
@@ -26,6 +26,24 @@ import qualified Storage.Queries.Person as QP
 
 -- Extra code goes here --
 
+getRideRequestStatsSince :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id Person -> UTCTime -> m (Int, Int, Int, Int, Maybe UTCTime, Maybe UTCTime)
+getRideRequestStatsSince driverId since = do
+  reqs <-
+    findAllWithKV
+      [ Se.And
+          [ Se.Is BeamSRFD.driverId $ Se.Eq (getId driverId),
+            Se.Is BeamSRFD.createdAt $ Se.GreaterThanOrEq (T.utcToLocalTime T.utc since)
+          ]
+      ]
+  let totalRequests = length reqs
+      acceptedReqs = filter (\req -> req.response == Just Domain.Accept) reqs
+      acceptedRequests = length acceptedReqs
+      rejectedRequests = length (filter (\req -> req.response == Just Domain.Reject) reqs)
+      pulledRequests = length (filter (\req -> req.response == Just Domain.Pulled) reqs)
+      lastRequestAt = if null reqs then Nothing else Just (maximum (map (.createdAt) reqs))
+      lastAcceptedRequestAt = if null acceptedReqs then Nothing else Just (maximum (map (.createdAt) acceptedReqs))
+  pure (totalRequests, acceptedRequests, rejectedRequests, pulledRequests, lastRequestAt, lastAcceptedRequestAt)
+
 searchReqestForDriverkey :: Text -> Text
 searchReqestForDriverkey prefix = "searchRequestForDriver_" <> prefix
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated driver endpoint for ride request statistics (`GET /driver/rideRequestStats`).
  * Drivers can view total, accepted, rejected, and pulled request counts for a selected duration.
  * Response includes timestamps for the latest request and latest accepted request.
  * If no duration is provided, the window defaults to the previous 24 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->