### PR TITLE
backend/feat: add customer block/unblock transaction history

### DIFF
--- a/Backend/app/dashboard/CommonAPIs/spec/RiderPlatform/Management/API/Customer.yaml
+++ b/Backend/app/dashboard/CommonAPIs/spec/RiderPlatform/Management/API/Customer.yaml
@@ -46,6 +46,17 @@ apis:
         type: BlockCustomerReq
       response:
         type: APISuccess
+      helperApi:
+        - POST:
+            endpoint: /{customerId}/block/{dashboardUserName}
+            auth: ApiAuthV2
+            params:
+              customerId: Id Customer
+              dashboardUserName: Text
+            request:
+              type: BlockCustomerReq
+            response:
+              type: APISuccess
       migrate:
         endpoint: CustomerAPI BlockCustomerEndpoint
         userActionType: ApiAuth APP_BACKEND_MANAGEMENT CUSTOMERS CUSTOMER_BLOCK
@@ -56,6 +67,15 @@ apis:
         customerId: Id Customer
       response:
         type: APISuccess
+      helperApi:
+        - POST:
+            endpoint: /{customerId}/unblock/{dashboardUserName}
+            auth: ApiAuthV2
+            params:
+              customerId: Id Customer
+              dashboardUserName: Text
+            response:
+              type: APISuccess
       migrate:
         endpoint: CustomerAPI UnblockCustomerEndpoint
         userActionType: ApiAuth APP_BACKEND_MANAGEMENT CUSTOMERS CUSTOMER_UNBLOCK
@@ -171,6 +191,19 @@ types:
     - totalSosCount: Int
     - paymentMode: Maybe PaymentMode
     - blockedReason: Maybe Text
+    - blockedInfo: [CustomerBlockTransactions]
+    - blockCount: Maybe Int
+  ActionType:
+    - enum: "BLOCK, UNBLOCK"
+  CustomerBlockTransactions:
+    - reasonCode: Maybe Text
+    - blockReason: Maybe Text
+    - blockTimeInHours: Maybe Int
+    - reportedAt: UTCTime
+    - blockLiftTime: Maybe UTCTime
+    - blockedBy: Text
+    - requestorId: Maybe Text
+    - actionType: Maybe ActionType
   CancellationDuesDetailsRes:
     - cancellationDues: PriceAPIEntity
     - cancellationDuesPaid: HighPrecMoney

--- a/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/RiderPlatform/Management/Endpoints/Customer.hs
+++ b/Backend/app/dashboard/CommonAPIs/src-read-only/API/Types/RiderPlatform/Management/Endpoints/Customer.hs
@@ -20,6 +20,12 @@ import qualified Kernel.Types.Id
 import Servant
 import Servant.Client
 
+data ActionType
+  = BLOCK
+  | UNBLOCK
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data ApplyCustomerOfferReq = ApplyCustomerOfferReq
   { mobileNumber :: Kernel.Prelude.Text,
     mobileCountryCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
@@ -82,6 +88,19 @@ data CancellationDuesPaymentStatus
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
+data CustomerBlockTransactions = CustomerBlockTransactions
+  { reasonCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    blockReason :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    blockTimeInHours :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    reportedAt :: Kernel.Prelude.UTCTime,
+    blockLiftTime :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
+    blockedBy :: Kernel.Prelude.Text,
+    requestorId :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    actionType :: Kernel.Prelude.Maybe ActionType
+  }
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON, ToSchema)
+
 data CustomerEnsureExistsReq = CustomerEnsureExistsReq {mobileNumber :: Kernel.Prelude.Text, mobileCountryCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text}
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -95,7 +114,9 @@ data CustomerInfoRes = CustomerInfoRes
     safetyCenterDisabledOnDate :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
     totalSosCount :: Kernel.Prelude.Int,
     paymentMode :: Kernel.Prelude.Maybe Domain.Types.PaymentMode.PaymentMode,
