### PR TITLE
feat: live aware cancellation and rescheduling

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
+++ b/Backend/app/rider-platform/rider-app/Main/rider-app.cabal
@@ -533,6 +533,7 @@ library
       SharedLogic.FRFSCancelJourney
       SharedLogic.FRFSConfirm
       SharedLogic.FRFSFareCalculator
+      SharedLogic.FRFSLiveTrip
       SharedLogic.FRFSPassConfirm
       SharedLogic.FRFSPassOverride
       SharedLogic.FRFSReschedule

--- a/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/Storage/FrfsTicket.yaml
@@ -1319,6 +1319,8 @@ FRFSVehicleServiceTier:
     # a negative maxCancellationCount means unlimited. See SharedLogic.FRFSUtils.getCancellationQuota.
     maxCancellationCount: Maybe Int
     cancellationWindowSeconds: Maybe Int
+    cancellationDelayThresholdSeconds: Maybe Seconds
+    useLiveForCancellationAndRescheduling: Maybe Bool
     merchantId: Id Merchant
     integratedBppConfigId: Id IntegratedBPPConfig
     merchantOperatingCityId: Id MerchantOperatingCity

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/FRFSVehicleServiceTier.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Domain/Types/FRFSVehicleServiceTier.hs
@@ -15,6 +15,7 @@ import qualified Tools.Beam.UtilsTH
 
 data FRFSVehicleServiceTier = FRFSVehicleServiceTier
   { _type :: BecknV2.FRFS.Enums.ServiceTierType,
+    cancellationDelayThresholdSeconds :: Kernel.Prelude.Maybe Kernel.Types.Time.Seconds,
     cancellationWindowSeconds :: Kernel.Prelude.Maybe Kernel.Prelude.Int,
     description :: Kernel.Prelude.Text,
     id :: Kernel.Types.Id.Id Domain.Types.FRFSVehicleServiceTier.FRFSVehicleServiceTier,
@@ -32,6 +33,7 @@ data FRFSVehicleServiceTier = FRFSVehicleServiceTier
     providerCode :: Kernel.Prelude.Text,
     shortName :: Kernel.Prelude.Text,
     trainType :: Kernel.Prelude.Maybe Kernel.Prelude.Text,
+    useLiveForCancellationAndRescheduling :: Kernel.Prelude.Maybe Kernel.Prelude.Bool,
     createdAt :: Kernel.Prelude.UTCTime,
     updatedAt :: Kernel.Prelude.UTCTime
   }

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/FRFSVehicleServiceTier.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Beam/FRFSVehicleServiceTier.hs
@@ -14,6 +14,7 @@ import Tools.Beam.UtilsTH
 
 data FRFSVehicleServiceTierT f = FRFSVehicleServiceTierT
   { _type :: B.C f BecknV2.FRFS.Enums.ServiceTierType,
+    cancellationDelayThresholdSeconds :: B.C f (Kernel.Prelude.Maybe Kernel.Types.Time.Seconds),
     cancellationWindowSeconds :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Int),
     description :: B.C f Kernel.Prelude.Text,
     id :: B.C f Kernel.Prelude.Text,
@@ -31,6 +32,7 @@ data FRFSVehicleServiceTierT f = FRFSVehicleServiceTierT
     providerCode :: B.C f Kernel.Prelude.Text,
     shortName :: B.C f Kernel.Prelude.Text,
     trainType :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Text),
