### PR TITLE
fix: consider dispatcher override for online waybills

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Dispatcher.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Dispatcher.hs
@@ -76,6 +76,9 @@ postDispatcherUpdateFleetSchedule (mbPersonId, _merchantId) req = do
     updatedFleetInfo <- OTPRest.getVehicleOperationInfo integratedBPPConfig req.updatedFleetId >>= fromMaybeM (DepotFleetInfoNotFound req.updatedFleetId)
     when (depotManager.depotCode.getId /= sourceFleetInfo.depot_id) $ throwError $ DepotManagerDoesNotHaveAccessToFleet depotManager.personId.getId req.sourceFleetId
     when (depotManager.depotCode.getId /= updatedFleetInfo.depot_id) $ throwError $ DepotManagerDoesNotHaveAccessToFleet depotManager.personId.getId req.updatedFleetId
+  sourceWaybillNo <-
+    sourceFleetInfo.waybill_no
+      & fromMaybeM (InvalidRequest $ "No active waybill for source fleet " <> req.sourceFleetId <> "; its schedule cannot be overridden")
   -- =========== validation done ===========
   -- Record history
   now <- getCurrentTime
@@ -103,7 +106,7 @@ postDispatcherUpdateFleetSchedule (mbPersonId, _merchantId) req = do
           }
   QVAH.create vehicleActionHistory
   -- adding fleet override info in redis for waybill.
-  Redis.setExp (fleetOverrideKey req.updatedFleetId) (req.sourceFleetId, sourceFleetInfo.waybill_no & fromMaybe "") 86400
+  Redis.setExp (fleetOverrideKey req.updatedFleetId) (req.sourceFleetId, sourceWaybillNo) 86400
   pure $ Kernel.Types.APISuccess.Success
 
 getFleetOverrideInfo :: (MonadFlow m, Redis.HedisFlow m r) => Text -> m (Maybe (Text, Text))

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -1136,13 +1136,14 @@ getPublicTransportDataImpl (mbPersonId, merchantId) mbCity mbEnableSwitchRoute _
       Just vehicleNumber -> do
         mbVehicleOverrideInfo <- Dispatcher.getFleetOverrideInfo vehicleNumber
         case mbVehicleOverrideInfo of
-          Just (updatedVehicleNumber, newDeviceWaybillNo) -> do
-            updatedVehicleRouteInfo <- JLU.getVehicleLiveRouteInfo integratedBPPConfigs updatedVehicleNumber Nothing >>= fromMaybeM (InvalidVehicleNumber $ "Vehicle override: " <> updatedVehicleNumber <> " for vehicle: " <> vehicleNumber <> ", not found on any route")
-            if Just newDeviceWaybillNo /= (snd updatedVehicleRouteInfo).waybillId
-              then do
+          Just (sourceVehicleNumber, overrideWaybillNo) -> do
+            mbSourceRouteInfo <- JLU.getVehicleLiveRouteInfo integratedBPPConfigs sourceVehicleNumber Nothing
+            case JLU.classifyFleetOverride overrideWaybillNo (snd <$> mbSourceRouteInfo) of
+              JLU.FleetOverrideUsable -> pure mbSourceRouteInfo
+              JLU.FleetOverrideFinished -> do
                 Dispatcher.delFleetOverrideInfo vehicleNumber
                 getVehicleLiveRouteInfo vehicleNumber integratedBPPConfigs
-              else pure $ Just updatedVehicleRouteInfo
+              JLU.FleetOverrideNotYetUsable -> getVehicleLiveRouteInfo vehicleNumber integratedBPPConfigs
           Nothing -> getVehicleLiveRouteInfo vehicleNumber integratedBPPConfigs
       Nothing -> return Nothing
 
@@ -2859,13 +2860,15 @@ postMultimodalOrderSublegSetOnboardedVehicleDetails (mbPersonId, merchantId) jou
       _ -> throwError $ UnsupportedVehicleType (show journeyLeg.mode)
   integratedBPPConfigs <- SIBC.findAllIntegratedBPPConfig journey.merchantOperatingCityId vehicleType DIBC.MULTIMODAL
   (integratedBPPConfig, vehicleLiveRouteInfo) <- case mbVehicleOverrideInfo of
