### PR TITLE
Return idempotent empty on_search for duplicate sync_search instead of HTTP 500

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
@@ -19,6 +19,7 @@ import qualified Beckn.OnDemand.Utils.Common as Utils
 import qualified Beckn.Types.Core.Taxi.API.Search as Search
 import qualified BecknV2.OnDemand.Types as Spec
 import qualified BecknV2.OnDemand.Utils.Common as Utils
+import qualified BecknV2.OnDemand.Utils.Context as ContextUtils
 import qualified Data.Aeson.Text as A
 import qualified Data.Text.Lazy as TL
 import qualified Domain.Action.Beckn.Search as DSearch
@@ -76,8 +77,16 @@ syncSearch merchantIdRaw mbToken mbIsShadowSearch mbParentTransactionId reqV2 = 
       -- A shadow search arrives under its own transaction id (the BAP creates a separate
       -- search request for it), so it never collides with the search it shadows here.
       isFirst <- Redis.withCrossAppRedis $ Redis.setNxExpire (DSearch.searchTxnDedupKey transactionId transporterId.getId) 60 True
-      unless isFirst $
-        throwError $ InternalError $ "Search already processed by beckn for txn " <> transactionId
-      (_, onSearchReq) <- SRP.processSearchRequest merchant dSearchReq transporterId msgId txnId bapUri city country (bool "sync_search" "sync_search_shadow" isShadowSearch) (toJSON reqV2)
-      logTagInfo "SyncSearchV2 Internal Flow" $ "Returning OnSearch inline:-" <> TL.toStrict (A.encodeToLazyText onSearchReq)
-      pure onSearchReq
+      if isFirst
+        then do
+          (_, onSearchReq) <- SRP.processSearchRequest merchant dSearchReq transporterId msgId txnId bapUri city country (bool "sync_search" "sync_search_shadow" isShadowSearch) (toJSON reqV2)
+          logTagInfo "SyncSearchV2 Internal Flow" $ "Returning OnSearch inline:-" <> TL.toStrict (A.encodeToLazyText onSearchReq)
+          pure onSearchReq
+        else do
+          logTagInfo "SyncSearchV2 Internal Flow" $ "Search already processed by beckn for txn " <> transactionId <> ", returning empty on_search"
+          pure $
+            Spec.OnSearchReq
+              { onSearchReqContext = context {Spec.contextAction = ContextUtils.mapToCbAction =<< context.contextAction},
+                onSearchReqError = Nothing,
+                onSearchReqMessage = Just $ Spec.OnSearchReqMessage $ Spec.Catalog Nothing Nothing
+              }


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/19l)

### Root cause
The GCP ELB 5xx alert is dominated by beckn-driver-offer-bpp-production returning HTTP 500 on POST /internal/sync_search/:merchantId/. When a duplicate Beckn search transaction arrives within the 60s Redis dedup window, API/Internal/SyncSearch.hs throws InternalError ("Search already processed by beckn for txn ..."). Kernel.Types.Error maps InternalError to HTTP 500. The async search path (API/Beckn/Search.hs) handles duplicates idempotently by skipping re-processing; the sync path should do the same.

### Evidence
_see RCA_

### Rollback
Revert the change in Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs to restore the InternalError throw on duplicate transactions.

---
_Draft PR — review and merge manually. Generated by Argus._