### PR TITLE
Backend:feat: tax Remittance Modes for Vat Deductions

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/dynamic-offer-driver-app.cabal
@@ -668,6 +668,7 @@ library
       SharedLogic.SpecialZoneDriverDemand
       SharedLogic.SurgeConfig
       SharedLogic.SyncRide
+      SharedLogic.TaxRemittance
       SharedLogic.TollDashboard
       SharedLogic.TollUpsert
       SharedLogic.Type

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/spec/Storage/Merchant.yaml
@@ -1049,6 +1049,8 @@ TransporterConfig:
       enum: "CONNECT_PLATFORM, CONNECT_DRIVER"
     ChargeFrequency:
       enum: "CHARGE_DAILY, CHARGE_WEEKLY, CHARGE_MONTHLY"
+    TaxRemittanceMode:
+      enum: "DRIVER_DIRECT, COMPANY_DIRECT, COMPANY_INDIRECT"
     PayoutFeeConfig:
       feeType: PayoutFeeType
       feeValue: HighPrecMoney
@@ -1109,6 +1111,10 @@ TransporterConfig:
       businessTds: Maybe TdsConfig
       serviceVatPercentage: Maybe Double
       commissionVatPercentage: Maybe Double
+      rideTaxRemittanceMode: Maybe TaxRemittanceMode
+      cancellationTaxRemittanceMode: Maybe TaxRemittanceMode
+      tollTaxRemittanceMode: Maybe TaxRemittanceMode
+      parkingTaxRemittanceMode: Maybe TaxRemittanceMode
       derive': Generic, Show, ToJSON, FromJSON, Read, Eq
     CommissionAggregationFrequency:
       enum: "DAILY, WEEKLY, MONTHLY"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src-read-only/Domain/Types/TransporterConfig.hs
@@ -596,18 +596,24 @@ data SubscriptionConfig = SubscriptionConfig
 data TaxConfig = TaxConfig
   { airportEntryFeeGst :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.GstBreakup,
     businessTds :: Kernel.Prelude.Maybe Domain.Types.Extra.TransporterConfig.TdsConfig,
+    cancellationTaxRemittanceMode :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.TaxRemittanceMode,
     commissionVatPercentage :: Kernel.Prelude.Maybe Kernel.Prelude.Double,
     defaultTdsRate :: Kernel.Prelude.Maybe Domain.Types.Extra.TransporterConfig.TdsConfig,
     individualLinked :: Kernel.Prelude.Maybe Domain.Types.Extra.TransporterConfig.TdsConfig,
     individualNotLinked :: Kernel.Prelude.Maybe Domain.Types.Extra.TransporterConfig.TdsConfig,
     invalidPanTdsRate :: Domain.Types.Extra.TransporterConfig.TdsConfig,
+    parkingTaxRemittanceMode :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.TaxRemittanceMode,
     rideGst :: Domain.Types.TransporterConfig.GstBreakup,
+    rideTaxRemittanceMode :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.TaxRemittanceMode,
     securityDepositGst :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.GstBreakup,
     serviceVatPercentage :: Kernel.Prelude.Maybe Kernel.Prelude.Double,
     subscriptionGst :: Domain.Types.TransporterConfig.GstBreakup,
-    subscriptionTdsRate :: Kernel.Prelude.Maybe Domain.Types.Extra.TransporterConfig.TdsConfig
+    subscriptionTdsRate :: Kernel.Prelude.Maybe Domain.Types.Extra.TransporterConfig.TdsConfig,
+    tollTaxRemittanceMode :: Kernel.Prelude.Maybe Domain.Types.TransporterConfig.TaxRemittanceMode
   }
   deriving (Generic, Show, ToJSON, FromJSON, Read, Eq)
+
+data TaxRemittanceMode = DRIVER_DIRECT | COMPANY_DIRECT | COMPANY_INDIRECT deriving (Eq, Ord, Show, Read, Generic, ToJSON, FromJSON, ToSchema)
 
 $(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''CallingOption)
 
@@ -622,3 +628,5 @@ $(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''PaymentChargeBearer)
 $(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''PayoutChargeBearer)
 
 $(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''PayoutFeeType)
+
+$(Tools.Beam.UtilsTH.mkBeamInstancesForEnumAndList ''TaxRemittanceMode)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/RefundLedger.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/RefundLedger.hs
@@ -37,6 +37,7 @@ import qualified Lib.Finance.Ledger.Service as LedgerSvc
 import qualified Lib.Finance.Storage.Queries.InvoiceExtra as QFinanceInvoiceExtra
 import SharedLogic.Finance.PostActions (runFinance)
 import qualified SharedLogic.Finance.Wallet as Wallet
+import qualified SharedLogic.TaxRemittance as SLT
 import qualified Storage.CachedQueries.Merchant as QM
 import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions (..))
 import qualified Storage.Queries.Booking as QBooking
