### PR TITLE
backend/feat: drainer config to skip dropped tables/columns (PG + ClickHouse)

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/server/Main.hs
@@ -6,8 +6,6 @@ import qualified Constants as C
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (async, cancel)
 import qualified DBSync.DBSync as DBSync
-import qualified Data.HashSet as HS
-import qualified "unordered-containers" Data.HashSet as HashSet
 import Data.Pool
 import Data.Pool.Internal
 import qualified Data.Text as T
@@ -38,7 +36,6 @@ main :: IO ()
 main = do
   appCfg <- (id :: AppCfg -> AppCfg) <$> readDhallConfigDefault "driver-drainer"
   hostname <- (T.pack <$>) <$> lookupEnv "POD_NAME"
-  let connString = getConnectionString $ appCfg.esqDBCfg
   connectionPool <- createDbPool appCfg.esqDBCfg
   let loggerRt = L.getEulerLoggerRuntime hostname $ appCfg.loggerConfig
   kafkaProducerTools <- buildKafkaProducerTools' appCfg.kafkaProducerCfg appCfg.secondaryKafkaProducerCfg appCfg.kafkaProperties
@@ -60,9 +57,33 @@ main = do
             )
 
           dbSyncMetric <- Event.mkDBSyncMetric
+          let pgDropCols = appCfg.dropColumnsForDb <> appCfg.dropColumnsForBoth
+              chDropCols = appCfg.dropColumnsForCh <> appCfg.dropColumnsForBoth
+              pgDropTables = appCfg.dropTablesForDb <> appCfg.dropTablesForBoth
+              chDropTables = appCfg.dropTablesForCh <> appCfg.dropTablesForBoth
+              -- A dropColumns entry must be exactly "table.column" (single dot, snake_case, no db prefix).
+              -- Anything else silently no-ops at match time, so warn loudly at startup instead of wedging the
+              -- stream later when the still-emitted dropped column hits PostgreSQL.
+              malformedDropCols =
+                filter (\c -> let parts = T.splitOn "." c in length parts /= 2 || any T.null parts) $
+                  appCfg.dropColumnsForDb <> appCfg.dropColumnsForCh <> appCfg.dropColumnsForBoth
           normalThreadCount <- Env.getThreadPerPodCount
           criticalThreadCount <- Env.getCriticalThreadPerPodCount
-          let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool appCfg.esqDBCfg
+          let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool appCfg.esqDBCfg pgDropCols chDropCols pgDropTables chDropTables
+          R.runFlow flowRt $
+            L.logInfo ("SchemaDrop" :: T.Text) $
+              "[DropConfig] PG tables=" <> T.pack (show pgDropTables)
+                <> " PG cols="
+                <> T.pack (show pgDropCols)
+                <> " CH tables="
+                <> T.pack (show chDropTables)
+                <> " CH cols="
+                <> T.pack (show chDropCols)
+          unless (null malformedDropCols) $
+            R.runFlow flowRt $
+              L.logWarning ("SchemaDrop" :: T.Text) $
+                "[DropConfig] Ignoring malformed dropColumns entries (expected exactly 'table.column', snake_case, no db prefix): "
+                  <> T.pack (show malformedDropCols)
           R.runFlow flowRt (runReaderT DBSync.fetchAndSetKvConfigs environment)
           -- one thread per stream by default; set either env count to 0 to stop draining that stream
           spawnDrainerThread criticalThreadCount True flowRt environment

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/BatchCreate.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/BatchCreate.hs
@@ -23,7 +23,7 @@ module DBSync.BatchCreate where
 import Config.Env (getInsertBatchSize, isPushToKafka)
 import qualified DBQuery.Functions as DBQ
 import DBQuery.Types
-import DBSync.Create (runCreate)
+import DBSync.Create (columnsForTable, filterChColumns, runCreate)
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
@@ -233,16 +233,20 @@ pushEntriesToKafka streamName entries = do
 --    Returns Either for success/failure tracking at the entry level.
 pushSingleEntryToKafka :: Text -> Bool -> KafkaProducerTools -> [Text] -> ParsedCreateEntry -> Flow (Either EL.KVDBStreamEntryID EL.KVDBStreamEntryID)
 pushSingleEntryToKafka streamName isPushToKafka' kafkaProducerTools dontEnableForKafka entry = do
+  Env {_dropTablesForCh, _dropColumnsForCh} <- ask
   let createDBModel = entry.createObject
       tableName = createDBModel.dbModel
+      tableSnake = DBQ.textToSnakeCaseText tableName.getDBModel
       entryId = entry.entryId
-
-  -- Use exact same logic as runCreate for deciding whether to push to Kafka
-  if shouldPushToDbOnly tableName dontEnableForKafka || not isPushToKafka'
+  if shouldPushToDbOnly tableName dontEnableForKafka
+    || tableSnake `elem` _dropTablesForCh
+    || tableName.getDBModel `elem` _dropTablesForCh
+    || not isPushToKafka'
     then return $ Right entryId
     else do
-      -- Use exact same object preparation logic as runCreate
-      let createObject = KBLU.replaceMappings (A.Object createDBModel.contentsObj) (HM.fromList . M.toList $ createDBModel.mappings.getMapping)
+      let chCols = columnsForTable tableSnake tableName.getDBModel _dropColumnsForCh
+          rawObject = KBLU.replaceMappings (A.Object createDBModel.contentsObj) (HM.fromList . M.toList $ createDBModel.mappings.getMapping)
+          createObject = filterChColumns chCols rawObject
       res <- EL.runIO $ createInKafka kafkaProducerTools createObject streamName tableName
       case res of
         Left err -> do