-    blockedReason :: Kernel.Prelude.Maybe Kernel.Prelude.Text
+    blockedReason :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    blockedInfo :: [CustomerBlockTransactions],
+    blockCount :: Kernel.Prelude.Maybe Kernel.Prelude.Int
   }
   deriving stock (Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
@@ -151,7 +172,7 @@ data UpdateSafetyCenterBlockingReq = UpdateSafetyCenterBlockingReq {incrementCou
 instance Kernel.Types.HideSecrets.HideSecrets UpdateSafetyCenterBlockingReq where
   hideSecrets = Kernel.Prelude.identity
 
-type API = ("customer" :> (GetCustomerList :<|> DeleteCustomerDelete :<|> PostCustomerBlock :<|> PostCustomerUnblock :<|> GetCustomerInfo :<|> GetCustomerCancellationDuesDetails :<|> PostCustomerUpdateSafetyCenterBlocking :<|> PostCustomerPersonNumbers :<|> PostCustomerPersonId :<|> PostCustomerUpdatePaymentMode :<|> PostCustomerOffersList :<|> PostCustomerApplyOffer :<|> PostCustomerEnsureExists :<|> PostCustomerBulkApplyOffer))
+type API = ("customer" :> (GetCustomerList :<|> DeleteCustomerDelete :<|> PostCustomerBlockHelper :<|> PostCustomerUnblockHelper :<|> GetCustomerInfo :<|> GetCustomerCancellationDuesDetails :<|> PostCustomerUpdateSafetyCenterBlocking :<|> PostCustomerPersonNumbers :<|> PostCustomerPersonId :<|> PostCustomerUpdatePaymentMode :<|> PostCustomerOffersList :<|> PostCustomerApplyOffer :<|> PostCustomerEnsureExists :<|> PostCustomerBulkApplyOffer))
 
 type GetCustomerList =
   ( "list" :> QueryParam "limit" Kernel.Prelude.Int :> QueryParam "offset" Kernel.Prelude.Int :> QueryParam "enabled" Kernel.Prelude.Bool
@@ -166,62 +187,77 @@ type GetCustomerList =
            "personId"
            (Kernel.Types.Id.Id Dashboard.Common.Customer)
       :> Get
-           '[JSON]
+           ('[JSON])
            CustomerListRes
   )
 
-type DeleteCustomerDelete = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "delete" :> Delete '[JSON] Kernel.Types.APISuccess.APISuccess)
+type DeleteCustomerDelete = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "delete" :> Delete ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
-type PostCustomerBlock = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "block" :> ReqBody '[JSON] BlockCustomerReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
+type PostCustomerBlock = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "block" :> ReqBody ('[JSON]) BlockCustomerReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
-type PostCustomerUnblock = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "unblock" :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
+type PostCustomerBlockHelper =
+  ( Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "block" :> Capture "dashboardUserName" Kernel.Prelude.Text
+      :> ReqBody
+           ('[JSON])
+           BlockCustomerReq
+      :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess
+  )
 
-type GetCustomerInfo = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "info" :> Get '[JSON] CustomerInfoRes)
+type PostCustomerUnblock = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "unblock" :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
-type GetCustomerCancellationDuesDetails = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "getCancellationDuesDetails" :> Get '[JSON] CancellationDuesDetailsRes)
+type PostCustomerUnblockHelper =
+  ( Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "unblock" :> Capture "dashboardUserName" Kernel.Prelude.Text
+      :> Post
+           ('[JSON])
+           Kernel.Types.APISuccess.APISuccess
+  )
+
+type GetCustomerInfo = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "info" :> Get ('[JSON]) CustomerInfoRes)
+
+type GetCustomerCancellationDuesDetails = (Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "getCancellationDuesDetails" :> Get ('[JSON]) CancellationDuesDetailsRes)
 
 type PostCustomerUpdateSafetyCenterBlocking =
   ( Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "updateSafetyCenterBlocking"
       :> ReqBody
-           '[JSON]
+           ('[JSON])
            UpdateSafetyCenterBlockingReq
-      :> Post '[JSON] Kernel.Types.APISuccess.APISuccess
+      :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess
   )
 
-type PostCustomerPersonNumbers = ("personNumbers" :> Kernel.ServantMultipart.MultipartForm Kernel.ServantMultipart.Tmp Dashboard.Common.PersonIdsReq :> Post '[JSON] [Dashboard.Common.PersonRes])
+type PostCustomerPersonNumbers = ("personNumbers" :> Kernel.ServantMultipart.MultipartForm Kernel.ServantMultipart.Tmp Dashboard.Common.PersonIdsReq :> Post ('[JSON]) [Dashboard.Common.PersonRes])
 
-type PostCustomerPersonId = ("personId" :> Kernel.ServantMultipart.MultipartForm Kernel.ServantMultipart.Tmp Dashboard.Common.PersonMobileNoReq :> Post '[JSON] [Dashboard.Common.PersonRes])
+type PostCustomerPersonId = ("personId" :> Kernel.ServantMultipart.MultipartForm Kernel.ServantMultipart.Tmp Dashboard.Common.PersonMobileNoReq :> Post ('[JSON]) [Dashboard.Common.PersonRes])
 
 type PostCustomerUpdatePaymentMode =
-  ( Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "updatePaymentMode" :> ReqBody '[JSON] UpdatePaymentModeReq
+  ( Capture "customerId" (Kernel.Types.Id.Id Dashboard.Common.Customer) :> "updatePaymentMode" :> ReqBody ('[JSON]) UpdatePaymentModeReq
       :> Post
-           '[JSON]
+           ('[JSON])
            Kernel.Types.APISuccess.APISuccess
   )
 
-type PostCustomerOffersList = ("offersList" :> ReqBody '[JSON] CustomerOffersListReq :> Post '[JSON] [CustomerOfferEntity])
+type PostCustomerOffersList = ("offersList" :> ReqBody ('[JSON]) CustomerOffersListReq :> Post ('[JSON]) [CustomerOfferEntity])
 
-type PostCustomerApplyOffer = ("applyOffer" :> ReqBody '[JSON] ApplyCustomerOfferReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
+type PostCustomerApplyOffer = ("applyOffer" :> ReqBody ('[JSON]) ApplyCustomerOfferReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
-type PostCustomerEnsureExists = ("ensureExists" :> ReqBody '[JSON] CustomerEnsureExistsReq :> Post '[JSON] Kernel.Types.APISuccess.APISuccess)
+type PostCustomerEnsureExists = ("ensureExists" :> ReqBody ('[JSON]) CustomerEnsureExistsReq :> Post ('[JSON]) Kernel.Types.APISuccess.APISuccess)
 
-type PostCustomerBulkApplyOffer = ("bulkApplyOffer" :> ReqBody '[JSON] BulkApplyCustomerOfferReq :> Post '[JSON] [BulkApplyCustomerOfferRes])
+type PostCustomerBulkApplyOffer = ("bulkApplyOffer" :> ReqBody ('[JSON]) BulkApplyCustomerOfferReq :> Post ('[JSON]) [BulkApplyCustomerOfferRes])
 
 data CustomerAPIs = CustomerAPIs
-  { getCustomerList :: Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> EulerHS.Types.EulerClient CustomerListRes,
-    deleteCustomerDelete :: Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    postCustomerBlock :: Kernel.Types.Id.Id Dashboard.Common.Customer -> BlockCustomerReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    postCustomerUnblock :: Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    getCustomerInfo :: Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient CustomerInfoRes,
-    getCustomerCancellationDuesDetails :: Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient CancellationDuesDetailsRes,
-    postCustomerUpdateSafetyCenterBlocking :: Kernel.Types.Id.Id Dashboard.Common.Customer -> UpdateSafetyCenterBlockingReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    postCustomerPersonNumbers :: (Data.ByteString.Lazy.ByteString, Dashboard.Common.PersonIdsReq) -> EulerHS.Types.EulerClient [Dashboard.Common.PersonRes],
-    postCustomerPersonId :: (Data.ByteString.Lazy.ByteString, Dashboard.Common.PersonMobileNoReq) -> EulerHS.Types.EulerClient [Dashboard.Common.PersonRes],
-    postCustomerUpdatePaymentMode :: Kernel.Types.Id.Id Dashboard.Common.Customer -> UpdatePaymentModeReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    postCustomerOffersList :: CustomerOffersListReq -> EulerHS.Types.EulerClient [CustomerOfferEntity],
-    postCustomerApplyOffer :: ApplyCustomerOfferReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    postCustomerEnsureExists :: CustomerEnsureExistsReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess,
-    postCustomerBulkApplyOffer :: BulkApplyCustomerOfferReq -> EulerHS.Types.EulerClient [BulkApplyCustomerOfferRes]
+  { getCustomerList :: (Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Bool) -> Kernel.Prelude.Maybe (Kernel.Prelude.Bool) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> EulerHS.Types.EulerClient CustomerListRes),
+    deleteCustomerDelete :: (Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    postCustomerBlock :: (Kernel.Types.Id.Id Dashboard.Common.Customer -> Kernel.Prelude.Text -> BlockCustomerReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    postCustomerUnblock :: (Kernel.Types.Id.Id Dashboard.Common.Customer -> Kernel.Prelude.Text -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    getCustomerInfo :: (Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient CustomerInfoRes),
+    getCustomerCancellationDuesDetails :: (Kernel.Types.Id.Id Dashboard.Common.Customer -> EulerHS.Types.EulerClient CancellationDuesDetailsRes),
+    postCustomerUpdateSafetyCenterBlocking :: (Kernel.Types.Id.Id Dashboard.Common.Customer -> UpdateSafetyCenterBlockingReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    postCustomerPersonNumbers :: ((Data.ByteString.Lazy.ByteString, Dashboard.Common.PersonIdsReq) -> EulerHS.Types.EulerClient [Dashboard.Common.PersonRes]),
+    postCustomerPersonId :: ((Data.ByteString.Lazy.ByteString, Dashboard.Common.PersonMobileNoReq) -> EulerHS.Types.EulerClient [Dashboard.Common.PersonRes]),
+    postCustomerUpdatePaymentMode :: (Kernel.Types.Id.Id Dashboard.Common.Customer -> UpdatePaymentModeReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    postCustomerOffersList :: (CustomerOffersListReq -> EulerHS.Types.EulerClient [CustomerOfferEntity]),
+    postCustomerApplyOffer :: (ApplyCustomerOfferReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    postCustomerEnsureExists :: (CustomerEnsureExistsReq -> EulerHS.Types.EulerClient Kernel.Types.APISuccess.APISuccess),
+    postCustomerBulkApplyOffer :: (BulkApplyCustomerOfferReq -> EulerHS.Types.EulerClient [BulkApplyCustomerOfferRes])
   }
 
 mkCustomerAPIs :: (Client EulerHS.Types.EulerClient API -> CustomerAPIs)
@@ -247,4 +283,4 @@ data CustomerUserActionType
   deriving stock (Show, Read, Generic, Eq, Ord)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
-$(Data.Singletons.TH.genSingletons [''CustomerUserActionType])
+$(Data.Singletons.TH.genSingletons [(''CustomerUserActionType)])

--- a/Backend/app/dashboard/provider-dashboard/src-read-only/API/Action/RiderPlatform/Management/Customer.hs
+++ b/Backend/app/dashboard/provider-dashboard/src-read-only/API/Action/RiderPlatform/Management/Customer.hs
@@ -30,117 +30,117 @@ handler merchantId city = getCustomerList merchantId city :<|> deleteCustomerDel
 
 type GetCustomerList =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_LIST)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_LIST))
       :> API.Types.RiderPlatform.Management.Customer.GetCustomerList
   )
 
 type DeleteCustomerDelete =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.DELETE_CUSTOMER_DELETE)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.DELETE_CUSTOMER_DELETE))
       :> API.Types.RiderPlatform.Management.Customer.DeleteCustomerDelete
   )
 
 type PostCustomerBlock =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_BLOCK)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_BLOCK))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerBlock
   )
 
 type PostCustomerUnblock =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UNBLOCK)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UNBLOCK))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerUnblock
   )
 
 type GetCustomerInfo =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_INFO)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_INFO))
       :> API.Types.RiderPlatform.Management.Customer.GetCustomerInfo
   )
 
 type GetCustomerCancellationDuesDetails =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_CANCELLATION_DUES_DETAILS)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_CANCELLATION_DUES_DETAILS))
       :> API.Types.RiderPlatform.Management.Customer.GetCustomerCancellationDuesDetails
   )
 
 type PostCustomerUpdateSafetyCenterBlocking =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UPDATE_SAFETY_CENTER_BLOCKING)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UPDATE_SAFETY_CENTER_BLOCKING))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerUpdateSafetyCenterBlocking
   )
 
 type PostCustomerPersonNumbers =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_PERSON_NUMBERS)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_PERSON_NUMBERS))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerPersonNumbers
   )
 
 type PostCustomerPersonId =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_PERSON_ID)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_PERSON_ID))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerPersonId
   )
 
 type PostCustomerUpdatePaymentMode =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UPDATE_PAYMENT_MODE)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UPDATE_PAYMENT_MODE))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerUpdatePaymentMode
   )
 
 type PostCustomerOffersList =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_OFFERS_LIST)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_OFFERS_LIST))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerOffersList
   )
 
 type PostCustomerApplyOffer =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_APPLY_OFFER)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_APPLY_OFFER))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerApplyOffer
   )
 
 type PostCustomerEnsureExists =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_ENSURE_EXISTS)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_ENSURE_EXISTS))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerEnsureExists
   )
 
 type PostCustomerBulkApplyOffer =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_BULK_APPLY_OFFER)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_BULK_APPLY_OFFER))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerBulkApplyOffer
   )
 
