### PR TITLE
Return 409 Conflict instead of 500 for duplicate sync_search requests

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
@@ -28,7 +28,7 @@ import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (id)
 import Kernel.Beam.Types (TxnIdKey (..))
 import qualified Kernel.Storage.Hedis as Redis
-import Kernel.Types.Error
+import Tools.Error
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import Kernel.Utils.DatastoreLatencyCalculator (withTimeAPI)
@@ -77,7 +77,7 @@ syncSearch merchantIdRaw mbToken mbIsShadowSearch mbParentTransactionId reqV2 = 
       -- search request for it), so it never collides with the search it shadows here.
       isFirst <- Redis.withCrossAppRedis $ Redis.setNxExpire (DSearch.searchTxnDedupKey transactionId transporterId.getId) 60 True
       unless isFirst $
-        throwError $ InternalError $ "Search already processed by beckn for txn " <> transactionId
+        throwError $ SearchAlreadyProcessed transactionId
       (_, onSearchReq) <- SRP.processSearchRequest merchant dSearchReq transporterId msgId txnId bapUri city country (bool "sync_search" "sync_search_shadow" isShadowSearch) (toJSON reqV2)
       logTagInfo "SyncSearchV2 Internal Flow" $ "Returning OnSearch inline:-" <> TL.toStrict (A.encodeToLazyText onSearchReq)
       pure onSearchReq

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
@@ -400,6 +400,23 @@ instance IsHTTPError SearchRequestErrorARDU where
 instance IsAPIError SearchRequestErrorARDU
 
 --
+data SyncSearchError = SearchAlreadyProcessed Text
+  deriving (Eq, Show, IsBecknAPIError)
+
+instanceExceptionWithParent 'HTTPException ''SyncSearchError
+
+instance IsBaseError SyncSearchError where
+  toMessage (SearchAlreadyProcessed txnId) = Just $ "Search already processed by beckn for txn " <> txnId
+
+instance IsHTTPError SyncSearchError where
+  toErrorCode = \case
+    SearchAlreadyProcessed _ -> "SEARCH_ALREADY_PROCESSED"
+  toHttpCode = \case
+    SearchAlreadyProcessed _ -> E409
+
+instance IsAPIError SyncSearchError
+
+--
 data DriverQuoteError
   = FoundActiveQuotes
   | DriverOnRide


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (2f/21l)

### Root cause
Driver internal sync_search endpoint (API/Internal/SyncSearch.hs) returns HTTP 500 via InternalError when a search transaction is duplicated within the 60s dedup window. This is a normal retry/idempotency condition, not an internal server error, and it inflates the GCP ELB 5xx rate (baseline ~200/min, spiking to ~457/min during the incident).

### Evidence
_see RCA_

### Rollback
Revert the throw in API/Internal/SyncSearch.hs back to `throwError $ InternalError $ "Search already processed by beckn for txn " <> transactionId` and remove the new SyncSearchError constructor from Tools/Error.hs.

---
_Draft PR — review and merge manually. Generated by Argus._