+    useLiveForCancellationAndRescheduling :: B.C f (Kernel.Prelude.Maybe Kernel.Prelude.Bool),
     createdAt :: B.C f Kernel.Prelude.UTCTime,
     updatedAt :: B.C f Kernel.Prelude.UTCTime
   }

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSVehicleServiceTier.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/Storage/Queries/FRFSVehicleServiceTier.hs
@@ -85,6 +85,7 @@ updateByPrimaryKey (Domain.Types.FRFSVehicleServiceTier.FRFSVehicleServiceTier {
   _now <- getCurrentTime
   updateWithKV
     [ Se.Set Beam._type _type,
+      Se.Set Beam.cancellationDelayThresholdSeconds cancellationDelayThresholdSeconds,
       Se.Set Beam.cancellationWindowSeconds cancellationWindowSeconds,
       Se.Set Beam.description description,
       Se.Set Beam.integratedBppConfigId (Kernel.Types.Id.getId integratedBppConfigId),
@@ -101,6 +102,7 @@ updateByPrimaryKey (Domain.Types.FRFSVehicleServiceTier.FRFSVehicleServiceTier {
       Se.Set Beam.providerCode providerCode,
       Se.Set Beam.shortName shortName,
       Se.Set Beam.trainType trainType,
+      Se.Set Beam.useLiveForCancellationAndRescheduling useLiveForCancellationAndRescheduling,
       Se.Set Beam.updatedAt _now
     ]
     [Se.And [Se.Is Beam.id $ Se.Eq (Kernel.Types.Id.getId id)]]
@@ -111,6 +113,7 @@ instance FromTType' Beam.FRFSVehicleServiceTier Domain.Types.FRFSVehicleServiceT
       Just
         Domain.Types.FRFSVehicleServiceTier.FRFSVehicleServiceTier
           { _type = _type,
+            cancellationDelayThresholdSeconds = cancellationDelayThresholdSeconds,
             cancellationWindowSeconds = cancellationWindowSeconds,
             description = description,
             id = Kernel.Types.Id.Id id,
@@ -128,6 +131,7 @@ instance FromTType' Beam.FRFSVehicleServiceTier Domain.Types.FRFSVehicleServiceT
             providerCode = providerCode,
             shortName = shortName,
             trainType = trainType,
+            useLiveForCancellationAndRescheduling = useLiveForCancellationAndRescheduling,
             createdAt = createdAt,
             updatedAt = updatedAt
           }
@@ -136,6 +140,7 @@ instance ToTType' Beam.FRFSVehicleServiceTier Domain.Types.FRFSVehicleServiceTie
   toTType' (Domain.Types.FRFSVehicleServiceTier.FRFSVehicleServiceTier {..}) = do
     Beam.FRFSVehicleServiceTierT
       { Beam._type = _type,
+        Beam.cancellationDelayThresholdSeconds = cancellationDelayThresholdSeconds,
         Beam.cancellationWindowSeconds = cancellationWindowSeconds,
         Beam.description = description,
         Beam.id = Kernel.Types.Id.getId id,
@@ -153,6 +158,7 @@ instance ToTType' Beam.FRFSVehicleServiceTier Domain.Types.FRFSVehicleServiceTie
         Beam.providerCode = providerCode,
         Beam.shortName = shortName,
         Beam.trainType = trainType,
+        Beam.useLiveForCancellationAndRescheduling = useLiveForCancellationAndRescheduling,
         Beam.createdAt = createdAt,
         Beam.updatedAt = updatedAt
       }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnConfirm.hs
@@ -145,7 +145,7 @@ validateRequest DOrder {..} = do
       void $ withTryCatch "onConfirmValidate:releaseTrip" (FRFSPassOverride.releasePassOverrideTripOnFailure booking)
       whenJust mbBookingPayment $ \bookingPayment -> void $ SPayment.markRefundPendingAndSyncOrderStatus merchantId booking.riderId bookingPayment.paymentOrderId
       let updatedBooking = booking {Booking.bppOrderId = Just bppOrderId}
-      void $ cancel merchant merchantOperatingCity bapConfig Spec.CONFIRM_CANCEL Technical False updatedBooking
+      void $ cancel merchant merchantOperatingCity bapConfig Spec.CONFIRM_CANCEL Technical False Nothing updatedBooking
       throwM $ InvalidRequest "Booking expired, initated cancel request"
     else return (merchant, booking, quoteCategories)
 
@@ -188,7 +188,7 @@ onConfirmFailure bapConfig ticketBooking = do
   whenJust mbBookingPayment $ \bookingPayment -> void $ SPayment.markRefundPendingAndSyncOrderStatus merchant.id ticketBooking.riderId bookingPayment.paymentOrderId
   -- enforceCap=False: this is a Technical cancellation, so it must not consume the rider's
   -- cancellation allowance (see ExternalBPP.CallAPI.Cancel).
-  void $ cancel merchant merchantOperatingCity bapConfig Spec.CONFIRM_CANCEL Technical False ticketBooking
+  void $ cancel merchant merchantOperatingCity bapConfig Spec.CONFIRM_CANCEL Technical False Nothing ticketBooking
 
 onConfirm ::
   ( CacheFlow m r,

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnSearch.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Beckn/FRFS/OnSearch.hs
@@ -706,6 +706,8 @@ createEntriesInFareTables merchantId merchantOperatingCityId routeCode startStop
                   maxRescheduleDaysAhead = Nothing,
                   maxCancellationCount = Nothing,
                   cancellationWindowSeconds = Nothing,
+                  cancellationDelayThresholdSeconds = Nothing,
+                  useLiveForCancellationAndRescheduling = Nothing,
                   createdAt = now,
                   updatedAt = now
                 }

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/FRFSTicketService.hs
@@ -95,6 +95,7 @@ import SharedLogic.External.Nandi.Types (GimsCurrentTripDetailsReq (..), GimsOpe
 import qualified SharedLogic.FRFSCancel as FRFSCancel
 import qualified SharedLogic.FRFSCancelJourney as FRFSCancelJourney
 import SharedLogic.FRFSConfirm
+import qualified SharedLogic.FRFSLiveTrip as FRFSLiveTrip
 import qualified SharedLogic.FRFSPassOverride as FRFSPassOverride
 import qualified SharedLogic.FRFSReschedule as FRFSReschedule
 import qualified SharedLogic.FRFSSeatBooking as SeatBooking
@@ -1147,7 +1148,8 @@ postFrfsBookingCanCancel (_, merchantId) bookingId = do
   ticketBooking <- QFRFSTicketBooking.findById bookingId >>= fromMaybeM (InvalidRequest "Invalid ticketBookingId")
   merchantOperatingCity <- CQMOC.findById ticketBooking.merchantOperatingCityId >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchantOperatingCityId- " <> show ticketBooking.merchantOperatingCityId)
   bapConfig <- getOneConfig (BecknConfigDimensions {merchantOperatingCityId = merchantOperatingCity.id.getId, merchantId = merchant.id.getId, domain = Just (show Spec.FRFS), vehicleCategory = Just (frfsVehicleCategoryToBecknVehicleCategory ticketBooking.vehicleType), becknProtocol = Nothing}) (Just (maybeToList <$> CQBC.findByMerchantIdDomainVehicleAndMerchantOperatingCityIdWithFallback merchantOperatingCity.id merchant.id (show Spec.FRFS) (frfsVehicleCategoryToBecknVehicleCategory ticketBooking.vehicleType))) >>= fromMaybeM (InternalError "Beckn Config not found")
-  mbSideEffectData <- CallExternalBPP.cancel merchant merchantOperatingCity bapConfig Spec.SOFT_CANCEL CallExternalBPP.UserInitiated True ticketBooking
+  mbLiveDecision <- FRFSLiveTrip.getLiveTripDecision ticketBooking
+  mbSideEffectData <- CallExternalBPP.cancel merchant merchantOperatingCity bapConfig Spec.SOFT_CANCEL CallExternalBPP.UserInitiated True mbLiveDecision ticketBooking
   whenJust mbSideEffectData $ \(mRiderNumber, mRiderMobileCountryCode, fareParameters, updatedBooking) ->
     FRFSCancel.handleCancelledSideEffects updatedBooking mRiderNumber mRiderMobileCountryCode fareParameters
   return APISuccess.Success
@@ -1163,11 +1165,13 @@ getFrfsBookingCanCancelStatus _ bookingId = do
       (mbCancelEntityId, mbCancelEntityName) = case (.source) <$> mbQuota of
         Just (FRFSUtils.PassQuota eid ename) -> (Just eid, ename)
         _ -> (Nothing, Nothing)
+  mbLiveDecision <- FRFSLiveTrip.getLiveTripDecision ticketBooking
+  let liveDenied = maybe False (not . (.canCancel)) mbLiveDecision
   return $
     FRFSCanCancelStatus
       { cancellationCharges = getAbsoluteValue ticketBooking.cancellationCharges,
         refundAmount = getAbsoluteValue ticketBooking.refundAmount,
-        isCancellable = if quotaExhausted then Just False else ticketBooking.isBookingCancellable,
+        isCancellable = if quotaExhausted || liveDenied then Just False else ticketBooking.isBookingCancellable,
         cancellationsUsed = mbCancellationsUsed,
         maxCancellationCount = (.maxCancellations) <$> mbQuota,
         cancelOverrideEntityType = DFRFSTicketBooking.PassOverride <$ mbCancelEntityId,
@@ -1181,7 +1185,8 @@ postFrfsBookingCancel (_, merchantId) bookingId = do
   ticketBooking <- QFRFSTicketBooking.findById bookingId >>= fromMaybeM (InvalidRequest "Invalid booking id")
   merchantOperatingCity <- CQMOC.findById ticketBooking.merchantOperatingCityId >>= fromMaybeM (InvalidRequest $ "Invalid merchant operating city id" <> ticketBooking.merchantOperatingCityId.getId)
   bapConfig <- getOneConfig (BecknConfigDimensions {merchantOperatingCityId = merchantOperatingCity.id.getId, merchantId = merchant.id.getId, domain = Just (show Spec.FRFS), vehicleCategory = Just (frfsVehicleCategoryToBecknVehicleCategory ticketBooking.vehicleType), becknProtocol = Nothing}) (Just (maybeToList <$> CQBC.findByMerchantIdDomainVehicleAndMerchantOperatingCityIdWithFallback merchantOperatingCity.id merchant.id (show Spec.FRFS) (frfsVehicleCategoryToBecknVehicleCategory ticketBooking.vehicleType))) >>= fromMaybeM (InternalError "Beckn Config not found")
-  mbSideEffectData <- CallExternalBPP.cancel merchant merchantOperatingCity bapConfig Spec.CONFIRM_CANCEL CallExternalBPP.UserInitiated True ticketBooking
+  mbLiveDecision <- FRFSLiveTrip.getLiveTripDecision ticketBooking
+  mbSideEffectData <- CallExternalBPP.cancel merchant merchantOperatingCity bapConfig Spec.CONFIRM_CANCEL CallExternalBPP.UserInitiated True mbLiveDecision ticketBooking
   whenJust mbSideEffectData $ \(mRiderNumber, mRiderMobileCountryCode, fareParameters, updatedBooking) -> do
     FRFSCancel.handleCancelledSideEffects updatedBooking mRiderNumber mRiderMobileCountryCode fareParameters
     FRFSCancelJourney.cancelJourney updatedBooking
@@ -1220,7 +1225,8 @@ postFrfsBookingReschedule (mbPersonId, merchantId) oldBookingId req = do
       serviceTierType <-
         FRFSUtils.getServiceTierTypeFromRouteStationsJson oldBooking.routeStationsJson
           & fromMaybeM (InvalidRequest "Cannot determine service tier for this booking, reschedule not supported")
-      FRFSReschedule.validateRescheduleEligibility oldBooking req.tripId newFromCode newToCode newRouteCode integratedBppConfig
+      mbLiveDecision <- FRFSLiveTrip.getLiveTripDecision oldBooking
+      FRFSReschedule.validateRescheduleEligibility oldBooking req.tripId newFromCode newToCode newRouteCode integratedBppConfig mbLiveDecision
       bapConfig <- getOneConfig (BecknConfigDimensions {merchantOperatingCityId = oldBooking.merchantOperatingCityId.getId, merchantId = oldBooking.merchantId.getId, domain = Just (show Spec.FRFS), vehicleCategory = Just (frfsVehicleCategoryToBecknVehicleCategory oldBooking.vehicleType), becknProtocol = Nothing}) (Just (maybeToList <$> CQBC.findByMerchantIdDomainVehicleAndMerchantOperatingCityIdWithFallback oldBooking.merchantOperatingCityId oldBooking.merchantId (show Spec.FRFS) (frfsVehicleCategoryToBecknVehicleCategory oldBooking.vehicleType))) >>= fromMaybeM (InternalError "Beckn Config not found")
       FRFSReschedule.withRescheduleLock oldBooking.id $ do
         freshOldBooking <- QFRFSTicketBooking.findById oldBooking.id >>= fromMaybeM (InvalidRequest "Invalid booking id")

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Cancel.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Cancel.hs
@@ -21,6 +21,7 @@ import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig)
 import qualified Lib.Finance.Core.Types as Finance
 import qualified SharedLogic.CallFRFSBPP as CallFRFSBPP
+import qualified SharedLogic.FRFSLiveTrip as FRFSLiveTrip
 import qualified SharedLogic.FRFSReschedule as FRFSReschedule
 import SharedLogic.FRFSUtils as FRFSUtils
 import qualified SharedLogic.IntegratedBPPConfig as SIBC
@@ -61,9 +62,10 @@ cancel ::
   CancellationInitiator ->
   -- | Enforce the per-rider cancellation cap. False for journey-driven cancellations.
   Bool ->
+  Maybe FRFSLiveTrip.LiveTripDecision ->
   DBooking.FRFSTicketBooking ->
   m (Maybe (Maybe Text, Maybe Text, FRFSUtils.FRFSFareParameters, DBooking.FRFSTicketBooking))
-cancel merchant merchantOperatingCity bapConfig cancellationType initiator enforceCap inputBooking =
+cancel merchant merchantOperatingCity bapConfig cancellationType initiator enforceCap mbLiveDecision inputBooking =
   FRFSReschedule.withRescheduleLock inputBooking.id $ do
     booking <- QFRFSTicketBooking.findById inputBooking.id >>= fromMaybeM (InvalidRequest "Booking not found for cancellation")
     when (booking.status == DFRFSTicketBooking.RESCHEDULED) $
@@ -81,6 +83,9 @@ cancel merchant merchantOperatingCity bapConfig cancellationType initiator enfor
     whenJust mbServiceTierType $ \serviceTierType -> do
       mbVst <- QFRFSVehicleServiceTier.findByServiceTierAndMerchantOperatingCityIdAndIntegratedBPPConfigId serviceTierType merchantOperatingCity.id integratedBPPConfig.id
       unless (fromMaybe True (mbVst >>= (.isCancellable))) $ throwError CancellationNotSupported
+    whenJust mbLiveDecision $ \decision ->
+      unless decision.canCancel $
+        throwError $ InvalidRequest (fromMaybe "Cancellation is not available for this trip" decision.cancelDenyReason)
     when (cancellationType == Spec.SOFT_CANCEL) $
       unless (booking.status == DFRFSTicketBooking.CONFIRMED) $ throwError (InvalidRequest $ "Cancellation during incorrect status: " <> show booking.status)
     -- Must stay last of the gates, and enforceCap must stay False on the journey path or route edits
@@ -100,7 +105,7 @@ cancel merchant merchantOperatingCity bapConfig cancellationType initiator enfor
           void $ CallFRFSBPP.cancel providerUrl bknCancelReq merchant.id
         return Nothing
       _ -> do
-        onCancelReq <- Flow.cancel merchant merchantOperatingCity integratedBPPConfig bapConfig cancellationType booking
+        onCancelReq <- Flow.cancel merchant merchantOperatingCity integratedBPPConfig bapConfig cancellationType mbLiveDecision booking
         mbSideEffectData <- OnCancelCore.onCancelCore merchant booking onCancelReq
         let updatedBooking = booking {DBooking.bppOrderId = Just onCancelReq.bppOrderId}
         return $ fmap (\(a, b, c) -> (a, b, c, updatedBooking)) mbSideEffectData

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/CallAPI/Types.hs
@@ -39,5 +39,6 @@ type FRFSConfirmFlow m r c =
     HasFlowEnv m r '["urlShortnerConfig" ::: UrlShortner.UrlShortnerConfig],
     HasFlowEnv m r '["googleSAPrivateKey" ::: String],
     HasField "ltsHedisEnv" r HedisEnv,
+    HedisLTSFlowEnv r,
     Finance.HasActorInfo m r
   )

--- a/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Common.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/ExternalBPP/Flow/Common.hs
@@ -43,6 +43,7 @@ import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig)
 import Lib.JourneyModule.Types (mkRouteDetail)
 import qualified Lib.JourneyModule.Utils as JMU
+import qualified SharedLogic.FRFSLiveTrip as FRFSLiveTrip
 import SharedLogic.FRFSUtils
 import qualified Storage.CachedQueries.FRFSCancellationConfig as CQFRFSCancellationConfig
 import Storage.CachedQueries.OTPRest.OTPRest as OTPRest
@@ -552,15 +553,21 @@ verifyTicket _merchantId _merchantOperatingCity integratedBPPConfig _bapConfig e
   TicketPayload {..} <- CallAPI.verifyTicket integratedBPPConfig encryptedQrData
   return DTicketPayload {..}
 
-cancel :: (CoreMetrics m, CacheFlow m r, EsqDBFlow m r, DB.EsqDBReplicaFlow m r, EncFlow m r, HasMasterCloudForwarder r) => Merchant -> MerchantOperatingCity -> IntegratedBPPConfig -> BecknConfig -> Spec.CancellationType -> DFRFSTicketBooking.FRFSTicketBooking -> m DOnCancel.DOnCancel
-cancel _merchant merchantOperatingCity integratedBPPConfig bapConfig cancellationType booking = do
+cancel :: (CoreMetrics m, CacheFlow m r, EsqDBFlow m r, DB.EsqDBReplicaFlow m r, EncFlow m r, HasMasterCloudForwarder r) => Merchant -> MerchantOperatingCity -> IntegratedBPPConfig -> BecknConfig -> Spec.CancellationType -> Maybe FRFSLiveTrip.LiveTripDecision -> DFRFSTicketBooking.FRFSTicketBooking -> m DOnCancel.DOnCancel
+cancel _merchant merchantOperatingCity integratedBPPConfig bapConfig cancellationType mbLiveDecision booking = do
   bppOrderId <- booking.bppOrderId & fromMaybeM (InternalError "BPP Order Id Not Found")
   let orderStatus = case cancellationType of
         Spec.SOFT_CANCEL -> Spec.SOFT_CANCELLED
         Spec.CONFIRM_CANCEL -> Spec.CANCELLED
   let baseFare = fromMaybe booking.totalPrice.amount booking.overriddenAmount
-      departureTime = fromMaybe booking.validTill booking.startTime
-  (charges, refund) <- calculateCancellationCharges merchantOperatingCity.id booking.vehicleType baseFare departureTime
+      scheduledDepartureTime = fromMaybe booking.validTill booking.startTime
+      tieredCharges departureTime = calculateCancellationCharges merchantOperatingCity.id booking.vehicleType baseFare departureTime
+  (charges, refund) <- case mbLiveDecision of
+    Just decision
+      | not decision.canCancel -> throwError CancellationNotSupported
+      | decision.fullRefund -> pure (0, baseFare)
+      | otherwise -> tieredCharges decision.chargeAnchor
+    Nothing -> tieredCharges scheduledDepartureTime
   return $
     DOnCancel.DOnCancel
       { providerId = bapConfig.uniqueKeyId,

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyLeg/Common/FRFS.hs
@@ -32,6 +32,7 @@ import ExternalBPP.CallAPI as CallExternalBPP
 import ExternalBPP.ExternalAPI.CallAPI as CallAPI
 import qualified ExternalBPP.Flow as Flow
 import Kernel.External.MasterCloudForward (HasMasterCloudForwarder)
+import Kernel.External.Types (ServiceFlow)
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto hiding (isNothing)
 import qualified Kernel.Storage.Esqueleto as DB
@@ -408,7 +409,7 @@ getFare riderId merchant merchantOperatingCity vehicleCategory serviecType route
           )
           fares
 
-getInfo :: (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, HasShortDurationRetryCfg r c) => Id FRFSSearch -> DJourneyLeg.JourneyLeg -> [DJourneyLeg.JourneyLeg] -> Maybe [FRFSPassOverride.PassCandidate] -> m (Maybe JT.LegInfo)
+getInfo :: (ServiceFlow m r, HasShortDurationRetryCfg r c, Hedis.HedisLTSFlowEnv r, HasField "cloudType" r (Maybe CloudType)) => Id FRFSSearch -> DJourneyLeg.JourneyLeg -> [DJourneyLeg.JourneyLeg] -> Maybe [FRFSPassOverride.PassCandidate] -> m (Maybe JT.LegInfo)
 getInfo searchId journeyLeg journeyLegs mbPassCandidates = do
   mbBooking <- QTBooking.findBySearchId searchId
   case mbBooking of
@@ -472,7 +473,7 @@ cancel searchId cancellationType = do
     merchant <- CQM.findById metroBooking.merchantId >>= fromMaybeM (MerchantDoesNotExist metroBooking.merchantId.getId)
     merchantOperatingCity <- CQMOC.findById metroBooking.merchantOperatingCityId >>= fromMaybeM (MerchantOperatingCityNotFound metroBooking.merchantOperatingCityId.getId)
     bapConfig <- getOneConfig (BecknConfigDimensions {merchantOperatingCityId = merchantOperatingCity.id.getId, merchantId = merchant.id.getId, domain = Just (show Spec.FRFS), vehicleCategory = Just (frfsVehicleCategoryToBecknVehicleCategory metroBooking.vehicleType), becknProtocol = Nothing}) (Just (maybeToList <$> CQBC.findByMerchantIdDomainVehicleAndMerchantOperatingCityIdWithFallback merchantOperatingCity.id merchant.id (show Spec.FRFS) (frfsVehicleCategoryToBecknVehicleCategory metroBooking.vehicleType))) >>= fromMaybeM (InternalError "Beckn Config not found")
-    mbSideEffectData <- CallExternalBPP.cancel merchant merchantOperatingCity bapConfig cancellationType CallExternalBPP.UserInitiated False metroBooking
+    mbSideEffectData <- CallExternalBPP.cancel merchant merchantOperatingCity bapConfig cancellationType CallExternalBPP.UserInitiated False Nothing metroBooking
     whenJust mbSideEffectData $ \(mRiderNumber, mRiderMobileCountryCode, fareParameters, updatedBooking) -> do
       FRFSCancel.handleCancelledSideEffects updatedBooking mRiderNumber mRiderMobileCountryCode fareParameters
       FRFSCancelJourney.cancelJourney updatedBooking

--- a/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Lib/JourneyModule/Types.hs
@@ -81,6 +81,7 @@ import Lib.SessionizerMetrics.Types.Event
 import qualified Lib.Yudhishthira.Types as YTypes
 import SharedLogic.Booking (getfareBreakups)
 import qualified SharedLogic.External.LocationTrackingService.Types as LT
+import qualified SharedLogic.FRFSLiveTrip as FRFSLiveTrip
 import qualified SharedLogic.FRFSPassOverride as FRFSPassOverride
 import SharedLogic.FRFSUtils
 import qualified SharedLogic.IntegratedBPPConfig as SIBC
@@ -889,7 +890,7 @@ mkWalkLegInfoFromWalkLegData personId legData@DJL.JourneyLeg {..} = do
         }
 
 mkLegInfoFromFrfsBooking ::
-  (CacheFlow m r, EncFlow m r, EsqDBFlow m r, MonadFlow m, HasShortDurationRetryCfg r c) => DFRFSBooking.FRFSTicketBooking -> DJourneyLeg.JourneyLeg -> m LegInfo
+  (ServiceFlow m r, HasShortDurationRetryCfg r c, Redis.HedisLTSFlowEnv r, HasField "cloudType" r (Maybe CloudType)) => DFRFSBooking.FRFSTicketBooking -> DJourneyLeg.JourneyLeg -> m LegInfo
 mkLegInfoFromFrfsBooking booking journeyLeg = do
   integratedBPPConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
   tickets <- QFRFSTicket.findAllByTicketBookingId (booking.id)
@@ -1239,7 +1240,7 @@ getLegRouteInfo mbFallback journeyRouteDetailsWithTrackingStatuses integratedBPP
         }
 
 computeIsCancellableAndReschedulable ::
-  (CacheFlow m r, EsqDBFlow m r, MonadFlow m) =>
+  (ServiceFlow m r, HasShortDurationRetryCfg r c, Redis.HedisLTSFlowEnv r, HasField "cloudType" r (Maybe CloudType)) =>
   DFRFSBooking.FRFSTicketBooking ->
   DIBC.IntegratedBPPConfig ->
   m (Maybe Bool, Maybe Bool, Maybe Int)
@@ -1252,30 +1253,29 @@ computeIsCancellableAndReschedulable booking integratedBPPConfig = do
   mbVst <- case mbServiceTierType of
     Just serviceTierType -> QFRFSVehicleServiceTier.findByServiceTierAndMerchantOperatingCityIdAndIntegratedBPPConfigId serviceTierType booking.merchantOperatingCityId integratedBPPConfig.id
     Nothing -> return Nothing
-  let isCancellable = case mbServiceTierType of
+  let remainingReschedules = max 0 (fromMaybe 1 (mbVst >>= (.maxRescheduleCount)) - fromMaybe 0 booking.rescheduleCount)
+      isCancellable = case mbServiceTierType of
         Just _ -> configCancellable && fromMaybe True (mbVst >>= (.isCancellable)) && userCancellationAllowed
         Nothing -> configCancellable && userCancellationAllowed
-  isReschedulable <- computeIsReschedulable mbVst configReschedulable
-  let remainingRescheduleCount =
-        if isReschedulable
-          then max 0 (fromMaybe 1 (mbVst >>= (.maxRescheduleCount)) - fromMaybe 0 booking.rescheduleCount)
-          else 0
+  isReschedulable <- computeIsReschedulable mbVst configReschedulable remainingReschedules
+  let remainingRescheduleCount = if isReschedulable then remainingReschedules else 0
   return (Just isCancellable, Just isReschedulable, Just remainingRescheduleCount)
   where
-    computeIsReschedulable mbVst configReschedulable = do
-      let vstReschedulable = fromMaybe False (mbVst >>= (.isRescheduleAllowed))
-          withinRescheduleCount = fromMaybe 0 booking.rescheduleCount < fromMaybe 1 (mbVst >>= (.maxRescheduleCount))
-          maxRescheduleTimeAfterStart = fromMaybe (Seconds 1800) (mbVst >>= (.maxRescheduleTimeAfterStart))
-      now <- getCurrentTime
-      let pastWindow = case booking.startTime of
-            Just startTime -> now > addUTCTime (fromIntegral (getSeconds maxRescheduleTimeAfterStart)) startTime
-            Nothing -> False
-      return $
-        booking.status == DFRFSBookingStatus.CONFIRMED
-          && configReschedulable
-          && vstReschedulable
-          && withinRescheduleCount
-          && not pastWindow
+    computeIsReschedulable mbVst configReschedulable remainingReschedules = do
+      let scheduleReschedulable =
+            booking.status == DFRFSBookingStatus.CONFIRMED
+              && configReschedulable
+              && fromMaybe False (mbVst >>= (.isRescheduleAllowed))
+              && remainingReschedules > 0
+      if not scheduleReschedulable
+        then return False
+        else do
+          mbLiveDecision <- FRFSLiveTrip.getLiveTripDecision booking
+          now <- getCurrentTime
+          let withinScheduledWindow = case booking.startTime of
+                Just startTime -> now <= addUTCTime (fromIntegral (getSeconds (fromMaybe (Seconds 1800) (mbVst >>= (.maxRescheduleTimeAfterStart))))) startTime
+                Nothing -> True
+          return $ maybe withinScheduledWindow (.canReschedule) mbLiveDecision
 
 castCategoryToMode :: Spec.VehicleCategory -> DTrip.MultimodalTravelMode
 castCategoryToMode Spec.METRO = DTrip.Metro

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Types.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Types.hs
@@ -963,7 +963,8 @@ data BusScheduleDetail = BusScheduleDetail
     service_tier :: BecknV2.FRFS.Enums.ServiceTierType,
     trip_number :: Maybe Int,
     waybill_no :: Maybe Text,
-    is_active_trip :: Maybe Bool
+    is_active_trip :: Maybe Bool,
+    is_completed :: Maybe Bool
   }
   deriving (Generic, FromJSON, ToJSON, ToSchema, Show)
 

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSLiveTrip.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSLiveTrip.hs
@@ -1,0 +1,134 @@
+module SharedLogic.FRFSLiveTrip
+  ( LiveTripDecision (..),
+    getLiveTripDecision,
+  )
+where
+
+import qualified BecknV2.FRFS.Enums as Spec
+import Data.Aeson
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import qualified Domain.Types.FRFSTicketBooking as DFRFSTicketBooking
+import qualified Domain.Types.JourneyLeg as DJourneyLeg
+import Kernel.External.Types (ServiceFlow)
+import Kernel.Prelude
+import qualified Kernel.Storage.Hedis as Hedis
+import Kernel.Types.Version (CloudType (..))
+import Kernel.Utils.Common
+import qualified Lib.JourneyModule.Utils as JourneyUtils
+import qualified SharedLogic.FRFSUtils as FRFSUtils
+import qualified SharedLogic.IntegratedBPPConfig as SIBC
+import qualified Storage.CachedQueries.FRFSVehicleServiceTier as CQFRFSVehicleServiceTier
+import qualified Storage.CachedQueries.Merchant.MultiModalBus as CQMMB
+import qualified Storage.CachedQueries.OTPRest.OTPRest as OTPRest
+
+data LiveTripDecision = LiveTripDecision
+  { canCancel :: Bool,
+    cancelDenyReason :: Maybe Text,
+    fullRefund :: Bool,
+    chargeAnchor :: UTCTime,
+    canReschedule :: Bool,
+    rescheduleDenyReason :: Maybe Text
+  }
+  deriving (Show, Eq, Generic, ToJSON)
+
+getLiveTripDecision ::
+  (ServiceFlow m r, HasShortDurationRetryCfg r c, Hedis.HedisLTSFlowEnv r, HasField "cloudType" r (Maybe CloudType)) =>
+  DFRFSTicketBooking.FRFSTicketBooking ->
+  m (Maybe LiveTripDecision)
+getLiveTripDecision booking = do
+  eDecision <- withTryCatch "FRFSLiveTrip:getLiveTripDecision" $ do
+    now <- getCurrentTime
+    case (booking.vehicleType, booking.tripId, booking.routeCode) of
+      (Spec.BUS, Just tripId, Just routeCode) -> do
+        integratedBppConfig <- SIBC.findIntegratedBPPConfigFromEntity booking
+        let (waybillNo, tripNo) = JourneyUtils.getWaybillNoAndTripNoFromTripId tripId
+        schedule <- OTPRest.getBusTripSchedule waybillNo tripNo routeCode integratedBppConfig
+        let allEtas = concatMap (.eta) schedule
+        let tripOverReason = "This trip has already been completed"
+        case find (\e -> e.stopCode == booking.fromStationCode) allEtas of
+          Nothing
+            | null schedule ->
+              pure $
+                Just
+                  LiveTripDecision
+                    { canCancel = False,
+                      cancelDenyReason = Just tripOverReason,
+                      fullRefund = False,
+                      chargeAnchor = now,
+                      canReschedule = False,
+                      rescheduleDenyReason = Just tripOverReason
+                    }
+            | otherwise -> pure Nothing
+          Just boardingEta -> do
+            mbVst <- fmap join $
+              forM (FRFSUtils.getServiceTierTypeFromRouteStationsJson booking.routeStationsJson) $ \serviceTierType ->
+                CQFRFSVehicleServiceTier.findByServiceTierAndMerchantOperatingCityIdAndIntegratedBPPConfigId serviceTierType booking.merchantOperatingCityId integratedBppConfig.id
+            let scheduledDeparture = FRFSUtils.unixToUTC boardingEta.arrivalTimeUnix
+                scheduledTripStart = FRFSUtils.unixToUTC (minimum (map (.arrivalTimeUnix) allEtas))
+                scheduledTripEnd = FRFSUtils.unixToUTC (maximum (map (.arrivalTimeUnix) allEtas))
+                mbDelayThreshold = mbVst >>= (.cancellationDelayThresholdSeconds)
+                windowEnd = addUTCTime (diffUTCTime scheduledTripEnd scheduledTripStart) scheduledDeparture
+                mbIsActiveTrip = listToMaybe (mapMaybe (.is_active_trip) schedule)
+                shouldCheckLive =
+                  fromMaybe False (mbVst >>= (.useLiveForCancellationAndRescheduling))
+                    && case mbIsActiveTrip of
+                      Just isActive -> isActive
+                      Nothing -> False
+            (hasLiveMatch, crossedBoardingStop, mbLiveDeparture) <-
+              case (if shouldCheckLive then booking.vehicleNumber else Nothing) of
+                Nothing -> pure (False, False, Nothing)
+                Just vehicleNumber -> do
+                  routeWithBuses <- CQMMB.getRoutesBuses routeCode integratedBppConfig
+                  let nowSec = floor (utcTimeToPOSIXSeconds now) :: Int
+                      mbEtas = do
+                        bus <- find (\b -> b.vehicleNumber == vehicleNumber) routeWithBuses.buses
+                        guard (nowSec - bus.busData.timestamp <= 300)
+                        etas <- bus.busData.eta_data
+                        guard (not (null etas))
+                        pure etas
+                  pure $ case mbEtas of
+                    Nothing -> (False, False, Nothing)
+                    Just etas -> case find (\e -> e.stopCode == booking.fromStationCode) etas of
+                      Just stopEta -> (True, False, Just (FRFSUtils.unixToUTC stopEta.arrivalTimeUnix))
+                      Nothing -> (True, True, Nothing)
+            let completed = any ((== Just True) . (.is_completed)) schedule
+                rescheduleGrace = secondsToNominalDiffTime (fromMaybe (Seconds 1800) (mbVst >>= (.maxRescheduleTimeAfterStart)))
+                deviationSecs = case mbLiveDeparture of
+                  Just liveDeparture -> round (diffUTCTime liveDeparture scheduledDeparture)
+                  Nothing
+                    | mbIsActiveTrip == Just True -> 0
+                    | isNothing mbDelayThreshold -> 0
+                    | otherwise -> max 0 (round (diffUTCTime now scheduledTripStart))
+                effectiveDeparture = addUTCTime (fromIntegral deviationSecs) scheduledDeparture
+                mbDenyReason
+                  | booking.finalBoardedVehicleNumberSource == Just DJourneyLeg.UserActivated = Just "You have already boarded this trip"
+                  | completed = Just tripOverReason
+                  | hasLiveMatch && crossedBoardingStop = Just "Your bus has already departed from the boarding stop"
+                  | now > windowEnd = Just "This trip's scheduled window has passed"
+                  | otherwise = Nothing
+                rescheduleWindowEnd
+                  | Just liveDeparture <- mbLiveDeparture = liveDeparture
+                  | mbIsActiveTrip == Just True = addUTCTime rescheduleGrace scheduledDeparture
+                  | otherwise = addUTCTime rescheduleGrace scheduledTripEnd
+                decision =
+                  LiveTripDecision
+                    { canCancel = isNothing mbDenyReason,
+                      cancelDenyReason = mbDenyReason,
+                      fullRefund =
+                        isNothing mbDenyReason
+                          && maybe False (\threshold -> deviationSecs >= getSeconds threshold) mbDelayThreshold,
+                      chargeAnchor = effectiveDeparture,
+                      canReschedule = isNothing mbDenyReason && now <= rescheduleWindowEnd,
+                      rescheduleDenyReason =
+                        case mbDenyReason of
+                          Just reason -> Just reason
+                          Nothing -> if now <= rescheduleWindowEnd then Nothing else Just "Reschedule window has passed for this booking"
+                    }
+            logInfo $ "FRFSLiveTrip: bookingId-" <> booking.id.getId <> " deviationSecs=" <> show deviationSecs <> " hasLiveMatch=" <> show hasLiveMatch <> " decision=" <> show decision
+            pure (Just decision)
+      _ -> pure Nothing
+  case eDecision of
+    Left err -> do
+      logWarning $ "FRFSLiveTrip: no decision for bookingId-" <> booking.id.getId <> ", leaving eligibility to legacy checks: " <> show err
+      pure Nothing
+    Right mbDecision -> pure mbDecision

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSReschedule.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/FRFSReschedule.hs
@@ -24,6 +24,7 @@ import Kernel.Types.Id
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getConfig)
 import qualified Lib.JourneyModule.Utils as JourneyUtils