@@ -96,8 +97,7 @@ refundLedger rideId req apiKey = do
     cancellationCommissionGross <- cancellationCommissionFromLedger ride
     overdueBenefit <- cancellationOverdueBenefitFromLedger ride
     let deductFromDriver = fromMaybe (fromMaybe False transporterConfig.defaultRefundDeductFromDriver) req.deductFromDriver
-        isVatMarket = fromMaybe False booking.fareParams.isVatTaxType
-        legs = refundLegs deductFromDriver transporterConfig.taxConfig.commissionVatPercentage cancellationCommissionGross overdueBenefit isVatMarket req ride
+        legs = refundLegs deductFromDriver cancellationCommissionGross overdueBenefit transporterConfig.taxConfig booking.fareParams.isVatTaxType req ride
     existing <- getRefundRequestLegs req.refundRequestId
     case req.refundRequestStatus of
       APPROVED ->
@@ -168,24 +168,26 @@ cancellationOverdueBenefitFromLedger ride = do
 --   from SellerExpense. Driver-deducted: each party gives back a prorated share of what it actually
 --   received — the driver his net share, the platform its commission slice and (if the fee went
 --   overdue) its kept benefit; toll/parking are fully driver-borne.
-refundLegs :: Bool -> Maybe Double -> HighPrecMoney -> (HighPrecMoney, HighPrecMoney) -> Bool -> RefundLedgerReq -> Ride -> [(AccountRole, AccountRole, HighPrecMoney, Text)]
-refundLegs deductFromDriver mbCommissionVatPct cancellationCommissionGross (overdueBenefit, overdueBenefitTax) isVatMarket req ride =
+refundLegs :: Bool -> HighPrecMoney -> (HighPrecMoney, HighPrecMoney) -> DTC.TaxConfig -> Maybe Bool -> RefundLedgerReq -> Ride -> [(AccountRole, AccountRole, HighPrecMoney, Text)]
+refundLegs deductFromDriver cancellationCommissionGross (overdueBenefit, overdueBenefitTax) taxConfig mbIsVat req ride =
   concatMap componentLegs (fromMaybe [] req.refundComponents)
   where
     commission = fromMaybe 0 ride.commission
     rideFareTotal = fromMaybe 0 req.rideFareComponentTotal
     cancellationTotal = fromMaybe 0 req.cancellationComponentTotal
-    -- Taxes return to where they sat forward: driver in VAT markets, government in GST.
-    cancelTaxDest = if isVatMarket then OwnerLiability else GovtIndirect
-    benefitTaxSource = if isVatMarket then SellerExpense else GovtIndirect
+    legacyRide = SLT.legacyRideMode mbIsVat
+    rideAccounts = SLT.taxAccountsFor (SLT.resolveMode taxConfig.rideTaxRemittanceMode Nothing legacyRide)
+    cancellationAccounts = SLT.taxAccountsFor (SLT.resolveMode taxConfig.cancellationTaxRemittanceMode taxConfig.rideTaxRemittanceMode legacyRide)
+    tollAccounts = SLT.taxAccountsFor (SLT.resolveMode taxConfig.tollTaxRemittanceMode taxConfig.rideTaxRemittanceMode DTC.DRIVER_DIRECT)
+    parkingAccounts = SLT.taxAccountsFor (SLT.resolveMode taxConfig.parkingTaxRemittanceMode taxConfig.rideTaxRemittanceMode DTC.DRIVER_DIRECT)
     -- Full precision, no rounding: legs must sum to the component exactly and a full refund must
     -- claw back exactly the charged commission (the commission aggregate nets to zero).
     rideFareLegs comp baseRef vatRef =
       -- ride-fare prorates by BASE (base/base); cancellation below prorates by GROSS (gross/gross)
       let slice = if rideFareTotal > 0 then commission * comp.fareAmount / rideFareTotal else 0
-          (sliceBase, sliceVat) = Wallet.splitGrossByVatPct mbCommissionVatPct slice
+          (sliceBase, sliceVat) = Wallet.splitGrossByVatPct taxConfig.commissionVatPercentage slice
        in [ (OwnerLiability, BuyerExternal, comp.fareAmount - slice, baseRef),
-            (OwnerLiability, BuyerExternal, comp.vatAmount, vatRef),
+            (rideAccounts.refundSource, BuyerExternal, comp.vatAmount, vatRef),
             (SellerExpense, BuyerExternal, sliceBase, Wallet.walletReferenceRideFareRefundCommission)
           ]
             <> [(SellerExpense, BuyerExternal, sliceVat, Wallet.walletReferenceRideFareRefundCommissionVAT) | sliceVat > 0]
