### PR TITLE
Guard TTL-expiry BPP cancel when bppBookingId is missing

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs
@@ -140,8 +140,15 @@ handleConfirmTtlExpiry booking = do
       ttlToNominalDiffTime = intToNominalDiffTime ttlInInt
       ttlUtcTime = addDurationToUTCTime booking.createdAt ttlToNominalDiffTime
   when (booking.status == SRB.NEW && (ttlUtcTime < now)) do
-    dCancelRes <- DCancel.cancel booking Nothing cancelReq SBCR.ByApplication
-    void . withShortRetry $ CallBPP.cancelV2 booking.merchantId dCancelRes.bppUrl =<< CancelACL.buildCancelReqV2 dCancelRes Nothing
+    case booking.bppBookingId of
+      Nothing ->
+        logError $
+          "handleConfirmTtlExpiry: booking "
+            <> booking.id.getId
+            <> " has expired TTL but bppBookingId is missing; skipping BPP cancel"
+      Just _ -> do
+        dCancelRes <- DCancel.cancel booking Nothing cancelReq SBCR.ByApplication
+        void . withShortRetry $ CallBPP.cancelV2 booking.merchantId dCancelRes.bppUrl =<< CancelACL.buildCancelReqV2 dCancelRes Nothing
     throwError $ RideInvalidStatus "Booking Invalid"
   where
     cancelReq =


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/11l)

### Root cause
The rider-app status endpoint /v2/rideBooking/v2/:rideBookingId/ calls handleConfirmTtlExpiry for NEW bookings whose TTL has expired. That function calls DCancel.cancel, which throws E500 BOOKING_FIELD_NOT_PRESENT when booking.bppBookingId is NULL. A spike in bookings created without bpp_ride_booking_id (7.4% in the 11:00 hour) caused mass 500s and the GCP ELB 5xx alert.

### Evidence
_see RCA_

### Rollback
Revert the change in Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Booking.hs to the previous handleConfirmTtlExpiry implementation.

---
_Draft PR — review and merge manually. Generated by Argus._