+import qualified SharedLogic.FRFSLiveTrip as FRFSLiveTrip
 import qualified SharedLogic.FRFSSeatBooking as SeatBooking
 import qualified SharedLogic.FRFSUtils as FRFSUtils
 import qualified Storage.CachedQueries.FRFSConfig as CQFRFS
@@ -54,8 +55,10 @@ validateRescheduleEligibility ::
   Text -> -- new destination stop code (defaults upstream to the old one)
   Text -> -- new route code (defaults upstream to the old one)
   DIBC.IntegratedBPPConfig ->
+  -- | Live-trip eligibility, resolved by the handler. Nothing leaves the schedule-only checks in charge.
+  Maybe FRFSLiveTrip.LiveTripDecision ->
   m ()
-validateRescheduleEligibility oldBooking newTripId newFromCode newToCode newRouteCode integratedBppConfig = do
+validateRescheduleEligibility oldBooking newTripId newFromCode newToCode newRouteCode integratedBppConfig mbLiveDecision = do
   unless (oldBooking.status == DFRFSTicketBookingStatus.CONFIRMED) $
     throwError $ InvalidRequest "Booking is not confirmed, cannot be rescheduled"
   frfsConfig <-
@@ -73,10 +76,15 @@ validateRescheduleEligibility oldBooking newTripId newFromCode newToCode newRout
     throwError $ InvalidRequest "Reschedule is not enabled for this service tier"
   when (fromMaybe 0 oldBooking.rescheduleCount >= fromMaybe 1 vst.maxRescheduleCount) $
     throwError $ InvalidRequest "Maximum number of reschedules exceeded for this booking"