-getCustomerList :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CustomerListRes)
+getCustomerList :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Bool) -> Kernel.Prelude.Maybe (Kernel.Prelude.Bool) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CustomerListRes)
 getCustomerList merchantShortId opCity apiTokenInfo limit offset enabled blocked phone countryCode personId = withFlowHandlerAPI' $ Domain.Action.RiderPlatform.Management.Customer.getCustomerList merchantShortId opCity apiTokenInfo limit offset enabled blocked phone countryCode personId
 
 deleteCustomerDelete :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)

--- a/Backend/app/dashboard/provider-dashboard/src/Domain/Action/RiderPlatform/Management/Customer.hs
+++ b/Backend/app/dashboard/provider-dashboard/src/Domain/Action/RiderPlatform/Management/Customer.hs
@@ -28,9 +28,12 @@ import EulerHS.Prelude
 import qualified Kernel.Prelude
 import qualified Kernel.Types.APISuccess
 import qualified Kernel.Types.Beckn.Context
+import Kernel.Types.Error
 import qualified Kernel.Types.Id
+import Kernel.Utils.Common
 import qualified SharedLogic.Transaction
 import Storage.Beam.CommonInstances ()
+import "lib-dashboard" Storage.Queries.Person as QP
 import Tools.Auth.Api
 import Tools.Auth.Merchant
 
@@ -60,16 +63,20 @@ postCustomerBlock ::
   Environment.Flow Kernel.Types.APISuccess.APISuccess
 postCustomerBlock merchantShortId opCity apiTokenInfo customerId req = do
   checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  person <- QP.findById apiTokenInfo.personId >>= fromMaybeM (PersonNotFound apiTokenInfo.personId.getId)
+  let dashboardUserName = person.firstName <> " " <> person.lastName
   transaction <- SharedLogic.Transaction.buildTransaction (Domain.Types.Transaction.castEndpoint apiTokenInfo.userActionType) (Kernel.Prelude.Just APP_BACKEND_MANAGEMENT) (Kernel.Prelude.Just apiTokenInfo) Kernel.Prelude.Nothing Kernel.Prelude.Nothing (Kernel.Prelude.Just req)
   SharedLogic.Transaction.withTransactionStoring transaction $
-    API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.postCustomerBlock) customerId req
+    API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.postCustomerBlock) customerId dashboardUserName req
 
 postCustomerUnblock :: Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.Flow Kernel.Types.APISuccess.APISuccess
 postCustomerUnblock merchantShortId opCity apiTokenInfo customerId = do
   checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  person <- QP.findById apiTokenInfo.personId >>= fromMaybeM (PersonNotFound apiTokenInfo.personId.getId)
+  let dashboardUserName = person.firstName <> " " <> person.lastName
   transaction <- SharedLogic.Transaction.buildTransaction (Domain.Types.Transaction.castEndpoint apiTokenInfo.userActionType) (Kernel.Prelude.Just APP_BACKEND_MANAGEMENT) (Kernel.Prelude.Just apiTokenInfo) Kernel.Prelude.Nothing Kernel.Prelude.Nothing SharedLogic.Transaction.emptyRequest
   SharedLogic.Transaction.withTransactionStoring transaction $ do
-    API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.postCustomerUnblock) customerId
+    API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.postCustomerUnblock) customerId dashboardUserName
 
 getCustomerInfo :: Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.Flow API.Types.RiderPlatform.Management.Customer.CustomerInfoRes
 getCustomerInfo merchantShortId opCity apiTokenInfo customerId = do

--- a/Backend/app/dashboard/rider-dashboard/src-read-only/API/Action/RiderPlatform/Management/Customer.hs
+++ b/Backend/app/dashboard/rider-dashboard/src-read-only/API/Action/RiderPlatform/Management/Customer.hs
@@ -30,117 +30,117 @@ handler merchantId city = getCustomerList merchantId city :<|> deleteCustomerDel
 
 type GetCustomerList =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_LIST)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_LIST))
       :> API.Types.RiderPlatform.Management.Customer.GetCustomerList
   )
 
 type DeleteCustomerDelete =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.DELETE_CUSTOMER_DELETE)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.DELETE_CUSTOMER_DELETE))
       :> API.Types.RiderPlatform.Management.Customer.DeleteCustomerDelete
   )
 
 type PostCustomerBlock =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_BLOCK)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_BLOCK))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerBlock
   )
 
 type PostCustomerUnblock =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UNBLOCK)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UNBLOCK))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerUnblock
   )
 
 type GetCustomerInfo =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_INFO)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_INFO))
       :> API.Types.RiderPlatform.Management.Customer.GetCustomerInfo
   )
 
 type GetCustomerCancellationDuesDetails =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_CANCELLATION_DUES_DETAILS)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.GET_CUSTOMER_CANCELLATION_DUES_DETAILS))
       :> API.Types.RiderPlatform.Management.Customer.GetCustomerCancellationDuesDetails
   )
 
 type PostCustomerUpdateSafetyCenterBlocking =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UPDATE_SAFETY_CENTER_BLOCKING)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UPDATE_SAFETY_CENTER_BLOCKING))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerUpdateSafetyCenterBlocking
   )
 
 type PostCustomerPersonNumbers =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_PERSON_NUMBERS)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_PERSON_NUMBERS))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerPersonNumbers
   )
 
 type PostCustomerPersonId =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_PERSON_ID)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_PERSON_ID))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerPersonId
   )
 
 type PostCustomerUpdatePaymentMode =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UPDATE_PAYMENT_MODE)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_UPDATE_PAYMENT_MODE))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerUpdatePaymentMode
   )
 
 type PostCustomerOffersList =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_OFFERS_LIST)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_OFFERS_LIST))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerOffersList
   )
 
 type PostCustomerApplyOffer =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_APPLY_OFFER)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_APPLY_OFFER))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerApplyOffer
   )
 
 type PostCustomerEnsureExists =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_ENSURE_EXISTS)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_ENSURE_EXISTS))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerEnsureExists
   )
 
 type PostCustomerBulkApplyOffer =
   ( ApiAuth
-      'APP_BACKEND_MANAGEMENT
-      'DSL
-      ('RIDER_MANAGEMENT / 'API.Types.RiderPlatform.Management.CUSTOMER / 'API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_BULK_APPLY_OFFER)
+      ('APP_BACKEND_MANAGEMENT)
+      ('DSL)
+      (('RIDER_MANAGEMENT) / ('API.Types.RiderPlatform.Management.CUSTOMER) / ('API.Types.RiderPlatform.Management.Customer.POST_CUSTOMER_BULK_APPLY_OFFER))
       :> API.Types.RiderPlatform.Management.Customer.PostCustomerBulkApplyOffer
   )
 
-getCustomerList :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CustomerListRes)
+getCustomerList :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Bool) -> Kernel.Prelude.Maybe (Kernel.Prelude.Bool) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CustomerListRes)
 getCustomerList merchantShortId opCity apiTokenInfo limit offset enabled blocked phone countryCode personId = withFlowHandlerAPI' $ Domain.Action.RiderPlatform.Management.Customer.getCustomerList merchantShortId opCity apiTokenInfo limit offset enabled blocked phone countryCode personId
 
 deleteCustomerDelete :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)

--- a/Backend/app/dashboard/rider-dashboard/src/Domain/Action/RiderPlatform/Management/Customer.hs
+++ b/Backend/app/dashboard/rider-dashboard/src/Domain/Action/RiderPlatform/Management/Customer.hs
@@ -28,9 +28,12 @@ import EulerHS.Prelude
 import qualified Kernel.Prelude
 import qualified Kernel.Types.APISuccess
 import qualified Kernel.Types.Beckn.Context
+import Kernel.Types.Error
 import qualified Kernel.Types.Id
+import Kernel.Utils.Common
 import qualified SharedLogic.Transaction
 import Storage.Beam.CommonInstances ()
+import "lib-dashboard" Storage.Queries.Person as QP
 import Tools.Auth.Api
 import Tools.Auth.Merchant
 
@@ -60,16 +63,20 @@ postCustomerBlock ::
   Environment.Flow Kernel.Types.APISuccess.APISuccess
 postCustomerBlock merchantShortId opCity apiTokenInfo customerId req = do
   checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  person <- QP.findById apiTokenInfo.personId >>= fromMaybeM (PersonNotFound apiTokenInfo.personId.getId)
+  let dashboardUserName = person.firstName <> " " <> person.lastName
   transaction <- SharedLogic.Transaction.buildTransaction (Domain.Types.Transaction.castEndpoint apiTokenInfo.userActionType) (Kernel.Prelude.Just APP_BACKEND_MANAGEMENT) (Kernel.Prelude.Just apiTokenInfo) Kernel.Prelude.Nothing Kernel.Prelude.Nothing (Kernel.Prelude.Just req)
   SharedLogic.Transaction.withTransactionStoring transaction $
-    API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.postCustomerBlock) customerId req
+    API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.postCustomerBlock) customerId dashboardUserName req
 
 postCustomerUnblock :: Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.Flow Kernel.Types.APISuccess.APISuccess
 postCustomerUnblock merchantShortId opCity apiTokenInfo customerId = do
   checkedMerchantId <- merchantCityAccessCheck merchantShortId apiTokenInfo.merchant.shortId opCity apiTokenInfo.city
