### PR TITLE
driver-app/fix: send driver hometown in knowYourDriver so rider app c…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/KnowYourDriver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/KnowYourDriver.hs
@@ -133,7 +133,7 @@ getDriverProfile withImages person = do
   pure $
     DriverProfileRes
       { certificates = map show $ mapMaybe (fmap (.category)) modules,
-        homeTown = Nothing,
+        homeTown = (.hometown) =<< driverProfile,
         driverName = person.firstName,
         onboardedAt = person.createdAt,
         pledges = maybe [] (.pledges) driverProfile,


### PR DESCRIPTION
## What

Populate the driver's `homeTown` in the `knowYourDriver` internal profile response instead of hardcoding it to `Nothing`.

`Domain/Action/Internal/KnowYourDriver.hs`

```haskell
- homeTown = Nothing,
+ homeTown = (.hometown) =<< driverProfile,
```

## Why

The driver profile shown on the rider side ("About Me") renders a **frozen `about_me` string** that the driver-app generates once (LLM/fallback) and never refreshes. That string bakes in two things that later go wrong:

- **Brand** — uses `merchant.name` ("Namma Yatri"), but Odisha Yatri cities (Bhubaneshwar, Cuttack) sit under the merchant literally named *Namma Yatri*. "Odisha Yatri" only exists as a rider-app build brand, so the stored text says the wrong brand.
- **Tenure** — "for 0 months", frozen at generation time; never recomputed.

Result (single screen, contradicting itself):

- About Me paragraph: *"Hailing from jatni, I have been with **Nammayatri** for **0 months**…"* ❌ (frozen blob)
- 📅 info row: *"With **Odisha Yatri** for **1+ years**"* ✅ (already computed live from `appReadableName` + `onboardedAt`)

**Scale (prod, ClickHouse):** of 361,581 driver profiles, **125,678 (34.8%)** contain the wrong brand and **48,413 (13.4%)** contain a frozen tenure.

The fix is to render About Me dynamically on the rider side from **structured fields** + live brand + live tenure. For that, the backend must actually send the structured `hometown` — currently dropped. Brand and tenure need no backend change (brand is rider-app-only; `onboardedAt` is already sent).

## Change

- Send `homeTown` from `driverProfile.hometown` (already loaded via `DPQ.findByPersonId`), consistent with the sibling fields `aboutMe` / `drivingSince` / `aspirations` in the same record.
- Types match: `DriverProfileQuestions.hometown :: Maybe Text` → `DriverProfileRes.homeTown :: Maybe Text`.

## Scope / risk

- One line, one file. No new imports, no migration, no codegen, no YAML.
- Only turns a previously-null field into its real value; no caller behavior changes.
- No DB backfill: once the rider app composes About Me from structured fields, the stale `about_me` rows self-correct on next view.

## Paired change

Rider frontend (`ny-react-native`) PR: composes the About Me paragraph dynamically from `homeTown` + `appReadableName` (brand) + `calculateTimeWithNY(onboardedAt)` (tenure), replacing the frozen blob.

- Branch: `fix/driver-about-me-dynamic-render`

**Ship order:** backend first (starts sending `homeTown`), then frontend. If frontend ships first, it simply omits the "Hailing from …" line until this lands — no breakage.

## Testing

- `cabal build dynamic-offer-driver-app` (green, `-Werror`).
- Manual: hit `/internal/{rideId}/knowYourDriver` for a driver with a hometown set → response now contains `homeTown` populated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Driver profiles now display the driver’s hometown when that information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->