@@ -196,17 +198,17 @@ refundLegs deductFromDriver mbCommissionVatPct cancellationCommissionGross (over
           commissionSlice = prorate cancellationCommissionGross
           benefitSlice = prorate overdueBenefit
           benefitTaxSlice = prorate overdueBenefitTax
-          (sliceBase, sliceVat) = Wallet.splitGrossByVatPct mbCommissionVatPct commissionSlice
+          (sliceBase, sliceVat) = Wallet.splitGrossByVatPct taxConfig.commissionVatPercentage commissionSlice
        in [ (OwnerLiability, BuyerExternal, comp.fareAmount - benefitSlice - commissionSlice, baseRef),
-            (cancelTaxDest, BuyerExternal, comp.vatAmount - benefitTaxSlice, vatRef)
+            (cancellationAccounts.refundSource, BuyerExternal, comp.vatAmount - benefitTaxSlice, vatRef)
           ]
             <> [(SellerExpense, BuyerExternal, sliceBase, Wallet.walletReferenceCancellationRefundCommission) | sliceBase > 0]
             <> [(SellerExpense, BuyerExternal, sliceVat, Wallet.walletReferenceCancellationRefundCommissionVAT) | sliceVat > 0]
             <> [(SellerExpense, BuyerExternal, benefitSlice, Wallet.walletReferenceCancellationOverdueBenefitRefund) | benefitSlice > 0]
-            <> [(benefitTaxSource, BuyerExternal, benefitTaxSlice, Wallet.walletReferenceCancellationOverdueBenefitRefundTax) | benefitTaxSlice > 0]
-    driverOnlyLegs comp baseRef vatRef =
+            <> [(cancellationAccounts.benefitRefundSource, BuyerExternal, benefitTaxSlice, Wallet.walletReferenceCancellationOverdueBenefitRefundTax) | benefitTaxSlice > 0]
+    driverOnlyLegs accts comp baseRef vatRef =
       [ (OwnerLiability, BuyerExternal, comp.fareAmount, baseRef),
-        (OwnerLiability, BuyerExternal, comp.vatAmount, vatRef)
+        (accts.refundSource, BuyerExternal, comp.vatAmount, vatRef)
       ]
     componentLegs comp =
       let (baseRef, vatRef) = refundRefTypesForComponent comp.component
@@ -219,8 +221,8 @@ refundLegs deductFromDriver mbCommissionVatPct cancellationCommissionGross (over
             else case comp.component of
               RIDE_FARE -> rideFareLegs comp baseRef vatRef
               CANCELLATION_FEE -> cancellationFeeLegs comp baseRef vatRef
-              TOLL -> driverOnlyLegs comp baseRef vatRef
-              PARKING -> driverOnlyLegs comp baseRef vatRef
+              TOLL -> driverOnlyLegs tollAccounts comp baseRef vatRef
+              PARKING -> driverOnlyLegs parkingAccounts comp baseRef vatRef
 
 -- | (base refType, VAT refType) for a refunded component — exhaustive over the enum.
 refundRefTypesForComponent :: RefundFareComponent -> (Text, Text)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
@@ -261,7 +261,7 @@ buildDriverRideResItem driverId driverInfo driverLanguage mbEarningsLabels trans
   isValueAddNP <- CQVAN.isValueAddNP booking.bapId
   stopsInfo <- if (fromMaybe False ride.hasStops) then QSI.findAllByRideId ride.id else return []
   let goHomeReqId = ride.driverGoHomeRequestId
-  RideCommon.mkDriverRideRes driverLanguage mbEarningsLabels rideDetail driverNumber rideRating mbExophone (ride, booking) bapMetadata goHomeReqId (Just driverInfo) isValueAddNP stopsInfo resolvedCalling
+  RideCommon.mkDriverRideRes driverLanguage mbEarningsLabels rideDetail driverNumber rideRating mbExophone (ride, booking) bapMetadata goHomeReqId (Just driverInfo) isValueAddNP stopsInfo resolvedCalling transporterConfig
 
 arrivedAtPickup :: (EncFlow m r, CacheFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r, HasShortDurationRetryCfg r c, HasFlowEnv m r '["nwAddress" ::: BaseUrl], HasHttpClientOptions r c, HasFlowEnv m r '["internalEndPointHashMap" ::: HM.HashMap BaseUrl BaseUrl], HasFlowEnv m r '["kafkaProducerTools" ::: KafkaProducerTools], HasFlowEnv m r '["ondcTokenHashMap" ::: HM.HashMap KeyConfig TokenConfig], HasFlowEnv m r '["fabricGatewayBaseUrl" ::: BaseUrl], Hedis.HedisLTSFlowEnv r) => Id DRide.Ride -> LatLong -> m APISuccess
 arrivedAtPickup rideId req = do
@@ -326,7 +326,7 @@ otpRideCreate driver otpCode booking clientId = do
   bapMetadata <- CQSM.findBySubscriberIdAndDomain (Id booking.bapId) Domain.MOBILITY
   resolvedCalling <- resolveCallingNumber booking ride (DTC.driverCallingOption transporterConfig) (fromMaybe False transporterConfig.forceDirectCalling) (RideCommon.mkExoPhone mbExophone booking)
   isValueAddNP <- CQVAN.isValueAddNP booking.bapId
-  RideCommon.mkDriverRideRes L.ENGLISH Nothing rideDetails driverNumber Nothing mbExophone (ride, booking) bapMetadata ride.driverGoHomeRequestId Nothing isValueAddNP stopsInfo resolvedCalling
+  RideCommon.mkDriverRideRes L.ENGLISH Nothing rideDetails driverNumber Nothing mbExophone (ride, booking) bapMetadata ride.driverGoHomeRequestId Nothing isValueAddNP stopsInfo resolvedCalling (Just transporterConfig)
   where
     errHandler uBooking transporter exc
       | Just BecknAPICallError {} <- fromException @BecknAPICallError exc = SBooking.cancelBooking uBooking (Just driver) transporter >> throwM exc

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -83,6 +83,7 @@ import SharedLogic.RuleBasedTierUpgrade
 import qualified SharedLogic.ScheduledBooking.OverlapCheck as SBOC
 import qualified SharedLogic.SearchTryLocker as CS
 import qualified SharedLogic.SpecialZoneDriverDemand as SpecialZoneDriverDemand
+import qualified SharedLogic.TaxRemittance as SLT
 import qualified Storage.CachedQueries.Driver.GoHomeRequest as CQDGR
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.CachedQueries.Merchant.MerchantPaymentMethod as CQMPM
@@ -319,8 +320,8 @@ createCancellationLedgerEntries booking ride baseCancellation gstOnCancellation 
           pure $ (.totalEarnings) <$> mbStats
       let rideGst = transporterConfig.taxConfig.rideGst
           cancelIsVat = fromMaybe False booking.fareParams.isVatTaxType
-          -- VAT stays with the driver (OwnerLiability), GST is remitted to govt (GovtIndirect) — mirrors createDriverWalletTransaction.
-          cancellationTaxDest = if cancelIsVat then OwnerLiability else GovtIndirect
+          cancellationAccounts = SLT.taxAccountsFor (SLT.resolveMode transporterConfig.taxConfig.cancellationTaxRemittanceMode transporterConfig.taxConfig.rideTaxRemittanceMode (SLT.legacyRideMode booking.fareParams.isVatTaxType))
+          cancellationTaxDest = cancellationAccounts.forwardDest
           cancellationComponents =
             [ (baseCancellation, walletReferenceCustomerCancellationCharges, OwnerLiability),
               (gstOnCancellation, walletReferenceCustomerCancellationGST, cancellationTaxDest)
@@ -463,14 +464,13 @@ applyCancellationLedgerAction booking ride action transporterConfig = do
       -- No overdue amounts configured => no reduction: the driver keeps the full fee.
       overdueCharge = fromMaybe cancellationFee (mbCancellationDuesDetails >>= (.overdueCancellationCharge))
       overdueTax = fromMaybe cancellationFeeTax (mbCancellationDuesDetails >>= (.overdueCancellationTax))
-      -- VAT stays with the driver (OwnerLiability), GST is remitted to govt (GovtIndirect) — mirrors createDriverWalletTransaction.
-      cancellationTaxDest = if fromMaybe False booking.fareParams.isVatTaxType then OwnerLiability else GovtIndirect
+      cancellationAccounts = SLT.taxAccountsFor (SLT.resolveMode transporterConfig.taxConfig.cancellationTaxRemittanceMode transporterConfig.taxConfig.rideTaxRemittanceMode (SLT.legacyRideMode booking.fareParams.isVatTaxType))
+      cancellationTaxDest = cancellationAccounts.forwardDest
       -- When a cancellation goes overdue the driver only gets the (lower) overdue charge; the
       -- platform keeps the (cancellation - overdue) difference as SellerRevenue.
       overdueBenefit = max 0 (cancellationFee - overdueCharge)
       overdueBenefitTax = max 0 (cancellationFeeTax - overdueTax)
-      -- Benefit tax: VAT portion is the platform's revenue, GST is remitted to govt.
-      overdueBenefitTaxDest = if fromMaybe False booking.fareParams.isVatTaxType then SellerRevenue else GovtIndirect
+      overdueBenefitTaxDest = cancellationAccounts.benefitForwardDest
       -- Only the driver's entries reach a payout, so only these ever carry a settlementStatus.
       overdueDriverRefs = [walletReferenceOverdueCancellationCharge, walletReferenceOverdueCancellationTax]
       overdueAllRefs = overdueDriverRefs <> [walletReferenceCancellationOverdueBenefit, walletReferenceCancellationOverdueBenefitTax]

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/Common.hs
@@ -300,15 +300,16 @@ buildRideEarnings ::
   HighPrecMoney ->
   Bool ->
   Bool ->
+  HighPrecMoney ->
   m RideEarnings
-buildRideEarnings lang labels booking ride estimatedFareParam finalFareParam ridePaymentChargeAmt customerBearsCharge driverBearsCharge = do
+buildRideEarnings lang labels booking ride estimatedFareParam finalFareParam ridePaymentChargeAmt customerBearsCharge driverBearsCharge vatDeduction = do
   let fare = fromMaybe booking.estimatedFare ride.fare
       discount = fromMaybe 0 ride.discountAmount
       commission = fromMaybe 0 ride.commission
       tips = fromMaybe 0 ride.tipAmount
       cur = ride.currency
       amountPaidByCustomer = fare - (if customerBearsCharge then ridePaymentChargeAmt else 0) - discount + tips
-      EarningsLabels {lblAmountPaid, lblDiscount, lblTips, lblCommission, lblFare, lblAirportConvenienceFee, lblServiceCharge, lblPaymentCharge} = labels
+      EarningsLabels {lblAmountPaid, lblDiscount, lblTips, lblCommission, lblFare, lblAirportConvenienceFee, lblServiceCharge, lblPaymentCharge, lblVatDeduction} = labels
       cancellationDues =
         fromMaybe 0 $
           case finalFareParam of
@@ -335,6 +336,7 @@ buildRideEarnings lang labels booking ride estimatedFareParam finalFareParam rid
             mkComp FareBreakup "DISCOUNT" lblDiscount discount (discount > 0),
             mkComp FareBreakup "TIPS" lblTips tips (tips > 0),
             mkComp FareBreakup "COMMISSION" lblCommission commission (commission /= 0),
+            mkComp FareBreakup "VAT_DEDUCTION" lblVatDeduction vatDeduction (vatDeduction > 0),
             mkComp FareBreakup "PAYMENT_CHARGE" lblPaymentCharge ridePaymentChargeAmt ((customerBearsCharge || driverBearsCharge) && ridePaymentChargeAmt > 0),
             mkComp FareBreakup "CUSTOMER_CANCELLATION_CHARGE" lblFare cancellationDues (cancellationDues > 0),
             mkComp FareBreakup "AIRPORT_CONVENIENCE_FEE" lblAirportConvenienceFee airportConvenienceFee (airportConvenienceFee > 0),
@@ -443,7 +445,8 @@ data EarningsLabels = EarningsLabels
     lblFare :: Maybe Text,
     lblAirportConvenienceFee :: Maybe Text,
     lblServiceCharge :: Maybe Text,
-    lblPaymentCharge :: Maybe Text
+    lblPaymentCharge :: Maybe Text,
+    lblVatDeduction :: Maybe Text
   }
 
 fetchEarningsLabels ::
@@ -462,6 +465,7 @@ fetchEarningsLabels lang =
     <*> resolveLabel lang "AIRPORT_CONVENIENCE_FEE"
     <*> resolveLabel lang "SERVICE_CHARGE"
     <*> resolveLabel lang "PAYMENT_CHARGE"
+    <*> resolveLabel lang "VAT_DEDUCTION"
 
 mkExoPhone :: Maybe DExophone.Exophone -> DRB.Booking -> Text
 mkExoPhone mbExophone booking =
@@ -488,8 +492,9 @@ mkDriverRideRes ::
   Bool ->
   [DSI.StopInformation] ->
   ResolvedCalling ->
+  Maybe DTConf.TransporterConfig ->
   m DriverRideRes
-mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mbExophone (ride, booking) bapMetadata goHomeReqId driverInfo isValueAddNP stopsInfo resolvedCalling = do
+mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mbExophone (ride, booking) bapMetadata goHomeReqId driverInfo isValueAddNP stopsInfo resolvedCalling mbTransporterConfig = do
   let estimatedFareParams = booking.fareParams
       bearerFlags mbT =
         let mb = (mbT >>= (readMaybe . T.unpack)) :: Maybe DTConf.PaymentChargeBearer
@@ -509,10 +514,22 @@ mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mb
       estimatedBaseFareV2 = max 0 (estimatedBaseFareGrossV2 - estimatedCommission - bookingAppFeeP)
       rideCommission = fromMaybe 0 ride.commission
       rideTipsAmount = fromMaybe 0 ride.tipAmount
-      computedFareNet = (\fareAmt -> max 0 (fareAmt - rideCommission - rideAppFeeP + rideTipsAmount)) <$> ride.fare
       edcCollectsParking = SL.edcCollectsParking booking.fareSettlementType
       displayParkingCharge = if edcCollectsParking then Nothing else estimatedFareParams.parkingCharge
   finalFareParams <- maybe (pure Nothing) SQFP.findById ride.fareParametersId
+  let mbTaxConfig = (.taxConfig) <$> mbTransporterConfig
+      rideVatMode = fromMaybe DTConf.DRIVER_DIRECT (mbTaxConfig >>= (.rideTaxRemittanceMode))
+      tollVatMode = fromMaybe rideVatMode (mbTaxConfig >>= (.tollTaxRemittanceMode))
+      parkingVatMode = fromMaybe rideVatMode (mbTaxConfig >>= (.parkingTaxRemittanceMode))
+      driverKeepsVat mode = case mode of DTConf.DRIVER_DIRECT -> True; _ -> False
+      rideVatAmt = fromMaybe 0 (finalFareParams >>= (.govtCharges))
+      tollVatAmt = fromMaybe 0 (finalFareParams >>= (.tollFareTax))
+      parkingVatAmt = if edcCollectsParking then 0 else fromMaybe 0 (finalFareParams >>= (.parkingChargeTax))
+      vatDeduction =
+        (if driverKeepsVat rideVatMode then 0 else rideVatAmt)
+          + (if driverKeepsVat tollVatMode then 0 else tollVatAmt)
+          + (if driverKeepsVat parkingVatMode then 0 else parkingVatAmt)
+      computedFareNet = (\fareAmt -> max 0 (fareAmt - rideCommission - rideAppFeeP - vatDeduction + rideTipsAmount)) <$> ride.fare
   let initial = "" :: Text
   (nextStopLocation, lastStopLocation) <- case booking.tripCategory of
     DTC.Rental _ -> calculateLocations booking.id booking.stopLocationId
@@ -564,18 +581,18 @@ mkDriverRideRes language mbEarningsLabels rideDetails driverNumber rideRating mb
         case booking.fareSettlementType of
           Just SL.FullPayment ->
             case ride.fare of
-              Just fareAmt -> Just $ max 0 (fareAmt - commission - rideAppFeeP + rideTipsAmount)
+              Just fareAmt -> Just $ max 0 (fareAmt - commission - rideAppFeeP - vatDeduction + rideTipsAmount)
               Nothing -> Nothing
           Just _ -> Nothing
           Nothing ->
             case booking.paymentInstrument of
               Just DMPM.Cash -> if offer > 0 then Just offer else Nothing
               _ -> case ride.fare of
-                Just fareAmt -> Just $ max 0 (fareAmt - commission - rideAppFeeP + rideTipsAmount)
+                Just fareAmt -> Just $ max 0 (fareAmt - commission - rideAppFeeP - vatDeduction + rideTipsAmount)
                 Nothing -> Nothing
 
   mbRideEarningsVal <- case mbEarningsLabels of
-    Just earningsLabels -> Just <$> buildRideEarnings language earningsLabels booking ride estimatedFareParams finalFareParams ridePaymentCharge customerBearsCharge driverBearsCharge
+    Just earningsLabels -> Just <$> buildRideEarnings language earningsLabels booking ride estimatedFareParams finalFareParams ridePaymentCharge customerBearsCharge driverBearsCharge vatDeduction
     Nothing -> pure Nothing
 
   return $

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide.hs
@@ -835,7 +835,8 @@ endRideHandler handle@ServiceHandle {..} rideId req = do
                         numberType = DUIRideCommon.ANONYMOUS
                       }
                 }
-        Just <$> DUIRideCommon.mkDriverRideRes endRideLanguage (Just endRideLabels) rideDetail driverNumber rideRating mbExophone (finalUpdatedRide, booking) bapMetadata goHomeReqId Nothing isValueAddNP stopsInfo endRideCalling
+        mbTransporterConfig <- getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = booking.merchantOperatingCityId.getId}) Nothing
+        Just <$> DUIRideCommon.mkDriverRideRes endRideLanguage (Just endRideLabels) rideDetail driverNumber rideRating mbExophone (finalUpdatedRide, booking) bapMetadata goHomeReqId Nothing isValueAddNP stopsInfo endRideCalling mbTransporterConfig
 
   return $
     EndRideResp

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -119,6 +119,7 @@ import SharedLogic.Finance.Wallet
 import qualified SharedLogic.MetricsLabels as SML
 import SharedLogic.Ride (makeSubscriptionRunningBalanceLockKey, multipleRouteKey, searchRequestKey, updateOnRideStatusWithAdvancedRideCheck)
 import qualified SharedLogic.RideEvents.Publisher as RideEventsPublisher
