### PR TITLE
Backend/fix: rideTakenOn Date

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -3047,7 +3047,7 @@ mkManualPaymentEntity mapDriverFeeByDriverFeeId' manualInvoice = do
           ManualInvoiceHistory
             { invoiceId = manualInvoice.invoiceShortId,
               rideDays = length allDriverFeeForInvoice,
-              rideTakenOn = if length allDriverFeeForInvoice == 1 then (.createdAt) <$> listToMaybe allDriverFeeForInvoice else Nothing,
+              rideTakenOn = if length allDriverFeeForInvoice == 1 then (.startTime) <$> listToMaybe allDriverFeeForInvoice else Nothing,
               amount,
               amountWithCurrency = PriceAPIEntity amount dfee.currency,
               createdAt = manualInvoice.createdAt,
@@ -3078,7 +3078,7 @@ mkAutoPayPaymentEntity mapDriverFeeByDriverFeeId' transporterConfig autoInvoice 
                   amountWithCurrency = PriceAPIEntity (sum $ mapToAmount [dfee]) dfee.currency,
                   executionAt = executionTime,
                   autoPayStage = dfee.autopayPaymentStage,
-                  rideTakenOn = dfee.createdAt,
+                  rideTakenOn = dfee.startTime,
                   isCoinCleared = dfee.status == DDF.CLEARED_BY_YATRI_COINS,
                   coinDiscountAmount = dfee.amountPaidByCoin,
                   coinDiscountAmountWithCurrency = flip PriceAPIEntity dfee.currency <$> (dfee.amountPaidByCoin)
@@ -3202,7 +3202,7 @@ mkDriverFeeInfoEntity driverFees invoiceStatus transporterConfig serviceName = d
               planAmount = fromMaybe 0 driverFee.feeWithoutDiscount,
               planAmountWithCurrency = PriceAPIEntity (fromMaybe 0 driverFee.feeWithoutDiscount) driverFee.currency,
               isSplit = length driverFeesInWindow > 1,
-              rideTakenOn = driverFee.createdAt,
+              rideTakenOn = driverFee.startTime,
               offerAndPlanDetails = driverFee.planOfferTitle,
               isCoinCleared = driverFee.status == DDF.CLEARED_BY_YATRI_COINS,
               coinDiscountAmount = driverFee.amountPaidByCoin,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Plan.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Plan.hs
@@ -1602,7 +1602,7 @@ mkDueDriverFeeInfoEntity serviceName driverFees transporterConfig = do
               planAmountWithCurrency = PriceAPIEntity (fromMaybe 0.0 driverFee.feeWithoutDiscount) driverFee.currency,
               isSplit = length driverFeesInWindow > 1,
               offerAndPlanDetails = driverFee.planOfferTitle,
-              rideTakenOn = driverFee.createdAt,
+              rideTakenOn = driverFee.startTime,
               driverFeeAmount,
               driverFeeAmountWithCurrency = PriceAPIEntity driverFeeAmount driverFee.currency,
               createdAt,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
use fee start time for rideTakenOn instead of createdAt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Driver payment, fee, and dues history now displays the associated ride’s start time instead of the payment, fee, or invoice creation time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->