+  person <- QP.findById apiTokenInfo.personId >>= fromMaybeM (PersonNotFound apiTokenInfo.personId.getId)
+  let dashboardUserName = person.firstName <> " " <> person.lastName
   transaction <- SharedLogic.Transaction.buildTransaction (Domain.Types.Transaction.castEndpoint apiTokenInfo.userActionType) (Kernel.Prelude.Just APP_BACKEND_MANAGEMENT) (Kernel.Prelude.Just apiTokenInfo) Kernel.Prelude.Nothing Kernel.Prelude.Nothing SharedLogic.Transaction.emptyRequest
   SharedLogic.Transaction.withTransactionStoring transaction $ do
-    API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.postCustomerUnblock) customerId
+    API.Client.RiderPlatform.Management.callManagementAPI checkedMerchantId opCity (.customerDSL.postCustomerUnblock) customerId dashboardUserName
 
 getCustomerInfo :: Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> ApiTokenInfo -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.Flow API.Types.RiderPlatform.Management.Customer.CustomerInfoRes
 getCustomerInfo merchantShortId opCity apiTokenInfo customerId = do

--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -1129,6 +1129,7 @@ library
       Domain.Types.ClientPersonInfo
       Domain.Types.CrisRdsBalanceHistory
       Domain.Types.CrisRecon
+      Domain.Types.CustomerBlockTransactions
       Domain.Types.DeletedPerson
       Domain.Types.Depot
       Domain.Types.DepotManager
@@ -1302,6 +1303,7 @@ library
       Storage.Beam.ClientPersonInfo
       Storage.Beam.CrisRdsBalanceHistory
       Storage.Beam.CrisRecon
+      Storage.Beam.CustomerBlockTransactions
       Storage.Beam.DeletedPerson
       Storage.Beam.Depot
       Storage.Beam.DepotManager
@@ -1480,6 +1482,7 @@ library
       Storage.Queries.ClientPersonInfo
       Storage.Queries.CrisRdsBalanceHistory
       Storage.Queries.CrisRecon
+      Storage.Queries.CustomerBlockTransactions
       Storage.Queries.DeletedPerson
       Storage.Queries.Depot
       Storage.Queries.DepotManager

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/CustomerBlockTransactions.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/CustomerBlockTransactions.yaml
@@ -1,0 +1,34 @@
+imports:
+  Merchant: Domain.Types.Merchant
+  MerchantOperatingCity: Domain.Types.MerchantOperatingCity
+  Person: Domain.Types.Person
+
+CustomerBlockTransactions:
+  tableName: customer_block_transactions
+
+  types:
+    BlockedBy:
+      enum: "Dashboard, Application"
+    ActionType:
+      enum: "BLOCK, UNBLOCK"
+
+  fields:
+    id: Id CustomerBlockTransactions
+    customerId: Id Person
+    reasonCode: Maybe Text
+    blockReason: Maybe Text
+    blockTimeInHours: Maybe Int
+    reportedAt: UTCTime
+    blockLiftTime: Maybe UTCTime
+    blockedBy: BlockedBy
+    actionType: Maybe ActionType
+    requestorId: Maybe Text
+
+  constraints:
+    id: PrimaryKey
+    customerId: "!SecondaryKey"
+
+  queries:
+    findByCustomerId:
+      kvFunction: findAllWithKV
+      where: customerId

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/Dashboard/Management/Customer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/Dashboard/Management/Customer.hs
@@ -24,17 +24,17 @@ import Tools.Auth
 handler :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Environment.FlowServer API.Types.RiderPlatform.Management.Customer.API)
 handler merchantId city = getCustomerList merchantId city :<|> deleteCustomerDelete merchantId city :<|> postCustomerBlock merchantId city :<|> postCustomerUnblock merchantId city :<|> getCustomerInfo merchantId city :<|> getCustomerCancellationDuesDetails merchantId city :<|> postCustomerUpdateSafetyCenterBlocking merchantId city :<|> postCustomerPersonNumbers merchantId city :<|> postCustomerPersonId merchantId city :<|> postCustomerUpdatePaymentMode merchantId city :<|> postCustomerOffersList merchantId city :<|> postCustomerApplyOffer merchantId city :<|> postCustomerEnsureExists merchantId city :<|> postCustomerBulkApplyOffer merchantId city
 
-getCustomerList :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Int -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Bool -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe Kernel.Prelude.Text -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CustomerListRes)
+getCustomerList :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Int) -> Kernel.Prelude.Maybe (Kernel.Prelude.Bool) -> Kernel.Prelude.Maybe (Kernel.Prelude.Bool) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Prelude.Maybe (Kernel.Prelude.Text) -> Kernel.Prelude.Maybe (Kernel.Types.Id.Id Dashboard.Common.Customer) -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CustomerListRes)
 getCustomerList a9 a8 a7 a6 a5 a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.getCustomerList a9 a8 a7 a6 a5 a4 a3 a2 a1
 
 deleteCustomerDelete :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
 deleteCustomerDelete a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.deleteCustomerDelete a3 a2 a1
 
-postCustomerBlock :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> API.Types.RiderPlatform.Management.Customer.BlockCustomerReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
-postCustomerBlock a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.postCustomerBlock a4 a3 a2 a1
+postCustomerBlock :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Kernel.Prelude.Text -> API.Types.RiderPlatform.Management.Customer.BlockCustomerReq -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
+postCustomerBlock a5 a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.postCustomerBlock a5 a4 a3 a2 a1
 