+import qualified SharedLogic.TaxRemittance as SLT
 import Storage.Beam.Toll ()
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.CachedQueries.Merchant.MerchantPaymentMethod as CQMPM
@@ -606,8 +607,6 @@ createDriverWalletTransaction ride booking fareParams driverInfo transporterConf
         (Just driverInfo)
         (taxAmount + absorbedVat)
     ctx <- buildFinanceCtx booking ride mbDriver mbPanCard (Just driverInfo) transporterConfig isOnline
-    let tollWithVat = tollAmount + tollVatAmount
-    let parkingWithVat = parkingAmount + parkingVatAmount
     let mbPaymentBearer = transporterConfig.driverWalletConfig.paymentChargeBearer
         paymentChargeGross = fromMaybe 0 ride.paymentCharge
         (paymentChargeAmt, paymentChargeVatAmt) =
@@ -757,29 +756,51 @@ createDriverWalletTransaction ride booking fareParams driverInfo transporterConf
                 transfer_ BuyerAsset BuyerExternal amt ref
                 void $ transfer BuyerExternal OwnerLiability amt ref Nothing
               else void $ transfer BuyerControl OwnerControl amt ref Nothing
-      if isVat
-        then do
-          let rideEarningComponents =
-                [ (baseFare, walletReferenceBaseRide),
-                  (taxAmount, if isOnline then taxRefOnline else taxRefCash),
-                  (tollWithVat, walletReferenceTollCharges),
-                  (parkingWithVat, walletReferenceParkingCharges)
-                ]
-          forM_ rideEarningComponents postEarning
-        else do
-          let rideEarningComponents =
-                [ (baseFare, walletReferenceBaseRide),
-                  (tollWithVat, walletReferenceTollCharges),
-                  (parkingWithVat, walletReferenceParkingCharges)
-                ]
-          forM_ rideEarningComponents postEarning
-          -- GST tax: online → BAP routes customer's GST to govt via BPP (2-leg);
-          --          cash   → driver remits cash-collected GST from wallet.
+      let rideMode = SLT.resolveMode transporterConfig.taxConfig.rideTaxRemittanceMode Nothing (SLT.legacyRideMode fareParams.isVatTaxType)
+          tollMode = SLT.resolveMode transporterConfig.taxConfig.tollTaxRemittanceMode transporterConfig.taxConfig.rideTaxRemittanceMode DRIVER_DIRECT
+          parkingMode = SLT.resolveMode transporterConfig.taxConfig.parkingTaxRemittanceMode transporterConfig.taxConfig.rideTaxRemittanceMode DRIVER_DIRECT
+          taxRef = if isOnline then taxRefOnline else taxRefCash
+          postComponentByMode fareAmt vatAmt ref mode = case mode of
+            DRIVER_DIRECT ->
+              postEarning (fareAmt + vatAmt, ref)
+            COMPANY_DIRECT -> do
+              postEarning (fareAmt, ref)
+              when (vatAmt > 0) $
+                if isOnline
+                  then do
+                    transfer_ BuyerAsset BuyerExternal vatAmt ref
+                    void $ transfer BuyerExternal GovtIndirect vatAmt ref Nothing
+                  else do
+                    postEarning (vatAmt, ref)
+                    void $ transfer OwnerLiability GovtIndirect vatAmt ref Nothing
+            COMPANY_INDIRECT -> do
+              postEarning (fareAmt + vatAmt, ref)
+              when (vatAmt > 0) $
+                void $ transfer OwnerLiability GovtIndirect vatAmt ref Nothing
+      case rideMode of
+        DRIVER_DIRECT -> do
+          postEarning (baseFare, walletReferenceBaseRide)
+          postEarning (taxAmount, taxRef)
+          postComponentByMode tollAmount tollVatAmount walletReferenceTollCharges tollMode
+          postComponentByMode parkingAmount parkingVatAmount walletReferenceParkingCharges parkingMode
+        COMPANY_DIRECT -> do
+          postEarning (baseFare, walletReferenceBaseRide)
+          postComponentByMode tollAmount tollVatAmount walletReferenceTollCharges tollMode
+          postComponentByMode parkingAmount parkingVatAmount walletReferenceParkingCharges parkingMode
           if isOnline
             then do
               transfer_ BuyerAsset BuyerExternal taxAmount taxRefOnline
               void $ transfer BuyerExternal GovtIndirect taxAmount taxRefOnline Nothing
