### PR TITLE
Add composite indexes on booking and journey to fix rider read-pool CPU saturation

### DIFF
--- a/Backend/dev/migrations-after-release/rider-app/0005-rider-booking-journey-cpu-indexes.sql
+++ b/Backend/dev/migrations-after-release/rider-app/0005-rider-booking-journey-cpu-indexes.sql
@@ -1,0 +1,7 @@
+-- Indexes to eliminate expensive sorts for rider my-rides / journey list APIs
+-- that caused rider-db-cluster read-pool saturation and primary CPU alert.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_booking_rider_id_status_start_time
+  ON atlas_app.booking (rider_id, status, start_time DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_journey_rider_id_status_created_at
+  ON atlas_app.journey (rider_id, status, created_at DESC);


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/7l)

### Root cause
Expensive pagination queries on atlas_app.booking and atlas_app.journey lack indexes covering the ORDER BY columns, forcing Postgres to sort large row sets on the rider read pool. This saturates the read pool (autoscale 1→3 nodes), causes statement timeouts, and loads the primary via replication/pooler, triggering the CPU alert.

### Evidence
_see RCA_

### Rollback
DROP INDEX CONCURRENTLY IF EXISTS atlas_app.idx_booking_rider_id_status_start_time; DROP INDEX CONCURRENTLY IF EXISTS atlas_app.idx_journey_rider_id_status_created_at;

---
_Draft PR — review and merge manually. Generated by Argus._