### PR TITLE
fix: consider dispatcher override for online waybills

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Dispatcher.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Dispatcher.hs
@@ -76,6 +76,9 @@ postDispatcherUpdateFleetSchedule (mbPersonId, _merchantId) req = do
     updatedFleetInfo <- OTPRest.getVehicleOperationInfo integratedBPPConfig req.updatedFleetId >>= fromMaybeM (DepotFleetInfoNotFound req.updatedFleetId)
     when (depotManager.depotCode.getId /= sourceFleetInfo.depot_id) $ throwError $ DepotManagerDoesNotHaveAccessToFleet depotManager.personId.getId req.sourceFleetId
     when (depotManager.depotCode.getId /= updatedFleetInfo.depot_id) $ throwError $ DepotManagerDoesNotHaveAccessToFleet depotManager.personId.getId req.updatedFleetId
+  sourceWaybillNo <-
+    sourceFleetInfo.waybill_no
+      & fromMaybeM (InvalidRequest $ "No active waybill for source fleet " <> req.sourceFleetId <> "; its schedule cannot be overridden")
   -- =========== validation done ===========
   -- Record history
   now <- getCurrentTime
@@ -103,7 +106,7 @@ postDispatcherUpdateFleetSchedule (mbPersonId, _merchantId) req = do
           }
   QVAH.create vehicleActionHistory
   -- adding fleet override info in redis for waybill.
-  Redis.setExp (fleetOverrideKey req.updatedFleetId) (req.sourceFleetId, sourceFleetInfo.waybill_no & fromMaybe "") 86400
+  Redis.setExp (fleetOverrideKey req.updatedFleetId) (req.sourceFleetId, sourceWaybillNo) 86400
   pure $ Kernel.Types.APISuccess.Success
 
 getFleetOverrideInfo :: (MonadFlow m, Redis.HedisFlow m r) => Text -> m (Maybe (Text, Text))

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -1136,13 +1136,14 @@ getPublicTransportDataImpl (mbPersonId, merchantId) mbCity mbEnableSwitchRoute _
       Just vehicleNumber -> do
         mbVehicleOverrideInfo <- Dispatcher.getFleetOverrideInfo vehicleNumber
         case mbVehicleOverrideInfo of
-          Just (updatedVehicleNumber, newDeviceWaybillNo) -> do
-            updatedVehicleRouteInfo <- JLU.getVehicleLiveRouteInfo integratedBPPConfigs updatedVehicleNumber Nothing >>= fromMaybeM (InvalidVehicleNumber $ "Vehicle override: " <> updatedVehicleNumber <> " for vehicle: " <> vehicleNumber <> ", not found on any route")
-            if Just newDeviceWaybillNo /= (snd updatedVehicleRouteInfo).waybillId
-              then do
+          Just (sourceVehicleNumber, overrideWaybillNo) -> do
+            mbSourceRouteInfo <- JLU.getVehicleLiveRouteInfo integratedBPPConfigs sourceVehicleNumber Nothing
+            case JLU.classifyFleetOverride overrideWaybillNo (snd <$> mbSourceRouteInfo) of
+              JLU.FleetOverrideUsable -> pure mbSourceRouteInfo
+              JLU.FleetOverrideFinished -> do
                 Dispatcher.delFleetOverrideInfo vehicleNumber
                 getVehicleLiveRouteInfo vehicleNumber integratedBPPConfigs
-              else pure $ Just updatedVehicleRouteInfo
+              JLU.FleetOverrideNotYetUsable -> getVehicleLiveRouteInfo vehicleNumber integratedBPPConfigs
           Nothing -> getVehicleLiveRouteInfo vehicleNumber integratedBPPConfigs
       Nothing -> return Nothing
 
@@ -2859,13 +2860,15 @@ postMultimodalOrderSublegSetOnboardedVehicleDetails (mbPersonId, merchantId) jou
       _ -> throwError $ UnsupportedVehicleType (show journeyLeg.mode)
   integratedBPPConfigs <- SIBC.findAllIntegratedBPPConfig journey.merchantOperatingCityId vehicleType DIBC.MULTIMODAL
   (integratedBPPConfig, vehicleLiveRouteInfo) <- case mbVehicleOverrideInfo of
-    Just (overridenVehicleNumber, waybillNo) -> do
-      vehicleLiveRouteInfo <- JLU.getVehicleLiveRouteInfo integratedBPPConfigs overridenVehicleNumber Nothing >>= fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
-      if Just waybillNo /= ((.waybillId) . snd $ vehicleLiveRouteInfo)
-        then do
+    Just (sourceVehicleNumber, overrideWaybillNo) -> do
+      mbSourceRouteInfo <- JLU.getVehicleLiveRouteInfo integratedBPPConfigs sourceVehicleNumber Nothing
+      let scannedVehicleRouteInfo = JLU.getVehicleLiveRouteInfo integratedBPPConfigs vehicleNumber Nothing >>= fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
+      case JLU.classifyFleetOverride overrideWaybillNo (snd <$> mbSourceRouteInfo) of
+        JLU.FleetOverrideUsable -> mbSourceRouteInfo & fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
+        JLU.FleetOverrideFinished -> do
           Dispatcher.delFleetOverrideInfo vehicleNumber
