### PR TITLE
Backend/fix: driver offers

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/DriverFeeUpdates/DriverFee.hs
@@ -459,7 +459,8 @@ getFinalOrderAmount feeWithoutDiscount merchantId transporterConfig driver plan 
   let dutyDate = driverFee.createdAt
       registrationDateLocal = addUTCTime (secondsToNominalDiffTime transporterConfig.timeDiffFromUtc) registrationDate
       waiveOffValidTillIst = fmap (addUTCTime (secondsToNominalDiffTime transporterConfig.timeDiffFromUtc)) waiveOffValidTill
-      waiveOffMultiplier = if (waiveOffMode == DPlan.NO_WAIVE_OFF || maybe True (driverFee.startTime >) waiveOffValidTillIst) then 1.0 else (1.0 - (waiveOffPercentage / 100)) -- If there is no driver plan or waive-off validity is Nothing, no discount applies
+      isWaiveOffActive = waiveOffMode /= DPlan.NO_WAIVE_OFF && maybe False (driverFee.startTime <=) waiveOffValidTillIst
+      waiveOffMultiplier = if isWaiveOffActive then (1.0 - (waiveOffPercentage / 100)) else 1.0
       feeWithoutDiscountWithWaiveOff = feeWithoutDiscount * waiveOffMultiplier
       feeWithoutDiscountWithWaiveOffAndSpecialZone = feeWithoutDiscountWithWaiveOff + driverFee.specialZoneAmount
       feeWithOutDiscountPlusSpecialZone = feeWithoutDiscount + driverFee.specialZoneAmount
@@ -470,7 +471,7 @@ getFinalOrderAmount feeWithoutDiscount merchantId transporterConfig driver plan 
     else do
       offerResp <- do
         case waiveOffMode of
-          DPlan.WITHOUT_OFFER -> return []
+          DPlan.WITHOUT_OFFER | isWaiveOffActive -> return []
           _ -> do
             subscriptionConfig <-
               CQSC.findSubscriptionConfigsByMerchantOpCityIdAndServiceName driverFee.merchantOperatingCityId Nothing plan.serviceName


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Enable offers based on the waive off duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected offer retrieval when waive-off settings are inactive.
  * Orders configured without an offer now fetch applicable offers when the waive-off period has ended.
  * Preserved existing behavior during active waive-off periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->