-  pastWindow <- isPastRescheduleWindow oldBooking (fromMaybe (Seconds 1800) vst.maxRescheduleTimeAfterStart)
-  when pastWindow $ throwError $ InvalidRequest "Reschedule window has passed for this booking"
-  when (oldBooking.finalBoardedVehicleNumberSource == Just DJourneyLeg.UserActivated) $
-    throwError $ InvalidRequest "Cannot reschedule a trip you have already boarded"
+  case mbLiveDecision of
+    Just decision ->
+      unless decision.canReschedule $
+        throwError $ InvalidRequest (fromMaybe "Reschedule is not available for this trip" decision.rescheduleDenyReason)
+    Nothing -> do
+      pastWindow <- isPastRescheduleWindow oldBooking (fromMaybe (Seconds 1800) vst.maxRescheduleTimeAfterStart)
+      when pastWindow $ throwError $ InvalidRequest "Reschedule window has passed for this booking"
+      when (oldBooking.finalBoardedVehicleNumberSource == Just DJourneyLeg.UserActivated) $
+        throwError $ InvalidRequest "Cannot reschedule a trip you have already boarded"
   -- When the rider moves to a different boarding/alighting stop, it must stay within the same cluster as the
   -- original (nearby-equivalent stop). Same-stop reschedules (trip-only) skip this. Fare is enforced separately.
   let stopsChanged = newFromCode /= oldBooking.fromStationCode || newToCode /= oldBooking.toStationCode

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/OTPRest/OTPRest.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/OTPRest/OTPRest.hs
@@ -62,7 +62,7 @@ getBusTripSchedule ::
   Text ->
   IntegratedBPPConfig ->
   m BusScheduleDetails
