### PR TITLE
Revert findByTransactionIdAndStatus to findAllWithKVAndConditionalDB to reduce rider DB read storm

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/BookingExtra.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/BookingExtra.hs
@@ -276,13 +276,11 @@ findAssignedByRiderId (Id personId) = findOneWithKV [Se.And [Se.Is BeamB.riderId
 
 findByTransactionIdAndStatus :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => Text -> [BookingStatus] -> m (Maybe Booking)
 findByTransactionIdAndStatus transactionId statusList =
-  findAllWithOptionsKV
+  findAllWithKVAndConditionalDB
     [ Se.Is BeamB.riderTransactionId $ Se.Eq transactionId,
       Se.Is BeamB.status $ Se.In statusList
     ]
-    (Se.Desc BeamB.createdAt)
-    Nothing
-    Nothing
+    (Just (Se.Desc BeamB.createdAt))
     <&> listToMaybe
 
 updateCommission :: (MonadFlow m, EsqDBFlow m r) => Id Booking -> Maybe HighPrecMoney -> m ()


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/6l)

### Root cause
Rider-app deploy 323a04 changed the hot query QBooking.findByTransactionIdAndStatus from findAllWithKVAndConditionalDB to findAllWithOptionsKV. findByTransactionIdAndStatus is invoked from many high-volume rider flows (Search, Select, Frontend, JourneyLeg, Cancel). The new path no longer uses the Redis/conditional-DB optimization and is generating a massive number of direct SELECTs against the 262 GB atlas_app.booking table, plus downstream location/quote/fare_breakup lookups. This saturated the rider AlloyDB primary CPU (>90%) and spiked rider app p99 latency to ~138 s.

### Evidence
_see RCA_

### Rollback
Redeploy the previous rider-app ReplicaSet beckn-app-backend-production-pilot-acc0ee-7dfbf8b67c, or revert the single hunk in Backend/app/rider-platform/rider-app/Main/src/Storage/Queries/BookingExtra.hs that changed findByTransactionIdAndStatus back to findAllWithOptionsKV.

---
_Draft PR — review and merge manually. Generated by Argus._