### PR TITLE
Backend/feat: add retry autopay job

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/Merchant.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/ProviderPlatform/Management/API/Merchant.yaml
@@ -1162,7 +1162,7 @@ types:
     - jobData: Text
     - derive: "'HideSecrets"
   JobName:
-    - enum: "BadDebtCalculationTrigger, DriverFeeCalculationTrigger, SendManualPaymentLinkTrigger, ReferralPayoutTrigger, SupplyDemandCalculation, CongestionChargeCalculation, ReconciliationTrigger, ScheduledBatchPayoutTrigger, IffcoTokioInsuranceTrigger, AggregatedCommissionInvoiceCreationTrigger"
+    - enum: "BadDebtCalculationTrigger, DriverFeeCalculationTrigger, SendManualPaymentLinkTrigger, ReferralPayoutTrigger, SupplyDemandCalculation, CongestionChargeCalculation, ReconciliationTrigger, ScheduledBatchPayoutTrigger, IffcoTokioInsuranceTrigger, AggregatedCommissionInvoiceCreationTrigger, RetryAutopayCollectionTrigger"
   UpdateOnboardingVehicleVariantMappingReq:
     - file: FilePath
     - vehicleCategory: Text

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/Merchant.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/ProviderPlatform/Management/Endpoints/Merchant.hs
@@ -510,6 +510,7 @@ data JobName
   | ScheduledBatchPayoutTrigger
   | IffcoTokioInsuranceTrigger
   | AggregatedCommissionInvoiceCreationTrigger