-getBusTripSchedule waybillNo tripNumber routeId integratedBPPConfig = IM.withInMemCache ["getBusTripSchedule", integratedBPPConfig.id.getId, waybillNo, show tripNumber, routeId] 7200 $ do
+getBusTripSchedule waybillNo tripNumber routeId integratedBPPConfig = IM.withInMemCache ["getBusTripSchedule", integratedBPPConfig.id.getId, waybillNo, show tripNumber, routeId] 300 $ do
   baseUrl <- MM.getOTPRestServiceReq integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
   Flow.getBusTripSchedule baseUrl integratedBPPConfig.feedKey waybillNo tripNumber routeId
 

--- a/Backend/dev/migrations-read-only/rider-app/frfs_vehicle_service_tier.sql
+++ b/Backend/dev/migrations-read-only/rider-app/frfs_vehicle_service_tier.sql
@@ -46,3 +46,8 @@ ALTER TABLE atlas_app.frfs_vehicle_service_tier ADD COLUMN max_reschedule_time_a
 ALTER TABLE atlas_app.frfs_vehicle_service_tier ADD COLUMN max_reschedule_days_ahead integer ;
 ALTER TABLE atlas_app.frfs_vehicle_service_tier ADD COLUMN max_reschedule_count integer ;
 ALTER TABLE atlas_app.frfs_vehicle_service_tier ADD COLUMN is_reschedule_allowed boolean ;