-            else void $ transfer OwnerLiability GovtIndirect taxAmount taxRefCash Nothing
+            else do
+              postEarning (taxAmount, taxRefCash)
+              void $ transfer OwnerLiability GovtIndirect taxAmount taxRefCash Nothing
+        COMPANY_INDIRECT -> do
+          postEarning (baseFare, walletReferenceBaseRide)
+          postEarning (taxAmount, taxRef)
+          postComponentByMode tollAmount tollVatAmount walletReferenceTollCharges tollMode
+          postComponentByMode parkingAmount parkingVatAmount walletReferenceParkingCharges parkingMode
+          when (taxAmount > 0) $
+            void $ transfer OwnerLiability GovtIndirect taxAmount taxRef Nothing
       -- TDS — driver wallet reduces in both modes (cash driver owes platform).
       whenJust mbTdsAmount $ \tdsAmount ->
         void $ transfer OwnerLiability GovtDirect tdsAmount tdsRef Nothing

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/TaxRemittance.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/TaxRemittance.hs
@@ -1,0 +1,64 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module SharedLogic.TaxRemittance
+  ( TaxAccounts (..),
+    taxAccountsFor,
+    resolveMode,
+    legacyRideMode,
+  )
+where
+
+import qualified Domain.Types.TransporterConfig as DTC
+import Kernel.Prelude
+import Lib.Finance (AccountRole (..))
+
+data TaxAccounts = TaxAccounts
+  { forwardDest :: AccountRole,
+    refundSource :: AccountRole,
+    benefitForwardDest :: AccountRole,
+    benefitRefundSource :: AccountRole
+  }
+  deriving (Eq, Show)
+
+taxAccountsFor :: DTC.TaxRemittanceMode -> TaxAccounts
+taxAccountsFor DTC.DRIVER_DIRECT =
+  TaxAccounts
+    { forwardDest = OwnerLiability,
+      refundSource = OwnerLiability,
+      benefitForwardDest = SellerRevenue,
+      benefitRefundSource = SellerExpense
+    }
+taxAccountsFor DTC.COMPANY_DIRECT =
+  TaxAccounts
+    { forwardDest = GovtIndirect,
+      refundSource = GovtIndirect,
+      benefitForwardDest = GovtIndirect,
+      benefitRefundSource = GovtIndirect
+    }
+taxAccountsFor DTC.COMPANY_INDIRECT =
+  TaxAccounts
+    { forwardDest = OwnerLiability,
+      refundSource = GovtIndirect,
+      benefitForwardDest = GovtIndirect,
+      benefitRefundSource = GovtIndirect
+    }
+
+resolveMode :: Maybe DTC.TaxRemittanceMode -> Maybe DTC.TaxRemittanceMode -> DTC.TaxRemittanceMode -> DTC.TaxRemittanceMode
+resolveMode (Just m) _ _ = m
+resolveMode Nothing (Just m) _ = m
+resolveMode Nothing Nothing legacyDefault = legacyDefault
+
+legacyRideMode :: Maybe Bool -> DTC.TaxRemittanceMode
+legacyRideMode mbIsVat = if fromMaybe False mbIsVat then DTC.DRIVER_DIRECT else DTC.COMPANY_DIRECT

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/TransporterConfig.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Transformers/TransporterConfig.hs
@@ -113,7 +113,11 @@ parseTaxConfig merchantOperatingCityId mbVal = do
             individualNotLinked = Nothing,
             businessTds = Nothing,
             serviceVatPercentage = Nothing,
