### PR TITLE
Return Beckn NACK instead of HTTP 500 for duplicate internal sync_search requests

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs
@@ -76,8 +76,22 @@ syncSearch merchantIdRaw mbToken mbIsShadowSearch mbParentTransactionId reqV2 = 
       -- A shadow search arrives under its own transaction id (the BAP creates a separate
       -- search request for it), so it never collides with the search it shadows here.
       isFirst <- Redis.withCrossAppRedis $ Redis.setNxExpire (DSearch.searchTxnDedupKey transactionId transporterId.getId) 60 True
-      unless isFirst $
-        throwError $ InternalError $ "Search already processed by beckn for txn " <> transactionId
-      (_, onSearchReq) <- SRP.processSearchRequest merchant dSearchReq transporterId msgId txnId bapUri city country (bool "sync_search" "sync_search_shadow" isShadowSearch) (toJSON reqV2)
-      logTagInfo "SyncSearchV2 Internal Flow" $ "Returning OnSearch inline:-" <> TL.toStrict (A.encodeToLazyText onSearchReq)
-      pure onSearchReq
+      if isFirst
+        then do
+          (_, onSearchReq) <- SRP.processSearchRequest merchant dSearchReq transporterId msgId txnId bapUri city country (bool "sync_search" "sync_search_shadow" isShadowSearch) (toJSON reqV2)
+          logTagInfo "SyncSearchV2 Internal Flow" $ "Returning OnSearch inline:-" <> TL.toStrict (A.encodeToLazyText onSearchReq)
+          pure onSearchReq
+        else do
+          logTagWarn "SyncSearchV2 Internal Flow" $ "Duplicate search request for txn " <> transactionId <> ", returning NACK"
+          pure $
+            Spec.OnSearchReq
+              { onSearchReqContext = context,
+                onSearchReqError =
+                  Just $
+                    Spec.Error
+                      { errorCode = Just "SEARCH_ALREADY_PROCESSED",
+                        errorMessage = Just $ "Search already processed by beckn for txn " <> transactionId,
+                        errorPaths = Nothing
+                      },
+                onSearchReqMessage = Nothing
+              }


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/24l)

### Root cause
beckn-driver-offer-bpp-production emits HTTP 500 when a duplicate /internal/sync_search/:merchantId/ request arrives within the 60s Redis dedup window, because API.Internal.SyncSearch throws InternalError. This elevates the global ELB 5xx rate.

### Evidence
_see RCA_

### Rollback
Revert the change in Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/Internal/SyncSearch.hs to restore the `unless isFirst $ throwError ...` block.

---
_Draft PR — review and merge manually. Generated by Argus._