### PR TITLE
fix(sync_search): return 400 instead of 500 for duplicate search transactions

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
@@ -77,7 +77,7 @@ syncSearch merchantIdRaw mbToken mbIsShadowSearch mbParentTransactionId reqV2 = 
       -- search request for it), so it never collides with the search it shadows here.
       isFirst <- Redis.withCrossAppRedis $ Redis.setNxExpire (DSearch.searchTxnDedupKey transactionId transporterId.getId) 60 True
       unless isFirst $
-        throwError $ InternalError $ "Search already processed by beckn for txn " <> transactionId
+        throwError $ InvalidRequest $ "Search already processed by beckn for txn " <> transactionId
       (_, onSearchReq) <- SRP.processSearchRequest merchant dSearchReq transporterId msgId txnId bapUri city country (bool "sync_search" "sync_search_shadow" isShadowSearch) (toJSON reqV2)
       logTagInfo "SyncSearchV2 Internal Flow" $ "Returning OnSearch inline:-" <> TL.toStrict (A.encodeToLazyText onSearchReq)
       pure onSearchReq


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/2l)

### Root cause
The /internal/sync_search/:merchantId/ handler in the driver BPP throws InternalError (HTTP 500) when a duplicate Beckn search transaction arrives within the 60-second Redis dedup window. Duplicate retries are expected in distributed Beckn flows; returning 500 inflates ELB 5xx metrics and alert noise. The fix maps the duplicate to InvalidRequest (HTTP 400), which reflects a client-condition error and is not a server failure.

### Evidence
_see RCA_

### Rollback
Revert the one-line change in Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs line 80 from InvalidRequest back to InternalError.

---
_Draft PR — review and merge manually. Generated by Argus._