-          JLU.getVehicleLiveRouteInfo integratedBPPConfigs vehicleNumber Nothing >>= fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
-        else pure vehicleLiveRouteInfo
+          scannedVehicleRouteInfo
+        JLU.FleetOverrideNotYetUsable -> scannedVehicleRouteInfo
     Nothing -> JLU.getVehicleLiveRouteInfo integratedBPPConfigs vehicleNumber Nothing >>= fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
   riderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = journey.merchantOperatingCityId.getId}) Nothing >>= fromMaybeM (RiderConfigNotFound journey.merchantOperatingCityId.getId)
   whenJust booking.vehicleNumber $ \bookingVeh ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
@@ -1627,6 +1627,35 @@ getVehicleLiveRouteInfo integratedBPPConfigs vehicleNumber mbPassVerifyReq = do
       return Nothing
     Right result -> return result
 
+data FleetOverrideStatus
+  = FleetOverrideUsable
+  | FleetOverrideNotYetUsable
+  | FleetOverrideFinished
+  deriving (Show, Eq)
+
+isTerminalWaybillStatus :: NandiTypes.WaybillStatus -> Bool
+isTerminalWaybillStatus status = case status of
+  NandiTypes.WaybillClosed -> True
+  NandiTypes.WaybillProcessed -> True
+  NandiTypes.WaybillAudited -> True
+  NandiTypes.WaybillOnline -> False
+  NandiTypes.WaybillUpcoming -> False
+  NandiTypes.WaybillNew -> False
+
+classifyFleetOverride :: Text -> Maybe VehicleLiveRouteInfo -> FleetOverrideStatus
+classifyFleetOverride overrideWaybillNo mbLiveRouteInfo
+  | T.null overrideWaybillNo = FleetOverrideFinished
+  | otherwise = case mbLiveRouteInfo of
+    Nothing -> FleetOverrideNotYetUsable
+    Just liveRouteInfo -> case liveRouteInfo.waybillNo of
+      Nothing -> FleetOverrideNotYetUsable
+      Just liveWaybillNo
+        | liveWaybillNo /= overrideWaybillNo -> FleetOverrideFinished
+        | otherwise -> case liveRouteInfo.waybillStatus of
+          Just NandiTypes.WaybillOnline -> FleetOverrideUsable
+          Just status -> if isTerminalWaybillStatus status then FleetOverrideFinished else FleetOverrideNotYetUsable
+          Nothing -> FleetOverrideNotYetUsable
+
 getVehicleServiceTypeFromInMem ::
   (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, Log m, CacheFlow m r, EsqDBFlow m r) =>
   [DIntegratedBPPConfig.IntegratedBPPConfig] ->
@@ -1922,13 +1951,14 @@ getLiveRouteInfo' integratedBPPConfig userPassedVehicleNumber userPassedRouteCod
   mbVehicleOverrideInfo <- Dispatcher.getFleetOverrideInfo userPassedVehicleNumber
   mbRouteLiveInfo <-
     case mbVehicleOverrideInfo of
-      Just (updatedVehicleNumber, newDeviceWaybillNo) -> do
-        mbUpdatedVehicleRouteInfo <- getVehicleLiveRouteInfo [integratedBPPConfig] updatedVehicleNumber Nothing
-        if Just newDeviceWaybillNo /= ((.waybillId) . snd =<< mbUpdatedVehicleRouteInfo)
-          then do
+      Just (sourceVehicleNumber, overrideWaybillNo) -> do
+        mbSourceRouteInfo <- getVehicleLiveRouteInfo [integratedBPPConfig] sourceVehicleNumber Nothing
+        case classifyFleetOverride overrideWaybillNo (snd <$> mbSourceRouteInfo) of
+          FleetOverrideUsable -> pure mbSourceRouteInfo
+          FleetOverrideFinished -> do
             Dispatcher.delFleetOverrideInfo userPassedVehicleNumber
             getVehicleLiveRouteInfo [integratedBPPConfig] userPassedVehicleNumber Nothing
-          else pure mbUpdatedVehicleRouteInfo
+          FleetOverrideNotYetUsable -> getVehicleLiveRouteInfo [integratedBPPConfig] userPassedVehicleNumber Nothing
       Nothing -> getVehicleLiveRouteInfo [integratedBPPConfig] userPassedVehicleNumber Nothing
   return $
     maybe


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet override validation by matching vehicle waybill IDs and confirming vehicles are online.
  * Prevented stale or invalid overrides from being used during route and boarding flows.
  * Automatically falls back to the scanned vehicle’s live route information when an override is invalid.
  * Corrected the waybill identifier saved for fleet overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->