### PR TITLE
Backend:fix: added custom error for already given consent

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/WMB.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/WMB.hs
@@ -500,6 +500,8 @@ postFleetConsent ::
 postFleetConsent (mbDriverId, _merchantId, merchantOperatingCityId) = do
   driverId <- fromMaybeM (DriverNotFoundWithId) mbDriverId
   driver <- QPerson.findById driverId >>= fromMaybeM (PersonNotFound driverId.getId)
+  mbActiveAssociation <- FDV.findByDriverId driverId True
+  whenJust mbActiveAssociation $ \_ -> throwError (FleetConsentAlreadyGiven driverId.getId)
   fleetDriverAssociation <- FDV.findByDriverId driverId False >>= fromMaybeM (InactiveFleetDriverAssociationNotFound driverId.getId)
 
   when (isJust fleetDriverAssociation.requestReason) $ throwError $ InvalidRequest "Cannot consent to driver-initiated request. Fleet owner must approve first"

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Error.hs
@@ -1886,6 +1886,7 @@ data WMBErrors
   | NoActiveFleetAssociated Text
   | FleetConfigNotFound Text
   | InactiveFleetDriverAssociationNotFound Text
+  | FleetConsentAlreadyGiven Text
   | InactiveOperatorDriverAssociationNotFound Text -- TODO separate error type
   | VehicleRouteMappingNotFound Text Text
   | InvalidTripStatus Text
@@ -1944,6 +1945,7 @@ instance IsBaseError WMBErrors where
     NoActiveFleetAssociated id -> Just $ "No Active Fleet Associated for driver :" <> id
     FleetConfigNotFound id -> Just $ "Fleet Config Info not found for owner id : " <> id
     InactiveFleetDriverAssociationNotFound id -> Just $ "Inactive Fleet Driver Association Not Found for driver : " <> id
+    FleetConsentAlreadyGiven id -> Just $ "Fleet consent already given for driver : " <> id
     InactiveOperatorDriverAssociationNotFound id -> Just $ "Inactive Operator Driver Association Not Found for driver : " <> id
     VehicleRouteMappingNotFound vhclNo routeCode -> Just $ "Vehicle Route Mapping not found for vehicle no hash : " <> vhclNo <> " and route code :" <> routeCode
     InvalidTripStatus id -> Just $ "Invalid trip status, current status : " <> id
@@ -2000,6 +2002,7 @@ instance IsHTTPError WMBErrors where
     NoActiveFleetAssociated _ -> "NO_ACTIVE_FLEET_ASSOCIATED"
     FleetConfigNotFound _ -> "FLEET_CONFIG_NOT_FOUND"
     InactiveFleetDriverAssociationNotFound _ -> "INACTIVE_FLEET_DRIVER_ASSOCIATION_NOT_FOUND"
+    FleetConsentAlreadyGiven _ -> "FLEET_CONSENT_ALREADY_GIVEN"
     InactiveOperatorDriverAssociationNotFound _ -> "INACTIVE_OPERATOR_DRIVER_ASSOCIATION_NOT_FOUND"
     VehicleRouteMappingNotFound _ _ -> "VEHICLE_ROUTE_MAPPING_NOT_FOUND"
     InvalidTripStatus _ -> "INVALID_TRIP_STATUS"
@@ -2052,6 +2055,7 @@ instance IsHTTPError WMBErrors where
     NoActiveFleetAssociated _ -> E400
     FleetConfigNotFound _ -> E404
     InactiveFleetDriverAssociationNotFound _ -> E404
+    FleetConsentAlreadyGiven _ -> E400
     InactiveOperatorDriverAssociationNotFound _ -> E404
     VehicleRouteMappingNotFound _ _ -> E404
     InvalidTripStatus _ -> E400


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate fleet consent submissions when an active fleet association already exists.
  - Added a clear error response with code `FLEET_CONSENT_ALREADY_GIVEN` and HTTP 400 status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->