### PR TITLE
Make driver /internal/sync_search idempotent for duplicate transactions

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
@@ -25,7 +25,7 @@ import qualified Domain.Action.Beckn.Search as DSearch
 import qualified Domain.Types.Merchant as DM
 import Environment
 import qualified EulerHS.Language as L
-import EulerHS.Prelude hiding (id)
+import EulerHS.Prelude hiding (id, unless)
 import Kernel.Beam.Types (TxnIdKey (..))
 import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Types.Error
@@ -76,8 +76,14 @@ syncSearch merchantIdRaw mbToken mbIsShadowSearch mbParentTransactionId reqV2 = 
       -- A shadow search arrives under its own transaction id (the BAP creates a separate
       -- search request for it), so it never collides with the search it shadows here.
       isFirst <- Redis.withCrossAppRedis $ Redis.setNxExpire (DSearch.searchTxnDedupKey transactionId transporterId.getId) 60 True
-      unless isFirst $
-        throwError $ InternalError $ "Search already processed by beckn for txn " <> transactionId
-      (_, onSearchReq) <- SRP.processSearchRequest merchant dSearchReq transporterId msgId txnId bapUri city country (bool "sync_search" "sync_search_shadow" isShadowSearch) (toJSON reqV2)
-      logTagInfo "SyncSearchV2 Internal Flow" $ "Returning OnSearch inline:-" <> TL.toStrict (A.encodeToLazyText onSearchReq)
-      pure onSearchReq
+      if isFirst
+        then do
+          (_, onSearchReq) <- SRP.processSearchRequest merchant dSearchReq transporterId msgId txnId bapUri city country (bool "sync_search" "sync_search_shadow" isShadowSearch) (toJSON reqV2)
+          Redis.withCrossAppRedis $ Redis.setExp (DSearch.searchTxnResultKey transactionId transporterId.getId) onSearchReq 60
+          logTagInfo "SyncSearchV2 Internal Flow" $ "Returning OnSearch inline:-" <> TL.toStrict (A.encodeToLazyText onSearchReq)
+          pure onSearchReq
+        else do
+          mbOnSearchReq <- Redis.withCrossAppRedis $ Redis.get (DSearch.searchTxnResultKey transactionId transporterId.getId)
+          case mbOnSearchReq of
+            Just onSearchReq -> pure onSearchReq
+            Nothing -> throwError $ InvalidRequest $ "Search already processed by beckn for txn " <> transactionId <> " but result not available"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -26,6 +26,7 @@ module Domain.Action.Beckn.Search
     buildEstimate,
     getIsInterCity,
     searchTxnDedupKey,
+    searchTxnResultKey,
   )
 where
 
@@ -1298,3 +1299,6 @@ transformReserveRideEsttoEst DBppEstimate.BppEstimate {..} = do
 
 searchTxnDedupKey :: Text -> Text -> Text
 searchTxnDedupKey txnId mId = "Driver:Search:TxnDedup-" <> txnId <> ":" <> mId
+
+searchTxnResultKey :: Text -> Text -> Text
+searchTxnResultKey txnId mId = "Driver:Search:TxnResult-" <> txnId <> ":" <> mId


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (2f/22l)

### Root cause
Driver BPP /internal/sync_search was throwing InternalError (mapped to HTTP 500) whenever a duplicate transaction arrived. The endpoint is synchronous and must return a Spec.OnSearchReq, so duplicates should be served from a cached result instead of failing. The fix stores the computed OnSearchReq in Redis for 60s and returns it on duplicate; if the cache is absent it returns a 4xx InvalidRequest instead of 500.

### Evidence
_see RCA_

### Rollback
Revert the commit or redeploy the previous image tag for beckn-driver-offer-bpp-production.

---
_Draft PR — review and merge manually. Generated by Argus._