### PR TITLE
Wallet Balance expiry validation during pooling

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -283,7 +283,7 @@ import qualified SharedLogic.External.LocationTrackingService.Types as LT
 import SharedLogic.FareCalculator
 import qualified SharedLogic.FareCalculator as FC
 import SharedLogic.FarePolicy
-import SharedLogic.Finance.Prepaid (counterpartyDriver, counterpartyFleetOwner, getPrepaidAvailableBalanceByOwner)
+import SharedLogic.Finance.Prepaid (counterpartyDriver, counterpartyFleetOwner, getPrepaidAvailableBalanceByOwner, hasPrepaidCreditsValidAt)
 import qualified SharedLogic.Finance.Wallet as FWallet
 import qualified SharedLogic.FleetEngine as FleetEngine
 import qualified SharedLogic.Merchant as SMerchant
@@ -3553,6 +3553,20 @@ acceptScheduledBookingWithPreFetched merchant transporterConfig booking driver c
         driverTagTexts = LYT.getTagNameValue . Yudhishthira.removeTagExpiry <$> Yudhishthira.filterExpiredTags' nowT (fromMaybe [] driver.driverTag)
     unless (scheduledTierEligibleForDriver True scheduledOpenToAll driverTagTexts cityServiceTiersHashMap booking.vehicleServiceTier) $
       throwError (InvalidRequest "Driver is not eligible for this scheduled booking")
+  -- Prepaid credits valid today can still be swept before pickup, so mirror the dispatch-side gate
+  -- on the direct-accept path. Solvency is not relaxed inside the R4 open-to-all window.
+  when (fromMaybe False merchant.prepaidSubscriptionAndWalletEnabled) $ do
+    mbFleetAssociation <- QFDA.findByDriverId driver.id True
+    let (ownerType, ownerId) = case mbFleetAssociation of
+          Just fda -> (DSP.FLEET_OWNER, fda.fleetOwnerId)
+          Nothing -> (DSP.DRIVER, driver.id.getId)
+        mbVehicleCategory =
+          if fromMaybe False transporterConfig.subscriptionConfig.vehicleCategoryScopedPrepaidEnabled
+            then Just (castServiceTierToVehicleCategory booking.vehicleServiceTier)
+            else Nothing
+    creditsValid <- hasPrepaidCreditsValidAt ownerId ownerType mbVehicleCategory booking.startTime
+    unless creditsValid $
+      throwError (InvalidRequest "Your ride credits expire before this booking's pickup time. Recharge to accept it.")
   mbActiveSearchTry <- QST.findActiveTryByQuoteId booking.quoteId
   void $ acceptStaticOfferDriverRequest mbActiveSearchTry driver booking.quoteId Nothing merchant clientId transporterConfig mbBooking
   pure Success

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverPool.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/DriverPool.hs
@@ -1046,6 +1046,7 @@ calculateDriverPoolWithActualDist CalculateDriverPoolReq {..} poolType currentSe
             isInterCity,
             isScheduled,
             scheduledOpenToAll,
+            scheduledPickupTime,
             currentRideTripCategoryValidForForwardBatching,
             govtCharges,
             tollCharges,

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Finance/Prepaid.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Finance/Prepaid.hs
@@ -16,6 +16,9 @@ module SharedLogic.Finance.Prepaid
     getPrepaidBalanceByOwner,
     getPrepaidPendingHoldByOwner,
     getPrepaidAvailableBalanceByOwner,
+    hasPrepaidCreditsValidAt,
+    fetchActivePrepaidPurchasesByOwners,
+    prepaidCreditsValidAtIn,
     getSubscriptionRemainingAvailableBalance,
     createPrepaidHold,
     voidPrepaidHold,
@@ -31,6 +34,7 @@ module SharedLogic.Finance.Prepaid
 where
 
 import qualified Data.List as DL
+import qualified Data.Map as Map
 import qualified Domain.Types.DriverPanCard as DPanCard
 import Domain.Types.Extra.Plan (ServiceNames (..))
 import "beckn-spec" Domain.Types.Invoice (InvoiceType (..), IssuedToType)
@@ -179,6 +183,43 @@ getPrepaidAvailableBalanceByOwner counterpartyType ownerId mbVehicleCategory = d
   mbBalance <- getPrepaidBalanceByOwner counterpartyType ownerId mbVehicleCategory
   pendingHold <- getPrepaidPendingHoldByOwner counterpartyType ownerId mbVehicleCategory
   pure $ (\balance -> balance - pendingHold) <$> mbBalance
