### PR TITLE
fix: returning service tier in stop route tracking

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -460,11 +460,18 @@ types:
     timeStamp: UTCTime
     towerInfo: [TowerInfo]
 
+  PassingVehicleInfo:
+    vehicleNumber: Text
+    serviceTierType: ServiceTierType
+    serviceTierName: Maybe Text
+    eta: BusStopETA
+
   PassingRoutes:
     routeCode: Text
-    eta: "Maybe [BusStopETA]"
+    routeShortName: Text
+    liveVehicles: [PassingVehicleInfo]
+    schedules: [PassingVehicleInfo]
     isLastStop: Bool
-    isLive: Bool
 
 apis:
   - POST:

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Types/UI/MultimodalConfirm.hs
@@ -300,11 +300,15 @@ data OnboardedVehicleDetailsReq = OnboardedVehicleDetailsReq
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-data PassingRoutes = PassingRoutes
-  { eta :: Kernel.Prelude.Maybe [Storage.CachedQueries.Merchant.MultiModalBus.BusStopETA],
-    isLastStop :: Kernel.Prelude.Bool,
-    isLive :: Kernel.Prelude.Bool,
-    routeCode :: Kernel.Prelude.Text
+data PassingRoutes = PassingRoutes {isLastStop :: Kernel.Prelude.Bool, liveVehicles :: [PassingVehicleInfo], routeCode :: Kernel.Prelude.Text, routeShortName :: Kernel.Prelude.Text, schedules :: [PassingVehicleInfo]}
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+data PassingVehicleInfo = PassingVehicleInfo
+  { eta :: Storage.CachedQueries.Merchant.MultiModalBus.BusStopETA,
+    serviceTierName :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    serviceTierType :: BecknV2.FRFS.Enums.ServiceTierType,
+    vehicleNumber :: Kernel.Prelude.Text
   }
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -2710,7 +2710,8 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) mbAllPassingRoutes r
             map
               ( \r ->
                   let (keptLive, keptScheduled) = fromMaybe ([], []) $ Map.lookup r.routeCode topByRoute
-                   in r {API.Types.UI.MultimodalConfirm.liveVehicles = keptLive, API.Types.UI.MultimodalConfirm.schedules = keptScheduled}
+                   in -- PassingRoutes shares liveVehicles/schedules, so the update needs the type spelled out.
+                      (r {API.Types.UI.MultimodalConfirm.liveVehicles = keptLive, API.Types.UI.MultimodalConfirm.schedules = keptScheduled} :: API.Types.UI.MultimodalConfirm.RouteWithLiveVehicle)
               )
               routes
 
@@ -3243,63 +3244,81 @@ getMultimodalTrackStopRoutes (mbPersonId, _merchantId) stopCode mbRouteCodes = d
     fromMaybeM (InvalidRequest "Integrated BPP config not found") . listToMaybe
       =<< SIBC.findAllIntegratedBPPConfig person.merchantOperatingCityId Enums.BUS DIBC.MULTIMODAL
   mappings <- OTPRest.getRouteStopMappingByStopCode stopCode integratedBPPConfig
-  -- `routeCodes` is an optional comma-separated filter; without it every route passing the stop is returned.
   let filterRouteCodes = maybe [] (filter (not . T.null) . map T.strip . T.splitOn ",") mbRouteCodes
       passingRouteCodes = nub (map (.routeCode) mappings)
       routeCodes =
         if null filterRouteCodes
           then passingRouteCodes
           else filter (`elem` filterRouteCodes) passingRouteCodes
-  mapConcurrently (getRouteEtaAtStop integratedBPPConfig) routeCodes
+
+  frfsTierMap <- map (\t -> (t._type, t)) <$> CQFRFSVehicleServiceTier.findAllByMerchantOperatingCityIdAndIntegratedBPPConfigId person.merchantOperatingCityId integratedBPPConfig.id
+  catMaybes <$> mapConcurrently (getRouteEtaAtStop integratedBPPConfig frfsTierMap) routeCodes
   where