+  | RetryAutopayCollectionTrigger
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
@@ -1035,11 +1036,11 @@ data WaitingChargeInfoAPIEntity = WaitingChargeInfoAPIEntity {freeWaitingTime ::
 
 type API = ("merchant" :> (PostMerchantUpdate :<|> GetMerchantConfigCommon :<|> PostMerchantConfigCommonUpdate :<|> GetMerchantConfigDriverPool :<|> PostMerchantConfigDriverPoolUpdate :<|> PostMerchantConfigDriverPoolCreate :<|> PostMerchantConfigDriverPoolUpsert :<|> GetMerchantConfigDriverPoolList :<|> GetMerchantConfigDriverIntelligentPool :<|> PostMerchantConfigDriverIntelligentPoolUpdate :<|> GetMerchantConfigOnboardingDocument :<|> PostMerchantConfigOnboardingDocumentUpdate :<|> PostMerchantConfigOnboardingDocumentCreate :<|> GetMerchantServiceUsageConfig :<|> PostMerchantServiceConfigMapsUpdate :<|> PostMerchantServiceUsageConfigMapsUpdate :<|> PostMerchantServiceConfigSmsUpdate :<|> PostMerchantServiceUsageConfigSmsUpdate :<|> PostMerchantServiceConfigVerificationUpdate :<|> PostMerchantConfigFarePolicyDriverExtraFeeBoundsCreate :<|> PostMerchantConfigFarePolicyDriverExtraFeeBoundsUpdate :<|> PostMerchantConfigFarePolicyPerExtraKmRateUpdate :<|> PostMerchantConfigFarePolicyUpdate :<|> PostMerchantConfigFarePolicyUpsert :<|> GetMerchantConfigFarePolicyExport :<|> GetMerchantConfigFarePolicyDetails :<|> GetMerchantConfigFareProductList :<|> PostMerchantConfigFareProductSetEnabled :<|> PostMerchantConfigOperatingCityCreateHelper :<|> PostMerchantSchedulerTrigger :<|> PostMerchantUpdateOnboardingVehicleVariantMapping :<|> PostMerchantConfigSpecialLocationUpsert :<|> GetMerchantConfigSpecialLocationList :<|> GetMerchantConfigGeometryList :<|> PutMerchantConfigGeometryUpdate :<|> PostMerchantSpecialLocationUpsertHelper :<|> DeleteMerchantSpecialLocationDelete :<|> PostMerchantSpecialLocationGatesUpsertHelper :<|> DeleteMerchantSpecialLocationGatesDelete :<|> PostMerchantConfigTollUpsert :<|> GetMerchantConfigTollList :<|> PostMerchantTollUpsert :<|> DeleteMerchantTollDelete :<|> PostMerchantConfigClearCacheSubscription :<|> PostMerchantConfigUpsertPlanAndConfigSubscription :<|> GetMerchantConfigVendorSplitDetailsList :<|> GetMerchantConfigSubscriptionConfigList :<|> PostMerchantConfigFailover :<|> PostMerchantPayoutConfigUpdate :<|> PostMerchantConfigOperatingCityWhiteList :<|> PostMerchantConfigMerchantCreateHelper :<|> GetMerchantConfigVehicleServiceTier :<|> GetMerchantConfigVehicleServiceTierList :<|> PostMerchantConfigVehicleServiceTierUpdate :<|> PostMerchantConfigVehicleServiceTierCreate :<|> PostMerchantConfigDebugLogUpdate :<|> GetMerchantMerchantDocumentList :<|> GetMerchantMerchantDocument :<|> PostMerchantMerchantDocumentCreate :<|> PostMerchantMerchantDocumentUpdate :<|> PostMerchantMerchantDocumentDelete :<|> GetMerchantMerchantMessageCatalog :<|> PostMerchantMerchantMessageUpsert :<|> DeleteMerchantMerchantMessage :<|> GetMerchantCityList))
 
-type PostMerchantUpdate = ("update" :> ReqBody ('[JSON]) MerchantUpdateReq :> Post ('[JSON]) MerchantUpdateRes)
+type PostMerchantUpdate = ("update" :> ReqBody '[JSON] MerchantUpdateReq :> Post '[JSON] MerchantUpdateRes)
 
-type GetMerchantConfigCommon = ("config" :> "common" :> Get ('[JSON]) MerchantCommonConfigRes)
+type GetMerchantConfigCommon = ("config" :> "common" :> Get '[JSON] MerchantCommonConfigRes)
 
-type PostMerchantConfigCommonUpdate = ("config" :> "common" :> "update" :> ReqBody ('[JSON]) MerchantCommonConfigUpdateReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+type PostMerchantConfigCommonUpdate = ("config" :> "common" :> "update" :> ReqBody '[JSON] MerchantCommonConfigUpdateReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
 
 type GetMerchantConfigDriverPool =
   ( "config" :> "driverPool" :> QueryParam "tripDistance" Kernel.Types.Common.Meters
@@ -1047,7 +1048,7 @@ type GetMerchantConfigDriverPool =
            "tripDistanceValue"
            Kernel.Types.Common.HighPrecDistance
       :> QueryParam "distanceUnit" Kernel.Types.Common.DistanceUnit
-      :> Get ('[JSON]) DriverPoolConfigRes
+      :> Get '[JSON] DriverPoolConfigRes
   )
 
 type PostMerchantConfigDriverPoolUpdate =
@@ -1066,10 +1067,10 @@ type PostMerchantConfigDriverPoolUpdate =
            "area"
            Lib.Types.SpecialLocation.Area
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            DriverPoolConfigUpdateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1089,10 +1090,10 @@ type PostMerchantConfigDriverPoolCreate =
            "area"
            Lib.Types.SpecialLocation.Area
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            DriverPoolConfigCreateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1101,24 +1102,24 @@ type PostMerchantConfigDriverPoolUpsert =
       :> Kernel.ServantMultipart.MultipartForm
            Kernel.ServantMultipart.Tmp
            Dashboard.Common.Merchant.UpsertDriverPoolConfigCsvReq
-      :> Post ('[JSON]) Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities
+      :> Post '[JSON] Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities
   )
 
-type GetMerchantConfigDriverPoolList = ("config" :> "driverPool" :> "list" :> Get ('[JSON]) DriverPoolConfigListRes)
+type GetMerchantConfigDriverPoolList = ("config" :> "driverPool" :> "list" :> Get '[JSON] DriverPoolConfigListRes)
 
-type GetMerchantConfigDriverIntelligentPool = ("config" :> "driverIntelligentPool" :> Get ('[JSON]) DriverIntelligentPoolConfigRes)
+type GetMerchantConfigDriverIntelligentPool = ("config" :> "driverIntelligentPool" :> Get '[JSON] DriverIntelligentPoolConfigRes)
 
 type PostMerchantConfigDriverIntelligentPoolUpdate =
-  ( "config" :> "driverIntelligentPool" :> "update" :> ReqBody ('[JSON]) DriverIntelligentPoolConfigUpdateReq
+  ( "config" :> "driverIntelligentPool" :> "update" :> ReqBody '[JSON] DriverIntelligentPoolConfigUpdateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type GetMerchantConfigOnboardingDocument =
   ( "config" :> "onboardingDocument" :> QueryParam "documentType" DocumentType :> QueryParam "vehicleCategory" Dashboard.Common.VehicleCategory
       :> Get
-           ('[JSON])
+           '[JSON]
            DocumentVerificationConfigRes
   )
 
@@ -1127,9 +1128,9 @@ type PostMerchantConfigOnboardingDocumentUpdate =
       :> MandatoryQueryParam
            "category"
            Dashboard.Common.VehicleCategory
-      :> ReqBody ('[JSON]) DocumentVerificationConfigUpdateReq
+      :> ReqBody '[JSON] DocumentVerificationConfigUpdateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1138,46 +1139,46 @@ type PostMerchantConfigOnboardingDocumentCreate =
       :> MandatoryQueryParam
            "category"
            Dashboard.Common.VehicleCategory
-      :> ReqBody ('[JSON]) DocumentVerificationConfigCreateReq
+      :> ReqBody '[JSON] DocumentVerificationConfigCreateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
-type GetMerchantServiceUsageConfig = ("serviceUsageConfig" :> Get ('[JSON]) Dashboard.Common.Merchant.ServiceUsageConfigRes)
+type GetMerchantServiceUsageConfig = ("serviceUsageConfig" :> Get '[JSON] Dashboard.Common.Merchant.ServiceUsageConfigRes)
 
 type PostMerchantServiceConfigMapsUpdate =
-  ( "serviceConfig" :> "maps" :> "update" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.MapsServiceConfigUpdateReq
+  ( "serviceConfig" :> "maps" :> "update" :> ReqBody '[JSON] Dashboard.Common.Merchant.MapsServiceConfigUpdateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantServiceUsageConfigMapsUpdate =
-  ( "serviceUsageConfig" :> "maps" :> "update" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.MapsServiceUsageConfigUpdateReq
+  ( "serviceUsageConfig" :> "maps" :> "update" :> ReqBody '[JSON] Dashboard.Common.Merchant.MapsServiceUsageConfigUpdateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantServiceConfigSmsUpdate =
-  ( "serviceConfig" :> "sms" :> "update" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.SmsServiceConfigUpdateReq
+  ( "serviceConfig" :> "sms" :> "update" :> ReqBody '[JSON] Dashboard.Common.Merchant.SmsServiceConfigUpdateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantServiceUsageConfigSmsUpdate =
-  ( "serviceUsageConfig" :> "sms" :> "update" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.SmsServiceUsageConfigUpdateReq
+  ( "serviceUsageConfig" :> "sms" :> "update" :> ReqBody '[JSON] Dashboard.Common.Merchant.SmsServiceUsageConfigUpdateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantServiceConfigVerificationUpdate =
-  ( "serviceConfig" :> "verification" :> "update" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.VerificationServiceConfigUpdateReq
+  ( "serviceConfig" :> "verification" :> "update" :> ReqBody '[JSON] Dashboard.Common.Merchant.VerificationServiceConfigUpdateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1196,10 +1197,10 @@ type PostMerchantConfigFarePolicyDriverExtraFeeBoundsCreate =
            "startDistance"
            Kernel.Types.Common.Meters
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            CreateFPDriverExtraFeeReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1218,10 +1219,10 @@ type PostMerchantConfigFarePolicyDriverExtraFeeBoundsUpdate =
            "startDistance"
            Kernel.Types.Common.Meters
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            CreateFPDriverExtraFeeReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1232,30 +1233,30 @@ type PostMerchantConfigFarePolicyPerExtraKmRateUpdate =
            Kernel.Types.Common.Meters
       :> "perExtraKmRate"
       :> "update"
-      :> ReqBody ('[JSON]) UpdateFPPerExtraKmRateReq
+      :> ReqBody '[JSON] UpdateFPPerExtraKmRateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantConfigFarePolicyUpdate =
   ( "config" :> "farePolicy" :> Capture "farePolicyId" (Kernel.Types.Id.Id Dashboard.Common.FarePolicy) :> "update"
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            UpdateFarePolicyReq
-      :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess
+      :> Post '[JSON] Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantConfigFarePolicyUpsert =
   ( "config" :> "farePolicy" :> "upsert" :> Kernel.ServantMultipart.MultipartForm Kernel.ServantMultipart.Tmp UpsertFarePolicyReq
       :> Post
-           ('[JSON])
+           '[JSON]
            UpsertFarePolicyResp
   )
 
-type GetMerchantConfigFarePolicyExport = ("config" :> "farePolicy" :> "export" :> Get ('[JSON]) Kernel.Prelude.Text)
+type GetMerchantConfigFarePolicyExport = ("config" :> "farePolicy" :> "export" :> Get '[JSON] Kernel.Prelude.Text)
 
-type GetMerchantConfigFarePolicyDetails = ("config" :> "farePolicy" :> Capture "farePolicyId" (Kernel.Types.Id.Id Dashboard.Common.FarePolicy) :> "details" :> Get ('[JSON]) FarePolicyDetailsResp)
+type GetMerchantConfigFarePolicyDetails = ("config" :> "farePolicy" :> Capture "farePolicyId" (Kernel.Types.Id.Id Dashboard.Common.FarePolicy) :> "details" :> Get '[JSON] FarePolicyDetailsResp)
 
 type GetMerchantConfigFareProductList =
   ( "config" :> "fareProduct" :> "list" :> MandatoryQueryParam "area" Lib.Types.SpecialLocation.Area
@@ -1263,13 +1264,13 @@ type GetMerchantConfigFareProductList =
            "enabled"
            Kernel.Prelude.Bool
       :> MandatoryQueryParam "tripCategory" Dashboard.Common.TripCategory
-      :> Get ('[JSON]) FareProductListRes
+      :> Get '[JSON] FareProductListRes
   )
 
 type PostMerchantConfigFareProductSetEnabled =
-  ( "config" :> "fareProduct" :> "setEnabled" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.SetFareProductEnabledReq
+  ( "config" :> "fareProduct" :> "setEnabled" :> ReqBody '[JSON] Dashboard.Common.Merchant.SetFareProductEnabledReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1278,24 +1279,24 @@ type PostMerchantConfigOperatingCityCreate =
       :> Kernel.ServantMultipart.MultipartForm
            Kernel.ServantMultipart.Tmp
            Dashboard.Common.Merchant.CreateMerchantOperatingCityReq
-      :> Post ('[JSON]) Dashboard.Common.Merchant.CreateMerchantOperatingCityRes
+      :> Post '[JSON] Dashboard.Common.Merchant.CreateMerchantOperatingCityRes
   )
 
 type PostMerchantConfigOperatingCityCreateHelper =
-  ( "config" :> "operatingCity" :> "create" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.CreateMerchantOperatingCityReqT
+  ( "config" :> "operatingCity" :> "create" :> ReqBody '[JSON] Dashboard.Common.Merchant.CreateMerchantOperatingCityReqT
       :> Post
-           ('[JSON])
+           '[JSON]
            Dashboard.Common.Merchant.CreateMerchantOperatingCityRes
   )
 
-type PostMerchantSchedulerTrigger = ("scheduler" :> "trigger" :> ReqBody ('[JSON]) SchedulerTriggerReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+type PostMerchantSchedulerTrigger = ("scheduler" :> "trigger" :> ReqBody '[JSON] SchedulerTriggerReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
 
 type PostMerchantUpdateOnboardingVehicleVariantMapping =
   ( "updateOnboardingVehicleVariantMapping"
       :> Kernel.ServantMultipart.MultipartForm
            Kernel.ServantMultipart.Tmp
            UpdateOnboardingVehicleVariantMappingReq
-      :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess
+      :> Post '[JSON] Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantConfigSpecialLocationUpsert =
@@ -1303,7 +1304,7 @@ type PostMerchantConfigSpecialLocationUpsert =
       :> Kernel.ServantMultipart.MultipartForm
            Kernel.ServantMultipart.Tmp
            Dashboard.Common.Merchant.UpsertSpecialLocationCsvReq
-      :> Post ('[JSON]) Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities
+      :> Post '[JSON] Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities
   )
 
 type GetMerchantConfigSpecialLocationList =
@@ -1315,18 +1316,18 @@ type GetMerchantConfigSpecialLocationList =
            "locationTypes"
            [Lib.Types.SpecialLocation.SpecialLocationType]
       :> Get
-           ('[JSON])
+           '[JSON]
            SpecialLocationResp
   )
 
-type GetMerchantConfigGeometryList = ("config" :> "geometry" :> "list" :> QueryParam "limit" Kernel.Prelude.Int :> QueryParam "offset" Kernel.Prelude.Int :> Get ('[JSON]) GeometryResp)
+type GetMerchantConfigGeometryList = ("config" :> "geometry" :> "list" :> QueryParam "limit" Kernel.Prelude.Int :> QueryParam "offset" Kernel.Prelude.Int :> Get '[JSON] GeometryResp)
 
 type PutMerchantConfigGeometryUpdate =
   ( "config" :> "geometry" :> "update"
       :> Kernel.ServantMultipart.MultipartForm
            Kernel.ServantMultipart.Tmp
            Dashboard.Common.Merchant.UpdateGeometryReq
-      :> Put ('[JSON]) Kernel.Types.APISuccess.APISuccess
+      :> Put '[JSON] Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantSpecialLocationUpsert =
@@ -1336,22 +1337,22 @@ type PostMerchantSpecialLocationUpsert =
            (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation)
       :> Kernel.ServantMultipart.MultipartForm Kernel.ServantMultipart.Tmp Dashboard.Common.Merchant.UpsertSpecialLocationReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantSpecialLocationUpsertHelper =
   ( "specialLocation" :> "upsert" :> QueryParam "specialLocationId" (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation)
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            Dashboard.Common.Merchant.UpsertSpecialLocationReqT
-      :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess
+      :> Post '[JSON] Kernel.Types.APISuccess.APISuccess
   )
 
 type DeleteMerchantSpecialLocationDelete =
   ( "specialLocation" :> Capture "specialLocationId" (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation) :> "delete"
       :> Delete
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1366,7 +1367,7 @@ type PostMerchantSpecialLocationGatesUpsert =
            Kernel.ServantMultipart.Tmp
            Dashboard.Common.Merchant.UpsertSpecialLocationGateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1377,9 +1378,9 @@ type PostMerchantSpecialLocationGatesUpsertHelper =
            (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation)
       :> "gates"
       :> "upsert"
-      :> ReqBody ('[JSON]) Dashboard.Common.Merchant.UpsertSpecialLocationGateReqT
+      :> ReqBody '[JSON] Dashboard.Common.Merchant.UpsertSpecialLocationGateReqT
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
@@ -1391,49 +1392,49 @@ type DeleteMerchantSpecialLocationGatesDelete =
       :> "gates"
       :> "delete"
       :> Capture "gateName" Kernel.Prelude.Text
-      :> Delete ('[JSON]) Kernel.Types.APISuccess.APISuccess
+      :> Delete '[JSON] Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantConfigTollUpsert =
   ( "config" :> "toll" :> "upsert" :> Kernel.ServantMultipart.MultipartForm Kernel.ServantMultipart.Tmp Dashboard.Common.Merchant.UpsertTollCsvReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities
   )
 
-type GetMerchantConfigTollList = ("config" :> "toll" :> "list" :> QueryParam "limit" Kernel.Prelude.Int :> QueryParam "offset" Kernel.Prelude.Int :> Get ('[JSON]) TollListResp)
+type GetMerchantConfigTollList = ("config" :> "toll" :> "list" :> QueryParam "limit" Kernel.Prelude.Int :> QueryParam "offset" Kernel.Prelude.Int :> Get '[JSON] TollListResp)
 
 type PostMerchantTollUpsert =
-  ( "toll" :> "upsert" :> QueryParam "tollId" (Kernel.Types.Id.Id Toll.Domain.Types.Toll.Toll) :> ReqBody ('[JSON]) Dashboard.Common.Merchant.UpsertTollReq
+  ( "toll" :> "upsert" :> QueryParam "tollId" (Kernel.Types.Id.Id Toll.Domain.Types.Toll.Toll) :> ReqBody '[JSON] Dashboard.Common.Merchant.UpsertTollReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
-type DeleteMerchantTollDelete = ("toll" :> Capture "tollId" (Kernel.Types.Id.Id Toll.Domain.Types.Toll.Toll) :> "delete" :> Delete ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+type DeleteMerchantTollDelete = ("toll" :> Capture "tollId" (Kernel.Types.Id.Id Toll.Domain.Types.Toll.Toll) :> "delete" :> Delete '[JSON] Kernel.Types.APISuccess.APISuccess)
 
-type PostMerchantConfigClearCacheSubscription = ("config" :> "clearCache" :> "subscription" :> ReqBody ('[JSON]) ClearCacheSubscriptionReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+type PostMerchantConfigClearCacheSubscription = ("config" :> "clearCache" :> "subscription" :> ReqBody '[JSON] ClearCacheSubscriptionReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
 
-type PostMerchantConfigUpsertPlanAndConfigSubscription = ("config" :> "upsertPlanAndConfig" :> "subscription" :> ReqBody ('[JSON]) UpsertPlanAndConfigReq :> Post ('[JSON]) UpsertPlanAndConfigResp)
+type PostMerchantConfigUpsertPlanAndConfigSubscription = ("config" :> "upsertPlanAndConfig" :> "subscription" :> ReqBody '[JSON] UpsertPlanAndConfigReq :> Post '[JSON] UpsertPlanAndConfigResp)
 
-type GetMerchantConfigVendorSplitDetailsList = ("config" :> "vendorSplitDetails" :> "list" :> Get ('[JSON]) [VendorSplitDetailsAPIEntity])
+type GetMerchantConfigVendorSplitDetailsList = ("config" :> "vendorSplitDetails" :> "list" :> Get '[JSON] [VendorSplitDetailsAPIEntity])
 
-type GetMerchantConfigSubscriptionConfigList = ("config" :> "subscriptionConfig" :> "list" :> Get ('[JSON]) [SubscriptionConfigAPIEntity])
+type GetMerchantConfigSubscriptionConfigList = ("config" :> "subscriptionConfig" :> "list" :> Get '[JSON] [SubscriptionConfigAPIEntity])
 
 type PostMerchantConfigFailover =
   ( "config" :> Capture "configName" Dashboard.Common.Merchant.ConfigNames :> "failover"
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            Dashboard.Common.Merchant.ConfigFailoverReq
-      :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess
+      :> Post '[JSON] Kernel.Types.APISuccess.APISuccess
   )
 
-type PostMerchantPayoutConfigUpdate = ("payoutConfig" :> "update" :> ReqBody ('[JSON]) PayoutConfigReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+type PostMerchantPayoutConfigUpdate = ("payoutConfig" :> "update" :> ReqBody '[JSON] PayoutConfigReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
 
 type PostMerchantConfigOperatingCityWhiteList =
-  ( "config" :> "operatingCity" :> "whiteList" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.WhiteListOperatingCityReq
+  ( "config" :> "operatingCity" :> "whiteList" :> ReqBody '[JSON] Dashboard.Common.Merchant.WhiteListOperatingCityReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Dashboard.Common.Merchant.WhiteListOperatingCityRes
   )
 
@@ -1442,46 +1443,46 @@ type PostMerchantConfigMerchantCreate =
       :> Kernel.ServantMultipart.MultipartForm
            Kernel.ServantMultipart.Tmp
            Dashboard.Common.Merchant.CreateMerchantOperatingCityReq
-      :> Post ('[JSON]) Dashboard.Common.Merchant.CreateMerchantOperatingCityRes
+      :> Post '[JSON] Dashboard.Common.Merchant.CreateMerchantOperatingCityRes
   )
 
 type PostMerchantConfigMerchantCreateHelper =
-  ( "config" :> "merchant" :> "create" :> ReqBody ('[JSON]) Dashboard.Common.Merchant.CreateMerchantOperatingCityReqT
+  ( "config" :> "merchant" :> "create" :> ReqBody '[JSON] Dashboard.Common.Merchant.CreateMerchantOperatingCityReqT
       :> Post
-           ('[JSON])
+           '[JSON]
            Dashboard.Common.Merchant.CreateMerchantOperatingCityRes
   )
 
-type GetMerchantConfigVehicleServiceTier = ("config" :> "vehicleServiceTier" :> QueryParam "serviceTierType" Dashboard.Common.ServiceTierType :> Get ('[JSON]) VehicleServiceTierRes)
+type GetMerchantConfigVehicleServiceTier = ("config" :> "vehicleServiceTier" :> QueryParam "serviceTierType" Dashboard.Common.ServiceTierType :> Get '[JSON] VehicleServiceTierRes)
 
-type GetMerchantConfigVehicleServiceTierList = ("config" :> "vehicleServiceTier" :> "list" :> Get ('[JSON]) VehicleServiceTierListRes)
+type GetMerchantConfigVehicleServiceTierList = ("config" :> "vehicleServiceTier" :> "list" :> Get '[JSON] VehicleServiceTierListRes)
 
 type PostMerchantConfigVehicleServiceTierUpdate =
   ( "config" :> "vehicleServiceTier" :> "update" :> MandatoryQueryParam "serviceTierType" Dashboard.Common.ServiceTierType
       :> ReqBody
-           ('[JSON])
+           '[JSON]
            VehicleServiceTierConfigUpdateReq
-      :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess
+      :> Post '[JSON] Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantConfigVehicleServiceTierCreate =
-  ( "config" :> "vehicleServiceTier" :> "create" :> ReqBody ('[JSON]) VehicleServiceTierConfigCreateReq
+  ( "config" :> "vehicleServiceTier" :> "create" :> ReqBody '[JSON] VehicleServiceTierConfigCreateReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type PostMerchantConfigDebugLogUpdate =
-  ( "config" :> "debugLog" :> "update" :> ReqBody ('[JSON]) Lib.Yudhishthira.Tools.DebugLog.SetJsonLogicDebugReq
+  ( "config" :> "debugLog" :> "update" :> ReqBody '[JSON] Lib.Yudhishthira.Tools.DebugLog.SetJsonLogicDebugReq
       :> Post
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
 type GetMerchantMerchantDocumentList =
   ( "merchantDocument" :> "list" :> QueryParam "language" Kernel.External.Types.Language :> MandatoryQueryParam "role" MerchantDocumentRoleT
       :> Get
-           ('[JSON])
+           '[JSON]
            MerchantDocumentListResp
   )
 
@@ -1490,109 +1491,106 @@ type GetMerchantMerchantDocument =
       :> MandatoryQueryParam
            "role"
            MerchantDocumentRoleT
-      :> Get ('[JSON]) MerchantDocumentItem
+      :> Get '[JSON] MerchantDocumentItem
   )
 
-type PostMerchantMerchantDocumentCreate = ("merchantDocument" :> "create" :> ReqBody ('[JSON]) CreateMerchantDocumentReq :> Post ('[JSON]) MerchantDocumentItem)
+type PostMerchantMerchantDocumentCreate = ("merchantDocument" :> "create" :> ReqBody '[JSON] CreateMerchantDocumentReq :> Post '[JSON] MerchantDocumentItem)
 
-type PostMerchantMerchantDocumentUpdate = ("merchantDocument" :> "update" :> ReqBody ('[JSON]) UpdateMerchantDocumentReq :> Post ('[JSON]) MerchantDocumentItem)
+type PostMerchantMerchantDocumentUpdate = ("merchantDocument" :> "update" :> ReqBody '[JSON] UpdateMerchantDocumentReq :> Post '[JSON] MerchantDocumentItem)
 
-type PostMerchantMerchantDocumentDelete = ("merchantDocument" :> "delete" :> ReqBody ('[JSON]) DeleteMerchantDocumentReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+type PostMerchantMerchantDocumentDelete = ("merchantDocument" :> "delete" :> ReqBody '[JSON] DeleteMerchantDocumentReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
 
-type GetMerchantMerchantMessageCatalog = ("merchantMessage" :> "catalog" :> MandatoryQueryParam "catalogType" MerchantMessageCatalogType :> Get ('[JSON]) MerchantMessageCatalogResp)
+type GetMerchantMerchantMessageCatalog = ("merchantMessage" :> "catalog" :> MandatoryQueryParam "catalogType" MerchantMessageCatalogType :> Get '[JSON] MerchantMessageCatalogResp)
 
-type PostMerchantMerchantMessageUpsert = ("merchantMessage" :> "upsert" :> ReqBody ('[JSON]) UpsertMerchantMessageReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
+type PostMerchantMerchantMessageUpsert = ("merchantMessage" :> "upsert" :> ReqBody '[JSON] UpsertMerchantMessageReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
 
 type DeleteMerchantMerchantMessage =
   ( "merchantMessage" :> Capture "messageKey" Kernel.Prelude.Text :> QueryParam "vehicleCategory" Dashboard.Common.VehicleCategory
       :> Delete
-           ('[JSON])
+           '[JSON]
            Kernel.Types.APISuccess.APISuccess
   )
 
-type GetMerchantCityList = ("cityList" :> Get ('[JSON]) CityListResp)
+type GetMerchantCityList = ("cityList" :> Get '[JSON] CityListResp)
 
 data MerchantAPIs = MerchantAPIs
-  { postMerchantUpdate :: (MerchantUpdateReq -> EulerHS.Types.EulerClient MerchantUpdateRes),
-    getMerchantConfigCommon :: (EulerHS.Types.EulerClient MerchantCommonConfigRes),
-    postMerchantConfigCommonUpdate :: (MerchantCommonConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    getMerchantConfigDriverPool :: (Kernel.Prelude.Maybe (Kernel.Types.Common.Meters) -> Kernel.Prelude.Maybe (Kernel.Types.Common.HighPrecDistance) -> Kernel.Prelude.Maybe (Kernel.Types.Common.DistanceUnit) -> EulerHS.Types.EulerClient DriverPoolConfigRes),
-    postMerchantConfigDriverPoolUpdate :: (Kernel.Prelude.Maybe (Kernel.Types.Common.HighPrecDistance) -> Kernel.Prelude.Maybe (Kernel.Types.Common.DistanceUnit) -> Kernel.Prelude.Maybe (Dashboard.Common.VehicleVariant) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Types.Common.Meters -> Lib.Types.SpecialLocation.Area -> DriverPoolConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigDriverPoolCreate :: (Kernel.Prelude.Maybe (Kernel.Types.Common.HighPrecDistance) -> Kernel.Prelude.Maybe (Kernel.Types.Common.DistanceUnit) -> Kernel.Prelude.Maybe (Dashboard.Common.VehicleVariant) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Types.Common.Meters -> Lib.Types.SpecialLocation.Area -> DriverPoolConfigCreateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+  { postMerchantUpdate :: MerchantUpdateReq -> EulerHS.Types.EulerClient MerchantUpdateRes,
+    getMerchantConfigCommon :: EulerHS.Types.EulerClient MerchantCommonConfigRes,
+    postMerchantConfigCommonUpdate :: MerchantCommonConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    getMerchantConfigDriverPool :: Kernel.Prelude.Maybe Kernel.Types.Common.Meters -> Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecDistance -> Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit -> EulerHS.Types.EulerClient DriverPoolConfigRes,
+    postMerchantConfigDriverPoolUpdate :: Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecDistance -> Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit -> Kernel.Prelude.Maybe Dashboard.Common.VehicleVariant -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Types.Common.Meters -> Lib.Types.SpecialLocation.Area -> DriverPoolConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigDriverPoolCreate :: Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecDistance -> Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit -> Kernel.Prelude.Maybe Dashboard.Common.VehicleVariant -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Types.Common.Meters -> Lib.Types.SpecialLocation.Area -> DriverPoolConfigCreateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
     postMerchantConfigDriverPoolUpsert ::
-      ( ( Data.ByteString.Lazy.ByteString,
-          Dashboard.Common.Merchant.UpsertDriverPoolConfigCsvReq
-        ) ->
-        EulerHS.Types.EulerClient Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities
-      ),
-    getMerchantConfigDriverPoolList :: (EulerHS.Types.EulerClient DriverPoolConfigListRes),
-    getMerchantConfigDriverIntelligentPool :: (EulerHS.Types.EulerClient DriverIntelligentPoolConfigRes),
-    postMerchantConfigDriverIntelligentPoolUpdate :: (DriverIntelligentPoolConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    getMerchantConfigOnboardingDocument :: (Kernel.Prelude.Maybe (DocumentType) -> Kernel.Prelude.Maybe (Dashboard.Common.VehicleCategory) -> EulerHS.Types.EulerClient DocumentVerificationConfigRes),
-    postMerchantConfigOnboardingDocumentUpdate :: (DocumentType -> Dashboard.Common.VehicleCategory -> DocumentVerificationConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigOnboardingDocumentCreate :: (DocumentType -> Dashboard.Common.VehicleCategory -> DocumentVerificationConfigCreateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    getMerchantServiceUsageConfig :: (EulerHS.Types.EulerClient Dashboard.Common.Merchant.ServiceUsageConfigRes),
-    postMerchantServiceConfigMapsUpdate :: (Dashboard.Common.Merchant.MapsServiceConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantServiceUsageConfigMapsUpdate :: (Dashboard.Common.Merchant.MapsServiceUsageConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantServiceConfigSmsUpdate :: (Dashboard.Common.Merchant.SmsServiceConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantServiceUsageConfigSmsUpdate :: (Dashboard.Common.Merchant.SmsServiceUsageConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantServiceConfigVerificationUpdate :: (Dashboard.Common.Merchant.VerificationServiceConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigFarePolicyDriverExtraFeeBoundsCreate :: (Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> Kernel.Prelude.Maybe (Kernel.Types.Common.HighPrecDistance) -> Kernel.Prelude.Maybe (Kernel.Types.Common.DistanceUnit) -> Kernel.Types.Common.Meters -> CreateFPDriverExtraFeeReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigFarePolicyDriverExtraFeeBoundsUpdate :: (Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> Kernel.Prelude.Maybe (Kernel.Types.Common.HighPrecDistance) -> Kernel.Prelude.Maybe (Kernel.Types.Common.DistanceUnit) -> Kernel.Types.Common.Meters -> CreateFPDriverExtraFeeReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigFarePolicyPerExtraKmRateUpdate :: (Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> Kernel.Types.Common.Meters -> UpdateFPPerExtraKmRateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigFarePolicyUpdate :: (Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> UpdateFarePolicyReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigFarePolicyUpsert :: ((Data.ByteString.Lazy.ByteString, UpsertFarePolicyReq) -> EulerHS.Types.EulerClient UpsertFarePolicyResp),
-    getMerchantConfigFarePolicyExport :: (EulerHS.Types.EulerClient Kernel.Prelude.Text),
-    getMerchantConfigFarePolicyDetails :: (Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> EulerHS.Types.EulerClient FarePolicyDetailsResp),
-    getMerchantConfigFareProductList :: (Lib.Types.SpecialLocation.Area -> Kernel.Prelude.Bool -> Dashboard.Common.TripCategory -> EulerHS.Types.EulerClient FareProductListRes),
-    postMerchantConfigFareProductSetEnabled :: (Dashboard.Common.Merchant.SetFareProductEnabledReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigOperatingCityCreate :: (Dashboard.Common.Merchant.CreateMerchantOperatingCityReqT -> EulerHS.Types.EulerClient Dashboard.Common.Merchant.CreateMerchantOperatingCityRes),
-    postMerchantSchedulerTrigger :: (SchedulerTriggerReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantUpdateOnboardingVehicleVariantMapping :: ((Data.ByteString.Lazy.ByteString, UpdateOnboardingVehicleVariantMappingReq) -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+      ( Data.ByteString.Lazy.ByteString,
+        Dashboard.Common.Merchant.UpsertDriverPoolConfigCsvReq
+      ) ->
+      EulerHS.Types.EulerClient Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities,
+    getMerchantConfigDriverPoolList :: EulerHS.Types.EulerClient DriverPoolConfigListRes,
+    getMerchantConfigDriverIntelligentPool :: EulerHS.Types.EulerClient DriverIntelligentPoolConfigRes,
+    postMerchantConfigDriverIntelligentPoolUpdate :: DriverIntelligentPoolConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    getMerchantConfigOnboardingDocument :: Kernel.Prelude.Maybe DocumentType -> Kernel.Prelude.Maybe Dashboard.Common.VehicleCategory -> EulerHS.Types.EulerClient DocumentVerificationConfigRes,
+    postMerchantConfigOnboardingDocumentUpdate :: DocumentType -> Dashboard.Common.VehicleCategory -> DocumentVerificationConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigOnboardingDocumentCreate :: DocumentType -> Dashboard.Common.VehicleCategory -> DocumentVerificationConfigCreateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    getMerchantServiceUsageConfig :: EulerHS.Types.EulerClient Dashboard.Common.Merchant.ServiceUsageConfigRes,
+    postMerchantServiceConfigMapsUpdate :: Dashboard.Common.Merchant.MapsServiceConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantServiceUsageConfigMapsUpdate :: Dashboard.Common.Merchant.MapsServiceUsageConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantServiceConfigSmsUpdate :: Dashboard.Common.Merchant.SmsServiceConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantServiceUsageConfigSmsUpdate :: Dashboard.Common.Merchant.SmsServiceUsageConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantServiceConfigVerificationUpdate :: Dashboard.Common.Merchant.VerificationServiceConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigFarePolicyDriverExtraFeeBoundsCreate :: Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecDistance -> Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit -> Kernel.Types.Common.Meters -> CreateFPDriverExtraFeeReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigFarePolicyDriverExtraFeeBoundsUpdate :: Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> Kernel.Prelude.Maybe Kernel.Types.Common.HighPrecDistance -> Kernel.Prelude.Maybe Kernel.Types.Common.DistanceUnit -> Kernel.Types.Common.Meters -> CreateFPDriverExtraFeeReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigFarePolicyPerExtraKmRateUpdate :: Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> Kernel.Types.Common.Meters -> UpdateFPPerExtraKmRateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigFarePolicyUpdate :: Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> UpdateFarePolicyReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigFarePolicyUpsert :: (Data.ByteString.Lazy.ByteString, UpsertFarePolicyReq) -> EulerHS.Types.EulerClient UpsertFarePolicyResp,
+    getMerchantConfigFarePolicyExport :: EulerHS.Types.EulerClient Kernel.Prelude.Text,
+    getMerchantConfigFarePolicyDetails :: Kernel.Types.Id.Id Dashboard.Common.FarePolicy -> EulerHS.Types.EulerClient FarePolicyDetailsResp,
+    getMerchantConfigFareProductList :: Lib.Types.SpecialLocation.Area -> Kernel.Prelude.Bool -> Dashboard.Common.TripCategory -> EulerHS.Types.EulerClient FareProductListRes,
+    postMerchantConfigFareProductSetEnabled :: Dashboard.Common.Merchant.SetFareProductEnabledReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigOperatingCityCreate :: Dashboard.Common.Merchant.CreateMerchantOperatingCityReqT -> EulerHS.Types.EulerClient Dashboard.Common.Merchant.CreateMerchantOperatingCityRes,
+    postMerchantSchedulerTrigger :: SchedulerTriggerReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantUpdateOnboardingVehicleVariantMapping :: (Data.ByteString.Lazy.ByteString, UpdateOnboardingVehicleVariantMappingReq) -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
     postMerchantConfigSpecialLocationUpsert ::
-      ( ( Data.ByteString.Lazy.ByteString,
-          Dashboard.Common.Merchant.UpsertSpecialLocationCsvReq
-        ) ->
-        EulerHS.Types.EulerClient Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities
-      ),
-    getMerchantConfigSpecialLocationList :: (Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Lib.Types.SpecialLocation.SpecialLocationType) -> Kernel.Prelude.Maybe ([Lib.Types.SpecialLocation.SpecialLocationType]) -> EulerHS.Types.EulerClient SpecialLocationResp),
-    getMerchantConfigGeometryList :: (Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> EulerHS.Types.EulerClient GeometryResp),
-    putMerchantConfigGeometryUpdate :: ((Data.ByteString.Lazy.ByteString, Dashboard.Common.Merchant.UpdateGeometryReq) -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantSpecialLocationUpsert :: (Kernel.Prelude.Maybe (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation) -> Dashboard.Common.Merchant.UpsertSpecialLocationReqT -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    deleteMerchantSpecialLocationDelete :: (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantSpecialLocationGatesUpsert :: (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation -> Dashboard.Common.Merchant.UpsertSpecialLocationGateReqT -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    deleteMerchantSpecialLocationGatesDelete :: (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation -> Kernel.Prelude.Text -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+      ( Data.ByteString.Lazy.ByteString,
+        Dashboard.Common.Merchant.UpsertSpecialLocationCsvReq
+      ) ->
+      EulerHS.Types.EulerClient Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities,
+    getMerchantConfigSpecialLocationList :: Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Lib.Types.SpecialLocation.SpecialLocationType -> Kernel.Prelude.Maybe [Lib.Types.SpecialLocation.SpecialLocationType] -> EulerHS.Types.EulerClient SpecialLocationResp,
+    getMerchantConfigGeometryList :: Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> EulerHS.Types.EulerClient GeometryResp,
+    putMerchantConfigGeometryUpdate :: (Data.ByteString.Lazy.ByteString, Dashboard.Common.Merchant.UpdateGeometryReq) -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantSpecialLocationUpsert :: Kernel.Prelude.Maybe (Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation) -> Dashboard.Common.Merchant.UpsertSpecialLocationReqT -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    deleteMerchantSpecialLocationDelete :: Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantSpecialLocationGatesUpsert :: Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation -> Dashboard.Common.Merchant.UpsertSpecialLocationGateReqT -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    deleteMerchantSpecialLocationGatesDelete :: Kernel.Types.Id.Id Lib.Types.SpecialLocation.SpecialLocation -> Kernel.Prelude.Text -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
     postMerchantConfigTollUpsert ::
-      ( ( Data.ByteString.Lazy.ByteString,
-          Dashboard.Common.Merchant.UpsertTollCsvReq
-        ) ->
-        EulerHS.Types.EulerClient Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities
-      ),
-    getMerchantConfigTollList :: (Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> EulerHS.Types.EulerClient TollListResp),
-    postMerchantTollUpsert :: (Kernel.Prelude.Maybe (Kernel.Types.Id.Id Toll.Domain.Types.Toll.Toll) -> Dashboard.Common.Merchant.UpsertTollReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    deleteMerchantTollDelete :: (Kernel.Types.Id.Id Toll.Domain.Types.Toll.Toll -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigClearCacheSubscription :: (ClearCacheSubscriptionReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigUpsertPlanAndConfigSubscription :: (UpsertPlanAndConfigReq -> EulerHS.Types.EulerClient UpsertPlanAndConfigResp),
-    getMerchantConfigVendorSplitDetailsList :: (EulerHS.Types.EulerClient [VendorSplitDetailsAPIEntity]),
-    getMerchantConfigSubscriptionConfigList :: (EulerHS.Types.EulerClient [SubscriptionConfigAPIEntity]),
-    postMerchantConfigFailover :: (Dashboard.Common.Merchant.ConfigNames -> Dashboard.Common.Merchant.ConfigFailoverReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantPayoutConfigUpdate :: (PayoutConfigReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigOperatingCityWhiteList :: (Dashboard.Common.Merchant.WhiteListOperatingCityReq -> EulerHS.Types.EulerClient Dashboard.Common.Merchant.WhiteListOperatingCityRes),
-    postMerchantConfigMerchantCreate :: (Dashboard.Common.Merchant.CreateMerchantOperatingCityReqT -> EulerHS.Types.EulerClient Dashboard.Common.Merchant.CreateMerchantOperatingCityRes),
-    getMerchantConfigVehicleServiceTier :: (Kernel.Prelude.Maybe (Dashboard.Common.ServiceTierType) -> EulerHS.Types.EulerClient VehicleServiceTierRes),
-    getMerchantConfigVehicleServiceTierList :: (EulerHS.Types.EulerClient VehicleServiceTierListRes),
-    postMerchantConfigVehicleServiceTierUpdate :: (Dashboard.Common.ServiceTierType -> VehicleServiceTierConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigVehicleServiceTierCreate :: (VehicleServiceTierConfigCreateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    postMerchantConfigDebugLogUpdate :: (Lib.Yudhishthira.Tools.DebugLog.SetJsonLogicDebugReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    getMerchantMerchantDocumentList :: (Kernel.Prelude.Maybe (Kernel.External.Types.Language) -> MerchantDocumentRoleT -> EulerHS.Types.EulerClient MerchantDocumentListResp),
-    getMerchantMerchantDocument :: (Kernel.Prelude.Text -> Kernel.Prelude.Maybe (Kernel.External.Types.Language) -> MerchantDocumentRoleT -> EulerHS.Types.EulerClient MerchantDocumentItem),
-    postMerchantMerchantDocumentCreate :: (CreateMerchantDocumentReq -> EulerHS.Types.EulerClient MerchantDocumentItem),
-    postMerchantMerchantDocumentUpdate :: (UpdateMerchantDocumentReq -> EulerHS.Types.EulerClient MerchantDocumentItem),
-    postMerchantMerchantDocumentDelete :: (DeleteMerchantDocumentReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    getMerchantMerchantMessageCatalog :: (MerchantMessageCatalogType -> EulerHS.Types.EulerClient MerchantMessageCatalogResp),
-    postMerchantMerchantMessageUpsert :: (UpsertMerchantMessageReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    deleteMerchantMerchantMessage :: (Kernel.Prelude.Text -> Kernel.Prelude.Maybe (Dashboard.Common.VehicleCategory) -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
-    getMerchantCityList :: (EulerHS.Types.EulerClient CityListResp)
+      ( Data.ByteString.Lazy.ByteString,
+        Dashboard.Common.Merchant.UpsertTollCsvReq
+      ) ->
+      EulerHS.Types.EulerClient Dashboard.Common.Merchant.APISuccessWithUnprocessedEntities,
+    getMerchantConfigTollList :: Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> EulerHS.Types.EulerClient TollListResp,
+    postMerchantTollUpsert :: Kernel.Prelude.Maybe (Kernel.Types.Id.Id Toll.Domain.Types.Toll.Toll) -> Dashboard.Common.Merchant.UpsertTollReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    deleteMerchantTollDelete :: Kernel.Types.Id.Id Toll.Domain.Types.Toll.Toll -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigClearCacheSubscription :: ClearCacheSubscriptionReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigUpsertPlanAndConfigSubscription :: UpsertPlanAndConfigReq -> EulerHS.Types.EulerClient UpsertPlanAndConfigResp,
+    getMerchantConfigVendorSplitDetailsList :: EulerHS.Types.EulerClient [VendorSplitDetailsAPIEntity],
+    getMerchantConfigSubscriptionConfigList :: EulerHS.Types.EulerClient [SubscriptionConfigAPIEntity],
+    postMerchantConfigFailover :: Dashboard.Common.Merchant.ConfigNames -> Dashboard.Common.Merchant.ConfigFailoverReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantPayoutConfigUpdate :: PayoutConfigReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigOperatingCityWhiteList :: Dashboard.Common.Merchant.WhiteListOperatingCityReq -> EulerHS.Types.EulerClient Dashboard.Common.Merchant.WhiteListOperatingCityRes,
+    postMerchantConfigMerchantCreate :: Dashboard.Common.Merchant.CreateMerchantOperatingCityReqT -> EulerHS.Types.EulerClient Dashboard.Common.Merchant.CreateMerchantOperatingCityRes,
+    getMerchantConfigVehicleServiceTier :: Kernel.Prelude.Maybe Dashboard.Common.ServiceTierType -> EulerHS.Types.EulerClient VehicleServiceTierRes,
+    getMerchantConfigVehicleServiceTierList :: EulerHS.Types.EulerClient VehicleServiceTierListRes,
+    postMerchantConfigVehicleServiceTierUpdate :: Dashboard.Common.ServiceTierType -> VehicleServiceTierConfigUpdateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigVehicleServiceTierCreate :: VehicleServiceTierConfigCreateReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    postMerchantConfigDebugLogUpdate :: Lib.Yudhishthira.Tools.DebugLog.SetJsonLogicDebugReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    getMerchantMerchantDocumentList :: Kernel.Prelude.Maybe Kernel.External.Types.Language -> MerchantDocumentRoleT -> EulerHS.Types.EulerClient MerchantDocumentListResp,
+    getMerchantMerchantDocument :: Kernel.Prelude.Text -> Kernel.Prelude.Maybe Kernel.External.Types.Language -> MerchantDocumentRoleT -> EulerHS.Types.EulerClient MerchantDocumentItem,
+    postMerchantMerchantDocumentCreate :: CreateMerchantDocumentReq -> EulerHS.Types.EulerClient MerchantDocumentItem,
+    postMerchantMerchantDocumentUpdate :: UpdateMerchantDocumentReq -> EulerHS.Types.EulerClient MerchantDocumentItem,
+    postMerchantMerchantDocumentDelete :: DeleteMerchantDocumentReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    getMerchantMerchantMessageCatalog :: MerchantMessageCatalogType -> EulerHS.Types.EulerClient MerchantMessageCatalogResp,
+    postMerchantMerchantMessageUpsert :: UpsertMerchantMessageReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    deleteMerchantMerchantMessage :: Kernel.Prelude.Text -> Kernel.Prelude.Maybe Dashboard.Common.VehicleCategory -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
+    getMerchantCityList :: EulerHS.Types.EulerClient CityListResp
   }
 
 mkMerchantAPIs :: (Client EulerHS.Types.EulerClient API -> MerchantAPIs)
@@ -1669,12 +1667,12 @@ data MerchantUserActionType
   deriving stock (Show, Read, Generic, Eq, Ord)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-$(mkHttpInstancesForEnum (''DocumentType))
+$(mkHttpInstancesForEnum ''DocumentType)
 
-$(mkHttpInstancesForEnum (''MerchantDocumentPlatformTypeT))
+$(mkHttpInstancesForEnum ''MerchantDocumentPlatformTypeT)
 
-$(mkHttpInstancesForEnum (''MerchantDocumentRoleT))
+$(mkHttpInstancesForEnum ''MerchantDocumentRoleT)
 
-$(mkHttpInstancesForEnum (''MerchantMessageCatalogType))
+$(mkHttpInstancesForEnum ''MerchantMessageCatalogType)
 
-$(Data.Singletons.TH.genSingletons [(''MerchantUserActionType)])
+$(Data.Singletons.TH.genSingletons [''MerchantUserActionType])

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Allocator/src/App.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Allocator/src/App.hs
@@ -58,6 +58,7 @@ import SharedLogic.Allocator.Jobs.Insurance.IffcoTokioInsurance (triggerIffcoTok
 import SharedLogic.Allocator.Jobs.Mandate.Execution (startMandateExecutionForDriver)
 import SharedLogic.Allocator.Jobs.Mandate.Notification (sendPDNNotificationToDriver)
 import SharedLogic.Allocator.Jobs.Mandate.OrderAndNotificationStatusUpdate (notificationAndOrderStatusUpdate)
+import SharedLogic.Allocator.Jobs.Mandate.RetryAutopayCollection (retryAutopayCollection)
 import SharedLogic.Allocator.Jobs.Overlay.SendOverlay (sendOverlayToDriver)
 import SharedLogic.Allocator.Jobs.Payout.ConnectAccountCharge (sendConnectAccountCharge)
 import SharedLogic.Allocator.Jobs.Payout.DriverReferralPayout (sendDriverReferralPayoutJobData)
@@ -149,6 +150,7 @@ allocatorHandle flowRt env =
           & putJobHandlerInListWrapper flowRt env sendPDNNotificationToDriver
           & putJobHandlerInListWrapper flowRt env startMandateExecutionForDriver
           & putJobHandlerInListWrapper flowRt env notificationAndOrderStatusUpdate
+          & putJobHandlerInListWrapper flowRt env retryAutopayCollection
           & putJobHandlerInListWrapper flowRt env sendOverlayToDriver
           & putJobHandlerInListWrapper flowRt env badDebtCalculation
           & putJobHandlerInListWrapper flowRt env sendManualPaymentLink

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -494,6 +494,7 @@ library
       SharedLogic.Allocator.Jobs.Mandate.Execution
       SharedLogic.Allocator.Jobs.Mandate.Notification
       SharedLogic.Allocator.Jobs.Mandate.OrderAndNotificationStatusUpdate
+      SharedLogic.Allocator.Jobs.Mandate.RetryAutopayCollection
       SharedLogic.Allocator.Jobs.Overlay.SendOverlay
       SharedLogic.Allocator.Jobs.Payout.ConnectAccountCharge
       SharedLogic.Allocator.Jobs.Payout.DriverReferralPayout

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/Merchant.hs
@@ -193,7 +193,7 @@ import qualified MerchantDocuments.Domain.Action.UI.MerchantDocument as SMD
 import qualified MerchantDocuments.Domain.Types.MerchantDocument as DMD
 import qualified Registry.Beckn.Interface as RegistryIF
 import qualified Registry.Beckn.Interface.Types as RegistryT
-import SharedLogic.Allocator (AggregatedCommissionInvoiceCreationJobData, AllocatorJobType (..), BadDebtCalculationJobData, CalculateDriverFeesJobData, CongestionChargeCalculationRequestJobData, DriverReferralPayoutJobData, IffcoTokioInsuranceJobData, ScheduledBatchPayoutJobData, SupplyDemandRequestJobData)
+import SharedLogic.Allocator (AggregatedCommissionInvoiceCreationJobData, AllocatorJobType (..), BadDebtCalculationJobData, CalculateDriverFeesJobData, CongestionChargeCalculationRequestJobData, DriverReferralPayoutJobData, IffcoTokioInsuranceJobData, RetryAutopayCollectionJobData, ScheduledBatchPayoutJobData, SupplyDemandRequestJobData)
 import qualified SharedLogic.Allocator.Jobs.SendSearchRequestToDrivers.Handle.Internal.DriverPool.Config as DriverPool -- still needed for BatchSplitByPickupDistance, OnRideRadiusConfig
 import qualified SharedLogic.DriverFee as SDF
 import qualified SharedLogic.DriverOnboarding as SDO
@@ -534,6 +534,15 @@ postMerchantSchedulerTrigger merchantShortId opCity req = do
           case jobData' of
             Just jobData -> do
               createJobIn @_ @'AggregatedCommissionInvoiceCreation (Just jobData.merchantId) (Just jobData.merchantOperatingCityId) diffTimeS (jobData :: AggregatedCommissionInvoiceCreationJobData)
+              pure Success
+            Nothing -> throwError $ InternalError "invalid job data"
+        Just Common.RetryAutopayCollectionTrigger -> do
+          let jobData' = decodeFromText jobDataRaw :: Maybe RetryAutopayCollectionJobData
+          case jobData' of
+            Just jobData -> do
+              merchant <- CQM.findById jobData.merchantId >>= fromMaybeM (MerchantNotFound jobData.merchantId.getId)
+              merchantOpCityId <- CQMOC.getMerchantOpCityId jobData.merchantOperatingCityId merchant Nothing
+              createJobIn @_ @'RetryAutopayCollection (Just merchant.id) (Just merchantOpCityId) diffTimeS (jobData :: RetryAutopayCollectionJobData)
               pure Success
             Nothing -> throwError $ InternalError "invalid job data"
         _ -> throwError $ InternalError "invalid job name"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -2911,6 +2911,8 @@ clearDriverDues (personId, _merchantId, opCityId) serviceName clearSelectedReq m
   forM_ allPaidFeeNotMarkedCleared $ \feeId -> QDF.updateStatus DDF.CLEARED feeId now
   let dueDriverFees = filter (\fee -> not $ fee.id `elem` allPaidFeeNotMarkedCleared) dueDriverFees'
   ----------------------------------------------------------
+  Redis.runInMasterCloudRedisCell $
+    forM_ dueDriverFees $ \fee -> Redis.setExp (DDF.manualPaymentInProgressKey fee.id.getId) True DDF.manualPaymentInProgressTtl
   invoices <- mapM (\fee -> runInMasterDbAndRedis (QINV.findActiveManualInvoiceByFeeId fee.id Domain.MANUAL_INVOICE Domain.ACTIVE_INVOICE)) dueDriverFees
   let paymentService = subscriptionConfig.paymentServiceName
       sortedInvoices = mergeSortAndRemoveDuplicate invoices

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Payment.hs
@@ -611,6 +611,8 @@ processPayment merchantId driver orderId sendNotification (serviceName, subsConf
       let nonClearedDriverFees = filter (\df -> df.status /= CLEARED) driverFees
       nowUtc <- getCurrentTime
       QDF.updateStatusByIds CLEARED driverFeeIds nowUtc
+      Redis.runInMasterCloudRedisCell $
+        forM_ driverFeeIds $ \driverFeeId -> Redis.del (manualPaymentInProgressKey driverFeeId.getId)
       mapM_ (processNonClearedDriverFees merchantId driver) nonClearedDriverFees
     QIN.updateInvoiceStatusByInvoiceId INV.SUCCESS (cast orderId)
     updatePaymentStatus driver.id driver.merchantOperatingCityId serviceName

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/DriverFee.hs
@@ -9,6 +9,12 @@ import Kernel.Prelude
 paymentProcessingLockKey :: Text -> Text
 paymentProcessingLockKey driverId = "Payment:Processing:DriverId" <> driverId
 
+manualPaymentInProgressKey :: Text -> Text
+manualPaymentInProgressKey driverFeeId = "Payment:Manual:InProgress:DriverFeeId:" <> driverFeeId
+
+manualPaymentInProgressTtl :: Int
+manualPaymentInProgressTtl = 1800
+
 mandateProcessingLockKey :: Text -> Text
 mandateProcessingLockKey driverId = "Mandate:Processing:DriverId" <> driverId
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator.hs
@@ -67,6 +67,7 @@ data AllocatorJobType
   | MandateExecution
   | CalculateDriverFees
   | OrderAndNotificationStatusUpdate
+  | RetryAutopayCollection
   | SendOverlay
   | BadDebtCalculation
   | SendManualPaymentLink
@@ -129,6 +130,7 @@ instance JobProcessor AllocatorJobType where
   restoreAnyJobInfo SMandateExecution jobData = AnyJobInfo <$> restoreJobInfo SMandateExecution jobData
   restoreAnyJobInfo SCalculateDriverFees jobData = AnyJobInfo <$> restoreJobInfo SCalculateDriverFees jobData
   restoreAnyJobInfo SOrderAndNotificationStatusUpdate jobData = AnyJobInfo <$> restoreJobInfo SOrderAndNotificationStatusUpdate jobData
+  restoreAnyJobInfo SRetryAutopayCollection jobData = AnyJobInfo <$> restoreJobInfo SRetryAutopayCollection jobData
   restoreAnyJobInfo SSendOverlay jobData = AnyJobInfo <$> restoreJobInfo SSendOverlay jobData
   restoreAnyJobInfo SBadDebtCalculation jobData = AnyJobInfo <$> restoreJobInfo SBadDebtCalculation jobData
   restoreAnyJobInfo SSendManualPaymentLink jobData = AnyJobInfo <$> restoreJobInfo SSendManualPaymentLink jobData
@@ -338,6 +340,25 @@ data MandateExecutionInfo = MandateExecutionInfo
 instance JobInfoProcessor 'MandateExecution
 
 type instance JobContent 'MandateExecution = MandateExecutionInfo
+
+data RetryAutopayCollectionJobData = RetryAutopayCollectionJobData
+  { merchantId :: Id DM.Merchant,
+    merchantOperatingCityId :: Maybe (Id DMOC.MerchantOperatingCity),
+    startTime :: UTCTime,
+    endTime :: UTCTime,
+    serviceName :: Maybe Plan.ServiceNames,
+    batchSize :: Maybe Int,
+    lastDriverFeeId :: Maybe Text,
+    dryRun :: Bool,
+    maxFeesToConvert :: Maybe Int,
+    convertedSoFar :: Maybe Int,
+    includeNotificationAttempting :: Bool
+  }
+  deriving (Generic, Show, Eq, FromJSON, ToJSON)
+
+instance JobInfoProcessor 'RetryAutopayCollection
+
+type instance JobContent 'RetryAutopayCollection = RetryAutopayCollectionJobData
 
 data CalculateDriverFeesJobData = CalculateDriverFeesJobData
   { merchantId :: Id DM.Merchant,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Mandate/RetryAutopayCollection.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Mandate/RetryAutopayCollection.hs
@@ -133,13 +133,19 @@ filterEligibleForRetry serviceName driverFees = do
   activeInvoices <- QINV.findAllActiveByDriverFeeIds (driverFees <&> (.id))
   let mandateByDriverId = Map.fromList $ mapMaybe (\driverPlan -> (\mandateId -> (driverPlan.driverId, mandateId)) <$> driverPlan.mandateId) driverPlans
       driverFeeIdsWithLiveManualInvoice = filter ((/= INV.AUTOPAY_INVOICE) . (.paymentMode)) activeInvoices <&> (.driverFeeId)
-  return $
-    filter
-      ( \driverFee ->
-          Map.member (cast @P.Driver @P.Person driverFee.driverId) mandateByDriverId
-            && driverFee.id `notElem` driverFeeIdsWithLiveManualInvoice
-      )
-      driverFees
+      driverFeesWithActiveMandate =
+        filter
+          ( \driverFee ->
+              Map.member (cast @P.Driver @P.Person driverFee.driverId) mandateByDriverId
+                && driverFee.id `notElem` driverFeeIdsWithLiveManualInvoice
+          )
+          driverFees
+  filterM (fmap not . isManualPaymentInProgress) driverFeesWithActiveMandate
+
+isManualPaymentInProgress :: (CacheFlow m r, MonadFlow m) => DriverFee -> m Bool
+isManualPaymentInProgress driverFee = do
+  mbInProgress <- Redis.runInMasterCloudRedisCell $ Redis.get (manualPaymentInProgressKey driverFee.id.getId)
+  return $ mbInProgress == Just True
 
 convertToAutoPay ::
   (CacheFlow m r, EsqDBFlow m r, MonadFlow m) =>
@@ -154,7 +160,6 @@ convertToAutoPay eligibleStages driverFees = do
   where
     convertDriverFee driverFee = do
       now <- getCurrentTime
-      QDF.updateManualToAutoPayForRetry eligibleStages driverFee.id
       let reconvertedDriverFee =
             driverFee
               { DF.feeType = DF.RECURRING_EXECUTION_INVOICE,
@@ -167,4 +172,5 @@ convertToAutoPay eligibleStages driverFees = do
       invoiceId <- generateGUID
       invoiceShortId <- generateShortId
       QINV.create $ mkInvoiceAgainstDriverFee (invoiceId :: Text) invoiceShortId.getShortId now Nothing INV.AUTOPAY_INVOICE reconvertedDriverFee
+      QDF.updateManualToAutoPayForRetry eligibleStages driverFee.id
       return reconvertedDriverFee

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Mandate/RetryAutopayCollection.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Mandate/RetryAutopayCollection.hs
@@ -1,0 +1,170 @@
+module SharedLogic.Allocator.Jobs.Mandate.RetryAutopayCollection (retryAutopayCollection) where
+
+import qualified Data.Map as M
+import qualified Data.Map.Strict as Map
+import Domain.Types.DriverFee as DF
+import qualified Domain.Types.DriverInformation as DI
+import qualified Domain.Types.Invoice as INV
+import qualified Domain.Types.Person as P
+import qualified Domain.Types.Plan as Plan
+import Kernel.Prelude
+import qualified Kernel.Storage.Hedis as Redis
+import Kernel.Types.Error
+import Kernel.Types.Id (cast)
+import Kernel.Utils.Common
+import Lib.ConfigPilot.Interface.Types (getOneConfig)
+import Lib.Scheduler
+import Lib.Scheduler.JobStorageType.SchedulerType (createJobIn)
+import SharedLogic.Allocator
+import SharedLogic.Payment (mkInvoiceAgainstDriverFee)
+import Storage.Beam.SchedulerJob ()
+import qualified Storage.CachedQueries.Merchant as CQM
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions (..))
+import qualified Storage.Queries.DriverFee as QDF
+import qualified Storage.Queries.DriverPlan as QDP
+import qualified Storage.Queries.Invoice as QINV
+import qualified Storage.Queries.Notification as QNTF
+
+retryLogTag :: Text
+retryLogTag = "[RETRY_AUTOPAY_COLLECTION]"
+
+defaultRetryBatchSize :: Int
+defaultRetryBatchSize = 500
+
+notificationJobScheduleDelay :: NominalDiffTime
+notificationJobScheduleDelay = 300
+
+retryWindowLockTtl :: Redis.ExpirationTime
+retryWindowLockTtl = 900
+
+retryWindowCloseOutTtl :: Redis.ExpirationTime
+retryWindowCloseOutTtl = 3600 * 12
+
+retryWindowKey :: Text -> Text -> Text -> Text -> UTCTime -> UTCTime -> Text
+retryWindowKey purpose merchantId merchantOpCityId serviceName startTime endTime =
+  "RetryAutopayCollection:" <> purpose <> ":" <> merchantId <> ":" <> merchantOpCityId <> ":" <> serviceName <> ":" <> show startTime <> ":" <> show endTime
+
+retryAutopayCollection ::
+  ( CacheFlow m r,
+    EsqDBFlow m r,
+    MonadFlow m,
+    HasField "maxShards" r Int,
+    HasField "schedulerSetName" r Text,
+    HasField "schedulerType" r SchedulerType,
+    HasField "jobInfoMap" r (M.Map Text Bool),
+    HasField "blackListedJobs" r [Text]
+  ) =>
+  Job 'RetryAutopayCollection ->
+  m ExecutionResult
+retryAutopayCollection Job {id, jobInfo} = withLogTag ("JobId-" <> id.getId) do
+  let jobData = jobInfo.jobData
+      merchantId = jobData.merchantId
+      startTime = jobData.startTime
+      endTime = jobData.endTime
+      serviceName = fromMaybe Plan.YATRI_SUBSCRIPTION jobData.serviceName
+      convertedSoFar = fromMaybe 0 jobData.convertedSoFar
+      eligibleStages = [DF.EXECUTION_SCHEDULED, DF.NOTIFICATION_SCHEDULED] <> [DF.NOTIFICATION_ATTEMPTING | jobData.includeNotificationAttempting]
+  merchant <- CQM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
+  merchantOpCityId <- CQMOC.getMerchantOpCityId jobData.merchantOperatingCityId merchant Nothing
+  transporterConfig <- getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = merchantOpCityId.getId}) Nothing >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
+  let batchSize = fromMaybe defaultRetryBatchSize jobData.batchSize
+      remainingToConvert = maybe batchSize (\maxFees -> maxFees - convertedSoFar) jobData.maxFeesToConvert
+      windowKey purpose = retryWindowKey purpose merchantId.getId merchantOpCityId.getId (show serviceName) startTime endTime
+      closeOutWindow = do
+        logInfo $ retryLogTag <> " done for window, " <> show convertedSoFar <> " driver fees converted, dryRun " <> show jobData.dryRun
+        when (convertedSoFar > 0 && not jobData.dryRun) $ do
+          isFirstCloseOut <- Redis.setNxExpire (windowKey "CloseOut") retryWindowCloseOutTtl True
+          when isFirstCloseOut $
+            Redis.runInMasterCloudRedisCell $
+              createJobIn @_ @'SendPDNNotificationToDriver (Just merchantId) (Just merchantOpCityId) notificationJobScheduleDelay $
+                SendPDNNotificationToDriverJobData
+                  { merchantId = merchantId,
+                    merchantOperatingCityId = Just merchantOpCityId,
+                    startTime = startTime,
+                    endTime = endTime,
+                    retryCount = Just 0,
+                    serviceName = Just serviceName,
+                    shardNum = Nothing
+                  }
+        return Complete
+      processBatch = do
+        driverFees <- QDF.findDriverFeeInRangeEligibleForAutopayRetry merchantId merchantOpCityId batchSize jobData.lastDriverFeeId startTime endTime serviceName eligibleStages
+        if null driverFees
+          then closeOutWindow
+          else do
+            eligibleDriverFees <- take remainingToConvert <$> filterEligibleForRetry serviceName driverFees
+            convertedDriverFees <- if jobData.dryRun then return [] else convertToAutoPay eligibleStages eligibleDriverFees
+            let newLastDriverFeeId = (.id.getId) <$> listToMaybe (reverse driverFees)
+                newConvertedSoFar = convertedSoFar + (if jobData.dryRun then length eligibleDriverFees else length convertedDriverFees)
+            Redis.runInMasterCloudRedisCell $
+              createJobIn @_ @'RetryAutopayCollection (Just merchantId) (Just merchantOpCityId) transporterConfig.mandateNotificationRescheduleInterval $
+                RetryAutopayCollectionJobData
+                  { merchantId = merchantId,
+                    merchantOperatingCityId = Just merchantOpCityId,
+                    startTime = startTime,
+                    endTime = endTime,
+                    serviceName = Just serviceName,
+                    batchSize = Just batchSize,
+                    lastDriverFeeId = newLastDriverFeeId,
+                    dryRun = jobData.dryRun,
+                    maxFeesToConvert = jobData.maxFeesToConvert,
+                    convertedSoFar = Just newConvertedSoFar,
+                    includeNotificationAttempting = jobData.includeNotificationAttempting
+                  }
+            return Complete
+  if remainingToConvert <= 0
+    then closeOutWindow
+    else do
+      batchResult <- Redis.whenWithLockRedisAndReturnValue (windowKey "Lock") retryWindowLockTtl processBatch
+      case batchResult of
+        Right result -> return result
+        Left () -> do
+          logInfo $ retryLogTag <> " window locked by another run, rescheduling this batch"
+          ReSchedule . addUTCTime transporterConfig.mandateNotificationRescheduleInterval <$> getCurrentTime
+
+filterEligibleForRetry ::
+  (CacheFlow m r, EsqDBFlow m r, MonadFlow m) =>
+  Plan.ServiceNames ->
+  [DriverFee] ->
+  m [DriverFee]
+filterEligibleForRetry serviceName driverFees = do
+  driverPlans <- QDP.findAllByDriverIdsPaymentModeAndServiceName (driverFees <&> (.driverId)) Plan.AUTOPAY serviceName (Just DI.ACTIVE)
+  activeInvoices <- QINV.findAllActiveByDriverFeeIds (driverFees <&> (.id))
+  let mandateByDriverId = Map.fromList $ mapMaybe (\driverPlan -> (\mandateId -> (driverPlan.driverId, mandateId)) <$> driverPlan.mandateId) driverPlans
+      driverFeeIdsWithLiveManualInvoice = filter ((/= INV.AUTOPAY_INVOICE) . (.paymentMode)) activeInvoices <&> (.driverFeeId)
+  return $
+    filter
+      ( \driverFee ->
+          Map.member (cast @P.Driver @P.Person driverFee.driverId) mandateByDriverId
+            && driverFee.id `notElem` driverFeeIdsWithLiveManualInvoice
+      )
+      driverFees
+
+convertToAutoPay ::
+  (CacheFlow m r, EsqDBFlow m r, MonadFlow m) =>
+  [AutopayPaymentStage] ->
+  [DriverFee] ->
+  m [DriverFee]
+convertToAutoPay eligibleStages driverFees = do
+  let driverFeeIds = driverFees <&> (.id)
+  QNTF.updateSuccessToFailedByDriverFeeIds driverFeeIds
+  QINV.updateActiveInvoiceStatusByDriverFeeIdsAndPaymentMode INV.INACTIVE driverFeeIds INV.AUTOPAY_INVOICE
+  forM driverFees convertDriverFee
+  where
+    convertDriverFee driverFee = do
+      now <- getCurrentTime
+      QDF.updateManualToAutoPayForRetry eligibleStages driverFee.id
+      let reconvertedDriverFee =
+            driverFee
+              { DF.feeType = DF.RECURRING_EXECUTION_INVOICE,
+                DF.status = DF.PAYMENT_PENDING,
+                DF.autopayPaymentStage = Just DF.NOTIFICATION_SCHEDULED,
+                DF.stageUpdatedAt = Just now,
+                DF.notificationRetryCount = 0,
+                DF.updatedAt = now
+              }
+      invoiceId <- generateGUID
+      invoiceShortId <- generateShortId
+      QINV.create $ mkInvoiceAgainstDriverFee (invoiceId :: Text) invoiceShortId.getShortId now Nothing INV.AUTOPAY_INVOICE reconvertedDriverFee
+      return reconvertedDriverFee

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverFeeExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/DriverFeeExtra.hs
@@ -812,6 +812,57 @@ updateManualToAutoPay driverFeeId = do
     ]
     [Se.Is BeamDF.id (Se.Eq driverFeeId.getId)]
 
+findDriverFeeInRangeEligibleForAutopayRetry ::
+  (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>
+  Id Merchant ->
+  Id MerchantOperatingCity ->
+  Int ->
+  Maybe Text ->
+  UTCTime ->
+  UTCTime ->
+  ServiceNames ->
+  [Domain.AutopayPaymentStage] ->
+  m [DriverFee]
+findDriverFeeInRangeEligibleForAutopayRetry merchantId merchantOperatingCityId limit mbLastDriverFeeId startTime endTime serviceName eligibleStages = do
+  findAllWithOptionsDb
+    [ Se.And
+        ( [ Se.Is BeamDF.startTime $ Se.GreaterThanOrEq startTime,
+            Se.Is BeamDF.endTime $ Se.LessThanOrEq endTime,
+            Se.Is BeamDF.feeType $ Se.Eq RECURRING_INVOICE,
+            Se.Is BeamDF.status $ Se.Eq PAYMENT_OVERDUE,
+            Se.Is BeamDF.autopayPaymentStage $ Se.In (Just <$> eligibleStages),
+            Se.Is BeamDF.badDebtDeclarationDate $ Se.Eq Nothing,
+            Se.Is BeamDF.merchantOperatingCityId $ Se.Eq (Just merchantOperatingCityId.getId),
+            Se.Is BeamDF.serviceName $ Se.Eq (Just serviceName),
+            Se.Is BeamDF.merchantId $ Se.Eq merchantId.getId
+          ]
+            <> maybe [] (\lastDriverFeeId -> [Se.Is BeamDF.id $ Se.GreaterThan lastDriverFeeId]) mbLastDriverFeeId
+        )
+    ]
+    (Se.Asc BeamDF.id)
+    (Just limit)
+    Nothing
+
+updateManualToAutoPayForRetry :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => [Domain.AutopayPaymentStage] -> Id DriverFee -> m ()
+updateManualToAutoPayForRetry eligibleStages driverFeeId = do
+  now <- getCurrentTime
+  updateOneWithKV
+    [ Se.Set BeamDF.feeType RECURRING_EXECUTION_INVOICE,
+      Se.Set BeamDF.status PAYMENT_PENDING,
+      Se.Set BeamDF.autopayPaymentStage (Just NOTIFICATION_SCHEDULED),
+      Se.Set BeamDF.stageUpdatedAt (Just now),
+      Se.Set BeamDF.notificationRetryCount 0,
+      Se.Set BeamDF.updatedAt now
+    ]
+    [ Se.And
+        [ Se.Is BeamDF.id (Se.Eq driverFeeId.getId),
+          Se.Is BeamDF.status $ Se.Eq PAYMENT_OVERDUE,
+          Se.Is BeamDF.feeType $ Se.Eq RECURRING_INVOICE,
+          Se.Is BeamDF.autopayPaymentStage $ Se.In (Just <$> eligibleStages),
+          Se.Is BeamDF.badDebtDeclarationDate $ Se.Eq Nothing
+        ]
+    ]
+
 --- note :- bad debt recovery date set in fork pls remeber to add fork in all places with driver fee status update in future----
 updateRegisterationFeeStatusByDriverIdForServiceName ::
   (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/InvoiceExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/InvoiceExtra.hs
@@ -193,6 +193,29 @@ updateInvoiceStatusByDriverFeeIdsAndMbPaymentMode status driverFeeIds paymentMod
         <> paymentModeCheck
     )
 
+findAllActiveByDriverFeeIds :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => [Id DF.DriverFee] -> m [Domain.Invoice]
+findAllActiveByDriverFeeIds driverFeeIds =
+  findAllWithKV
+    [ Se.And
+        [ Se.Is BeamI.driverFeeId $ Se.In (getId <$> driverFeeIds),
+          Se.Is BeamI.invoiceStatus $ Se.Eq Domain.ACTIVE_INVOICE
+        ]
+    ]
+
+updateActiveInvoiceStatusByDriverFeeIdsAndPaymentMode :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Domain.InvoiceStatus -> [Id DF.DriverFee] -> Domain.InvoicePaymentMode -> m ()
+updateActiveInvoiceStatusByDriverFeeIdsAndPaymentMode status driverFeeIds paymentMode = do
+  now <- getCurrentTime
+  updateWithKV
+    [ Se.Set BeamI.invoiceStatus status,
+      Se.Set BeamI.updatedAt now
+    ]
+    [ Se.And
+        [ Se.Is BeamI.driverFeeId $ Se.In (getId <$> driverFeeIds),
+          Se.Is BeamI.paymentMode $ Se.Eq paymentMode,
+          Se.Is BeamI.invoiceStatus $ Se.Eq Domain.ACTIVE_INVOICE
+        ]
+    ]
+
 updateStatusAndTypeByMbdriverFeeIdAndInvoiceId :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id Domain.Invoice -> Maybe Domain.InvoiceStatus -> Maybe Domain.InvoicePaymentMode -> Maybe (Id DF.DriverFee) -> m ()
 updateStatusAndTypeByMbdriverFeeIdAndInvoiceId invoiceId status paymentMode driverFeeId = do
   now <- getCurrentTime

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/NotificationExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/NotificationExtra.hs
@@ -73,6 +73,19 @@ updatePendingToFailed merchantOperatingCityId = do
         ]
     ]
 
+updateSuccessToFailedByDriverFeeIds :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => [Id DF.DriverFee] -> m ()
+updateSuccessToFailedByDriverFeeIds driverFeeIds = do
+  now <- getCurrentTime
+  updateWithKV
+    [ Se.Set BeamI.status NOTIFICATION_FAILURE,
+      Se.Set BeamI.updatedAt now
+    ]
+    [ Se.And
+        [ Se.Is BeamI.driverFeeId $ Se.In (getId <$> driverFeeIds),
+          Se.Is BeamI.status $ Se.Eq Payment.SUCCESS
+        ]
+    ]
+
 updateLastCheckedOn :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => [Id Domain.Notification] -> m ()
 updateLastCheckedOn notificationIds = do
   now <- getCurrentTime

--- a/Backend/dhall-configs/dev/dynamic-offer-driver-app.dhall
+++ b/Backend/dhall-configs/dev/dynamic-offer-driver-app.dhall
@@ -283,6 +283,7 @@ let AllocatorJobType =
       | MandateExecution
       | CalculateDriverFees
       | OrderAndNotificationStatusUpdate
+      | RetryAutopayCollection
       | SendOverlay
       | SupplyDemand
       | CongestionCharge
@@ -352,6 +353,7 @@ let jobInfoMapx =
       , { mapKey = AllocatorJobType.OrderAndNotificationStatusUpdate
         , mapValue = True
         }
+      , { mapKey = AllocatorJobType.RetryAutopayCollection, mapValue = True }
       , { mapKey = AllocatorJobType.SendOverlay, mapValue = True }
       , { mapKey = AllocatorJobType.BadDebtCalculation, mapValue = True }
       , { mapKey = AllocatorJobType.RetryDocumentVerification


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Add Retry AutoPay Job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a scheduler job to retry eligible overdue autopay collections.
  - Eligible fees can be converted back to autopay in batches, with progress tracking, dry-run support, and follow-up processing.
  - Added notification and invoice updates as part of the retry workflow.
  - Added merchant operating-city GSTIN support with fallback behavior.
- **Bug Fixes**
  - Improved handling of manual payment state to prevent stale status from blocking autopay retries.
- **Configuration**
  - Enabled the new retry-autopay scheduler job in development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->