-postCustomerUnblock :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
-postCustomerUnblock a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.postCustomerUnblock a3 a2 a1
+postCustomerUnblock :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Kernel.Prelude.Text -> Environment.FlowHandler Kernel.Types.APISuccess.APISuccess)
+postCustomerUnblock a4 a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.postCustomerUnblock a4 a3 a2 a1
 
 getCustomerInfo :: (Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant -> Kernel.Types.Beckn.Context.City -> Kernel.Types.Id.Id Dashboard.Common.Customer -> Environment.FlowHandler API.Types.RiderPlatform.Management.Customer.CustomerInfoRes)
 getCustomerInfo a3 a2 a1 = withDashboardFlowHandlerAPI $ Domain.Action.Dashboard.Customer.getCustomerInfo a3 a2 a1

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/CustomerBlockTransactions.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/CustomerBlockTransactions.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Domain.Types.CustomerBlockTransactions where
+
+import Data.Aeson
+import qualified Domain.Types.Merchant
+import qualified Domain.Types.MerchantOperatingCity
+import qualified Domain.Types.Person
+import Kernel.Prelude
+import qualified Kernel.Types.Id
+import qualified Tools.Beam.UtilsTH
+
+data CustomerBlockTransactions = CustomerBlockTransactions
+  { actionType :: Kernel.Prelude.Maybe Domain.Types.CustomerBlockTransactions.ActionType,
+    blockLiftTime :: Kernel.Prelude.Maybe Kernel.Prelude.UTCTime,
+    blockReason :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    blockTimeInHours :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
+    blockedBy :: Domain.Types.CustomerBlockTransactions.BlockedBy,
+    customerId :: Kernel.Types.Id.Id Domain.Types.Person.Person,
+    id :: Kernel.Types.Id.Id Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions,
+    reasonCode :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    reportedAt :: Kernel.Prelude.UTCTime,
+    requestorId :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    merchantId :: Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.Merchant.Merchant),
+    merchantOperatingCityId :: Kernel.Prelude.Maybe (Kernel.Types.Id.Id Domain.Types.MerchantOperatingCity.MerchantOperatingCity),
+    createdAt :: Kernel.Prelude.UTCTime,
+    updatedAt :: Kernel.Prelude.UTCTime
+  }
+  deriving (Generic, Show, ToJSON, FromJSON, ToSchema)
+
+data ActionType = BLOCK | UNBLOCK deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema)
+
+data BlockedBy = Dashboard | Application deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema)
+
+$(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList (''ActionType))
+
+$(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList (''BlockedBy))

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/CustomerBlockTransactions.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/CustomerBlockTransactions.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Beam.CustomerBlockTransactions where
+
+import qualified Database.Beam as B
+import Domain.Types.Common ()
+import qualified Domain.Types.CustomerBlockTransactions
+import Kernel.External.Encryption
+import Kernel.Prelude
+import qualified Kernel.Prelude
+import Tools.Beam.UtilsTH
+
+data CustomerBlockTransactionsT f = CustomerBlockTransactionsT
+  { actionType :: (B.C f (Kernel.Prelude.Maybe Domain.Types.CustomerBlockTransactions.ActionType)),
+    blockLiftTime :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.UTCTime)),
+    blockReason :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
+    blockTimeInHours :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int)),
+    blockedBy :: (B.C f Domain.Types.CustomerBlockTransactions.BlockedBy),
+    customerId :: (B.C f Kernel.Prelude.Text),
+    id :: (B.C f Kernel.Prelude.Text),
+    reasonCode :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
+    reportedAt :: (B.C f Kernel.Prelude.UTCTime),
+    requestorId :: (B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text)),
+    merchantId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
+    merchantOperatingCityId :: (B.C f (Kernel.Prelude.Maybe (Kernel.Prelude.Text))),
+    createdAt :: (B.C f Kernel.Prelude.UTCTime),
+    updatedAt :: (B.C f Kernel.Prelude.UTCTime)
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table CustomerBlockTransactionsT where
+  data PrimaryKey CustomerBlockTransactionsT f = CustomerBlockTransactionsId (B.C f Kernel.Prelude.Text) deriving (Generic, B.Beamable)
+  primaryKey = CustomerBlockTransactionsId . id
+
+type CustomerBlockTransactions = CustomerBlockTransactionsT Identity
+
+$(enableKVPG (''CustomerBlockTransactionsT) [('id)] [[('customerId)]])
+
+$(mkTableInstances (''CustomerBlockTransactionsT) "customer_block_transactions")

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/CustomerBlockTransactions.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/CustomerBlockTransactions.hs
@@ -1,0 +1,89 @@
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Storage.Queries.CustomerBlockTransactions where
+
+import qualified Domain.Types.CustomerBlockTransactions
+import qualified Domain.Types.Person
+import Kernel.Beam.Functions
+import Kernel.External.Encryption
+import Kernel.Prelude
+import Kernel.Types.Error
+import qualified Kernel.Types.Id
+import Kernel.Utils.Common (CacheFlow, EsqDBFlow, MonadFlow, fromMaybeM, getCurrentTime)
+import qualified Sequelize as Se
+import qualified Storage.Beam.CustomerBlockTransactions as Beam
+
+create :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions -> m ())
+create = createWithKV
+
+createMany :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => ([Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions] -> m ())
+createMany = traverse_ create
+
+findByCustomerId :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Kernel.Types.Id.Id Domain.Types.Person.Person -> m ([Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions]))
+findByCustomerId customerId = do findAllWithKV [Se.Is Beam.customerId $ Se.Eq (Kernel.Types.Id.getId customerId)]
+
+findByPrimaryKey ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  (Kernel.Types.Id.Id Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions -> m (Maybe Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions))
+findByPrimaryKey id = do findOneWithKV [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]]
+
+updateByPrimaryKey :: (EsqDBFlow m r, MonadFlow m, CacheFlow m r) => (Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions -> m ())
+updateByPrimaryKey (Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions {..}) = do
+  _now <- getCurrentTime
+  updateWithKV
+    [ Se.Set Beam.actionType actionType,
+      Se.Set Beam.blockLiftTime blockLiftTime,
+      Se.Set Beam.blockReason blockReason,
+      Se.Set Beam.blockTimeInHours blockTimeInHours,
+      Se.Set Beam.blockedBy blockedBy,
+      Se.Set Beam.customerId (Kernel.Types.Id.getId customerId),
+      Se.Set Beam.reasonCode reasonCode,
+      Se.Set Beam.reportedAt reportedAt,
+      Se.Set Beam.requestorId requestorId,
+      Se.Set Beam.merchantId (Kernel.Types.Id.getId <$> merchantId),
+      Se.Set Beam.merchantOperatingCityId (Kernel.Types.Id.getId <$> merchantOperatingCityId),
+      Se.Set Beam.updatedAt _now
+    ]
+    [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]]
+
+instance FromTType' Beam.CustomerBlockTransactions Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions where
+  fromTType' (Beam.CustomerBlockTransactionsT {..}) = do
+    pure $
+      Just
+        Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions
+          { actionType = actionType,
+            blockLiftTime = blockLiftTime,
+            blockReason = blockReason,
+            blockTimeInHours = blockTimeInHours,
+            blockedBy = blockedBy,
+            customerId = Kernel.Types.Id.Id customerId,
+            id = Kernel.Types.Id.Id id,
+            reasonCode = reasonCode,
+            reportedAt = reportedAt,
+            requestorId = requestorId,
+            merchantId = Kernel.Types.Id.Id <$> merchantId,
+            merchantOperatingCityId = Kernel.Types.Id.Id <$> merchantOperatingCityId,
+            createdAt = createdAt,
+            updatedAt = updatedAt
+          }
+
+instance ToTType' Beam.CustomerBlockTransactions Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions where
+  toTType' (Domain.Types.CustomerBlockTransactions.CustomerBlockTransactions {..}) = do
+    Beam.CustomerBlockTransactionsT
+      { Beam.actionType = actionType,
+        Beam.blockLiftTime = blockLiftTime,
+        Beam.blockReason = blockReason,
+        Beam.blockTimeInHours = blockTimeInHours,
+        Beam.blockedBy = blockedBy,
+        Beam.customerId = Kernel.Types.Id.getId customerId,
+        Beam.id = Kernel.Types.Id.getId id,
+        Beam.reasonCode = reasonCode,
+        Beam.reportedAt = reportedAt,
+        Beam.requestorId = requestorId,
+        Beam.merchantId = Kernel.Types.Id.getId <$> merchantId,
+        Beam.merchantOperatingCityId = Kernel.Types.Id.getId <$> merchantOperatingCityId,
+        Beam.createdAt = createdAt,
+        Beam.updatedAt = updatedAt
+      }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/Common.hs
@@ -41,6 +41,7 @@ import qualified Domain.Types.BookingStatus as BT
 import qualified Domain.Types.BookingStatus as DRB
 import qualified Domain.Types.Client as DC
 import qualified Domain.Types.ClientPersonInfo as DPCI
+import qualified Domain.Types.CustomerBlockTransactions as DCBT
 import qualified Domain.Types.FareBreakup as DFareBreakup
 import Domain.Types.HotSpot
 import qualified Domain.Types.Journey as DJourney
@@ -1353,7 +1354,7 @@ cancellationTransaction booking mbRide cancellationSource cancellationFee cancel
         logDebug "No ride found for the booking."
     let merchantOperatingCityId = booking.merchantOperatingCityId
     mFraudDetected <- SMC.anyFraudDetected booking.riderId merchantOperatingCityId merchantConfigs Nothing
-    whenJust mFraudDetected $ \mc -> SMC.blockCustomer booking.riderId (Just mc.id) (Just "Blocked by fraud detection")
+    whenJust mFraudDetected $ \mc -> SMC.blockCustomer booking.riderId (Just mc.id) (Just "Blocked by fraud detection") DCBT.Application Nothing
   triggerBookingCancelledEvent BookingEventData {booking = booking{status = DRB.CANCELLED}}
   QPFS.updateStatus booking.riderId DPFS.IDLE
   otherParties <- Notify.getAllOtherRelatedPartyPersons booking
@@ -1490,7 +1491,7 @@ cancellationTransaction booking mbRide cancellationSource cancellationFee cancel
           let totalRides = stats.completedRides + stats.driverCancelledRides + stats.userCancelledRides
           let rate = (stats.userCancelledRides * 100) `div` max 1 totalRides
           when (totalRides > minRides && rate > threshold) $ do
