### PR TITLE
Add local in-memory cache for AppDynamicLogicElement cached queries

### DIFF
--- a/Backend/lib/yudhishthira/src/Lib/Yudhishthira/Storage/CachedQueries/AppDynamicLogicElement.hs
+++ b/Backend/lib/yudhishthira/src/Lib/Yudhishthira/Storage/CachedQueries/AppDynamicLogicElement.hs
@@ -4,18 +4,20 @@ module Lib.Yudhishthira.Storage.CachedQueries.AppDynamicLogicElement where
 
 import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Hedis
+import qualified Kernel.Storage.InMem as IM
 import qualified Lib.Yudhishthira.Storage.Beam.BeamFlow as BeamFlow
 import qualified Lib.Yudhishthira.Storage.Queries.AppDynamicLogicElement as Queries
 import qualified Lib.Yudhishthira.Types
 import qualified Lib.Yudhishthira.Types.AppDynamicLogicElement
 
 findByDomain :: (BeamFlow.BeamFlow m r) => (Lib.Yudhishthira.Types.LogicDomain -> m ([Lib.Yudhishthira.Types.AppDynamicLogicElement.AppDynamicLogicElement]))
-findByDomain domain = do
-  Hedis.withCrossAppRedis (Hedis.safeGet $ domainCacheKey domain)
-    >>= ( \case
-            Just a -> if null a then fetchAndCase else pure a
-            Nothing -> fetchAndCase
-        )
+findByDomain domain =
+  IM.withInMemCache (domainInMemCacheKey domain) 10 $ do
+    Hedis.withCrossAppRedis (Hedis.safeGet $ domainCacheKey domain)
+      >>= ( \case
+              Just a -> if null a then fetchAndCase else pure a
+              Nothing -> fetchAndCase
+          )
   where
     fetchAndCase =
       ( \dataToBeCached -> do
@@ -27,12 +29,13 @@ findByDomain domain = do
 findByDomainAndVersion ::
   (BeamFlow.BeamFlow m r) =>
   (Lib.Yudhishthira.Types.LogicDomain -> Kernel.Prelude.Int -> m ([Lib.Yudhishthira.Types.AppDynamicLogicElement.AppDynamicLogicElement]))
-findByDomainAndVersion domain version = do
-  Hedis.withCrossAppRedis (Hedis.safeGet $ domainAndVersionCacheKey domain version)
-    >>= ( \case
-            Just a -> if null a then fetchAndCase else pure a
-            Nothing -> fetchAndCase
-        )
+findByDomainAndVersion domain version =
+  IM.withInMemCache (domainAndVersionInMemCacheKey domain version) 10 $ do
+    Hedis.withCrossAppRedis (Hedis.safeGet $ domainAndVersionCacheKey domain version)
+      >>= ( \case
+              Just a -> if null a then fetchAndCase else pure a
+              Nothing -> fetchAndCase
+          )
   where
     fetchAndCase =
       ( \dataToBeCached -> do
@@ -61,3 +64,10 @@ domainCacheKey domain = "yudhishthira-CachedQueries:AppDynamicLogicElement:" <> 
 
 domainAndVersionCacheKey :: Lib.Yudhishthira.Types.LogicDomain -> Kernel.Prelude.Int -> Text
 domainAndVersionCacheKey domain version = "yudhishthira-CachedQueries:AppDynamicLogicElement:" <> ":Domain-" <> show domain <> ":Version-" <> show version
+
+-- In-memory cache key functions
+domainInMemCacheKey :: Lib.Yudhishthira.Types.LogicDomain -> [Text]
+domainInMemCacheKey domain = ["AppDynamicLogicElement:Domain", show domain]
+
+domainAndVersionInMemCacheKey :: Lib.Yudhishthira.Types.LogicDomain -> Kernel.Prelude.Int -> [Text]
+domainAndVersionInMemCacheKey domain version = ["AppDynamicLogicElement:DomainAndVersion", show domain, show version]


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/34l)

### Root cause
findByDomainAndVersion/findByDomain in AppDynamicLogicElement CachedQueries fetch a ~1 MB list from Redis on every call with no local in-memory cache. A newly published DYNAMIC-PRICING-UNIFIED v450 config caused ~80 GETs/sec of this key, driving Redis node network-out above 6 GB.

### Evidence
_see RCA_

### Rollback
Revert the wrapping of findByDomain and findByDomainAndVersion to remove IM.withInMemCache and the two new helper functions.

---
_Draft PR — review and merge manually. Generated by Argus._