### PR TITLE
Fixed KV query and Added Audio Support for AutoAccept Rides

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
@@ -242,7 +242,8 @@ data DriverRideRes = DriverRideRes
     amountToBeSettledOnlineWithCurrency :: Maybe PriceAPIEntity,
     rideEarnings :: Maybe RideEarnings,
     customerLanguage :: Maybe Maps.Language,
-    driverCancellationNotAllowed :: Maybe Bool
+    driverCancellationNotAllowed :: Maybe Bool,
+    isAutoAccepted :: Maybe Bool
   }
   deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
 
@@ -334,7 +335,6 @@ buildRideEarnings lang labels booking ride estimatedFareParam finalFareParam rid
             mkComp FareBreakup "DISCOUNT" lblDiscount discount (discount > 0),
             mkComp FareBreakup "TIPS" lblTips tips (tips > 0),
             mkComp FareBreakup "COMMISSION" lblCommission commission (commission /= 0),
-
             mkComp FareBreakup "PAYMENT_CHARGE" lblPaymentCharge ridePaymentChargeAmt ((customerBearsCharge || driverBearsCharge) && ridePaymentChargeAmt > 0),
             mkComp FareBreakup "CUSTOMER_CANCELLATION_CHARGE" lblFare cancellationDues (cancellationDues > 0),
             mkComp FareBreakup "AIRPORT_CONVENIENCE_FEE" lblAirportConvenienceFee airportConvenienceFee (airportConvenienceFee > 0),
@@ -452,8 +452,7 @@ fetchEarningsLabels ::
   m EarningsLabels
 fetchEarningsLabels lang =
   EarningsLabels
-
-  -- TODO MAKE THIS AMOUNT PAID BY CUST TO KEEP IT BACKWARD COMPATIBLE.. WE WILL CHANGBE IN DB.
+    -- TODO MAKE THIS AMOUNT PAID BY CUST TO KEEP IT BACKWARD COMPATIBLE.. WE WILL CHANGBE IN DB.
     <$> resolveLabel lang "FARE_PAID_BY_CUSTOMER"
     <*> resolveLabel lang "DISCOUNT"
     <*> resolveLabel lang "TIPS"
@@ -694,7 +693,8 @@ mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mb
         amountToCollectInCashWithCurrency = (\amt -> PriceAPIEntity (roundAmountByCurrency' ride.currency amt) ride.currency) <$> mbAmountToCollectInCash,
         amountToBeSettledOnlineWithCurrency = (\amt -> PriceAPIEntity (roundAmountByCurrency' ride.currency amt) ride.currency) <$> mbAmountToBeSettledOnline,
         rideEarnings = mbRideEarningsVal,
-        customerLanguage = booking.customerLanguage
+        customerLanguage = booking.customerLanguage,
+        isAutoAccepted = booking.isAutoAccepted
       }
 
 -- calculateLocations moved from UI.Ride

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/BookingExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/BookingExtra.hs
@@ -3,7 +3,8 @@ module Storage.Queries.BookingExtra where
 -- (Day, UTCTime (UTCTime), DT.secondsToDiffTime, utctDay, DT.addDays)
 
 import qualified Data.Aeson as A
-import Data.List.Extra (notNull)
+import Data.List.Extra (notNull, sortOn)
+import Data.Ord (Down (..))
 import qualified Data.Time as DT
 import qualified Domain.Types as DTC
 import qualified Domain.Types as DVST
@@ -84,12 +85,11 @@ findAllByTransactionId txnId =
 
 findByTransactionIdAndStatuses :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Text -> [BookingStatus] -> m (Maybe Booking)
 findByTransactionIdAndStatuses transactionId statusList =
-  findAllWithKVAndConditionalDB
+  findAllWithKV
     [ Se.Is BeamB.transactionId $ Se.Eq transactionId,
       Se.Is BeamB.status $ Se.In statusList
     ]
-    (Just (Se.Desc BeamB.createdAt))
-    <&> listToMaybe
+    <&> (listToMaybe . sortOn (Down . (.createdAt)))
 
 findAllByStatusAndDateRange :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => Id DMOC.MerchantOperatingCity -> [BookingStatus] -> UTCTime -> UTCTime -> m [Booking]
 findAllByStatusAndDateRange merchantOpCityId statuses startTime endTime =


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ride details can now indicate whether a booking was automatically accepted.

* **Bug Fixes**
  * Booking lookups now use the primary cache and maintain the expected booking order.
  * Bookings unavailable in the primary cache are no longer retrieved through the database fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->