+
+-- | Whether the owner still has prepaid credits backing a ride that runs at @atTime@.
+-- A queued purchase (expiryDate = Nothing) has not started its timer yet and takes over when the
+-- FIFO head expires, so it keeps the owner funded past the head's expiry.
+hasPrepaidCreditsValidAt ::
+  (BeamFlow m r) =>
+  Text -> -- Owner ID
+  DSP.SubscriptionOwnerType ->
+  Maybe DVC.VehicleCategory -> -- Sub-ledger scope (Nothing = pooled)
+  UTCTime ->
+  m Bool
+hasPrepaidCreditsValidAt ownerId ownerType mbVehicleCategory atTime = do
+  actives <- QSPE.findAllActiveByOwnerAndServiceName ownerId ownerType PREPAID_SUBSCRIPTION mbVehicleCategory
+  pure $ any (\purchase -> maybe True (>= atTime) purchase.expiryDate) actives
+
+fetchActivePrepaidPurchasesByOwners ::
+  (BeamFlow m r) =>
+  [Text] ->
+  m (Map.Map Text [DSP.SubscriptionPurchase])
+fetchActivePrepaidPurchasesByOwners ownerIds = do
+  purchases <- QSPE.findAllActiveByOwnersAndServiceName (DL.nub ownerIds) PREPAID_SUBSCRIPTION
+  pure $ Map.fromListWith (<>) [(purchase.ownerId, [purchase]) | purchase <- purchases]
+
+prepaidCreditsValidAtIn ::
+  Map.Map Text [DSP.SubscriptionPurchase] ->
+  Text ->
+  DSP.SubscriptionOwnerType ->
+  Maybe DVC.VehicleCategory ->
+  UTCTime ->
+  Bool
+prepaidCreditsValidAtIn purchasesByOwner ownerId ownerType mbVehicleCategory atTime =
+  any (\purchase -> maybe True (>= atTime) purchase.expiryDate) relevant
+  where
+    relevant = filter matchesScope $ Map.findWithDefault [] ownerId purchasesByOwner
+    matchesScope purchase =
+      purchase.ownerType == ownerType
+        && maybe True (\vc -> purchase.vehicleCategory == Just vc) mbVehicleCategory
 
 counterpartyTypeForSubscription :: DSP.SubscriptionPurchase -> CounterpartyType
 counterpartyTypeForSubscription subscription = case subscription.ownerType of

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Person/GetNearestDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Person/GetNearestDrivers.hs
@@ -25,6 +25,7 @@ import Domain.Types.DriverLocation (DriverLocation)
 import qualified Domain.Types.Extra.MerchantPaymentMethod as MP
 import Domain.Types.Merchant
 import Domain.Types.Person as Person
+import qualified Domain.Types.SubscriptionPurchase as DSP
 import qualified Domain.Types.TransporterConfig as DTC
 import Domain.Types.VehicleServiceTier as DVST
 import Domain.Types.VehicleVariant as DV
@@ -99,6 +100,7 @@ data NearestDriversReq = NearestDriversReq
     isInterCity :: Bool,
     isScheduled :: Bool,
     scheduledOpenToAll :: Bool,
+    scheduledPickupTime :: Maybe UTCTime,
     currentRideTripCategoryValidForForwardBatching :: [Text],
     prepaidSubscriptionThreshold :: Maybe HighPrecMoney,
     fleetPrepaidSubscriptionThreshold :: Maybe HighPrecMoney,
@@ -371,17 +373,18 @@ filterByWalletBalance ::
 filterByWalletBalance NearestDriversReq {..} isPrepaidEnabled results = do
   afterPrepaid <-
     if isPrepaidEnabled
