### PR TITLE
backend/feat: forward driver chat messages to XyneSpaces

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Issue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/API/UI/Issue.hs
@@ -21,6 +21,7 @@ import qualified IssueManagement.Domain.Types.MediaFile as DMF
 import Kernel.Beam.Functions
 import Kernel.External.Encryption
 import qualified Kernel.External.Ticket.Interface.Types as TIT
+import qualified Kernel.External.Ticket.Types as TicketTypes
 import Kernel.External.Types (Language)
 import Kernel.Prelude
 import qualified Kernel.Storage.Hedis as Redis
@@ -34,6 +35,7 @@ import Storage.Beam.IssueManagement ()
 import Storage.Beam.SystemConfigs ()
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import Storage.ConfigPilot.Config.IssueConfig (IssueConfigDimensions (..))
+import Storage.ConfigPilot.Config.MerchantServiceUsageConfig (MerchantServiceUsageConfigDimensions (..))
 import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions (..))
 import qualified Storage.Queries.Booking as QB
 import qualified Storage.Queries.Merchant as QM
@@ -129,10 +131,7 @@ driverIssueHandle =
       mbFindFRFSTicketBookingById = Nothing,
       mbFindStationByIdWithContext = Nothing,
       mbSendChatNotification = Just (\pid payload -> Notify.notifyOnIssueChatMessage (cast pid) payload),
-      -- Nothing = never forward driver-side chat messages to the ticket
-      -- service. Driver-app doesn't use XyneSpaces today; enable this by
-      -- returning a check against MerchantServiceUsageConfig if that changes.
-      mbShouldForwardChatToTicketService = Nothing,
+      mbShouldForwardChatToTicketService = Just isXyneTicketService,
       mbFetchMediaBase64 = Just fetchMediaBase64FromS3,
       findIssueConfig = \mocId issueIdentifier ->
         getConfig (IssueConfigDimensions {merchantOperatingCityId = mocId.getId, identifier = show issueIdentifier}) Nothing,
@@ -140,6 +139,11 @@ driverIssueHandle =
       mbUpdateTicketStatus = Just castUpdateTicketStatus,
       mbUpdateTicketCsat = Just castUpdateTicketCsat
     }
+
+isXyneTicketService :: Id Common.Merchant -> Id Common.MerchantOperatingCity -> Flow Bool
+isXyneTicketService _merchantId mocId = do
+  mbUsage <- getConfig (MerchantServiceUsageConfigDimensions {merchantOperatingCityId = mocId.getId}) Nothing
+  pure $ maybe False (\c -> c.issueTicketService == TicketTypes.XyneSpaces) mbUsage
 
 -- | Fetch a MediaFile's bytes directly from S3 (returning the base64 payload
 -- 'AWS.S3.get' produces). Same mechanism the shared IssueManagement handler


### PR DESCRIPTION
mbShouldForwardChatToTicketService was Nothing, so no driver chat body ever reached the ticket service — threads went silent after the opening message. Gate it on the city's configured issue ticket service instead, so only XyneSpaces cities forward; Kapture and Zendesk are unaffected.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

`driverIssueHandle` set `mbShouldForwardChatToTicketService = Nothing`. Both
`forwardChatToTicketService` and `forwardChatToTicketServiceAs` open with:

```Haskell
shouldForward <- maybe (pure False) (\chk -> chk merchantId mocId) issueHandle.mbShouldForwardChatToTicketService
when shouldForward $ doForward merchantId mocId
```


so every one of the ten call sites that append to a ticket thread was a no-op on
driver-app — the driver's typed description (UI/Issue.hs:839), the option they
tapped (:256), auto-replies (:260, :844, :1286, :1310), mid-flow bot and
user messages (:1144, :1145), messages typed in the thread (:1742), and
dashboard-side replies (Dashboard/Issue.hs:580, :2228).

Ticket creation was never gated, which made the symptom misleading: a ticket
appears in Xyne with an opening body and then goes permanently silent, looking
like Xyne dropped the thread when driver-app had simply never sent anything after
creation.

This replaces Nothing with a per-city predicate that reads
merchant_service_usage_config.issue_ticket_service and returns True only for
XyneSpaces. Kapture and Zendesk cities keep returning False deliberately —
they already receive dashboard-side updates, so forwarding there would post every
chat message twice.

Unlike rider-app there is no secondary fan-out to consider: driver-app's
MerchantServiceUsageConfig has no additionalIssueTicketServices, so Xyne can
only ever be the primary and updateTicket already targets it. That is why
mbUpdateTicketOnService correctly stays Nothing.

Inert on merge — no city is on XyneSpaces today, so behaviour is unchanged until
a merchant_service_usage_config row is flipped.

Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes

No schema migration and no dhall change in this PR. Enabling the feature for a
city is data + deployment config only, and is not part of this PR:

- merchant_service_config row with service_name = 'Ticket_XyneSpaces'
  (url, passetto-encrypted token, channelId)
- merchant_service_usage_config.issue_ticket_service = 'XyneSpaces'
- xyneWebhookSigningSecret / xyneWebhookBearerToken set on the deployment —
  the fields already exist in dhall-configs/*/dynamic-offer-driver-app.dhall
  as placeholders, so this PR does not touch them, but inbound agent replies fail
  HMAC verification silently until they are populated.

Motivation and Context

Support chats raised in the Lynx driver app need to be visible to human agents in
XyneSpaces, and agent replies need to reach the driver. Ticket creation and the
entire inbound path (/internal/xyne/webhook, HMAC verification, SENDER_OPERATOR
chat message, FCM push) already work. The only missing link was outbound chat
forwarding, which this enables.

How did you test it?

Manually, end to end, against a local stack with a seeded Lynx merchant and
Helsinki operating city on issue_ticket_service = 'XyneSpaces':

- raising an issue created a real XyneSpaces ticket (cmtjru6cm0rxthancp3nugc4f)
- each subsequent driver chat message produced exactly one additional
  appDeskInbound call — this is the behaviour the change adds; before it, zero
- an inbound DESK_REPLY webhook produced a chat_message row with
  SENDER_OPERATOR and dispatched the FCM notification
- all four /issue/{id}/chat/* endpoints returned the expected shapes

Not covered: a reply from a real Xyne agent, which needs the webhook URL
registered against a publicly reachable host. Inbound was exercised with a
signed webhook request rather than a live agent.


Screenshot of test results

<!-- Provide screenshot of the test results -->

Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors ./dev/format-all-files.sh
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a CHANGELOG (/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Driver-side chat messages are now forwarded to the ticket service when XyneSpaces is configured for the merchant’s operating city.
- **Bug Fixes**
  - Corrected issue handling so eligible driver-app conversations can reach the configured ticketing system instead of being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->