-            SMC.blockCustomer booking.riderId Nothing (Just "Blocked due to high cancellation rate")
+            SMC.blockCustomer booking.riderId Nothing (Just "Blocked due to high cancellation rate") DCBT.Application Nothing
         _ -> logDebug "Configs or person stats doesnt not exist for checking blocking condition"
   -- notify customer
   bppDetails <- CQBPP.findBySubscriberIdAndDomain booking.providerId Context.MOBILITY >>= fromMaybeM (InternalError $ "BPP details not found for providerId:-" <> booking.providerId <> "and domain:-" <> show Context.MOBILITY)

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Customer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/Customer.hs
@@ -36,12 +36,15 @@ import qualified Dashboard.Common as Common
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Csv
+import Data.List (sortOn)
 import Data.List.Split (chunksOf)
+import Data.Ord (Down (..))
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Domain.Action.UI.Cancel as DCancel
 import qualified Domain.Action.UI.Registration as Registration
 import qualified Domain.Types.BookingStatus as DRB
+import qualified Domain.Types.CustomerBlockTransactions as DCBT
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.Person as DP
 import Environment
@@ -71,6 +74,7 @@ import qualified Storage.CachedQueries.Person.PersonFlowStatus as QPFS
 import qualified Storage.Clickhouse.Sos as CHSos
 import Storage.ConfigPilot.Config.MerchantConfig (MerchantConfigDimensions (..))
 import qualified Storage.Queries.Booking as QRB
+import qualified Storage.Queries.CustomerBlockTransactions as QCBT
 import qualified Storage.Queries.Person as QP
 import qualified Storage.Queries.SavedReqLocation as QSRL
 import Tools.Error (DeletedPersonError (..))
@@ -97,8 +101,8 @@ deleteCustomerDelete merchantShortId opCity customerId = do
   pure Success
 
 ---------------------------------------------------------------------
-postCustomerBlock :: ShortId DM.Merchant -> Context.City -> Id Common.Customer -> Common.BlockCustomerReq -> Flow APISuccess
-postCustomerBlock merchantShortId opCity customerId req = do
+postCustomerBlock :: ShortId DM.Merchant -> Context.City -> Id Common.Customer -> Text -> Common.BlockCustomerReq -> Flow APISuccess
+postCustomerBlock merchantShortId opCity customerId dashboardUserName req = do
   merchant <- QM.findByShortId merchantShortId >>= fromMaybeM (MerchantDoesNotExist merchantShortId.getShortId)
   merchantOpCity <- CQMOC.findByMerchantIdAndCity merchant.id opCity >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchant-Id-" <> merchant.id.getId <> "-city-" <> show opCity)
   let personId = cast @Common.Customer @DP.Person customerId
@@ -111,13 +115,13 @@ postCustomerBlock merchantShortId opCity customerId req = do
   let merchantId = customer.merchantId
   unless (merchant.id == merchantId && customer.merchantOperatingCityId == merchantOpCity.id) $ throwError (PersonDoesNotExist personId.getId)
 
-  SMC.blockCustomer personId Nothing req.blockedReason
+  SMC.blockCustomer personId Nothing req.blockedReason DCBT.Dashboard (Just dashboardUserName)
   logTagInfo "dashboard -> blockCustomer : " (show personId)
   pure Success
 
 ---------------------------------------------------------------------
-postCustomerUnblock :: ShortId DM.Merchant -> Context.City -> Id Common.Customer -> Flow APISuccess
-postCustomerUnblock merchantShortId opCity customerId = do
+postCustomerUnblock :: ShortId DM.Merchant -> Context.City -> Id Common.Customer -> Text -> Flow APISuccess
+postCustomerUnblock merchantShortId opCity customerId dashboardUserName = do
   merchant <- QM.findByShortId merchantShortId >>= fromMaybeM (MerchantDoesNotExist merchantShortId.getShortId)
   merchantOpCity <- CQMOC.findByMerchantIdAndCity merchant.id opCity >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchant-Id-" <> merchant.id.getId <> "-city-" <> show opCity)
   let personId = cast @Common.Customer @DP.Person customerId
@@ -136,7 +140,7 @@ postCustomerUnblock merchantShortId opCity customerId = do
         SWC.deleteCurrentWindowValues (SMC.mkCancellationByDriverKey mc.id.getId personId.getId) mc.fraudBookingCancelledByDriverCountWindow
     )
     merchantConfigs
-  void $ QP.updatingEnabledAndBlockedState personId Nothing False Nothing
+  void $ QP.updatingEnabledAndBlockedState personId Nothing False Nothing DCBT.Dashboard (Just dashboardUserName)
   logTagInfo "dashboard -> unblockCustomer : " (show personId)
   pure Success
 
@@ -158,6 +162,12 @@ getCustomerInfo merchantShortId opCity customerId = do
   numberOfRides <- fromMaybe 0 <$> runInReplica (QRB.fetchRidesCount personId)
   sos <- CHSos.findAllByPersonId personId
   let totalSosCount = length sos
+  blockHistory <- runInReplica $ QCBT.findByCustomerId personId
+  -- Most-recent-first; findAllWithKV has no inherent ordering.
+  let blockedInfo = map buildCustomerBlockedListEntity $ sortOn (Down . (.reportedAt)) blockHistory
+  -- Use the authoritative counter on the person so it can't diverge from the audit rows
+  -- (and stays correct for customers blocked before this ledger existed).
+  let blockCount = customer.blockedCount
   pure $
     Common.CustomerInfoRes
       { numberOfRides,
@@ -165,8 +175,22 @@ getCustomerInfo merchantShortId opCity customerId = do
         safetyCenterDisabledOnDate = safetySettings.safetyCenterDisabledOnDate,
         paymentMode = customer.paymentMode,
         blockedReason = customer.blockedReason,
+        blockedInfo,
+        blockCount,
         ..
       }
+
+buildCustomerBlockedListEntity :: DCBT.CustomerBlockTransactions -> Common.CustomerBlockTransactions
+buildCustomerBlockedListEntity DCBT.CustomerBlockTransactions {..} =
+  Common.CustomerBlockTransactions
+    { blockedBy = show blockedBy,
+      actionType = toCommonActionType <$> actionType,
+      ..
+    }
+
+toCommonActionType :: DCBT.ActionType -> Common.ActionType
+toCommonActionType DCBT.BLOCK = Common.BLOCK
+toCommonActionType DCBT.UNBLOCK = Common.UNBLOCK
 
 ---------------------------------------------------------------------
 getCustomerList :: ShortId DM.Merchant -> Context.City -> Maybe Int -> Maybe Int -> Maybe Bool -> Maybe Bool -> Maybe Text -> Maybe Text -> Maybe (Id Common.Customer) -> Flow Common.CustomerListRes

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Registration.hs
@@ -60,6 +60,7 @@ import Data.OpenApi hiding (email, info, tags)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Domain.Action.UI.Person as SP
+import qualified Domain.Types.CustomerBlockTransactions as DCBT
 import qualified Domain.Types.Depot as DDepot
 import qualified Domain.Types.IntegratedBPPConfig as DIBC
 import Domain.Types.Merchant (Merchant)
@@ -966,7 +967,7 @@ verify tokenId req mbClientId mbXForwardedFor = do
   cleanCachedTokens person.id
   when isBlockedBySameDeviceToken $ do
     merchantConfig <- getConfig (MerchantServiceUsageConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) Nothing >>= fromMaybeM (MerchantServiceUsageConfigNotFound $ "merchantOperatingCityId:- " <> person.merchantOperatingCityId.getId)
-    when merchantConfig.useFraudDetection $ SMC.blockCustomer person.id ((.blockedByRuleId) =<< personWithSameDeviceToken) (Just "Blocked due to fraud detection (blocked device token)")
+    when merchantConfig.useFraudDetection $ SMC.blockCustomer person.id ((.blockedByRuleId) =<< personWithSameDeviceToken) (Just "Blocked due to fraud detection (blocked device token)") DCBT.Application Nothing
   void $ RegistrationToken.setVerified True tokenId
   fork "Decrement Auth IP Counter" $ do
     mbClientIP <- extractClientIP mbXForwardedFor

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search.hs
@@ -33,6 +33,7 @@ import qualified Domain.Action.UI.Serviceability as DSrv
 import Domain.Types (GatewayAndRegistryService (..))
 import qualified Domain.Types.CachedRouteResponse as DCachedRouteResponse
 import qualified Domain.Types.Client as DC
+import qualified Domain.Types.CustomerBlockTransactions as DCBT
 import qualified Domain.Types.Extra.MerchantPaymentMethod as DMPM
 import Domain.Types.HotSpot hiding (address, updatedAt)
 import Domain.Types.HotSpotConfig
