### PR TITLE
backend/fix: normalize state names to letters-only for GST jurisdiction comparison

### DIFF
--- a/Backend/lib/finance-kernel/src/Lib/Finance/Utils/GstBreakdown.hs
+++ b/Backend/lib/finance-kernel/src/Lib/Finance/Utils/GstBreakdown.hs
@@ -11,6 +11,7 @@ module Lib.Finance.Utils.GstBreakdown
   )
 where
 
+import Data.Char (isAlpha)
 import qualified Data.Text as T
 import Kernel.Prelude
 import Kernel.Types.Common (HighPrecMoney)
@@ -35,13 +36,15 @@ newtype GstRateInterStateBreakup = GstRateInterStateBreakup
   }
   deriving (Eq, Show)
 
+-- Letters-only lowercase form, so enum-rendered names ("TamilNadu") match
+-- free-text geocoder names ("Tamil Nadu", "tamil-nadu").
 normalizeGeoComponent :: Maybe Text -> Maybe Text
 normalizeGeoComponent mbText =
-  case T.toLower . T.strip <$> mbText of
+  case T.filter isAlpha . T.toLower <$> mbText of
     Just value | not (T.null value) -> Just value
     _ -> Nothing
 
--- | Compare two Indian state names (case-insensitive).
+-- | Compare two Indian state names (case-insensitive, ignoring non-letter characters).
 --   Returns Nothing (unknown jurisdiction) when either state is missing;
 --   state resolution must happen upstream.
 compareIndianState :: Maybe Text -> Maybe Text -> Maybe GstJurisdiction


### PR DESCRIPTION
Stacked on #15756. Fixes an inter-state misclassification bug in the new GST jurisdiction logic.

## Bug

`compareIndianState` compares the driver/fleet residence state against the booking pickup state, but the two sides come from different sources with different formats:

- residence side: `show <$> addressState` renders the `IndianState` **enum** — `"TamilNadu"`, `"WestBengal"`, `"UttarPradesh"` (no spaces)
- pickup side: `fromLocation.address.state` is **free-text geocoder output** — `"Tamil Nadu"`, `"West Bengal"`

`normalizeGeoComponent` only lowercased and trimmed, so `"tamilnadu" /= "tamil nadu"` → jurisdiction resolves to `InterState` → **IGST is charged on a genuinely intra-state ride** for every multi-word state (Tamil Nadu, West Bengal, Uttar/Madhya/Andhra/Himachal Pradesh, …), even when all data is present and correct.

## Fix

Normalize both sides to a letters-only lowercase form (`T.filter isAlpha . T.toLower`) before comparing. This makes enum-rendered and free-text names equal, and also absorbs hyphen/spacing variants from geocoders (`"tamil-nadu"`). Single-word states are unaffected.

## QA

- Intra-state ride in a multi-word state (e.g. driver residence Tamil Nadu, pickup in Chennai with geocoded state "Tamil Nadu") → CGST/SGST split, not IGST.
- Inter-state ride (residence ≠ pickup state) → still IGST.
- GSTIN state-code comparison path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)