### PR TITLE
backend/fix:- if stopinfo is already their return success and calling…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride.hs
@@ -375,37 +375,45 @@ stopAction rideId pt stopLocId action = do
       stopInfo <- find (\stop -> stop.stopLocId == stopLocId) stopsInfo & fromMaybeM (InvalidRequest ("Invalid Stop depart request with stopLocId" <> stopLocId.getId <> "for ride " <> ride.id.getId))
       QSI.updateByStopLocIdAndRideId (Just now) (Just pt) stopLocId rideId
       let request = CallBAPInternal.StopEventsReq CallBAPInternal.Depart rideId stopLM.order stopInfo.waitingTimeStart (Just now)
-      void $ CallBAPInternal.stopEvents appBackendBapInternal.apiKey appBackendBapInternal.url request
+      fork "BAPInternal:stopEventsDepart" . withShortRetry $
+        void $ CallBAPInternal.stopEvents appBackendBapInternal.apiKey appBackendBapInternal.url request
       let mbNextStopFEIndex = if currentStopFEIndex + 1 < length stopsLM then Just (currentStopFEIndex + 1) else Nothing
       fork "FleetEngine:notifyStopDeparted" $
         FleetEngine.notifyStopDeparted ride.merchantOperatingCityId ride.id mbNextStopFEIndex
       pure Success
-    ARRIVE -> do
-      unless (isValidStopArrivedAction stopLM stopsInfo) $ throwError $ InvalidRequest ("Invalid Stop arrived request with stopLocId " <> stopLocId.getId <> "for ride " <> ride.id.getId)
-      id <- generateGUID
-      let stopInfo =
-            DSI.StopInformation
-              { stopLocId = stopLocId,
-                stopOrder = stopLM.order,
-                waitingTimeStart = now,
-                waitingTimeEnd = Nothing,
-                stopStartLatLng = pt,
-                rideId = rideId,
-                stopEndLatLng = Nothing,
-                createdAt = now,
-                updatedAt = now,
-                id,
-                merchantOperatingCityId = Just ride.merchantOperatingCityId,
-                merchantId = ride.merchantId
-              }
-      QSI.create stopInfo
-      let nowTs = floor $ utcTimeToPOSIXSeconds now
-      VID.addReachedStop rideId stopLM.order pt nowTs
-      let request = CallBAPInternal.StopEventsReq CallBAPInternal.Arrive rideId stopLM.order now Nothing
-      void $ CallBAPInternal.stopEvents appBackendBapInternal.apiKey appBackendBapInternal.url request
-      fork "FleetEngine:notifyStopArrived" $
-        FleetEngine.notifyStopArrived ride.merchantOperatingCityId ride.id currentStopFEIndex
-      pure Success
+    ARRIVE ->
+      case find (\stop -> stop.stopLocId == stopLocId) stopsInfo of
+        Just _ -> do
+          -- Idempotent retry: stop already marked arrived (e.g. first request's response was lost); return Success so the app can sync its UI
+          logInfo $ "Stop already marked arrived with stopLocId " <> stopLocId.getId <> " for ride " <> ride.id.getId <> ", returning Success"
+          pure Success
+        Nothing -> do
+          unless (isValidStopArrivedAction stopLM stopsInfo) $ throwError $ InvalidRequest ("Invalid Stop arrived request with stopLocId " <> stopLocId.getId <> "for ride " <> ride.id.getId)
+          id <- generateGUID
+          let stopInfo =
+                DSI.StopInformation
+                  { stopLocId = stopLocId,
+                    stopOrder = stopLM.order,
+                    waitingTimeStart = now,
+                    waitingTimeEnd = Nothing,
+                    stopStartLatLng = pt,
+                    rideId = rideId,
+                    stopEndLatLng = Nothing,
+                    createdAt = now,
+                    updatedAt = now,
+                    id,
+                    merchantOperatingCityId = Just ride.merchantOperatingCityId,
+                    merchantId = ride.merchantId
+                  }
+          QSI.create stopInfo
+          let nowTs = floor $ utcTimeToPOSIXSeconds now
+          VID.addReachedStop rideId stopLM.order pt nowTs
+          let request = CallBAPInternal.StopEventsReq CallBAPInternal.Arrive rideId stopLM.order now Nothing
+          fork "BAPInternal:stopEventsArrive" . withShortRetry $
+            void $ CallBAPInternal.stopEvents appBackendBapInternal.apiKey appBackendBapInternal.url request
+          fork "FleetEngine:notifyStopArrived" $
+            FleetEngine.notifyStopArrived ride.merchantOperatingCityId ride.id currentStopFEIndex
+          pure Success
   where
     isValidStopArrivedAction stopLM =
       all (\stopInfo -> stopInfo.stopOrder < stopLM.order && isJust stopInfo.waitingTimeEnd && isJust stopInfo.stopEndLatLng)


### PR DESCRIPTION
… bap stopEvents with retries

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when stopping rides by retrying event updates automatically.
  * Prevented duplicate stop records when an arrival stop has already been registered.
  * Repeated arrival-stop requests now complete successfully instead of returning an invalid-request error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->