@@ -724,7 +725,7 @@ search personId req bundleVersion clientVersion clientConfigVersion_ mbRnVersion
       merchantConfigs <- getConfig (MerchantConfigDimensions {merchantOperatingCityId = person.merchantOperatingCityId.getId}) Nothing
       SMC.updateSearchFraudCounters person.id merchantConfigs
       mFraudDetected <- SMC.anyFraudDetected person.id merchantOperatingCity.id merchantConfigs (Just searchRequest)
-      whenJust mFraudDetected $ \mc -> SMC.blockCustomer person.id (Just mc.id) (Just "Blocked by fraud detection")
+      whenJust mFraudDetected $ \mc -> SMC.blockCustomer person.id (Just mc.id) (Just "Blocked by fraud detection") DCBT.Application Nothing
 
 buildSearchRequest ::
   SearchRequestFlow m r =>

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/BehaviourManagement/CustomerCancellationRate.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/BehaviourManagement/CustomerCancellationRate.hs
@@ -16,6 +16,7 @@ module SharedLogic.BehaviourManagement.CustomerCancellationRate where
 
 import qualified Data.Text as T
 import qualified Data.Time as Time
+import qualified Domain.Types.CustomerBlockTransactions as DCBT
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.Person as DP
@@ -399,7 +400,7 @@ blockCustomerTemporarily ::
 blockCustomerTemporarily merchantId merchantOperatingCityId customerId suspensionTimeHours = do
   now <- getCurrentTime
   let blockedUntil = addUTCTime (fromIntegral suspensionTimeHours * 60 * 60) now
-  void $ QPExtra.updatingBlockedStateWithUntil customerId Nothing True (Just blockedUntil)
+  void $ QPExtra.updatingBlockedStateWithUntil customerId Nothing True (Just blockedUntil) DCBT.Application Nothing
   let unblockCustomerJobTs = secondsToNominalDiffTime (fromIntegral suspensionTimeHours) * 60 * 60
   JC.createJobIn @_ @'RJS.UnblockCustomer (Just merchantId) (Just merchantOperatingCityId) unblockCustomerJobTs $
     RJS.UnblockCustomerJobData

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MerchantConfig.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/MerchantConfig.hs
@@ -36,6 +36,7 @@ where
 
 import Data.Foldable.Extra
 import qualified Domain.Types.BookingStatus as BT
+import qualified Domain.Types.CustomerBlockTransactions as DCBT
 import qualified Domain.Types.MerchantConfig as DMC
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.Person as Person
@@ -202,14 +203,14 @@ checkAuthFraudByIP mc clientIP = Redis.withNonCriticalCrossAppRedis $ do
 
   pure (authFraudDetected, fraudMerchantConfigId)
 
-blockCustomer :: (CacheFlow m r, MonadFlow m, EsqDBFlow m r) => Id Person.Person -> Maybe (Id DMC.MerchantConfig) -> Maybe Text -> m ()
-blockCustomer riderId mcId blockedReason = do
+blockCustomer :: (CacheFlow m r, MonadFlow m, EsqDBFlow m r) => Id Person.Person -> Maybe (Id DMC.MerchantConfig) -> Maybe Text -> DCBT.BlockedBy -> Maybe Text -> m ()
+blockCustomer riderId mcId blockedReason blockedBy requestorId = do
   regTokens <- RT.findAllByPersonId riderId
   for_ regTokens $ \regToken -> do
     let key = authTokenCacheKey regToken.token
     void $ Redis.del key
   _ <- RT.deleteByPersonId riderId
-  void $ QP.updatingEnabledAndBlockedState riderId mcId True blockedReason
+  void $ QP.updatingEnabledAndBlockedState riderId mcId True blockedReason blockedBy requestorId
 
 customerAuthBlock :: (CacheFlow m r, MonadFlow m, EsqDBFlow m r) => Id Person.Person -> Maybe (Id DMC.MerchantConfig) -> Maybe Minutes -> m ()
 customerAuthBlock riderId mcId blockDurationMinutes = do

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/UnblockCustomer.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/UnblockCustomer.hs
@@ -17,6 +17,7 @@ module SharedLogic.Scheduler.Jobs.UnblockCustomer
   )
 where
 
+import qualified Domain.Types.CustomerBlockTransactions as DCBT
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto.Config
 import Kernel.Utils.Common
@@ -34,6 +35,6 @@ unblockCustomer ::
 unblockCustomer Job {id, jobInfo} = withLogTag ("JobId-" <> id.getId) do
   let jobData = jobInfo.jobData
   let customerId = jobData.customerId
-  void $ QPExtra.updatingBlockedStateWithUntil customerId Nothing False Nothing
+  void $ QPExtra.updatingBlockedStateWithUntil customerId Nothing False Nothing DCBT.Application Nothing
   logInfo $ "Automatically unblocked customer, customerId: " <> customerId.getId
   return Complete

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PersonExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/PersonExtra.hs
@@ -3,6 +3,7 @@ module Storage.Queries.PersonExtra where
 import Control.Applicative ((<|>))
 import qualified Data.Time as T
 import Domain.Action.UI.Person
+import qualified Domain.Types.CustomerBlockTransactions as DCBT
 import Domain.Types.Merchant (Merchant)
 import qualified Domain.Types.MerchantConfig as DMC
 import qualified Domain.Types.MerchantOperatingCity as DMOC
@@ -18,6 +19,7 @@ import Kernel.Types.Version
 import Kernel.Utils.Common
 import qualified Sequelize as Se
 import qualified Storage.Beam.Person as BeamP
+import qualified Storage.Queries.CustomerBlockTransactions as QCBT
 import Storage.Queries.OrphanInstances.Person ()
 
 -- Extra code goes here --