+
+------- SQL updates -------
+
+ALTER TABLE atlas_app.frfs_vehicle_service_tier ADD COLUMN cancellation_delay_threshold_seconds integer ;
+ALTER TABLE atlas_app.frfs_vehicle_service_tier ADD COLUMN use_live_for_cancellation_and_rescheduling boolean ;

--- a/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
+++ b/Backend/lib/gtfs-data-server/src/Lib/GtfsDataServer/Types.hs
@@ -98,7 +98,8 @@ data BusScheduleDetail = BusScheduleDetail
     service_tier :: BecknV2.FRFS.Enums.ServiceTierType,
     trip_number :: Maybe Int,
     waybill_no :: Maybe Text,
-    is_active_trip :: Maybe Bool
+    is_active_trip :: Maybe Bool,
+    is_completed :: Maybe Bool
   }
   deriving (Generic, FromJSON, ToJSON, Show)
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


# FRFS live-aware cancel & reschedule — case reference

## Symbols

| Symbol | Meaning | Source |
|---|---|---|
| `S` | scheduled departure at the **rider's boarding stop** | `bus-trip-schedule` `.eta`, matched on `stop_id` |
| `origin` | scheduled time at the trip's **first stop** | `min arrival_time` over that trip's `.eta` |
| `E` | scheduled time at the trip's **last stop** | `max arrival_time` over that trip's `.eta` |
| `L` | **live** ETA at the rider's boarding stop | Redis `route:{routeCode}` → `eta_data` |
| `D` | delay, signed | derived — see below |
| `T` | `cancellationDelayThresholdSeconds` | `frfs_vehicle_service_tier`. **Unset = the delay concept is off for this tier**: no inferred delay (`D = 0`), no full refund, and `windowEnd = E` exactly |
| `G` | `maxRescheduleTimeAfterStart` | `frfs_vehicle_service_tier`, default 1800 |
| `windowEnd` | `S + (E − origin)` | outer boundary for cancelling — one trip duration after this rider's own scheduled departure |

