### PR TITLE
Backend:fix: EasyBooking send Just 0 for distance , so NOT nullable values do not break

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Search.hs
@@ -698,10 +698,10 @@ search personId req bundleVersion clientVersion clientConfigVersion_ mbRnVersion
     processEasyBookingSearch _person _easyBookingReq _originCity =
       return
         ( RouteDetails
-            { longestRouteDistance = Nothing,
-              shortestRouteDistance = Nothing,
-              shortestRouteDuration = Nothing,
-              shortestRouteStaticDuration = Nothing,
+            { longestRouteDistance = Just 0,
+              shortestRouteDistance = Just 0,
+              shortestRouteDuration = Just 0,
+              shortestRouteStaticDuration = Just 0,
               shortestRouteInfo = Nothing,
               multipleRoutes = Nothing,
               routeCacheUsed = False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * EasyBooking search results now report zero distance and duration when no route details are available, instead of showing those values as unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->