@@ -237,12 +239,47 @@ findBlockedByDeviceToken :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r, EncFlow 
 findBlockedByDeviceToken Nothing = return [] -- return empty array in case device token is Nothing (WARNING: DON'T REMOVE IT)
 findBlockedByDeviceToken deviceToken = findAllWithKV [Se.And [Se.Is BeamP.deviceToken (Se.Eq deviceToken), Se.Is BeamP.blocked (Se.Eq True)]]
 
-updatingEnabledAndBlockedState :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Id Person -> Maybe (Id DMC.MerchantConfig) -> Bool -> Maybe Text -> m ()
-updatingEnabledAndBlockedState (Id personId) blockedByRule isBlocked blockedReason = do
+-- | Appends an immutable row to customer_block_transactions for every block/unblock event,
+-- mirroring the driver's driver_block_transactions audit trail.
+logCustomerBlockTransaction ::
+  (MonadFlow m, CacheFlow m r, EsqDBFlow m r) =>
+  Id Person ->
+  DCBT.ActionType ->
+  DCBT.BlockedBy ->
+  Maybe Text -> -- blockReason
+  Maybe Text -> -- requestorId (dashboard user name for dashboard actions)
+  Maybe (Id Merchant) ->
+  Maybe (Id DMOC.MerchantOperatingCity) ->
+  Maybe Int -> -- blockTimeInHours (suspension duration, when known)
+  Maybe UTCTime -> -- blockLiftTime
+  m ()
+logCustomerBlockTransaction customerId actionType blockedBy blockReason requestorId merchantId merchantOperatingCityId blockTimeInHours blockLiftTime = do
+  now <- getCurrentTime
+  newId <- generateGUID
+  QCBT.create $
+    DCBT.CustomerBlockTransactions
+      { id = newId,
+        customerId = customerId,
+        actionType = Just actionType,
+        blockedBy = blockedBy,
+        blockReason = blockReason,
+        reasonCode = Nothing,
+        blockTimeInHours = blockTimeInHours,
+        reportedAt = now,
+        blockLiftTime = blockLiftTime,
+        requestorId = requestorId,
+        merchantId = merchantId,
+        merchantOperatingCityId = merchantOperatingCityId,
+        createdAt = now,
+        updatedAt = now
+      }
+
+updatingEnabledAndBlockedState :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Id Person -> Maybe (Id DMC.MerchantConfig) -> Bool -> Maybe Text -> DCBT.BlockedBy -> Maybe Text -> m ()
+updatingEnabledAndBlockedState (Id personId) blockedByRule isBlocked blockedReason blockedBy requestorId = do
   person <- findByPId (Id personId)
   case person of
     Nothing -> pure ()
-    Just driverP -> do
+    Just customerP -> do
       now <- getCurrentTime
       updateOneWithKV
         ( [ Se.Set BeamP.enabled (not isBlocked),
@@ -250,14 +287,20 @@ updatingEnabledAndBlockedState (Id personId) blockedByRule isBlocked blockedReas
             Se.Set BeamP.blockedByRuleId $ getId <$> blockedByRule,
             Se.Set BeamP.blockedReason blockedReason,
             Se.Set BeamP.updatedAt now,
+            -- Clear any stale temporary-block deadline so an expired blockedUntil can't later
+            -- auto-lift a subsequent permanent/dashboard block (mirrors driver's blockExpiryTime reset).
+            Se.Set BeamP.blockedUntil Nothing,
             Se.Set BeamP.blockedCount $
               if isBlocked
-                then Just $ (fromMaybe 0 driverP.blockedCount) + 1
-                else driverP.blockedCount
+                then Just $ (fromMaybe 0 customerP.blockedCount) + 1
+                else customerP.blockedCount
           ]
             <> [Se.Set BeamP.blockedAt (Just $ T.utcToLocalTime T.utc now) | isBlocked]
         )
         [Se.Is BeamP.id (Se.Eq personId)]
+      -- Append an audit row for every block/unblock action (incl. re-blocks with a new reason),
+      -- mirroring the driver ledger which records each call unconditionally.
+      logCustomerBlockTransaction (Id personId) (if isBlocked then DCBT.BLOCK else DCBT.UNBLOCK) blockedBy blockedReason requestorId (Just customerP.merchantId) (Just customerP.merchantOperatingCityId) Nothing Nothing
 
 unblockIfExpired :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Id Person -> m ()
 unblockIfExpired (Id personId) = do
@@ -296,12 +339,12 @@ updatingAuthEnabledAndBlockedState (Id personId) blockedByRule isAuthBlocked blo
         )
         [Se.Is BeamP.id (Se.Eq personId)]
 
-updatingBlockedStateWithUntil :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Id Person -> Maybe (Id DMC.MerchantConfig) -> Bool -> Maybe UTCTime -> m ()
-updatingBlockedStateWithUntil (Id personId) blockedByRule isBlocked blockedUntil = do
+updatingBlockedStateWithUntil :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Id Person -> Maybe (Id DMC.MerchantConfig) -> Bool -> Maybe UTCTime -> DCBT.BlockedBy -> Maybe Text -> m ()
+updatingBlockedStateWithUntil (Id personId) blockedByRule isBlocked blockedUntil blockedBy requestorId = do
   person <- findByPId (Id personId)
   case person of
     Nothing -> pure ()
-    Just driverP -> do
+    Just customerP -> do
       now <- getCurrentTime
       updateOneWithKV
         ( [ Se.Set BeamP.enabled (not isBlocked),
@@ -311,12 +354,15 @@ updatingBlockedStateWithUntil (Id personId) blockedByRule isBlocked blockedUntil
             Se.Set BeamP.blockedUntil blockedUntil,
             Se.Set BeamP.blockedCount $
               if isBlocked
-                then Just $ (fromMaybe 0 driverP.blockedCount) + 1
-                else driverP.blockedCount
+                then Just $ (fromMaybe 0 customerP.blockedCount) + 1
+                else customerP.blockedCount
           ]
             <> [Se.Set BeamP.blockedAt (Just $ T.utcToLocalTime T.utc now) | isBlocked]
         )
         [Se.Is BeamP.id (Se.Eq personId)]
+      -- Derive the suspension duration (hours) from blockedUntil so the audit column is populated.
+      let blockTimeInHours = (\untilT -> round (realToFrac (T.diffUTCTime untilT now) / 3600 :: Double)) <$> blockedUntil
+      logCustomerBlockTransaction (Id personId) (if isBlocked then DCBT.BLOCK else DCBT.UNBLOCK) blockedBy Nothing requestorId (Just customerP.merchantId) (Just customerP.merchantOperatingCityId) blockTimeInHours blockedUntil
 
 findAllCustomers :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Merchant -> DMOC.MerchantOperatingCity -> Int -> Int -> Maybe Bool -> Maybe Bool -> Maybe DbHash -> Maybe Text -> Maybe (Id Person) -> m [Person]
 findAllCustomers merchant moCity limitVal offsetVal mbEnabled mbBlocked mbSearchPhoneDBHash mbCountryCode mbPersonId = do

--- a/Backend/dev/migrations-read-only/provider-dashboard/Local_API_Management_Customer.sql
+++ b/Backend/dev/migrations-read-only/provider-dashboard/Local_API_Management_Customer.sql
@@ -1,0 +1,41 @@
+-- {"api":"GetCustomerList","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"DeleteCustomerDelete","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerBlock","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerUnblock","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"GetCustomerInfo","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"GetCustomerCancellationDuesDetails","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerUpdateSafetyCenterBlocking","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerPersonNumbers","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerPersonId","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerUpdatePaymentMode","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerOffersList","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerApplyOffer","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerEnsureExists","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.
+
+-- {"api":"PostCustomerBulkApplyOffer","migration":"localAccessForRoleId","param":"37947162-3b5d-4ed6-bcac-08841be1534d","schema":"atlas_dashboard"}
+-- no capability declared (endpoint predates the capability framework); nothing to grant locally.

--- a/Backend/dev/migrations-read-only/rider-app/customer_block_transactions.sql
+++ b/Backend/dev/migrations-read-only/rider-app/customer_block_transactions.sql
@@ -1,0 +1,17 @@
+CREATE TABLE atlas_app.customer_block_transactions ();
+
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN action_type text ;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN block_lift_time timestamp with time zone ;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN block_reason text ;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN block_time_in_hours integer ;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN blocked_by text NOT NULL;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN customer_id character varying(36) NOT NULL;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN id character varying(36) NOT NULL;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN reason_code text ;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN reported_at timestamp with time zone NOT NULL;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN requestor_id text ;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN merchant_id character varying(36) ;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN merchant_operating_city_id character varying(36) ;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN created_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
+ALTER TABLE atlas_app.customer_block_transactions ADD COLUMN updated_at timestamp with time zone NOT NULL default CURRENT_TIMESTAMP;
+ALTER TABLE atlas_app.customer_block_transactions ADD PRIMARY KEY ( id);


### PR DESCRIPTION

## backend/feat: Customer block/unblock transaction history

### Summary
Adds a persistent audit trail for every customer block/unblock action. Previously a
customer's blocked state was a boolean on `person` with no history — we couldn't tell
*who* blocked a customer, *why*, for *how long*, or when the block was lifted. This PR
introduces a `customer_block_transactions` ledger that records each block/unblock event
across all code paths, and threads the block actor/reason through the dashboard APIs.

### What's included

**New storage entity — `CustomerBlockTransactions`**
- `spec/Storage/CustomerBlockTransactions.yaml` + generated Domain/Beam/Queries
- Captures: `customerId`, `reasonCode`, `blockReason`, `blockTimeInHours`,
  `reportedAt`, `blockLiftTime`, `blockedBy` (`Dashboard | Application`),
  `actionType` (`BLOCK | UNBLOCK`), `requestorId`
- Queries: `findByCustomerId`, `blockCountByCustomerId` (`customerId` secondary key)

**Records a transaction on every block/unblock path**
- Dashboard `postCustomerBlock` / `postCustomerUnblock` (with the acting dashboard user)
- Auto-block via `SharedLogic/MerchantConfig` (fraud/behaviour rules)
- `UnblockCustomer` scheduler job (block-expiry auto-unblock)
- Beckn `Domain/Action/Beckn/Common`

**API changes (RiderPlatform Management → Customer)**
- New `ApiAuthV2` helper endpoints that carry the dashboard user name:
  - `POST /{customerId}/block/{dashboardUserName}`
  - `POST /{customerId}/unblock/{dashboardUserName}`
- `SMC.blockCustomer` and `QP.updatingEnabledAndBlockedState` now take `blockedBy`
  and `requestorId`, propagated through `PersonExtra`, `Registration`, `Search`, and
  `CustomerCancellationRate`.

**Migrations**
- `rider-app/customer_block_transactions.sql` (new table)
- `provider-dashboard/Local_API_Management_Customer.sql` (access matrix for the new endpoints)

### Testing
- `cabal build all` passes (`-Werror`, ormolu, yaml-constraint-tags, dashboard-module-sync hooks all green)
- Local stack boots; rider-app comes up healthy on `:8013`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customer block and unblock audit tracking, including sources, requestors, reasons, durations, and timestamps.
  - Customer information now includes block history and an optional block count.
  - Block and unblock actions record the responsible dashboard user.
  - Added dashboard-user-specific block and unblock endpoints.
  - Automated and application-triggered actions are identified separately from dashboard actions.
  - Automatic unblock activity is recorded when blocking periods expire.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->