### PR TITLE
Handle AWS S3 CLI failures gracefully in get'' to stop raw 500s

### DIFF
--- a/Backend/lib/beckn-services/src/AWS/S3/Flow.hs
+++ b/Backend/lib/beckn-services/src/AWS/S3/Flow.hs
@@ -40,6 +40,8 @@ import qualified Amazonka
 import qualified Amazonka.S3 as Amazonka
 import qualified Amazonka.S3.HeadObject as Amazonka
 import Control.Lens.Getter ((^.))
+import qualified Control.Exception.Safe as E
+import Control.Monad.Catch (throwM)
 import qualified Crypto.Hash.MD5 as MD5
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as B16
@@ -165,10 +167,14 @@ get'' ::
 get'' bucketName path = withLogTag "S3" $ do
   let tmpPath = getTmpPath path
   let cmd = "aws s3api get-object --bucket " <> T.unpack bucketName <> " --key " <> path <> " " <> tmpPath
-  liftIO $ callCommand cmd
-  result <- liftIO $ readFile tmpPath
-  liftIO $ removeFile tmpPath
-  return result
+  eResult <- liftIO $ E.try @E.IOException $ do
+    callCommand cmd
+    content <- readFile tmpPath
+    removeFile tmpPath
+    return content
+  case eResult of
+    Left _ -> throwM S3ServerError
+    Right content -> return content
 
 put'' ::
   ( CoreMetrics m,


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/14l)

### Root cause
BAP /v2/ride/driver/photo/media/ returns HTTP 500 because AWS.S3.Flow.get'' shells out to `aws s3api get-object` and the GCP pods have no AWS credentials, so the CLI exits 255 and the unhandled IOException surfaces as an internal 500. Wrapping the CLI call, cleaning up the temp file, and throwing the typed S3ServerError prevents the raw crash.

### Evidence
_see RCA_

### Rollback
Revert the PR / commit changing Backend/lib/beckn-services/src/AWS/S3/Flow.hs

---
_Draft PR — review and merge manually. Generated by Argus._