## The three live states

`is_active_trip` and `is_completed` come from the GIMS `bus-trip-schedule` response; both are
written by **conductor actions** in the operator app, never by GPS or clock.

**The live plane is consulted only when the tier flag is on AND `is_active_trip == Just True`.**
`false` and `null` both mean no read — so a route whose conductors never mark trips is permanently
DARK, however well the bus is tracked.

| State | Condition |
|---|---|
| **LIVE** | flag on, `is_active_trip = true`, booked vehicle found in the route hash, reading fresh (≤300s), boarding stop still in `eta_data` |
| **PASSED** | as LIVE, but the boarding stop is **absent** from `eta_data` |
| **DARK** | flag off, `is_active_trip` false/null, no vehicle match, stale reading, or no `vehicleNumber` on the booking |

## Kill switch

`cancellationDelayThresholdSeconds` unset turns off the delay concept for a tier:

- `fullRefund` can never fire
- `D = 0` on the dark branches, so the charge anchor stays at `S` — the same timestamp legacy used
  (`booking.startTime`, from `getScheduledTripStartTime`), i.e. **charges are unchanged**

`useLiveForCancellationAndRescheduling` separately gates the route-hash read.

**What the switch does *not* cover:** `windowEnd` is derived from the schedule, not from `T`, so the
"scheduled window has passed" denial applies on every bus tier regardless. Together with the three
other new denials (boarded, `is_completed`, closed waybill) and the `E + G` reschedule window, those
are the behaviour differences that remain with both columns unset. All refuse rather than overpay.

