### PR TITLE
Backend/feat: add reviver metrics to vm

### DIFF
--- a/Backend/lib/producer/src/Producer/Flow.hs
+++ b/Backend/lib/producer/src/Producer/Flow.hs
@@ -28,6 +28,7 @@ import Kernel.Utils.DatastoreLatencyCalculator
 import Kernel.Utils.Time ()
 import Lib.Scheduler.JobStorageType.DB.Queries (getPendingStuckJobs)
 import qualified Lib.Scheduler.JobStorageType.DB.Table as BeamST hiding (Id)
+import Lib.Scheduler.Metrics (ReviverJobStatus (..), ReviverStage (..), addReviverStageCount, incrementReviverJobCounter)
 import Lib.Scheduler.Types as ST
 import Producer.SchedulerJob ()
 import qualified Sequelize as Se
@@ -80,13 +81,31 @@ runProducer = do
 
 runReviver :: ProducerType -> Flow ()
 runReviver producerType = do
+  addReviverStageCount ReviverTick 1
   reviverInterval <- asks (.reviverInterval)
   T.UTCTime _ todaysDiffTime <- getCurrentTime
   let secondsTillNow = T.diffTimeToPicoseconds todaysDiffTime `div` 1000000000000
       minutesTillNow = secondsTillNow `div` 60
       shouldRunReviver = minutesTillNow `mod` (fromIntegral reviverInterval.getMinutes) == 0