@@ -342,7 +346,10 @@ groupByColumnSignature = M.fromListWith (++) . map (\entry -> (entry.columnSigna
 --    per-entry Kafka decision overhead.
 processTableSignatureGroups :: Text -> (DBModel, Map ColumnSignature [ParsedCreateEntry]) -> Flow [([EL.KVDBStreamEntryID], [EL.KVDBStreamEntryID])]
 processTableSignatureGroups dbStreamKey (tableName, signatureGroups) = do
-  Env {_dontEnableDbTables} <- ask
+  Env {_dontEnableDbTables, _dropTablesForDb, _dropTablesForCh} <- ask
+  let tableSnake = DBQ.textToSnakeCaseText tableName.getDBModel
+      pgDropTable = tableSnake `elem` _dropTablesForDb || tableName.getDBModel `elem` _dropTablesForDb
+      chDropTable = tableSnake `elem` _dropTablesForCh || tableName.getDBModel `elem` _dropTablesForCh
 
   -- Alert if table has too many schema variations (schema drift detection)
   let signatureCount = M.size signatureGroups
@@ -350,15 +357,22 @@ processTableSignatureGroups dbStreamKey (tableName, signatureGroups) = do
     EL.logWarning ("SCHEMA_VARIATION_DETECTED" :: Text) $ tableName.getDBModel <> "|signatures:" <> show signatureCount <> "signatures found" <> show signatureGroups
     void $ publishDBSyncMetric $ Event.SchemaVariationAlert tableName.getDBModel signatureCount
 
-  -- Check if this table should be Kafka-only (single check for entire table)
-  if shouldPushToKafkaOnly tableName _dontEnableDbTables
-    then do
-      -- All entries skip DB and go to Kafka only (memory-efficient)
-      let allEntries = concat $ M.elems signatureGroups
-      kafkaResults <- pushEntriesToKafka dbStreamKey allEntries
-      pure [kafkaResults]
-    else -- Normal DB processing for this table
-      mapM (processSignatureGroup dbStreamKey tableName) (M.toList signatureGroups)
+  let allEntries = concat $ M.elems signatureGroups
+  if pgDropTable
+    then
+      if chDropTable
+        then pure [(map (.entryId) allEntries, [])]
+        else do
+          kafkaResults <- pushEntriesToKafka dbStreamKey allEntries
+          pure [kafkaResults]
+    else
+      if shouldPushToKafkaOnly tableName _dontEnableDbTables
+        then do
+          -- All entries skip DB and go to Kafka only (memory-efficient)
+          kafkaResults <- pushEntriesToKafka dbStreamKey allEntries
+          pure [kafkaResults]
+        else -- Normal DB processing for this table
+          mapM (processSignatureGroup dbStreamKey tableName) (M.toList signatureGroups)
 
 -- | Process a single column signature group with batching decision.
 --
@@ -411,41 +425,67 @@ executeBatchForSignature _dbStreamKey signature entries = do
       pure (concat successes, concat failures)
   where
     executeSingleBatch sig batchEntries objects = do
-      case generateBulkInsertForSignature sig objects of
-        Nothing -> do
-          EL.logError ("BATCH_QUERY_GENERATION_FAILED" :: Text) (show sig)
-          processIndividualEntries _dbStreamKey batchEntries
-        Just bulkQuery -> do
-          Env {_connectionPool} <- ask
-          startTime <- EL.getCurrentDateInMillis
-          result <- EL.runIO $ try $ DBQ.executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 bulkQuery)
-          endTime <- EL.getCurrentDateInMillis
-          let executionTime = int2Double (endTime - startTime)
-          case result of
-            Left (QueryError errorMsg) -> do
-              EL.logError ("BATCH_INSERT_FAILED" :: Text) $
-                sig.tableName.getDBModel <> "|entries:" <> show (length batchEntries) <> "|error:" <> errorMsg <> "|query:" <> bulkQuery
-              void $ publishDBSyncMetric $ Event.QueryExecutionFailure "BatchCreate" sig.tableName.getDBModel
-              EL.logInfo ("FALLING_BACK_TO_INDIVIDUAL" :: Text) ("Batch size: " <> show (length batchEntries))
-              processIndividualEntries _dbStreamKey batchEntries
-            Right _ -> do
-              EL.logInfo ("BATCH_INSERT_SUCCESS" :: Text) $
-                sig.tableName.getDBModel <> "|entries:" <> show (length batchEntries) <> "|time:" <> show executionTime
-              void $ publishDBSyncMetric $ Event.BatchExecutionTime sig.tableName.getDBModel executionTime
-              void $ publishDBSyncMetric $ Event.BatchEntriesProcessed sig.tableName.getDBModel (length batchEntries)
+      Env {_dropColumnsForDb, _dropTablesForCh} <- ask
+      let tableSnake = DBQ.textToSnakeCaseText sig.tableName.getDBModel
+          tableCamel = sig.tableName.getDBModel
+          pgCols = columnsForTable tableSnake tableCamel _dropColumnsForDb
+          (filteredSig, filteredObjects) =
+            if null pgCols
+              then (sig, objects)
+              else
+                let fNames = filter (`notElem` pgCols) sig.columnNames
+                    fSig = sig {columnNames = fNames, columnCount = length fNames}
+                    fObjs =
+                      map
+                        ( \obj ->
+                            let DBCreateObjectContent tws = obj.contents
+                                fTws = filter (\(TermWrap col _) -> DBQ.replaceMappings col obj.mappings `notElem` pgCols) tws
+                             in (obj :: DBCreateObject) {contents = DBCreateObjectContent fTws}
+                        )
+                        objects
+                 in (fSig, fObjs)
+      if null filteredSig.columnNames
+        then do
+          -- All DB columns intentionally dropped; still push to Kafka/CH unless table is CH-dropped too.
+          let chDropTable = tableSnake `elem` _dropTablesForCh || tableCamel `elem` _dropTablesForCh
+          if chDropTable
+            then pure (map (.entryId) batchEntries, [])
+            else pushEntriesToKafka _dbStreamKey batchEntries
+        else case generateBulkInsertForSignature filteredSig filteredObjects of
+          Nothing -> do
+            EL.logError ("BATCH_QUERY_GENERATION_FAILED" :: Text) (show sig)
+            processIndividualEntries _dbStreamKey batchEntries
+          Just bulkQuery -> do
+            Env {_connectionPool} <- ask
+            startTime <- EL.getCurrentDateInMillis
+            result <- EL.runIO $ try $ DBQ.executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 bulkQuery)
+            endTime <- EL.getCurrentDateInMillis
+            let executionTime = int2Double (endTime - startTime)
+            case result of
+              Left (QueryError errorMsg) -> do
+                EL.logError ("BATCH_INSERT_FAILED" :: Text) $
+                  sig.tableName.getDBModel <> "|entries:" <> show (length batchEntries) <> "|error:" <> errorMsg <> "|query:" <> bulkQuery
+                void $ publishDBSyncMetric $ Event.QueryExecutionFailure "BatchCreate" sig.tableName.getDBModel
+                EL.logInfo ("FALLING_BACK_TO_INDIVIDUAL" :: Text) ("Batch size: " <> show (length batchEntries))
+                processIndividualEntries _dbStreamKey batchEntries
+              Right _ -> do
+                EL.logInfo ("BATCH_INSERT_SUCCESS" :: Text) $
+                  sig.tableName.getDBModel <> "|entries:" <> show (length batchEntries) <> "|time:" <> show executionTime
+                void $ publishDBSyncMetric $ Event.BatchExecutionTime sig.tableName.getDBModel executionTime
+                void $ publishDBSyncMetric $ Event.BatchEntriesProcessed sig.tableName.getDBModel (length batchEntries)
 
-              forM_ batchEntries $ \entry -> setDrainerTtl entry.createObject.dbModel entry.createObject.primaryKey
+                forM_ batchEntries $ \entry -> setDrainerTtl entry.createObject.dbModel entry.createObject.primaryKey
 
-              -- Push successful batch entries to Kafka
-              kafkaResults <- pushEntriesToKafka _dbStreamKey batchEntries
-              let (kafkaSuccesses, kafkaFailures) = kafkaResults
+                -- Push successful batch entries to Kafka
+                kafkaResults <- pushEntriesToKafka _dbStreamKey batchEntries
+                let (kafkaSuccesses, kafkaFailures) = kafkaResults
 
-              -- Log Kafka results
-              when (not $ null kafkaFailures) $
-                EL.logError ("BATCH_KAFKA_FAILURES" :: Text) $
-                  sig.tableName.getDBModel <> "|kafka_failed:" <> show (length kafkaFailures)
+                -- Log Kafka results
+                unless (null kafkaFailures) $
+                  EL.logError ("BATCH_KAFKA_FAILURES" :: Text) $
+                    sig.tableName.getDBModel <> "|kafka_failed:" <> show (length kafkaFailures)
 
-              pure (kafkaSuccesses, kafkaFailures)
+                pure (kafkaSuccesses, kafkaFailures)
 
 -- | Get global batch size from environment variables
 getGlobalBatchSize :: Flow Int

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Create.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Create.hs
@@ -7,13 +7,12 @@ import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
-import Data.Maybe
-import Data.Text as T hiding (any, map, null)
+import Data.Text as T hiding (any, concatMap, elem, filter, map, null)
 import qualified Data.Text.Encoding as TE
 import Database.PostgreSQL.Simple.Types
 import EulerHS.Language as EL
 import EulerHS.Prelude
-import Kernel.Beam.Lib.Utils as KBLU
+import qualified Kernel.Beam.Lib.Utils as KBLU
 import Text.Casing (pascal)
 import Types.DBSync
 import Types.DBSync.Create
@@ -32,10 +31,13 @@ runCreate createDataEntry streamName = do
     Right createDBModel -> do
       EL.logDebug ("DB OBJECT" :: Text) (show createDBModel)
       let tableName = createDBModel.dbModel
-      if shouldPushToDbOnly tableName _dontEnableForKafka || not isPushToKafka'
+          tableSnake = textToSnakeCaseText tableName.getDBModel
+      if shouldPushToDbOnly tableName _dontEnableForKafka || tableSnake `elem` _dropTablesForCh || tableName.getDBModel `elem` _dropTablesForCh || not isPushToKafka'
         then runCreateQuery createDataEntry createDBModel
         else do
-          let createObject = KBLU.replaceMappings (A.Object createDBModel.contentsObj) (HM.fromList . M.toList $ createDBModel.mappings.getMapping)
+          let chCols = columnsForTable tableSnake tableName.getDBModel _dropColumnsForCh
+              rawObject = KBLU.replaceMappings (A.Object createDBModel.contentsObj) (HM.fromList . M.toList $ createDBModel.mappings.getMapping)
+              createObject = filterChColumns chCols rawObject
           res <- EL.runIO $ createInKafka _kafkaProducerTools createObject streamName tableName
           case res of
             Left err -> do
@@ -56,27 +58,34 @@ runCreateQuery createDataEntry dbCreateObject = do
   Env {..} <- ask
   let (entryId, byteString) = createDataEntry
       dbModel = dbCreateObject.dbModel
-  if shouldPushToKafkaOnly dbModel _dontEnableDbTables && not dbCreateObject.forceDrainToDB
+      tableSnake = textToSnakeCaseText dbModel.getDBModel
+      pgDropTable = tableSnake `elem` _dropTablesForDb || dbModel.getDBModel `elem` _dropTablesForDb
+  if pgDropTable || (shouldPushToKafkaOnly dbModel _dontEnableDbTables && not dbCreateObject.forceDrainToDB)
     then return $ Right entryId
     else do
