### PR TITLE
provider-platform/fix: retract only re-offered drivers when sending a new batch

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/SendSearchRequestToDrivers.hs
@@ -224,11 +224,14 @@ sendSearchRequestToDrivers isAllocatorBatch tripQuoteDetails oldSearchReq search
       let timedOutQueueDrivers = filter (.pickupZone) unrespondedSRFDs
       forM_ timedOutQueueDrivers $ \srfd ->
         SpecialZoneDriverDemand.handleQueueSkipIfApplicable searchReq.pickupZoneGateId (show searchTry.vehicleServiceTier) srfd.driverId searchReq.providerId (searchTry.id.getId <> ":" <> srfd.driverId.getId)
-  whenM (anyM (\driverId -> CQDGR.getDriverGoHomeRequestInfo driverId searchReq.merchantOperatingCityId (Just goHomeConfig) <&> isNothing . (.status)) prevBatchDrivers) $ do
-    -- these unresponded requests are being retracted here: count them as expired
-    forM_ (M.toList $ M.fromListWith (+) $ map (\srfd -> (srfd.vehicleServiceTier, 1 :: Int)) unrespondedSRFDs) $ \(serviceTier, expiredCount) ->
-      TM.addSearchRequestExpiredCount merchantLabel cityLabel (show serviceTier) (SML.searchReqFunnelLabels metricsDistanceBucketEdges searchReq) expiredCount
-    QSRD.setInactiveBySTId Nothing searchTry.id.getId -- inactive previous request by drivers so that they can make new offers.
+  let dispatchDriverIds = map (\dp -> dp.driverPoolResult.driverId.getId) dispatchPool
+      reOfferedSRFDs = filter (\srfd -> srfd.driverId.getId `elem` dispatchDriverIds) unrespondedSRFDs
+  unless (null reOfferedSRFDs) $
+    whenM (anyM (\driverId -> CQDGR.getDriverGoHomeRequestInfo driverId searchReq.merchantOperatingCityId (Just goHomeConfig) <&> isNothing . (.status)) prevBatchDrivers) $ do
+      -- these unresponded requests are being retracted here: count them as expired
+      forM_ (M.toList $ M.fromListWith (+) $ map (\srfd -> (srfd.vehicleServiceTier, 1 :: Int)) reOfferedSRFDs) $ \(serviceTier, expiredCount) ->
+        TM.addSearchRequestExpiredCount merchantLabel cityLabel (show serviceTier) (SML.searchReqFunnelLabels metricsDistanceBucketEdges searchReq) expiredCount
+      QSRD.setInactiveAndPulledByIds reOfferedSRFDs
   _ <- QSRD.createMany searchRequestsForDrivers
   -- Batch size on record, so the respond API can recognise a *fully* rejected batch
   -- (rejects == sent) and advance the batch chain early instead of idling out the timer.


### PR DESCRIPTION
## Problem

When the allocator sends a new driver batch, `sendSearchRequestToDrivers` calls:

```haskell
QSRD.setInactiveBySTId Nothing searchTry.id.getId
```

That update is keyed on `searchTryId` alone (`SearchRequestForDriverExtra.hs:64`), so it marks **every** Active `search_request_for_driver` row of the search try Inactive and `zRem`s each one from `searchReqestForDriverkey <driverId>` — the Redis list the driver app reads to render live offers. Drivers who are not in the new batch get their request card pulled off the screen mid-decision, and every retracted row is counted as an expiry via `addSearchRequestExpiredCount`.

## Why the retraction exists

It is protecting an invariant, not making a product decision. `respondQuote` resolves the driver's offer with:

```haskell
mSReqFD <- QSRD.findByDriverAndSearchTryId driverId searchTry.id
```

which is `findOneWithKV [searchTryId == X, driverId == D, status == Active]` — no batch predicate and no `searchRequestValidTill` predicate. A driver can be offered the same search try more than once, because `previouslyAttemptedDrivers` sorts prior-attempted drivers to the *tail* of the LTS candidates rather than excluding them. Without the retraction that driver ends up with two Active rows and `findOneWithKV` returns an arbitrary one, potentially carrying the stale `searchRequestValidTill`, `batchNumber` and fare fields.

So the retraction is needed — but only for the drivers actually being re-offered.

## Change

Intersect the previous batch's unresponded rows with the drivers this batch is about to dispatch to, and retract only those, by id, using the existing `setInactiveAndPulledByIds` (already used for the same purpose in `Domain.Action.Beckn.Cancel`):

```haskell
let dispatchDriverIds = map (\dp -> dp.driverPoolResult.driverId.getId) dispatchPool
    reOfferedSRFDs = filter (\srfd -> srfd.driverId.getId `elem` dispatchDriverIds) unrespondedSRFDs
```

Both `unrespondedSRFDs` and `dispatchPool` were already computed a few lines above; no new queries.

The `addSearchRequestExpiredCount` accounting now counts only rows that were actually retracted.

## Scope / safety

- The existing go-home guard is kept, so the retracted set is always a **subset** of what is retracted today. Behaviour never widens.
- Guarded with `unless (null reOfferedSRFDs)`, so no empty `IN ()` update and no needless `getDriverGoHomeRequestInfo` calls when there is nothing to retract.
- `setInactiveAndPulledByIds` additionally sets `response = Pulled` where the old path left it null. That is the more accurate label for a system-retracted offer, and it matches how cancellation already records it. The rows are Inactive either way, so `findByDriverAndSearchTryId` and `findAllActiveBySTId` do not return them.
- Retraction on ride assignment (`SharedLogic.Ride`) and on cancellation (`Domain.Action.Beckn.Cancel`) is untouched — those are the cases where every outstanding offer genuinely must die.

## Why it matters beyond the immediate fix

This is a prerequisite for shortening the batch interval below the offer TTL. Today `getRescheduleTime` is `singleBatchProcessTime + singleBatchProcessingTempDelay`, so batches never overlap and the blanket retraction is mostly invisible — the rows it kills had already expired. The moment the interval drops below the TTL to keep more requests live concurrently, this line is what would destroy the overlap.

## Testing

`cabal build lib:dynamic-offer-driver-app` passes locally (`-Werror`, clean). No automated test covers this path.

Worth a look on staging at: a driver in batch N who is not re-offered in batch N+1 keeps their card until `searchRequestValidTill`, and a driver who *is* re-offered gets exactly one Active row.

## Follow-up (not in this PR)

`findByDriverAndSearchTryId` ignores `searchRequestValidTill`, so an expired-but-Active row is still returned. The Accept branch catches it via `expiryTimeWithBuffer`, but the Reject branch has no expiry check — so a driver can reject an already-expired offer and it still increments `incrementSearchTryRejectCount` and `incrementBatchRejectCount`, feeding noise into `cumulativeRejectCount` for the POOLING ruleset and into the full-reject test behind `enableEarlyBatchAdvanceOnFullReject`.