-    Just (overridenVehicleNumber, waybillNo) -> do
-      vehicleLiveRouteInfo <- JLU.getVehicleLiveRouteInfo integratedBPPConfigs overridenVehicleNumber Nothing >>= fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
-      if Just waybillNo /= ((.waybillId) . snd $ vehicleLiveRouteInfo)
-        then do
+    Just (sourceVehicleNumber, overrideWaybillNo) -> do
+      mbSourceRouteInfo <- JLU.getVehicleLiveRouteInfo integratedBPPConfigs sourceVehicleNumber Nothing
+      let scannedVehicleRouteInfo = JLU.getVehicleLiveRouteInfo integratedBPPConfigs vehicleNumber Nothing >>= fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
+      case JLU.classifyFleetOverride overrideWaybillNo (snd <$> mbSourceRouteInfo) of
+        JLU.FleetOverrideUsable -> mbSourceRouteInfo & fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
+        JLU.FleetOverrideFinished -> do
           Dispatcher.delFleetOverrideInfo vehicleNumber
-          JLU.getVehicleLiveRouteInfo integratedBPPConfigs vehicleNumber Nothing >>= fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
-        else pure vehicleLiveRouteInfo
+          scannedVehicleRouteInfo
+        JLU.FleetOverrideNotYetUsable -> scannedVehicleRouteInfo
     Nothing -> JLU.getVehicleLiveRouteInfo integratedBPPConfigs vehicleNumber Nothing >>= fromMaybeM (VehicleUnserviceableOnRoute "Vehicle not found on any route")
   riderConfig <- getConfig (RiderConfigDimensions {merchantOperatingCityId = journey.merchantOperatingCityId.getId}) Nothing >>= fromMaybeM (RiderConfigNotFound journey.merchantOperatingCityId.getId)
   whenJust booking.vehicleNumber $ \bookingVeh ->

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Utils.hs
@@ -1627,6 +1627,35 @@ getVehicleLiveRouteInfo integratedBPPConfigs vehicleNumber mbPassVerifyReq = do
       return Nothing
     Right result -> return result
 
+data FleetOverrideStatus
+  = FleetOverrideUsable
+  | FleetOverrideNotYetUsable
+  | FleetOverrideFinished
+  deriving (Show, Eq)
+
+isTerminalWaybillStatus :: NandiTypes.WaybillStatus -> Bool
+isTerminalWaybillStatus status = case status of
+  NandiTypes.WaybillClosed -> True
+  NandiTypes.WaybillProcessed -> True
+  NandiTypes.WaybillAudited -> True
+  NandiTypes.WaybillOnline -> False
+  NandiTypes.WaybillUpcoming -> False
+  NandiTypes.WaybillNew -> False
+
+classifyFleetOverride :: Text -> Maybe VehicleLiveRouteInfo -> FleetOverrideStatus
+classifyFleetOverride overrideWaybillNo mbLiveRouteInfo
+  | T.null overrideWaybillNo = FleetOverrideFinished
+  | otherwise = case mbLiveRouteInfo of
+    Nothing -> FleetOverrideNotYetUsable
+    Just liveRouteInfo -> case liveRouteInfo.waybillNo of
+      Nothing -> FleetOverrideNotYetUsable
+      Just liveWaybillNo
+        | liveWaybillNo /= overrideWaybillNo -> FleetOverrideFinished
+        | otherwise -> case liveRouteInfo.waybillStatus of
+          Just NandiTypes.WaybillOnline -> FleetOverrideUsable
+          Just status -> if isTerminalWaybillStatus status then FleetOverrideFinished else FleetOverrideNotYetUsable
+          Nothing -> FleetOverrideNotYetUsable
+
 getVehicleServiceTypeFromInMem ::
   (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, Log m, CacheFlow m r, EsqDBFlow m r) =>
   [DIntegratedBPPConfig.IntegratedBPPConfig] ->
@@ -1922,13 +1951,14 @@ getLiveRouteInfo' integratedBPPConfig userPassedVehicleNumber userPassedRouteCod
   mbVehicleOverrideInfo <- Dispatcher.getFleetOverrideInfo userPassedVehicleNumber
   mbRouteLiveInfo <-
     case mbVehicleOverrideInfo of