-    getRouteEtaAtStop integratedBPPConfig routeCode = do
-      liveEtasFork <-
-        awaitableFork "getMultimodalTrackStopRoutes->liveEtas" $ do
-          busesForRoutes <- CQMMB.getBusesForRoutes [routeCode] integratedBPPConfig
-          pure
-            [ etaEntry
-              | routeWithBuses <- busesForRoutes,
-                bus <- routeWithBuses.buses,
-                etaEntry <- fromMaybe [] bus.busData.eta_data,
-                etaEntry.stopCode == stopCode
-            ]
-      scheduleEtasFork <-
-        awaitableFork "getMultimodalTrackStopRoutes->scheduleEtas" $ do
-          schedules <- OTPRest.getRouteBusSchedule routeCode Nothing integratedBPPConfig
-          pure
-            [ etaEntry
-              | scheduleDetail <- schedules,
-                etaEntry <- scheduleDetail.eta,
-                etaEntry.stopCode == stopCode
-            ]
-      liveEtas <-
-        L.await Nothing liveEtasFork >>= \case
-          Left err -> do
-            logError $ "getMultimodalTrackStopRoutes live ETA fetch failed for route " <> routeCode <> ": " <> show err
-            pure []
-          Right result -> pure result
-      scheduleEtas <-
-        L.await Nothing scheduleEtasFork >>= \case
-          Left err -> do
-            logError $ "getMultimodalTrackStopRoutes schedule ETA fetch failed for route " <> routeCode <> ": " <> show err
-            pure []
-          Right result -> pure result
-      let (etas, isLive) =
-            if not (null liveEtas)
-              then (liveEtas, True)
-              else (scheduleEtas, False)
-      if null etas
-        then pure $ ApiTypes.PassingRoutes {routeCode = routeCode, eta = Nothing, isLastStop = False, isLive = False}
-        else do
-          enrichedEtas <- mapM (JMRouteServiceability.enrichBusStopETA integratedBPPConfig) etas
+    etaAtStop etaEntries = listToMaybe (sortOn (.arrivalTimeUnix) (filter (\etaEntry -> etaEntry.stopCode == stopCode) etaEntries))
+
+    getRouteEtaAtStop integratedBPPConfig frfsTierMap routeCode = do
+      mbRoute <- OTPRest.getRouteByRouteId integratedBPPConfig routeCode
+      case mbRoute of
+        Nothing -> do
+          logError $ "getMultimodalTrackStopRoutes route not found: " <> routeCode
+          pure Nothing
+        Just route -> do
+          liveVehiclesFork <-
+            awaitableFork "getMultimodalTrackStopRoutes->liveVehicles" $ do
+              busesForRoutes <- CQMMB.getBusesForRoutes [routeCode] integratedBPPConfig
+              catMaybes
+                <$> mapConcurrently
+                  ( \(vehicleNo, busEta) -> do
+                      mbVehicleMetadata <- JMU.getVehicleMetadataFromInMem [integratedBPPConfig] vehicleNo
+                      pure $ (\(_, metadata) -> (vehicleNo, metadata.serviceType, busEta)) <$> mbVehicleMetadata
+                  )
+                  [ (bus.vehicleNumber, busEta)
+                    | routeWithBuses <- busesForRoutes,
+                      bus <- routeWithBuses.buses,
+                      Just busEta <- [etaAtStop (fromMaybe [] bus.busData.eta_data)]
+                  ]
+          scheduleVehiclesFork <-
+            awaitableFork "getMultimodalTrackStopRoutes->schedules" $ do
+              schedules <- OTPRest.getRouteBusSchedule routeCode Nothing integratedBPPConfig
+              pure
+                [ (scheduleDetail.vehicle_no, scheduleDetail.service_tier, detailEta)
+                  | scheduleDetail <- schedules,
+                    Just detailEta <- [etaAtStop scheduleDetail.eta]
+                ]
+          liveVehicles <-
+            L.await Nothing liveVehiclesFork >>= \case
+              Left err -> do
+                logError $ "getMultimodalTrackStopRoutes live vehicle fetch failed for route " <> routeCode <> ": " <> show err
+                pure []
+              Right result -> pure result
+          scheduleVehicles <-
+            L.await Nothing scheduleVehiclesFork >>= \case
+              Left err -> do
+                logError $ "getMultimodalTrackStopRoutes schedule fetch failed for route " <> routeCode <> ": " <> show err
+                pure []
+              Right result -> pure result
+          liveVehicleInfos <- mapM (mkPassingVehicle integratedBPPConfig frfsTierMap) liveVehicles
+          scheduleVehicleInfos <- mapM (mkPassingVehicle integratedBPPConfig frfsTierMap) scheduleVehicles
           routeMappings <- OTPRest.getRouteStopMappingByRouteCode routeCode integratedBPPConfig
           let isLastStop = case sortOn (Down . (.sequenceNum)) routeMappings of
                 (lastStopMapping : _) -> lastStopMapping.stopCode == stopCode
                 [] -> False
           pure $
-            ApiTypes.PassingRoutes
-              { routeCode = routeCode,
-                eta = Just enrichedEtas,
-                isLastStop = isLastStop,
-                isLive = isLive
-              }
+            Just
+              ApiTypes.PassingRoutes
+                { routeCode = routeCode,
+                  routeShortName = route.shortName,
+                  liveVehicles = liveVehicleInfos,
+                  schedules = scheduleVehicleInfos,
+                  isLastStop = isLastStop
+                }
+
+    mkPassingVehicle integratedBPPConfig frfsTierMap (vehicleNo, serviceTier, etaEntry) = do
+      enrichedEta <- JMRouteServiceability.enrichBusStopETA integratedBPPConfig etaEntry
+      pure $
+        ApiTypes.PassingVehicleInfo
+          { vehicleNumber = vehicleNo,
+            serviceTierType = serviceTier,
+            serviceTierName = (.shortName) <$> lookup serviceTier frfsTierMap,
+            eta = enrichedEta
+          }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Passing route information now includes route short names and separate lists for live vehicles and scheduled vehicles.
  * Vehicle entries include vehicle numbers, service tier details, and estimated arrival times.
  * Live vehicle information is enriched with available service metadata.

* **Bug Fixes**
  * Routes with unavailable vehicle metadata are excluded from live vehicle results.
  * Live vehicle and schedule results now fall back independently when information cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->