## Master table

`windowEnd = S + (E − origin)` — one trip duration after this rider's own scheduled departure.
`G` = `maxRescheduleTimeAfterStart`.

| # | Situation | `D` | Cancel | Refund | Reschedule until |
|---|---|---|---|---|---|
| 1 | Not a bus / no `tripId` / no `routeCode` | — | *no opinion* — legacy | legacy | legacy |
| 2 | GIMS schedule fetch throws | — | *no opinion* — legacy | legacy | legacy |
| 3 | Schedule returns `[]` (waybill closed) | — | **deny** | — | **deny** |
| 4 | Boarding stop not in the schedule | — | *no opinion* — legacy | legacy | legacy |
| 5 | Rider boarded (`UserActivated`) | — | **deny** | — | **deny** |
| 6 | `is_completed = true` | — | **deny** | — | **deny** |
| 7 | PASSED (live, stop crossed) | — | **deny** | — | **deny** |
| 8 | `now > windowEnd` | — | **deny** | — | **deny** |
| 9 | LIVE, `T` set, `D < T` | `L − S` | allow | tiers vs `L` | `L` |
| 10 | LIVE, `T` set, `D ≥ T` | `L − S` | allow | **100%** | `L` |
| 11 | LIVE, `T` unset | `L − S` | allow | tiers vs `L` | `L` |
| 12 | `is_active_trip = true`, no live match (flag off, not in hash, or stale) | `0` | allow | tiers vs `S` | `S + G` |
| 13 | `is_active_trip` false/null, `T` unset | `0` | allow | tiers vs `S` | `E + G` |
| 14 | `is_active_trip` false/null, `T` set, not yet overdue | `0` | allow | tiers vs `S` | `E + G` |
| 15 | `is_active_trip` false/null, `T` set, overdue, `D < T` | `now − origin` | allow | tiers vs `S + D` | `E + G` |
| 16 | `is_active_trip` false/null, `T` set, overdue, `D ≥ T` | `now − origin` | allow | **100%** | `E + G` |

Rows 1, 2 and 4 return `Nothing` — the caller keeps whatever it did before this change. Rows 5–8 are
the hard denials, evaluated in exactly that order, so a boarded rider on a completed trip is told
they boarded. Row 3 is a separate early return taken before any of them.

Rows 9–11 require `is_active_trip = true`; rows 12–16 are everything else.

**Charge anchor is one expression in every row:** `S + D`. It yields `L` when live, `S` whenever
`D = 0`, and `now + (S − origin)` for a trip that never showed — the earliest it could still reach
this stop if it left the origin now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live-trip-based eligibility checks for FRFS ticket cancellation and rescheduling.
  - Cancellation decisions can now account for trip progress, completion status, and live departure times.
  - Refund eligibility and cancellation charges may be calculated using live trip information.
  - Added service-tier settings for cancellation delay thresholds and live cancellation/rescheduling behavior.
  - Bus schedule data now includes trip completion status.

- **Bug Fixes**
  - Improved accuracy of cancellation and rescheduling status shown for ongoing trips.
  - Increased freshness of bus schedule information used for these decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->