### PR TITLE
rider-app/fix: give Meta webhook errors distinct error codes

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MetaWhatsappWebhook.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MetaWhatsappWebhook.hs
@@ -40,10 +40,10 @@ import qualified Kernel.External.Meta as Meta
 import Kernel.External.Meta.Webhook (RawByteString)
 import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Types.APISuccess (APISuccess (Success))
-import Kernel.Types.Error
 import Kernel.Utils.Common
 import qualified Storage.CachedQueries.MetaWebhookConfig as CQMWC
 import qualified Storage.Queries.MetaWebhookConfig as QMWC
+import Tools.Error (MetaWebhookError (MetaAppSecretNotConfigured, MetaWebhookSignatureInvalid, MetaWebhookVerifyFailed))
 import qualified WhatsappBot.Adapter.Env as Env
 import WhatsappBot.Inbound (parseInbound)
 import WhatsappBot.Types (InboundEvent)
@@ -85,8 +85,8 @@ getWebhookChallenge mMode mToken mChallenge = withLogTag "MetaWebhook" $
       matched <- anyM (tokenMatches token) configs
       if matched
         then pure challenge
-        else throwError (InvalidRequest "META_WEBHOOK_VERIFY_FAILED")
-    _ -> throwError (InvalidRequest "META_WEBHOOK_VERIFY_FAILED")
+        else throwError MetaWebhookVerifyFailed
+    _ -> throwError MetaWebhookVerifyFailed
   where
     -- anyM comes from EulerHS.Prelude (Universum) — don't shadow it with a
     -- hand-rolled version.
@@ -118,8 +118,13 @@ handleVerifiedWebhook cfg mbSig rawBody = do
   appSecret <- decrypt cfg.appSecret
   -- Fail-closed: an empty appSecret makes the HMAC forgeable (empty key), so
   -- never verify against it — reject as misconfigured instead.
-  when (T.null appSecret) $ throwError (InvalidRequest "META_APP_SECRET_NOT_CONFIGURED")
-  Meta.verifyMetaSignature appSecret mbSig rawBody -- throws INVALID_META_SIGNATURE on mismatch; verified against the SAME rawBody the peek read
+  when (T.null appSecret) $ throwError MetaAppSecretNotConfigured
+  -- Pure check (not Meta.verifyMetaSignature, which throws the same generic
+  -- InvalidRequest "INVALID_META_SIGNATURE" this whole file moved away from)
+  -- so a mismatch surfaces as our own typed MetaWebhookSignatureInvalid
+  -- instead. Verified against the SAME rawBody the peek read.
+  unless (Meta.verifyMetaSignaturePure appSecret mbSig (Meta.getRawByteString rawBody)) $
+    throwError MetaWebhookSignatureInvalid
   case Meta.decodeWebhookEnvelope rawBody of
     Left err -> do
       logError $ "Meta webhook decode failed (acking to stop 7d retries): " <> T.pack err

--- a/Backend/app/rider-platform/rider-app/Main/src/Tools/Error.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Tools/Error.hs
@@ -1394,3 +1394,35 @@ instance IsHTTPError SeatLayoutError where
     InvalidSleeperSeatPosition _ -> E400
 
 instance IsAPIError SeatLayoutError
+
+-- | Thrown by Domain.Action.UI.MetaWhatsappWebhook. Each constructor is a
+-- genuinely distinct failure with its own errorCode -- replaces 3 separate
+-- @InvalidRequest "SOME_STRING"@ throws that all collapsed to the same
+-- generic "INVALID_REQUEST" errorCode (InvalidRequest's toErrorCode ignores
+-- its Text argument; only toMessage keeps it), making every real cause
+-- indistinguishable from the response's errorCode alone.
+data MetaWebhookError
+  = MetaWebhookVerifyFailed
+  | MetaAppSecretNotConfigured
+  | MetaWebhookSignatureInvalid
+  deriving (Eq, Show, IsBecknAPIError)
+
+instanceExceptionWithParent 'HTTPException ''MetaWebhookError
+
+instance IsBaseError MetaWebhookError where
+  toMessage = \case
+    MetaWebhookVerifyFailed -> Just "Meta webhook verification failed: hub.verify_token did not match any enabled config."
+    MetaAppSecretNotConfigured -> Just "Meta webhook app secret is not configured for this phone number."
+    MetaWebhookSignatureInvalid -> Just "Meta webhook X-Hub-Signature-256 did not match the computed HMAC."
+
+instance IsHTTPError MetaWebhookError where
+  toErrorCode = \case
+    MetaWebhookVerifyFailed -> "META_WEBHOOK_VERIFY_FAILED"
+    MetaAppSecretNotConfigured -> "META_APP_SECRET_NOT_CONFIGURED"
+    MetaWebhookSignatureInvalid -> "META_WEBHOOK_SIGNATURE_INVALID"
+  toHttpCode = \case
+    MetaWebhookVerifyFailed -> E400
+    MetaAppSecretNotConfigured -> E500
+    MetaWebhookSignatureInvalid -> E400
+
+instance IsAPIError MetaWebhookError


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp webhook error handling with distinct responses for:
    * Invalid signatures
    * Failed verification requests
    * Missing app configuration
  * Webhook signature validation now consistently checks the original request data.
  * API clients receive clearer error codes and HTTP responses for webhook failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->