-            commissionVatPercentage = Nothing
+            commissionVatPercentage = Nothing,
+            rideTaxRemittanceMode = Nothing,
+            cancellationTaxRemittanceMode = Nothing,
+            tollTaxRemittanceMode = Nothing,
+            parkingTaxRemittanceMode = Nothing
           }
   -- Legacy flat-number TDS fields are tolerated by TdsConfig's hand-written
   -- FromJSON (Domain.Types.Extra.TransporterConfig), so no post-parse backfill

--- a/Backend/dev/migrations-read-only/dynamic-offer-driver-app/transporter_config.sql
+++ b/Backend/dev/migrations-read-only/dynamic-offer-driver-app/transporter_config.sql
@@ -1143,3 +1143,8 @@ ALTER TABLE atlas_driver_offer_bpp.transporter_config ADD COLUMN limits_config j
 ------- SQL updates -------
 
 ALTER TABLE atlas_driver_offer_bpp.transporter_config ADD COLUMN enable_estimated_toll_fallback boolean  default false;
+
+
+
+------- SQL updates -------
+

--- a/Backend/test/src/Mobility/ARDU/NearestDrivers.hs
+++ b/Backend/test/src/Mobility/ARDU/NearestDrivers.hs
@@ -80,7 +80,11 @@ createNearestDriverReq nearestRadius now =
             subscriptionTdsRate = Nothing,
             airportEntryFeeGst = Nothing,
             serviceVatPercentage = Nothing,
-            subscriptionGst = DTC.GstBreakup Nothing Nothing Nothing
+            subscriptionGst = DTC.GstBreakup Nothing Nothing Nothing,
+            rideTaxRemittanceMode = Nothing,
+            cancellationTaxRemittanceMode = Nothing,
+            tollTaxRemittanceMode = Nothing,
+            parkingTaxRemittanceMode = Nothing
           },
       minWalletAmountForCashRides = Nothing,
       currentRideTripCategoryValidForForwardBatching = [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable tax remittance modes for ride, cancellation, toll, and parking charges.
  - Added VAT deductions to driver earnings and fare breakdowns.
  - Added transporter-level limits for bulk operations and cash-ride synchronization.
  - Added an option to use estimated tolls when toll detection is unavailable.
- **Improvements**
  - Tax amounts and refunds are now routed according to selected remittance modes.
  - Ride earnings and settlement calculations now reflect applicable tax deductions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->