-  when shouldRunReviver $ Hedis.whenWithLockRedis reviverLockKey 300 (runReviver' producerType)
+  when shouldRunReviver $ do
+    someErr <- withTryCatch "runReviver:reviverFlow" $ do
+      gotLock <- Hedis.tryLockRedis reviverLockKey 300
+      if gotLock
+        then do
+          addReviverStageCount ReviverLockAcquired 1
+          finally (runReviver' producerType) (Hedis.unlockRedis reviverLockKey)
+        else addReviverStageCount ReviverLockMissed 1
+    case someErr of
+      Left err -> do
+        logError $ "reviver pass failed: " <> show err
+        addReviverStageCount ReviverPassFailed 1
+      Right _ -> pure ()
   threadDelayMilliSec 60000
+
+countJobTypes :: (JobProcessor t) => ReviverJobStatus -> [AnyJob t] -> Flow ()
+countJobTypes reviverStatus jobs =
+  forM_ jobs $ \(AnyJob Job {..}) ->
+    incrementReviverJobCounter (show (fromSing $ jobType jobInfo)) reviverStatus
 
 mkRunningJobKey :: Text -> Text
 mkRunningJobKey jobId = "RunnningJob:" <> jobId
@@ -97,6 +116,7 @@ runReviver' producerType = do
   case producerType of
     Driver -> do
       pendingJobs :: [AnyJob AllocatorJobType] <- getFirst100PendingStuckJobs
+      countJobTypes ReviverStuckPending pendingJobs
       let jobsIds = map @_ @(Id AnyJob, Id AnyJob) (\(AnyJob Job {..}) -> (id, parentJobId)) pendingJobs
       filteredPendingJobs <- filterM (\(AnyJob Job {..}) -> Hedis.withCrossAppRedis $ Hedis.tryLockRedis (mkRunningJobKey id.getId) 65) pendingJobs
       logDebug $ "Total number of pendingJobs in DB : " <> show (length filteredPendingJobs) <> " Pending (JobsIDs, ParentJobIds) : " <> show jobsIds
@@ -131,12 +151,14 @@ runReviver' producerType = do
           Hedis.withCrossAppRedis $ Hedis.unlockRedis (mkRunningJobKey x.id.getId)
           logDebug $ "Driver side Job Revived and inserted into DB with parentJobId : " <> show x.id <> " JobId : " <> show newid
           pure (AnyJob newJob)
+      countJobTypes ReviverRevived newJobsToExecute
       let newJobsToExecute_ = map (BSL.toStrict . Ae.encode) newJobsToExecute
       logDebug $ "Job produced to be inserted into stream of reviver: " <> show newJobsToExecute_
       result <- insertIntoStream newJobsToExecute_
       logDebug $ "Job Revived and inserted into stream with timestamp" <> show result
     Rider -> do
       pendingJobs :: [AnyJob RiderJobType] <- getFirst100PendingStuckJobs
+      countJobTypes ReviverStuckPending pendingJobs
       let jobsIds = map @_ @(Id AnyJob, Id AnyJob) (\(AnyJob Job {..}) -> (id, parentJobId)) pendingJobs
       filteredPendingJobs <- filterM (\(AnyJob Job {..}) -> Hedis.withCrossAppRedis $ Hedis.tryLockRedis (mkRunningJobKey id.getId) 65) pendingJobs
       logDebug $ "Total number of pendingJobs in DB : " <> show (length filteredPendingJobs) <> " Pending (JobsIDs, ParentJobIds) : " <> show jobsIds
@@ -171,6 +193,7 @@ runReviver' producerType = do
           Hedis.withCrossAppRedis $ Hedis.unlockRedis (mkRunningJobKey x.id.getId)
           logDebug $ "Rider sideJob Revived and inserted into DB with parentJobId : " <> show x.id <> " JobId : " <> show newid
           pure (AnyJob newJob)
+      countJobTypes ReviverRevived newJobsToExecute
       let newJobsToExecute_ = map (BSL.toStrict . Ae.encode) newJobsToExecute
       logDebug $ "Job produced to be inserted into stream of reviver: " <> show newJobsToExecute_
       result <- insertIntoStream newJobsToExecute_

--- a/Backend/lib/scheduler/src/Lib/Scheduler/Metrics.hs
+++ b/Backend/lib/scheduler/src/Lib/Scheduler/Metrics.hs
@@ -79,3 +79,45 @@ jobLifecycleStatusLabel = \case
 incrementJobLifecycleCounter :: CoreMetrics m => Text -> JobLifecycleStatus -> m ()
 incrementJobLifecycleCounter jobType status =
   incrementSchedulerJobLifecycleCounter jobType (jobLifecycleStatusLabel status)
+
+{-# NOINLINE reviverStageCounter #-}
+reviverStageCounter :: P.Vector P.Label1 P.Counter
+reviverStageCounter =
+  P.unsafeRegister . P.vector "stage" . P.counter $
+    P.Info "scheduler_reviver_stage_counter" "Reviver pass lifecycle, by stage (tick/lock_acquired/lock_missed/pass_failed)"
+
+{-# NOINLINE reviverJobCounter #-}
+reviverJobCounter :: P.Vector P.Label2 P.Counter
+reviverJobCounter =
+  P.unsafeRegister . P.vector ("job_type", "status") . P.counter $
+    P.Info "scheduler_reviver_job_counter" "Jobs seen by the reviver, by job type and status (stuck_pending/revived)"
+
+data ReviverStage
+  = ReviverTick
+  | ReviverLockAcquired
+  | ReviverLockMissed
+  | ReviverPassFailed
+
+reviverStageLabel :: ReviverStage -> Text
+reviverStageLabel = \case
+  ReviverTick -> "tick"
+  ReviverLockAcquired -> "lock_acquired"
+  ReviverLockMissed -> "lock_missed"
+  ReviverPassFailed -> "pass_failed"
+
+addReviverStageCount :: MonadIO m => ReviverStage -> Int -> m ()
+addReviverStageCount stage count =
+  liftIO $ P.withLabel reviverStageCounter (reviverStageLabel stage) (\c -> void $ P.addCounter c (fromIntegral count))
+
+data ReviverJobStatus
+  = ReviverStuckPending
+  | ReviverRevived
+
+reviverJobStatusLabel :: ReviverJobStatus -> Text
+reviverJobStatusLabel = \case
+  ReviverStuckPending -> "stuck_pending"
+  ReviverRevived -> "revived"
+
+incrementReviverJobCounter :: MonadIO m => Text -> ReviverJobStatus -> m ()
+incrementReviverJobCounter jobType status =
+  liftIO $ P.withLabel reviverJobCounter (jobType, reviverJobStatusLabel status) P.incCounter


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Add reviver metrics to Vm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Monitoring & Reliability**
  - Added detailed metrics for the job recovery process, including recovery attempts, lock acquisition, lock contention, and pass failures.
  - Added visibility into jobs that remain pending and jobs successfully recovered, categorized by job type.
  - These metrics improve operational monitoring and help identify recovery issues more quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->