-      Just (updatedVehicleNumber, newDeviceWaybillNo) -> do
-        mbUpdatedVehicleRouteInfo <- getVehicleLiveRouteInfo [integratedBPPConfig] updatedVehicleNumber Nothing
-        if Just newDeviceWaybillNo /= ((.waybillId) . snd =<< mbUpdatedVehicleRouteInfo)
-          then do
+      Just (sourceVehicleNumber, overrideWaybillNo) -> do
+        mbSourceRouteInfo <- getVehicleLiveRouteInfo [integratedBPPConfig] sourceVehicleNumber Nothing
+        case classifyFleetOverride overrideWaybillNo (snd <$> mbSourceRouteInfo) of
+          FleetOverrideUsable -> pure mbSourceRouteInfo
+          FleetOverrideFinished -> do
             Dispatcher.delFleetOverrideInfo userPassedVehicleNumber
             getVehicleLiveRouteInfo [integratedBPPConfig] userPassedVehicleNumber Nothing
-          else pure mbUpdatedVehicleRouteInfo
+          FleetOverrideNotYetUsable -> getVehicleLiveRouteInfo [integratedBPPConfig] userPassedVehicleNumber Nothing
       Nothing -> getVehicleLiveRouteInfo [integratedBPPConfig] userPassedVehicleNumber Nothing
   return $
     maybe


### PR DESCRIPTION
# Dispatcher fleet override

When a depot swaps bus **A** out for bus **B**, the dispatcher records the swap in Redis so
that a rider scanning **B** is served **A**'s live route instead of B's own.

```
depot swaps A -> B
  POST /dispatcher/updateFleetSchedule {sourceFleetId: A, updatedFleetId: B}
       └─> redis  fleetOverride:sourceFleetId:B = (A, A.waybill_no)   ttl 24h

rider scans B
  GET /publicTransport/data?vehicleNumber=B
       ├─ key hit -> fetch A's liveRouteInfo -> classifyFleetOverride
       └─ no key  -> B's own liveRouteInfo
```

## Current Issue
So since I made GIMS's `vehicle/service-type` endpoint to include non-empty statuses (Audited, Closed, New, Processed), the status check is always un-gated and let's the key prevail for its whole TTL and causes dirty overrides
 
## New behavior

The check on read used to be a boolean — waybill matches and is online, or else delete the
key and fall back. That conflates "this override is finished" with "we can't use it right
now", and the key *is* the dispatcher's action for the day: nothing recreates it.

`classifyFleetOverride` now returns three states:

- `FleetOverrideUsable` — serve A's route
- `FleetOverrideNotYetUsable` — serve B's route, but **keep the key** so the override still
  applies once A comes online
- `FleetOverrideFinished` — serve B's route and **delete the key**; A won't be back on this
  waybill

Deleting is reserved for genuine staleness: A moved to a different waybill, or this one is
terminal. A not-yet-started waybill, a feed that omits `waybill_status`, or a transient
nandi failure no longer lets the first rider to scan B destroy the swap for the day.

`isTerminalWaybillStatus` enumerates all six `WaybillStatus` constructors with no wildcard,
so a new one has to make its choice explicitly rather than default into "delete".

## Cases

In the order `classifyFleetOverride` evaluates them:

| # | condition | `waybillNo ≠ redis?` | verdict | key | returns |
|---|---|---|---|---|---|
| 1 | stored waybill is `""` | — *(not reached)* | `Finished` | **deleted** | B's info |
| 2 | nandi call failed → `Nothing` | — *(not reached)* | `NotYetUsable` | kept | B's info |
| 3 | A has no `waybillNo` (between duties) | — *(not reached)* | `NotYetUsable` | kept | B's info |
| 4 | A moved to a different waybill | **true** | `Finished` | **deleted** | B's info |
| 5 | waybill matches, status `online` | false | `Usable` | kept | **A's info** |
| 6 | waybill matches, `closed`/`processed`/`audited` | false | `Finished` | **deleted** | B's info |
| 7 | waybill matches, `upcoming`/`new` | false | `NotYetUsable` | kept | B's info |
| 8 | waybill matches, status absent from feed | false | `NotYetUsable` | kept | B's info |

Cases 1–3 short-circuit before any comparison, which is why the override survives 2 and 3
(nothing was proven about it) but not 1 (a `""` entry can never match, so there is nothing
to wait for). Case 4 is the only `true`. Cases 6 vs 7/8 are the split that matters: same
"not online", opposite treatment of the key.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation requiring a source fleet to have an active waybill before a schedule override can be recorded.
  - Improved fleet-override handling across journey and boarding workflows based on live vehicle status.

- **Bug Fixes**
  - Prevented invalid or outdated fleet overrides from being used.
  - Preserved pending overrides until they become valid, while removing completed overrides and correctly falling back to the original vehicle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->