-      then case (rideFare, prepaidSubscriptionThreshold <|> fleetPrepaidSubscriptionThreshold) of
-        (Just fare, Just _) ->
-          filterM
-            ( \r -> do
-                let mbVehicleCategory = if vehicleCategoryScopedPrepaidEnabled then Just (DV.castServiceTierToVehicleCategory r.serviceTier) else Nothing
-                    (counterpartyType, ownerId, threshold) = resolveOwnerAndThreshold r
-                mbBalance <- getPrepaidAvailableBalanceByOwner counterpartyType ownerId mbVehicleCategory
-                pure $ maybe False (>= (fare + threshold)) mbBalance
-            )
-            results
-        _ -> pure results
+      then do
+        let mbFareRequirement = case (rideFare, prepaidSubscriptionThreshold <|> fleetPrepaidSubscriptionThreshold) of
+              (Just fare, Just _) -> Just fare
+              _ -> Nothing
+            mbCreditsValidAt = if isScheduled then scheduledPickupTime else Nothing
+        if isNothing mbFareRequirement && isNothing mbCreditsValidAt
+          then pure results
+          else do
+            purchasesByOwner <- case mbCreditsValidAt of
+              Just _ -> fetchActivePrepaidPurchasesByOwners (map candidateOwnerId results)
+              Nothing -> pure mempty
+            filterM (passesPrepaidGates mbFareRequirement mbCreditsValidAt purchasesByOwner) results
       else pure results
   let cashRequirement =
         case minWalletAmountForCashRides of
@@ -402,6 +405,20 @@ filterByWalletBalance NearestDriversReq {..} isPrepaidEnabled results = do
     resolveOwnerAndThreshold r = case r.fleetOwnerId of
       Just fleetOwnerId -> (counterpartyFleetOwner, fleetOwnerId, fromMaybe 0 fleetPrepaidSubscriptionThreshold)
       Nothing -> (counterpartyDriver, r.driverId.getId, fromMaybe 0 prepaidSubscriptionThreshold)
+
+    candidateOwnerId r = let (_, ownerId, _) = resolveOwnerAndThreshold r in ownerId
+    passesPrepaidGates mbFareRequirement mbCreditsValidAt purchasesByOwner r = do
+      let mbVehicleCategory = if vehicleCategoryScopedPrepaidEnabled then Just (DV.castServiceTierToVehicleCategory r.serviceTier) else Nothing
+          (counterpartyType, ownerId, threshold) = resolveOwnerAndThreshold r
+          ownerType = maybe DSP.DRIVER (const DSP.FLEET_OWNER) r.fleetOwnerId
+      balanceOk <- case mbFareRequirement of
+        Nothing -> pure True
+        Just fare -> do
+          mbBalance <- getPrepaidAvailableBalanceByOwner counterpartyType ownerId mbVehicleCategory
+          pure $ maybe False (>= (fare + threshold)) mbBalance
+      if not balanceOk
+        then pure False
+        else pure $ maybe True (prepaidCreditsValidAtIn purchasesByOwner ownerId ownerType mbVehicleCategory) mbCreditsValidAt
 
     checkBalance (counterpartyType, ownerId) required = do
       mbBalance <- getWalletBalanceByOwner counterpartyType ownerId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SubscriptionPurchaseExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SubscriptionPurchaseExtra.hs
@@ -52,6 +52,23 @@ findActiveDistinctOwnersByOwnerIds ownerIds ownerType = do
           [Se.And [Se.Is Beam.ownerId $ Se.In ownerIds, Se.Is Beam.ownerType $ Se.Eq ownerType, Se.Is Beam.status $ Se.Eq ACTIVE]]
       pure $ Set.size $ Set.fromList $ map (.ownerId) subs
 
+findAllActiveByOwnersAndServiceName ::
+  (EsqDBFlow m r, MonadFlow m, CacheFlow m r) =>
+  [Text] ->
+  ServiceNames ->
+  m [SubscriptionPurchase]
+findAllActiveByOwnersAndServiceName ownerIds serviceName =
+  if null ownerIds
+    then pure []
+    else
+      findAllWithKV
+        [ Se.And
+            [ Se.Is Beam.ownerId $ Se.In ownerIds,
+              Se.Is Beam.status $ Se.Eq ACTIVE,
+              Se.Is Beam.serviceName $ Se.Eq serviceName
+            ]
+        ]
+
 -- | Find all ACTIVE subscriptions for an owner, sorted by purchaseTimestamp ASC (FIFO order).
 -- When mbVehicleCategory is Just, restricts results to that category only (wallet isolation).
 findAllActiveByOwnerAndServiceName ::


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Wallet Balance expiry validation during pooling


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled bookings now verify that prepaid credits remain valid through the scheduled pickup time.
  - Drivers and fleet owners with prepaid plans are filtered more accurately when matching scheduled rides.
  - Direct acceptance of scheduled bookings is blocked when prepaid coverage expires before pickup.
  - Driver matching now accounts for the scheduled pickup time when selecting eligible candidates.
  - Prepaid eligibility checks now consistently account for owner type and, where applicable, vehicle category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->