-      let insertQuery = generateInsertForTable dbCreateObject
-      case insertQuery of
-        Just query -> do
-          result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
-          case result of
-            Left (QueryError errorMsg) -> do
-              EL.logError ("QUERY INSERT FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
-              EL.logError ("QUERY INSERT FAILED: BYTE STRING" :: Text) (show byteString)
-              EL.logError ("QUERY INSERT FAILED: DB OBJECT" :: Text) (show dbCreateObject)
-              void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Create" dbModel.getDBModel
-              return $ Left entryId
-            Right _ -> do
-              EL.logDebug ("QUERY INSERT SUCCESSFUL" :: Text) (" Insert successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
-              setDrainerTtl dbCreateObject.dbModel dbCreateObject.primaryKey
-              return $ Right entryId
-        Nothing -> do
-          EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
-          return $ Left entryId
+      let pgCols = columnsForTable tableSnake dbModel.getDBModel _dropColumnsForDb
+          filteredObj = if null pgCols then dbCreateObject else (dbCreateObject :: DBCreateObject) {contents = filterInsertContents pgCols (dbCreateObject.contents) (dbCreateObject.mappings)}
+          DBCreateObjectContent filteredTerms = filteredObj.contents
+          insertQuery = generateInsertForTable filteredObj
+      if not (null pgCols) && null filteredTerms
+        then return $ Right entryId
+        else case insertQuery of
+          Just query -> do
+            result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
+            case result of
+              Left (QueryError errorMsg) -> do
+                EL.logError ("QUERY INSERT FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
+                EL.logError ("QUERY INSERT FAILED: BYTE STRING" :: Text) (show byteString)
+                EL.logError ("QUERY INSERT FAILED: DB OBJECT" :: Text) (show dbCreateObject)
+                void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Create" dbModel.getDBModel
+                return $ Left entryId
+              Right _ -> do
+                EL.logDebug ("QUERY INSERT SUCCESSFUL" :: Text) (" Insert successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
+                setDrainerTtl dbCreateObject.dbModel dbCreateObject.primaryKey
+                return $ Right entryId
+          Nothing -> do
+            EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
+            return $ Left entryId
 
 -- | Generate an insert query for a given table and schema
 generateInsertForTable :: DBCreateObject -> Maybe Text
@@ -92,3 +101,30 @@ getCreateObjectForKafka model content =
       "tag" A..= ((T.pack . pascal . T.unpack) model.getDBModel <> "Object"),
       "type" A..= ("INSERT" :: Text)
     ]
+
+-- Extract column names to filter for the given table.
+-- Accepts both snake_case and camelCase table prefix (e.g. "driver_location.col" or "DriverLocation.col").
+-- The column part is matched both as-written and normalised to snake_case, so a config entry in either
+-- case (e.g. "driver_location.some_field" or "driver_location.someField") is handled correctly, because
+-- replaceMappings normalises identifiers to snake_case before comparison.
+columnsForTable :: Text -> Text -> [Text] -> [Text]
+columnsForTable tableSnake tableCamel = concatMap $ \tc ->
+  case T.breakOn "." tc of
+    (tbl, dotCol)
+      | (tbl == tableSnake || tbl == tableCamel) && dotCol /= mempty ->
+        let col = T.drop 1 dotCol in [col, textToSnakeCaseText col]
+    _ -> []
+
+-- Filter TermWraps to exclude configured columns before INSERT.
+filterInsertContents :: [Text] -> DBCreateObjectContent -> Mapping -> DBCreateObjectContent
+filterInsertContents [] c _ = c
+filterInsertContents cols (DBCreateObjectContent tws) mp =
+  DBCreateObjectContent $ filter (\(TermWrap col _) -> replaceMappings col mp `notElem` cols) tws
+
+-- Filter keys from the Kafka/CH JSON payload.
+filterChColumns :: [Text] -> A.Value -> A.Value
+filterChColumns [] v = v
+filterChColumns cols v =
+  case A.fromJSON @(M.Map Text A.Value) v of
+    A.Success m -> A.toJSON $ M.filterWithKey (\k _ -> k `notElem` cols) m
+    A.Error _ -> v

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Delete.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Delete.hs
@@ -6,7 +6,7 @@ import DBQuery.Types
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe
-import qualified Data.Text as T hiding (elem)
+import Data.Text as T hiding (elem)
 import qualified Data.Text.Encoding as TE
 import Database.PostgreSQL.Simple.Types (Query (..))
 import qualified EulerHS.Language as EL
@@ -34,23 +34,27 @@ runDeleteQuery deleteEntries dbDeleteObject = do
   Env {..} <- ask
   let (entryId, byteString) = deleteEntries
   let dbModel = dbDeleteObject.dbModel
-  let deleteQuery = getDeleteQueryForTable dbDeleteObject
-  case deleteQuery of
-    Just query -> do
-      result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
-      case result of
-        Left (QueryError errorMsg) -> do
-          EL.logError ("QUERY DELETE FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
-          EL.logError ("QUERY DELETE FAILED : BYTE STRING" :: Text) (TE.decodeUtf8 byteString)
-          EL.logError ("QUERY DELETE FAILED : DB OBJECT" :: Text) (show dbDeleteObject)
-          void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Delete" dbModel.getDBModel
+      tableSnake = textToSnakeCaseText dbModel.getDBModel
+  if tableSnake `elem` _dropTablesForDb || dbModel.getDBModel `elem` _dropTablesForDb
+    then return $ Right entryId
+    else do
+      let deleteQuery = getDeleteQueryForTable dbDeleteObject
+      case deleteQuery of
+        Just query -> do
+          result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
+          case result of
+            Left (QueryError errorMsg) -> do
+              EL.logError ("QUERY DELETE FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
+              EL.logError ("QUERY DELETE FAILED : BYTE STRING" :: Text) (TE.decodeUtf8 byteString)
+              EL.logError ("QUERY DELETE FAILED : DB OBJECT" :: Text) (show dbDeleteObject)
+              void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Delete" dbModel.getDBModel
+              return $ Left entryId
+            Right _ -> do
+              EL.logDebug ("QUERY DELETE SUCCESSFUL" :: Text) (" Delete successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
+              return $ Right entryId
+        Nothing -> do
+          EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
           return $ Left entryId
-        Right _ -> do
-          EL.logDebug ("QUERY DELETE SUCCESSFUL" :: Text) (" Delete successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
-          return $ Right entryId
-    Nothing -> do
-      EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
-      return $ Left entryId
 
 getDeleteQueryForTable :: DBDeleteObject -> Maybe Text
 getDeleteQueryForTable DBDeleteObject {dbModel, contents, mappings} = do

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/DBSync/Update.hs
@@ -8,12 +8,12 @@ import Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
-import Data.Text as T hiding (elem, map)
+import Data.Text as T hiding (concatMap, elem, filter, map, null)
 import qualified Data.Text.Encoding as TE
 import Database.PostgreSQL.Simple.Types
 import qualified EulerHS.Language as EL
 import EulerHS.Prelude hiding (id, try)
-import Kernel.Beam.Lib.Utils as KBLU
+import qualified Kernel.Beam.Lib.Utils as KBLU
 import Types.DBSync
 import Types.DBSync.Update
 import Types.Event as Event
@@ -30,10 +30,13 @@ runUpdate updateDataEntries streamName = do
     Right updateDBModel -> do
       EL.logDebug ("DB OBJECT" :: Text) (show updateDBModel)
       let tableName = updateDBModel.dbModel
-      if shouldPushToDbOnly tableName _dontEnableForKafka || not isPushToKafka'
+          tableSnake = textToSnakeCaseText tableName.getDBModel
+      if shouldPushToDbOnly tableName _dontEnableForKafka || tableSnake `elem` _dropTablesForCh || tableName.getDBModel `elem` _dropTablesForCh || not isPushToKafka'
         then runUpdateQuery updateDataEntries updateDBModel
         else do
-          let updateObject = KBLU.replaceMappings (maybe (A.object []) A.Object (updateDBModel.updatedModel)) (HM.fromList . M.toList $ updateDBModel.mappings.getMapping)
+          let chCols = columnsForTable tableSnake tableName.getDBModel _dropColumnsForCh
+              rawObject = KBLU.replaceMappings (maybe (A.object []) A.Object (updateDBModel.updatedModel)) (HM.fromList . M.toList $ updateDBModel.mappings.getMapping)
+              updateObject = filterChColumns chCols rawObject
           res <- EL.runIO $ createInKafka _kafkaProducerTools updateObject streamName tableName
           case res of
             Left err -> do
@@ -52,31 +55,68 @@ runUpdateQuery :: (EL.KVDBStreamEntryID, ByteString) -> DBUpdateObject -> Reader
 runUpdateQuery updateDataEntries dbUpdateObject = do
   Env {..} <- ask
   let (entryId, byteString) = updateDataEntries
-  let dbModel = dbUpdateObject.dbModel
-  if shouldPushToKafkaOnly dbModel _dontEnableDbTables && not dbUpdateObject.forceDrainToDB
+      dbModel = dbUpdateObject.dbModel
+      tableSnake = textToSnakeCaseText dbModel.getDBModel
+      pgDropTable = tableSnake `elem` _dropTablesForDb || dbModel.getDBModel `elem` _dropTablesForDb
+  if pgDropTable || (shouldPushToKafkaOnly dbModel _dontEnableDbTables && not dbUpdateObject.forceDrainToDB)
     then return $ Right entryId
     else do
-      let updateQuery = getUpdateQueryForTable dbUpdateObject
-      case updateQuery of
-        Just query -> do
-          result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
-          case result of
-            Left (QueryError errorMsg) -> do
-              EL.logError ("QUERY UPDATE FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
-              EL.logError ("QUERY UPDATE FAILED : BYTE STRING" :: Text) (TE.decodeUtf8 byteString)
-              EL.logError ("QUERY UPDATE FAILED : DB OBJECT" :: Text) (show dbUpdateObject)
-              void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Update" dbModel.getDBModel
+      let pgCols = columnsForTable tableSnake dbModel.getDBModel _dropColumnsForDb
+      let filteredObj = if null pgCols then dbUpdateObject else (dbUpdateObject :: DBUpdateObject) {contents = filterUpdateContents pgCols (dbUpdateObject.contents) (dbUpdateObject.mappings)}
+          DBUpdateObjectContent setClauses _ = filteredObj.contents
+      if null setClauses
+        then do
+          EL.logInfo ("UPDATE_SKIPPED_ALL_COLS_DROPPED" :: Text) dbModel.getDBModel
+          return $ Right entryId
+        else do
+          let updateQuery = getUpdateQueryForTable filteredObj
+          case updateQuery of
+            Just query -> do
+              result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
+              case result of
+                Left (QueryError errorMsg) -> do
+                  EL.logError ("QUERY UPDATE FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
+                  EL.logError ("QUERY UPDATE FAILED : BYTE STRING" :: Text) (TE.decodeUtf8 byteString)
+                  EL.logError ("QUERY UPDATE FAILED : DB OBJECT" :: Text) (show dbUpdateObject)
+                  void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Update" dbModel.getDBModel
+                  return $ Left entryId
+                Right _ -> do
+                  EL.logDebug ("QUERY UPDATE SUCCESSFUL" :: Text) (" Update successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
+                  setDrainerTtl dbUpdateObject.dbModel dbUpdateObject.primaryKey
+                  return $ Right entryId
+            Nothing -> do
+              EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
               return $ Left entryId
-            Right _ -> do
-              EL.logDebug ("QUERY UPDATE SUCCESSFUL" :: Text) (" Update successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
-              setDrainerTtl dbUpdateObject.dbModel dbUpdateObject.primaryKey
-              return $ Right entryId
-        Nothing -> do
-          EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
-          return $ Left entryId
 
 getUpdateQueryForTable :: DBUpdateObject -> Maybe Text
 getUpdateQueryForTable DBUpdateObject {dbModel, contents, mappings} = do
   let DBUpdateObjectContent setClauses whereClause = contents
   let schema = SchemaName $ T.pack currentSchemaName
   generateUpdateQuery UpdateQuery {..}
+
+-- Extract column names to filter for the given table.
+-- Accepts both snake_case and camelCase table prefix (e.g. "driver_location.col" or "DriverLocation.col").
+-- The column part is matched both as-written and normalised to snake_case, so a config entry in either
+-- case (e.g. "driver_location.some_field" or "driver_location.someField") is handled correctly, because
+-- replaceMappings normalises identifiers to snake_case before comparison.
+columnsForTable :: Text -> Text -> [Text] -> [Text]
+columnsForTable tableSnake tableCamel = concatMap $ \tc ->
+  case T.breakOn "." tc of
+    (tbl, dotCol)
+      | (tbl == tableSnake || tbl == tableCamel) && dotCol /= mempty ->
+        let col = T.drop 1 dotCol in [col, textToSnakeCaseText col]
+    _ -> []
+
+-- Filter SetClauses to exclude configured columns before UPDATE.
+filterUpdateContents :: [Text] -> DBUpdateObjectContent -> Mapping -> DBUpdateObjectContent
+filterUpdateContents [] c _ = c
+filterUpdateContents cols (DBUpdateObjectContent sets wh) mp =
+  DBUpdateObjectContent (filter (\(Set col _) -> replaceMappings col mp `notElem` cols) sets) wh
+
+-- Filter keys from the Kafka/CH JSON payload.
+filterChColumns :: [Text] -> A.Value -> A.Value
+filterChColumns [] v = v
+filterChColumns cols v =
+  case A.fromJSON @(M.Map Text A.Value) v of
+    A.Success m -> A.toJSON $ M.filterWithKey (\k _ -> k `notElem` cols) m
+    A.Error _ -> v

--- a/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Types/DBSync.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-drainer/src/Types/DBSync.hs
@@ -42,7 +42,11 @@ data Env = Env
     _dontEnableDbTables :: [Text],
     _dontEnableForKafka :: [Text],
     _connectionPool :: Pool Connection,
-    _esqDBCfg :: EsqDBConfig
+    _esqDBCfg :: EsqDBConfig,
+    _dropColumnsForDb :: [Text],
+    _dropColumnsForCh :: [Text],
+    _dropTablesForDb :: [Text],
+    _dropTablesForCh :: [Text]
   }
 
 data AppCfg = AppCfg
@@ -56,7 +60,13 @@ data AppCfg = AppCfg
     loggerConfig :: LoggerConfig,
     dontEnableForDb :: [Text],
     dontEnableForKafka :: [Text],
-    kafkaProperties :: [KTC.KafkaProperties]
+    kafkaProperties :: [KTC.KafkaProperties],
+    dropColumnsForDb :: [Text],
+    dropColumnsForCh :: [Text],
+    dropColumnsForBoth :: [Text],
+    dropTablesForDb :: [Text],
+    dropTablesForCh :: [Text],
+    dropTablesForBoth :: [Text]
   }
   deriving (Generic, FromDhall)
 

--- a/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/server/Main.hs
@@ -5,8 +5,6 @@ import qualified Constants as C
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (async, cancel)
 import qualified DBSync.DBSync as DBSync
-import qualified Data.HashSet as HS
-import qualified "unordered-containers" Data.HashSet as HashSet
 import Data.Pool
 import Data.Pool.Internal
 import qualified Data.Text as T
@@ -36,7 +34,6 @@ main :: IO ()
 main = do
   appCfg <- (id :: AppCfg -> AppCfg) <$> readDhallConfigDefault "rider-drainer"
   hostname <- (T.pack <$>) <$> lookupEnv "POD_NAME"
-  let connString = getConnectionString $ appCfg.esqDBCfg
   connectionPool <- createDbPool appCfg.esqDBCfg
   let loggerRt = L.getEulerLoggerRuntime hostname $ appCfg.loggerConfig
   kafkaProducerTools <- buildKafkaProducerTools' appCfg.kafkaProducerCfg appCfg.secondaryKafkaProducerCfg appCfg.kafkaProperties
@@ -58,9 +55,33 @@ main = do
             )
 
           dbSyncMetric <- Event.mkDBSyncMetric
-          let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool (appCfg.esqDBCfg)
+          let pgDropCols = appCfg.dropColumnsForDb <> appCfg.dropColumnsForBoth
+              chDropCols = appCfg.dropColumnsForCh <> appCfg.dropColumnsForBoth
+              pgDropTables = appCfg.dropTablesForDb <> appCfg.dropTablesForBoth
+              chDropTables = appCfg.dropTablesForCh <> appCfg.dropTablesForBoth
+              -- A dropColumns entry must be exactly "table.column" (single dot, snake_case, no db prefix).
+              -- Anything else silently no-ops at match time, so warn loudly at startup instead of wedging the
+              -- stream later when the still-emitted dropped column hits PostgreSQL.
+              malformedDropCols =
+                filter (\c -> let parts = T.splitOn "." c in length parts /= 2 || any T.null parts) $
+                  appCfg.dropColumnsForDb <> appCfg.dropColumnsForCh <> appCfg.dropColumnsForBoth
           normalThreadCount <- Env.getThreadPerPodCount
           criticalThreadCount <- Env.getCriticalThreadPerPodCount
+          let environment = Env (T.pack C.kvRedis) dbSyncMetric kafkaProducerTools appCfg.dontEnableForDb appCfg.dontEnableForKafka connectionPool (appCfg.esqDBCfg) pgDropCols chDropCols pgDropTables chDropTables
+          R.runFlow flowRt $
+            L.logInfo ("SchemaDrop" :: T.Text) $
+              "[DropConfig] PG tables=" <> T.pack (show pgDropTables)
+                <> " PG cols="
+                <> T.pack (show pgDropCols)
+                <> " CH tables="
+                <> T.pack (show chDropTables)
+                <> " CH cols="
+                <> T.pack (show chDropCols)
+          unless (null malformedDropCols) $
+            R.runFlow flowRt $
+              L.logWarning ("SchemaDrop" :: T.Text) $
+                "[DropConfig] Ignoring malformed dropColumns entries (expected exactly 'table.column', snake_case, no db prefix): "
+                  <> T.pack (show malformedDropCols)
           R.runFlow flowRt (runReaderT DBSync.fetchAndSetKvConfigs environment)
           -- one thread per stream by default; set either env count to 0 to stop draining that stream
           spawnDrainerThread criticalThreadCount True flowRt environment

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/BatchCreate.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/BatchCreate.hs
@@ -23,7 +23,7 @@ module DBSync.BatchCreate where
 import Config.Env (getInsertBatchSize, isPushToKafka)
 import qualified DBQuery.Functions as DBQ
 import DBQuery.Types
-import DBSync.Create (runCreate)
+import DBSync.Create (columnsForTable, filterChColumns, runCreate)
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
@@ -232,16 +232,20 @@ pushEntriesToKafka streamName entries = do
 --    Returns Either for success/failure tracking at the entry level.
 pushSingleEntryToKafka :: Text -> Bool -> KafkaProducerTools -> [Text] -> ParsedCreateEntry -> Flow (Either EL.KVDBStreamEntryID EL.KVDBStreamEntryID)
 pushSingleEntryToKafka streamName isPushToKafka' kafkaProducerTools dontEnableForKafka entry = do
+  Env {_dropTablesForCh, _dropColumnsForCh} <- ask
   let createDBModel = entry.createObject
       tableName = createDBModel.dbModel
+      tableSnake = DBQ.textToSnakeCaseText tableName.getDBModel
       entryId = entry.entryId
-
-  -- Use exact same logic as runCreate for deciding whether to push to Kafka
-  if shouldPushToDbOnly tableName dontEnableForKafka || not isPushToKafka'
+  if shouldPushToDbOnly tableName dontEnableForKafka
+    || tableSnake `elem` _dropTablesForCh
+    || tableName.getDBModel `elem` _dropTablesForCh
+    || not isPushToKafka'
     then return $ Right entryId
     else do
-      -- Use exact same object preparation logic as runCreate
-      let createObject = KBLU.replaceMappings (A.Object createDBModel.contentsObj) (HM.fromList . M.toList $ createDBModel.mappings.getMapping)
+      let chCols = columnsForTable tableSnake tableName.getDBModel _dropColumnsForCh
+          rawObject = KBLU.replaceMappings (A.Object createDBModel.contentsObj) (HM.fromList . M.toList $ createDBModel.mappings.getMapping)
+          createObject = filterChColumns chCols rawObject
       res <- EL.runIO $ createInKafka kafkaProducerTools createObject streamName tableName
       case res of
         Left err -> do
@@ -341,7 +345,10 @@ groupByColumnSignature = M.fromListWith (++) . map (\entry -> (entry.columnSigna
 --    per-entry Kafka decision overhead.
 processTableSignatureGroups :: Text -> (DBModel, Map ColumnSignature [ParsedCreateEntry]) -> Flow [([EL.KVDBStreamEntryID], [EL.KVDBStreamEntryID])]
 processTableSignatureGroups dbStreamKey (tableName, signatureGroups) = do
-  Env {_dontEnableDbTables} <- ask
+  Env {_dontEnableDbTables, _dropTablesForDb, _dropTablesForCh} <- ask
+  let tableSnake = DBQ.textToSnakeCaseText tableName.getDBModel
+      pgDropTable = tableSnake `elem` _dropTablesForDb || tableName.getDBModel `elem` _dropTablesForDb
+      chDropTable = tableSnake `elem` _dropTablesForCh || tableName.getDBModel `elem` _dropTablesForCh
 
   -- Alert if table has too many schema variations (schema drift detection)
   let signatureCount = M.size signatureGroups
@@ -349,15 +356,22 @@ processTableSignatureGroups dbStreamKey (tableName, signatureGroups) = do
     EL.logWarning ("SCHEMA_VARIATION_DETECTED" :: Text) $ tableName.getDBModel <> "|signatures:" <> show signatureCount <> "signatures found" <> show signatureGroups
     void $ publishDBSyncMetric $ Event.SchemaVariationAlert tableName.getDBModel signatureCount
 
-  -- Check if this table should be Kafka-only (single check for entire table)
-  if shouldPushToKafkaOnly tableName _dontEnableDbTables
-    then do
-      -- All entries skip DB and go to Kafka only (memory-efficient)
-      let allEntries = concat $ M.elems signatureGroups
-      kafkaResults <- pushEntriesToKafka dbStreamKey allEntries
-      pure [kafkaResults]
-    else -- Normal DB processing for this table
-      mapM (processSignatureGroup dbStreamKey tableName) (M.toList signatureGroups)
+  let allEntries = concat $ M.elems signatureGroups
+  if pgDropTable
+    then
+      if chDropTable
+        then pure [(map (.entryId) allEntries, [])]
+        else do
+          kafkaResults <- pushEntriesToKafka dbStreamKey allEntries
+          pure [kafkaResults]
+    else
+      if shouldPushToKafkaOnly tableName _dontEnableDbTables
+        then do
+          -- All entries skip DB and go to Kafka only (memory-efficient)
+          kafkaResults <- pushEntriesToKafka dbStreamKey allEntries
+          pure [kafkaResults]
+        else -- Normal DB processing for this table
+          mapM (processSignatureGroup dbStreamKey tableName) (M.toList signatureGroups)
 
 -- | Process a single column signature group with batching decision.
 --
@@ -410,41 +424,67 @@ executeBatchForSignature _dbStreamKey signature entries = do
       pure (concat successes, concat failures)
   where
     executeSingleBatch sig batchEntries objects = do
-      case generateBulkInsertForSignature sig objects of
-        Nothing -> do
-          EL.logError ("BATCH_QUERY_GENERATION_FAILED" :: Text) (show sig)
-          processIndividualEntries _dbStreamKey batchEntries
-        Just bulkQuery -> do
-          Env {_connectionPool} <- ask
-          startTime <- EL.getCurrentDateInMillis
-          result <- EL.runIO $ try $ DBQ.executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 bulkQuery)
-          endTime <- EL.getCurrentDateInMillis
-          let executionTime = int2Double (endTime - startTime)
-          case result of
-            Left (QueryError errorMsg) -> do
-              EL.logError ("BATCH_INSERT_FAILED" :: Text) $
-                sig.tableName.getDBModel <> "|entries:" <> show (length batchEntries) <> "|error:" <> errorMsg <> "|query:" <> bulkQuery
-              void $ publishDBSyncMetric $ Event.QueryExecutionFailure "BatchCreate" sig.tableName.getDBModel
-              EL.logInfo ("FALLING_BACK_TO_INDIVIDUAL" :: Text) ("Batch size: " <> show (length batchEntries))
-              processIndividualEntries _dbStreamKey batchEntries
-            Right _ -> do
-              EL.logInfo ("BATCH_INSERT_SUCCESS" :: Text) $
-                sig.tableName.getDBModel <> "|entries:" <> show (length batchEntries) <> "|time:" <> show executionTime
-              void $ publishDBSyncMetric $ Event.BatchExecutionTime sig.tableName.getDBModel executionTime
-              void $ publishDBSyncMetric $ Event.BatchEntriesProcessed sig.tableName.getDBModel (length batchEntries)
+      Env {_dropColumnsForDb, _dropTablesForCh} <- ask
+      let tableSnake = DBQ.textToSnakeCaseText sig.tableName.getDBModel
+          tableCamel = sig.tableName.getDBModel
+          pgCols = columnsForTable tableSnake tableCamel _dropColumnsForDb
+          (filteredSig, filteredObjects) =
+            if null pgCols
+              then (sig, objects)
+              else
+                let fNames = filter (`notElem` pgCols) sig.columnNames
+                    fSig = sig {columnNames = fNames, columnCount = length fNames}
+                    fObjs =
+                      map
+                        ( \obj ->
+                            let DBCreateObjectContent tws = obj.contents
+                                fTws = filter (\(TermWrap col _) -> DBQ.replaceMappings col obj.mappings `notElem` pgCols) tws
+                             in (obj :: DBCreateObject) {contents = DBCreateObjectContent fTws}
+                        )
+                        objects
+                 in (fSig, fObjs)
+      if null filteredSig.columnNames
+        then do
+          -- All DB columns intentionally dropped; still push to Kafka/CH unless table is CH-dropped too.
+          let chDropTable = tableSnake `elem` _dropTablesForCh || tableCamel `elem` _dropTablesForCh
+          if chDropTable
+            then pure (map (.entryId) batchEntries, [])
+            else pushEntriesToKafka _dbStreamKey batchEntries
+        else case generateBulkInsertForSignature filteredSig filteredObjects of
+          Nothing -> do
+            EL.logError ("BATCH_QUERY_GENERATION_FAILED" :: Text) (show sig)
+            processIndividualEntries _dbStreamKey batchEntries
+          Just bulkQuery -> do
+            Env {_connectionPool} <- ask
+            startTime <- EL.getCurrentDateInMillis
+            result <- EL.runIO $ try $ DBQ.executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 bulkQuery)
+            endTime <- EL.getCurrentDateInMillis
+            let executionTime = int2Double (endTime - startTime)
+            case result of
+              Left (QueryError errorMsg) -> do
+                EL.logError ("BATCH_INSERT_FAILED" :: Text) $
+                  sig.tableName.getDBModel <> "|entries:" <> show (length batchEntries) <> "|error:" <> errorMsg <> "|query:" <> bulkQuery
+                void $ publishDBSyncMetric $ Event.QueryExecutionFailure "BatchCreate" sig.tableName.getDBModel
+                EL.logInfo ("FALLING_BACK_TO_INDIVIDUAL" :: Text) ("Batch size: " <> show (length batchEntries))
+                processIndividualEntries _dbStreamKey batchEntries
+              Right _ -> do
+                EL.logInfo ("BATCH_INSERT_SUCCESS" :: Text) $
+                  sig.tableName.getDBModel <> "|entries:" <> show (length batchEntries) <> "|time:" <> show executionTime
+                void $ publishDBSyncMetric $ Event.BatchExecutionTime sig.tableName.getDBModel executionTime
+                void $ publishDBSyncMetric $ Event.BatchEntriesProcessed sig.tableName.getDBModel (length batchEntries)
 
-              forM_ batchEntries $ \entry -> setDrainerTtl entry.createObject.dbModel entry.createObject.primaryKey
+                forM_ batchEntries $ \entry -> setDrainerTtl entry.createObject.dbModel entry.createObject.primaryKey
 
-              -- Push successful batch entries to Kafka
-              kafkaResults <- pushEntriesToKafka _dbStreamKey batchEntries
-              let (kafkaSuccesses, kafkaFailures) = kafkaResults
+                -- Push successful batch entries to Kafka
+                kafkaResults <- pushEntriesToKafka _dbStreamKey batchEntries
+                let (kafkaSuccesses, kafkaFailures) = kafkaResults
 
-              -- Log Kafka results
-              when (not $ null kafkaFailures) $
-                EL.logError ("BATCH_KAFKA_FAILURES" :: Text) $
-                  sig.tableName.getDBModel <> "|kafka_failed:" <> show (length kafkaFailures)
+                -- Log Kafka results
+                unless (null kafkaFailures) $
+                  EL.logError ("BATCH_KAFKA_FAILURES" :: Text) $
+                    sig.tableName.getDBModel <> "|kafka_failed:" <> show (length kafkaFailures)
 
-              pure (kafkaSuccesses, kafkaFailures)
+                pure (kafkaSuccesses, kafkaFailures)
 
 -- | Get global batch size from environment variables
 getGlobalBatchSize :: Flow Int

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Create.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Create.hs
@@ -7,13 +7,12 @@ import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
-import Data.Maybe
-import Data.Text as T hiding (any, map, null)
+import Data.Text as T hiding (any, concatMap, elem, filter, map, null)
 import qualified Data.Text.Encoding as TE
 import Database.PostgreSQL.Simple.Types
 import EulerHS.Language as EL
 import EulerHS.Prelude
-import Kernel.Beam.Lib.Utils as KBLU
+import qualified Kernel.Beam.Lib.Utils as KBLU
 import Text.Casing (pascal)
 import Types.DBSync
 import Types.Event as Event
@@ -30,10 +29,13 @@ runCreate createDataEntry streamName = do
     Right createDBModel -> do
       EL.logDebug ("DB OBJECT" :: Text) (show createDBModel)
       let tableName = createDBModel.dbModel
-      if shouldPushToDbOnly tableName _dontEnableForKafka || not isPushToKafka'
+          tableSnake = textToSnakeCaseText tableName.getDBModel
+      if shouldPushToDbOnly tableName _dontEnableForKafka || tableSnake `elem` _dropTablesForCh || tableName.getDBModel `elem` _dropTablesForCh || not isPushToKafka'
         then runCreateQuery createDataEntry createDBModel
         else do
-          let createObject = KBLU.replaceMappings (A.Object createDBModel.contentsObj) (HM.fromList . M.toList $ createDBModel.mappings.getMapping)
+          let chCols = columnsForTable tableSnake tableName.getDBModel _dropColumnsForCh
+              rawObject = KBLU.replaceMappings (A.Object createDBModel.contentsObj) (HM.fromList . M.toList $ createDBModel.mappings.getMapping)
+              createObject = filterChColumns chCols rawObject
           res <- EL.runIO $ createInKafka _kafkaProducerTools createObject streamName tableName
           case res of
             Left err -> do
@@ -54,27 +56,34 @@ runCreateQuery createDataEntry dbCreateObject = do
   Env {..} <- ask
   let (entryId, byteString) = createDataEntry
       dbModel = dbCreateObject.dbModel
-  if shouldPushToKafkaOnly dbModel _dontEnableDbTables && not dbCreateObject.forceDrainToDB
+      tableSnake = textToSnakeCaseText dbModel.getDBModel
+      pgDropTable = tableSnake `elem` _dropTablesForDb || dbModel.getDBModel `elem` _dropTablesForDb
+  if pgDropTable || (shouldPushToKafkaOnly dbModel _dontEnableDbTables && not dbCreateObject.forceDrainToDB)
     then return $ Right entryId
     else do
-      let insertQuery = generateInsertForTable dbCreateObject
-      case insertQuery of
-        Just query -> do
-          result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
-          case result of
-            Left (QueryError errorMsg) -> do
-              EL.logError ("QUERY INSERT FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
-              EL.logError ("QUERY INSERT FAILED: BYTE STRING" :: Text) (show byteString)
-              EL.logError ("QUERY INSERT FAILED: DB OBJECT" :: Text) (show dbCreateObject)
-              void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Create" dbModel.getDBModel
-              return $ Left entryId
-            Right _ -> do
-              EL.logDebug ("QUERY INSERT SUCCESSFUL" :: Text) (" Insert successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
-              setDrainerTtl dbCreateObject.dbModel dbCreateObject.primaryKey
-              return $ Right entryId
-        Nothing -> do
-          EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
-          return $ Left entryId
+      let pgCols = columnsForTable tableSnake dbModel.getDBModel _dropColumnsForDb
+          filteredObj = if null pgCols then dbCreateObject else (dbCreateObject :: DBCreateObject) {contents = filterInsertContents pgCols (dbCreateObject.contents) (dbCreateObject.mappings)}
+          DBCreateObjectContent filteredTerms = filteredObj.contents
+          insertQuery = generateInsertForTable filteredObj
+      if not (null pgCols) && null filteredTerms
+        then return $ Right entryId
+        else case insertQuery of
+          Just query -> do
+            result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
+            case result of
+              Left (QueryError errorMsg) -> do
+                EL.logError ("QUERY INSERT FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
+                EL.logError ("QUERY INSERT FAILED: BYTE STRING" :: Text) (show byteString)
+                EL.logError ("QUERY INSERT FAILED: DB OBJECT" :: Text) (show dbCreateObject)
+                void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Create" dbModel.getDBModel
+                return $ Left entryId
+              Right _ -> do
+                EL.logDebug ("QUERY INSERT SUCCESSFUL" :: Text) (" Insert successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
+                setDrainerTtl dbCreateObject.dbModel dbCreateObject.primaryKey
+                return $ Right entryId
+          Nothing -> do
+            EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
+            return $ Left entryId
 
 -- | Generate an insert query for the rider_app schema
 generateInsertForTable :: DBCreateObject -> Maybe Text
@@ -90,3 +99,30 @@ getCreateObjectForKafka model content =
       "tag" A..= ((T.pack . pascal . T.unpack) model.getDBModel <> "Object"),
       "type" A..= ("INSERT" :: Text)
     ]
+
+-- Extract column names to filter for the given table.
+-- Accepts both snake_case and camelCase table prefix (e.g. "driver_location.col" or "DriverLocation.col").
+-- The column part is matched both as-written and normalised to snake_case, so a config entry in either
+-- case (e.g. "driver_location.some_field" or "driver_location.someField") is handled correctly, because
+-- replaceMappings normalises identifiers to snake_case before comparison.
+columnsForTable :: Text -> Text -> [Text] -> [Text]
+columnsForTable tableSnake tableCamel = concatMap $ \tc ->
+  case T.breakOn "." tc of
+    (tbl, dotCol)
+      | (tbl == tableSnake || tbl == tableCamel) && dotCol /= mempty ->
+        let col = T.drop 1 dotCol in [col, textToSnakeCaseText col]
+    _ -> []
+
+-- Filter TermWraps to exclude configured columns before INSERT.
+filterInsertContents :: [Text] -> DBCreateObjectContent -> Mapping -> DBCreateObjectContent
+filterInsertContents [] c _ = c
+filterInsertContents cols (DBCreateObjectContent tws) mp =
+  DBCreateObjectContent $ filter (\(TermWrap col _) -> replaceMappings col mp `notElem` cols) tws
+
+-- Filter keys from the Kafka/CH JSON payload.
+filterChColumns :: [Text] -> A.Value -> A.Value
+filterChColumns [] v = v
+filterChColumns cols v =
+  case A.fromJSON @(M.Map Text A.Value) v of
+    A.Success m -> A.toJSON $ M.filterWithKey (\k _ -> k `notElem` cols) m
+    A.Error _ -> v

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Delete.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Delete.hs
@@ -6,7 +6,7 @@ import DBQuery.Types
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe
-import Data.Text as T
+import Data.Text as T hiding (elem)
 import qualified Data.Text.Encoding as TE
 import Database.PostgreSQL.Simple.Types (Query (..))
 import qualified EulerHS.Language as EL
@@ -33,23 +33,27 @@ runDeleteQuery deleteEntries dbDeleteObject = do
   Env {..} <- ask
   let (entryId, byteString) = deleteEntries
   let dbModel = dbDeleteObject.dbModel
-  let deleteQuery = getDeleteQueryForTable dbDeleteObject
-  case deleteQuery of
-    Just query -> do
-      result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
-      case result of
-        Left (QueryError errorMsg) -> do
-          EL.logError ("QUERY DELETE FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
-          EL.logError ("QUERY DELETE FAILED : BYTE STRING" :: Text) (TE.decodeUtf8 byteString)
-          EL.logError ("QUERY DELETE FAILED : DB OBJECT" :: Text) (show dbDeleteObject)
-          void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Delete" dbModel.getDBModel
+      tableSnake = textToSnakeCaseText dbModel.getDBModel
+  if tableSnake `elem` _dropTablesForDb || dbModel.getDBModel `elem` _dropTablesForDb
+    then return $ Right entryId
+    else do
+      let deleteQuery = getDeleteQueryForTable dbDeleteObject
+      case deleteQuery of
+        Just query -> do
+          result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
+          case result of
+            Left (QueryError errorMsg) -> do
+              EL.logError ("QUERY DELETE FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
+              EL.logError ("QUERY DELETE FAILED : BYTE STRING" :: Text) (TE.decodeUtf8 byteString)
+              EL.logError ("QUERY DELETE FAILED : DB OBJECT" :: Text) (show dbDeleteObject)
+              void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Delete" dbModel.getDBModel
+              return $ Left entryId
+            Right _ -> do
+              EL.logDebug ("QUERY DELETE SUCCESSFUL" :: Text) (" Delete successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
+              return $ Right entryId
+        Nothing -> do
+          EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
           return $ Left entryId
-        Right _ -> do
-          EL.logDebug ("QUERY DELETE SUCCESSFUL" :: Text) (" Delete successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
-          return $ Right entryId
-    Nothing -> do
-      EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
-      return $ Left entryId
 
 getDeleteQueryForTable :: DBDeleteObject -> Maybe Text
 getDeleteQueryForTable DBDeleteObject {dbModel, contents, mappings} = do

--- a/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/DBSync/Update.hs
@@ -8,12 +8,12 @@ import Data.Aeson as A
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
-import Data.Text as T hiding (map)
+import Data.Text as T hiding (concatMap, elem, filter, map, null)
 import qualified Data.Text.Encoding as TE
 import Database.PostgreSQL.Simple.Types
 import qualified EulerHS.Language as EL
 import EulerHS.Prelude hiding (id, try)
-import Kernel.Beam.Lib.Utils as KBLU
+import qualified Kernel.Beam.Lib.Utils as KBLU
 import Types.DBSync
 import Types.Event as Event
 import Utils.Utils
@@ -29,10 +29,13 @@ runUpdate updateDataEntries streamName = do
     Right updateDBModel -> do
       EL.logDebug ("DB OBJECT" :: Text) (show updateDBModel)
       let tableName = updateDBModel.dbModel
-      if shouldPushToDbOnly tableName _dontEnableForKafka || not isPushToKafka'
+          tableSnake = textToSnakeCaseText tableName.getDBModel
+      if shouldPushToDbOnly tableName _dontEnableForKafka || tableSnake `elem` _dropTablesForCh || tableName.getDBModel `elem` _dropTablesForCh || not isPushToKafka'
         then runUpdateQuery updateDataEntries updateDBModel
         else do
-          let updateObject = KBLU.replaceMappings (maybe (A.object []) A.Object (updateDBModel.updatedModel)) (HM.fromList . M.toList $ updateDBModel.mappings.getMapping)
+          let chCols = columnsForTable tableSnake tableName.getDBModel _dropColumnsForCh
+              rawObject = KBLU.replaceMappings (maybe (A.object []) A.Object (updateDBModel.updatedModel)) (HM.fromList . M.toList $ updateDBModel.mappings.getMapping)
+              updateObject = filterChColumns chCols rawObject
           res <- EL.runIO $ createInKafka _kafkaProducerTools updateObject streamName tableName
           case res of
             Left err -> do
@@ -51,31 +54,68 @@ runUpdateQuery :: (EL.KVDBStreamEntryID, ByteString) -> DBUpdateObject -> Reader
 runUpdateQuery updateDataEntries dbUpdateObject = do
   Env {..} <- ask
   let (entryId, byteString) = updateDataEntries
-  let dbModel = dbUpdateObject.dbModel
-  if shouldPushToKafkaOnly dbModel _dontEnableDbTables && not dbUpdateObject.forceDrainToDB
+      dbModel = dbUpdateObject.dbModel
+      tableSnake = textToSnakeCaseText dbModel.getDBModel
+      pgDropTable = tableSnake `elem` _dropTablesForDb || dbModel.getDBModel `elem` _dropTablesForDb
+  if pgDropTable || (shouldPushToKafkaOnly dbModel _dontEnableDbTables && not dbUpdateObject.forceDrainToDB)
     then return $ Right entryId
     else do
-      let updateQuery = getUpdateQueryForTable dbUpdateObject
-      case updateQuery of
-        Just query -> do
-          result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
-          case result of
-            Left (QueryError errorMsg) -> do
-              EL.logError ("QUERY UPDATE FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
-              EL.logError ("QUERY UPDATE FAILED : BYTE STRING" :: Text) (TE.decodeUtf8 byteString)
-              EL.logError ("QUERY UPDATE FAILED : DB OBJECT" :: Text) (show dbUpdateObject)
-              void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Update" dbModel.getDBModel
+      let pgCols = columnsForTable tableSnake dbModel.getDBModel _dropColumnsForDb
+      let filteredObj = if null pgCols then dbUpdateObject else (dbUpdateObject :: DBUpdateObject) {contents = filterUpdateContents pgCols (dbUpdateObject.contents) (dbUpdateObject.mappings)}
+          DBUpdateObjectContent setClauses _ = filteredObj.contents
+      if null setClauses
+        then do
+          EL.logInfo ("UPDATE_SKIPPED_ALL_COLS_DROPPED" :: Text) dbModel.getDBModel
+          return $ Right entryId
+        else do
+          let updateQuery = getUpdateQueryForTable filteredObj
+          case updateQuery of
+            Just query -> do
+              result <- EL.runIO $ try $ executeQueryUsingConnectionPool _connectionPool (Query $ TE.encodeUtf8 query)
+              case result of
+                Left (QueryError errorMsg) -> do
+                  EL.logError ("QUERY UPDATE FAILED" :: Text) ("(ENTRY ID :: " <> show entryId <> ") => " <> errorMsg <> " for query :: " <> query)
+                  EL.logError ("QUERY UPDATE FAILED : BYTE STRING" :: Text) (TE.decodeUtf8 byteString)
+                  EL.logError ("QUERY UPDATE FAILED : DB OBJECT" :: Text) (show dbUpdateObject)
+                  void $ publishDBSyncMetric $ Event.QueryExecutionFailure "Update" dbModel.getDBModel
+                  return $ Left entryId
+                Right _ -> do
+                  EL.logDebug ("QUERY UPDATE SUCCESSFUL" :: Text) (" Update successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
+                  setDrainerTtl dbUpdateObject.dbModel dbUpdateObject.primaryKey
+                  return $ Right entryId
+            Nothing -> do
+              EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
               return $ Left entryId
-            Right _ -> do
-              EL.logDebug ("QUERY UPDATE SUCCESSFUL" :: Text) (" Update successful for query :: " <> query <> " with streamData :: " <> TE.decodeUtf8 byteString)
-              setDrainerTtl dbUpdateObject.dbModel dbUpdateObject.primaryKey
-              return $ Right entryId
-        Nothing -> do
-          EL.logError ("No query generated for streamData: " :: Text) (TE.decodeUtf8 byteString)
-          return $ Left entryId
 
 getUpdateQueryForTable :: DBUpdateObject -> Maybe Text
 getUpdateQueryForTable DBUpdateObject {dbModel, contents, mappings} = do
   let DBUpdateObjectContent setClauses whereClause = contents
   let schema = SchemaName $ T.pack currentSchemaName
   generateUpdateQuery UpdateQuery {..}
+
+-- Extract column names to filter for the given table.
+-- Accepts both snake_case and camelCase table prefix (e.g. "driver_location.col" or "DriverLocation.col").
+-- The column part is matched both as-written and normalised to snake_case, so a config entry in either
+-- case (e.g. "driver_location.some_field" or "driver_location.someField") is handled correctly, because
+-- replaceMappings normalises identifiers to snake_case before comparison.
+columnsForTable :: Text -> Text -> [Text] -> [Text]
+columnsForTable tableSnake tableCamel = concatMap $ \tc ->
+  case T.breakOn "." tc of
+    (tbl, dotCol)
+      | (tbl == tableSnake || tbl == tableCamel) && dotCol /= mempty ->
+        let col = T.drop 1 dotCol in [col, textToSnakeCaseText col]
+    _ -> []
+
+-- Filter SetClauses to exclude configured columns before UPDATE.
+filterUpdateContents :: [Text] -> DBUpdateObjectContent -> Mapping -> DBUpdateObjectContent
+filterUpdateContents [] c _ = c
+filterUpdateContents cols (DBUpdateObjectContent sets wh) mp =
+  DBUpdateObjectContent (filter (\(Set col _) -> replaceMappings col mp `notElem` cols) sets) wh
+
+-- Filter keys from the Kafka/CH JSON payload.
+filterChColumns :: [Text] -> A.Value -> A.Value
+filterChColumns [] v = v
+filterChColumns cols v =
+  case A.fromJSON @(M.Map Text A.Value) v of
+    A.Success m -> A.toJSON $ M.filterWithKey (\k _ -> k `notElem` cols) m
+    A.Error _ -> v

--- a/Backend/app/rider-platform/rider-app-drainer/src/Types/DBSync.hs
+++ b/Backend/app/rider-platform/rider-app-drainer/src/Types/DBSync.hs
@@ -51,7 +51,11 @@ data Env = Env
     _dontEnableDbTables :: [Text],
     _dontEnableForKafka :: [Text],
     _connectionPool :: Pool Connection,
-    _esqDBCfg :: EsqDBConfig
+    _esqDBCfg :: EsqDBConfig,
+    _dropColumnsForDb :: [Text],
+    _dropColumnsForCh :: [Text],
+    _dropTablesForDb :: [Text],
+    _dropTablesForCh :: [Text]
   }
 
 data AppCfg = AppCfg
@@ -65,7 +69,13 @@ data AppCfg = AppCfg
     loggerConfig :: LoggerConfig,
     dontEnableForDb :: [Text],
     dontEnableForKafka :: [Text],
-    kafkaProperties :: [KTC.KafkaProperties]
+    kafkaProperties :: [KTC.KafkaProperties],
+    dropColumnsForDb :: [Text],
+    dropColumnsForCh :: [Text],
+    dropColumnsForBoth :: [Text],
+    dropTablesForDb :: [Text],
+    dropTablesForCh :: [Text],
+    dropTablesForBoth :: [Text]
   }
   deriving (Generic, FromDhall)
 

--- a/Backend/dhall-configs/dev/driver-drainer.dhall
+++ b/Backend/dhall-configs/dev/driver-drainer.dhall
@@ -60,6 +60,18 @@ let dontEnableForDb = [] : List Text
 
 let dontEnableForKafka = [] : List Text
 
+let dropColumnsForDb = [] : List Text
+
+let dropColumnsForCh = [] : List Text
+
+let dropColumnsForBoth = [] : List Text
+
+let dropTablesForDb = [] : List Text
+
+let dropTablesForCh = [] : List Text
+
+let dropTablesForBoth = [] : List Text
+
 let kafkaProperties =
         [ { propName = "queue.buffering.max.messages", propValue = "5000" }
         , { propName = "message.max.bytes", propValue = "1000000" }
@@ -79,4 +91,10 @@ in  { esqDBCfg
     , dontEnableForDb
     , dontEnableForKafka
     , kafkaProperties
+    , dropColumnsForDb
+    , dropColumnsForCh
+    , dropColumnsForBoth
+    , dropTablesForDb
+    , dropTablesForCh
+    , dropTablesForBoth
     }

--- a/Backend/dhall-configs/dev/rider-drainer.dhall
+++ b/Backend/dhall-configs/dev/rider-drainer.dhall
@@ -60,6 +60,18 @@ let dontEnableForDb = [] : List Text
 
 let dontEnableForKafka = [] : List Text
 
+let dropColumnsForDb = [] : List Text
+
+let dropColumnsForCh = [] : List Text
+
+let dropColumnsForBoth = [] : List Text
+
+let dropTablesForDb = [] : List Text
+
+let dropTablesForCh = [] : List Text
+
+let dropTablesForBoth = [] : List Text
+
 let kafkaProperties =
         [ { propName = "queue.buffering.max.messages", propValue = "5000" }
         , { propName = "message.max.bytes", propValue = "1000000" }
@@ -79,4 +91,10 @@ in  { esqDBCfg
     , dontEnableForDb
     , dontEnableForKafka
     , kafkaProperties
+    , dropColumnsForDb
+    , dropColumnsForCh
+    , dropColumnsForBoth
+    , dropTablesForDb
+    , dropTablesForCh
+    , dropTablesForBoth
     }


### PR DESCRIPTION
## What

Six optional dhall config fields on the driver and rider drainers that skip already-dropped schema at drain time (all inert when empty):

- `dropTablesForDb` / `dropTablesForCh` / `dropTablesForBoth`
- `dropColumnsForDb` / `dropColumnsForCh` / `dropColumnsForBoth`

`*ForDb` skips the PostgreSQL write, `*ForCh` skips the Kafka/ClickHouse push, `*ForBoth` applies to both. Column entries are `table.column` (snake_case), matched to the physical column name (both as-written and snake-normalised).

## Behaviour

- A dropped table short-circuits before query generation in Create/Update/Delete/BatchCreate, and wins over `forceDrainToDB`, so a physically-dropped table is never written.
- Column drops filter INSERT/SET terms (PostgreSQL) and JSON keys (ClickHouse payload).
- Malformed `dropColumns` entries (not `table.column`) are logged as a startup warning.
- Covers Create, Update, Delete and BatchCreate in both drainers.

## Scope note

This supersedes the earlier ClickHouse direct-DDL drop approach (the env-var-driven code in kafka-consumers/driver-app `App.hs`); that code has been removed. ClickHouse handling now flows through the drainer's `*ForCh`/`*ForBoth` routing. (Earlier HLint/CodeRabbit comments referenced that removed code and no longer apply.)

## Rollout notes

- Deploy config at or before the physical `DROP` (config-first) to avoid a transient, self-healing error blip.
- Only list columns that never appear in a `WHERE` (never used to address a row), not merely non-PK.
- `*ForCh`/`*ForBoth` stops emitting to the table's Kafka topic — confirm ClickHouse is the sole consumer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration options to exclude specific tables or columns from database and ClickHouse synchronization.
  - Excluded data is filtered from create and update operations, while excluded tables skip processing.
  - Records can be routed to the alternate synchronization destination when appropriate.
  - Table and column matching supports common naming formats.

- **Bug Fixes**
  - Prevented unnecessary database operations when all requested fields are excluded.

- **Monitoring**
  - Added startup logging for resolved exclusions and warnings for malformed column configuration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->