### PR TITLE
feat: add pickup/drop special-zone labels to BPP funnel metrics [prodHotPush-BPP]

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Cancel.hs
@@ -124,7 +124,8 @@ cancel req merchant booking mbActiveSearchTry = do
     bookingCR <- buildBookingCancellationReason disToPickup currentLocation mbRide
     QBCR.upsert bookingCR
     cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
-    Metrics.incrementRideCancelledCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCR.source) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) booking.estimatedDistance)
+    let (pickupZone, dropZone) = SML.specialZoneLabels booking.area
+    Metrics.incrementRideCancelledCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCR.source) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) booking.estimatedDistance) pickupZone dropZone
     QRB.updateStatus booking.id SRB.CANCELLED
     when booking.isScheduled $ removeBookingFromRedis booking
     -- ONE decision (signals → fault verdict → consequence-matrix row), resolved up front

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Confirm.hs
@@ -239,7 +239,8 @@ handler merchant req validatedQuote = do
     mkDConfirmResp mbRideInfo uBooking riderDetails = do
       cityLabel <- SML.getCityLabel uBooking.merchantOperatingCityId
       metricsDistanceBucketEdges <- SML.getDistanceBucketEdges uBooking.merchantOperatingCityId
-      Metrics.incrementBookingCreatedCount merchant.shortId.getShortId cityLabel (show uBooking.vehicleServiceTier) (SML.distanceBucketLabel metricsDistanceBucketEdges uBooking.estimatedDistance)
+      let (pickupZone, dropZone) = SML.specialZoneLabels uBooking.area
+      Metrics.incrementBookingCreatedCount merchant.shortId.getShortId cityLabel (show uBooking.vehicleServiceTier) (SML.distanceBucketLabel metricsDistanceBucketEdges uBooking.estimatedDistance) pickupZone dropZone
       mDriverStats <-
         if isNothing mbRideInfo
           then pure Nothing

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Init.hs
@@ -166,11 +166,14 @@ handler merchantId req validatedReq = do
         QRB.createBooking booking
         cityLabel <- SML.getCityLabel searchRequest.merchantOperatingCityId
         distanceEdges <- SML.getDistanceBucketEdges searchRequest.merchantOperatingCityId
+        let (pickupZone, dropZone) = SML.specialZoneLabels booking.area
         BPPMetrics.incrementRiderAcceptanceCount
           transporter.shortId.getShortId
           cityLabel
           (show booking.vehicleServiceTier)
           (SML.distanceBucketLabel distanceEdges booking.estimatedDistance)
+          pickupZone
+          dropZone
         when booking.isScheduled $ void $ addScheduledBookingInRedis booking
         return (booking, Nothing, Nothing)
   -- Special zone driver demand pipeline: fires for BOTH estimate-based (normal Select → Init)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Select.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Select.hs
@@ -85,11 +85,14 @@ handler merchant sReq searchReq estimates = do
   whenJust (listToMaybe estimates) $ \primaryEstimate -> do
     cityLabel <- SML.getCityLabel searchReq.merchantOperatingCityId
     distanceEdges <- SML.getDistanceBucketEdges searchReq.merchantOperatingCityId
+    let (pickupZone, dropZone) = SML.specialZoneLabels searchReq.area
     BPPMetrics.incrementRiderAcceptanceCount
       merchant.shortId.getShortId
       cityLabel
       (show primaryEstimate.vehicleServiceTier)
       (SML.distanceBucketLabel distanceEdges primaryEstimate.estimatedDistance)
+      pickupZone
+      dropZone
   now <- getCurrentTime
   riderId <- case sReq.customerPhoneNum of
     Just number -> do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/CancelRide/Internal.hs
@@ -273,7 +273,8 @@ cancelRideTransaction booking ride bookingCReason merchant rideEndedBy transport
   void $ QRide.updateStatusAndRideEndedBy ride.id DRide.CANCELLED rideEndedBy
   QBCR.upsert bookingCReason
   cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
-  Metrics.incrementRideCancelledCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCReason.source) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) booking.estimatedDistance)
+  let (pickupZone, dropZone) = SML.specialZoneLabels booking.area
+  Metrics.incrementRideCancelledCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCReason.source) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) booking.estimatedDistance) pickupZone dropZone
   void $ QRB.updateStatus booking.id SRB.CANCELLED
   when (bookingCReason.source == SBCR.ByDriver) $ QDriverStats.updateIdleTime driverId
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/EndRide/Internal.hs
@@ -189,7 +189,8 @@ endRideTransaction ::
   m ()
 endRideTransaction driverId booking ride mbFareParams mbRiderDetailsId newFareParams thresholdConfig = do
   (merchantLabel, cityLabel) <- SML.getMetricsLabels booking.providerId booking.merchantOperatingCityId
-  Metrics.incrementRideCompletedCount merchantLabel cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel (SML.distanceBucketEdges thresholdConfig) booking.estimatedDistance)
+  let (pickupZone, dropZone) = SML.specialZoneLabels booking.area
+  Metrics.incrementRideCompletedCount merchantLabel cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel (SML.distanceBucketEdges thresholdConfig) booking.estimatedDistance) pickupZone dropZone
   updateOnRideStatusWithAdvancedRideCheck ride.driverId (Just ride)
   oldDriverInfo <- QDI.findById (cast ride.driverId) >>= fromMaybeM (PersonNotFound ride.driverId.getId)
   let newFlowStatus = DDriverMode.getDriverFlowStatus oldDriverInfo.mode oldDriverInfo.active

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Ride/StartRide.hs
@@ -279,7 +279,8 @@ startRideHandler ServiceHandle {..} rideId req = do
       fork "Push Start Ride Metric" $ do
         incrementRideStartCounter "startRide"
         (merchantLabel, cityLabel) <- SML.getMetricsLabels booking.providerId booking.merchantOperatingCityId
-        TMetrics.incrementRideStartedCount merchantLabel cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) booking.estimatedDistance)
+        let (pickupZone, dropZone) = SML.specialZoneLabels booking.area
+        TMetrics.incrementRideStartedCount merchantLabel cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) booking.estimatedDistance) pickupZone dropZone
       -- Schedule payout for special zone rides if enabled
       let paymentInstrument = fromMaybe DMPM.Cash booking.paymentInstrument
       when

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Booking.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Booking.hs
@@ -90,7 +90,8 @@ cancelBooking booking mbDriver transporter = do
     QBCR.upsert bookingCancellationReason
     cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
     metricsDistanceBucketEdges <- SML.getDistanceBucketEdges booking.merchantOperatingCityId
-    Metrics.incrementRideCancelledCount transporter.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCancellationReason.source) (SML.distanceBucketLabel metricsDistanceBucketEdges booking.estimatedDistance)
+    let (pickupZone, dropZone) = SML.specialZoneLabels booking.area
+    Metrics.incrementRideCancelledCount transporter.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (show bookingCancellationReason.source) (SML.distanceBucketLabel metricsDistanceBucketEdges booking.estimatedDistance) pickupZone dropZone
     whenJust mbRide $ \ride -> do
       void $ CQDGR.setDriverGoHomeIsOnRideStatus ride.driverId booking.merchantOperatingCityId False
       QRide.updateStatus ride.id SRide.CANCELLED

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/MetricsLabels.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/MetricsLabels.hs
@@ -22,6 +22,7 @@ module SharedLogic.MetricsLabels
     poolingVersionLabel,
     searchReqFunnelLabels,
     driverSearchReqFunnelLabels,
+    specialZoneLabels,
   )
 where
 
@@ -35,6 +36,7 @@ import Kernel.Prelude
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import Lib.ConfigPilot.Interface.Types (getOneConfig)
+import qualified Lib.Types.SpecialLocation as SL
 import qualified Storage.CachedQueries.Merchant as CQM
 import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
 import Storage.ConfigPilot.Config.TransporterConfig (TransporterConfigDimensions (..))
@@ -107,6 +109,18 @@ distanceBucketLabel (DistanceBucketEdges edgesKm) (Just distance) = go 0 edgesKm
 
 poolingVersionLabel :: Maybe Int -> Text
 poolingVersionLabel = maybe "unknown" show
+
+-- | Pickup and drop special-zone ids taken straight from the ride's in-memory Area;
+-- "none" when the ride has no special zone at that end. PURE — no lookup, no added
+-- compute; regular rides are just ("none","none"). The two ends are independent, so a ride
+-- can be filtered by its pickup zone, drop zone, or both. The id is opaque: map it to a
+-- readable name in Grafana (the same way the dashboard already maps city ids to names).
+specialZoneLabels :: Maybe SL.Area -> (Text, Text)
+specialZoneLabels Nothing = ("none", "none")
+specialZoneLabels (Just area) =
+  ( fromMaybe "none" (SL.pickupSpecialZoneIdFromArea area),
+    fromMaybe "none" (SL.dropSpecialZoneIdFromArea area)
+  )
 
 -- | The three allocation-funnel label values, in the order every counter expects:
 -- (distance_bucket, pooling_logic_version, pooling_config_version).

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Ride.hs
@@ -187,7 +187,8 @@ initializeRide merchant driver booking mbOtpCode enableFrequentLocationUpdates m
   QRB.updateStatus booking.id DBooking.TRIP_ASSIGNED
   QRide.createRide ride
   cityLabel <- SML.getCityLabel booking.merchantOperatingCityId
-  Metrics.incrementRideCreatedCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) booking.estimatedDistance)
+  let (pickupZone, dropZone) = SML.specialZoneLabels booking.area
+  Metrics.incrementRideCreatedCount merchant.shortId.getShortId cityLabel (show booking.vehicleServiceTier) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) booking.estimatedDistance) pickupZone dropZone
   QRideD.create rideDetails
   fork "updateRiderDetails" $ do
     whenJust booking.riderId (QRiderD.updateTotalBookingsCount . getId)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SearchTry.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/SearchTry.hs
@@ -243,7 +243,8 @@ initiateDriverSearchBatch searchBatchInput@DriverSearchBatchInput {..} = do
               <> "; estimated base fare:"
               <> show estimatedFare
           cityLabel <- SML.getCityLabel searchReq.merchantOperatingCityId
-          Metrics.incrementSearchTryCount merchant.shortId.getShortId cityLabel (show searchTry.vehicleServiceTier) (show searchTry.searchRepeatType) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) searchReq.estimatedDistance)
+          let (pickupZone, dropZone) = SML.specialZoneLabels searchReq.area
+          Metrics.incrementSearchTryCount merchant.shortId.getShortId cityLabel (show searchTry.vehicleServiceTier) (show searchTry.searchRepeatType) (SML.distanceBucketLabel (SML.distanceBucketEdges transporterConfig) searchReq.estimatedDistance) pickupZone dropZone
           return searchTry
 
 buildSearchTry ::

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics.hs
@@ -39,11 +39,11 @@ incrementSearchRequestCount merchantId merchantOpCityId distanceBucket = do
   version <- asks (.version)
   liftIO $ P.withLabel bmContainer.searchRequestCounter (merchantId, merchantOpCityId, distanceBucket, version.getDeploymentVersion) P.incCounter
 
-incrementSearchTryCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> m ()
-incrementSearchTryCount merchantId merchantOpCityId vehicleServiceTier searchRepeatType distanceBucket = do
+incrementSearchTryCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> Text -> Text -> m ()
+incrementSearchTryCount merchantId merchantOpCityId vehicleServiceTier searchRepeatType distanceBucket pickupZone dropZone = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.searchTryCounter (merchantId, merchantOpCityId, vehicleServiceTier, searchRepeatType, distanceBucket, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.searchTryCounter (merchantId, merchantOpCityId, vehicleServiceTier, searchRepeatType, distanceBucket, version.getDeploymentVersion, pickupZone, dropZone) P.incCounter
 
 addSearchRequestSentToDriverCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> (Text, Text, Text) -> Int -> m ()
 addSearchRequestSentToDriverCount merchantId merchantOpCityId vehicleServiceTier (distanceBucket, poolingLogicV, poolingConfigV) count = do
@@ -57,41 +57,41 @@ addSearchRequestExpiredCount merchantId merchantOpCityId vehicleServiceTier (dis
   version <- asks (.version)
   liftIO $ P.withLabel bmContainer.searchRequestExpiredCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, poolingLogicV, poolingConfigV, version.getDeploymentVersion) (void . (`P.addCounter` fromIntegral count))
 
-incrementRiderAcceptanceCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
-incrementRiderAcceptanceCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
+incrementRiderAcceptanceCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> Text -> m ()
+incrementRiderAcceptanceCount merchantId merchantOpCityId vehicleServiceTier distanceBucket pickupZone dropZone = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.riderAcceptanceCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.riderAcceptanceCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion, pickupZone, dropZone) P.incCounter
 
-incrementBookingCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
-incrementBookingCreatedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
+incrementBookingCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> Text -> m ()
+incrementBookingCreatedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket pickupZone dropZone = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.bookingCreatedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.bookingCreatedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion, pickupZone, dropZone) P.incCounter
 
-incrementRideCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
-incrementRideCreatedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
+incrementRideCreatedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> Text -> m ()
+incrementRideCreatedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket pickupZone dropZone = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.rideCreatedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.rideCreatedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion, pickupZone, dropZone) P.incCounter
 
-incrementRideStartedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
-incrementRideStartedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
+incrementRideStartedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> Text -> m ()
+incrementRideStartedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket pickupZone dropZone = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.rideStartedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.rideStartedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion, pickupZone, dropZone) P.incCounter
 
-incrementRideCompletedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> m ()
-incrementRideCompletedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket = do
+incrementRideCompletedCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> Text -> m ()
+incrementRideCompletedCount merchantId merchantOpCityId vehicleServiceTier distanceBucket pickupZone dropZone = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.rideCompletedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.rideCompletedCounter (merchantId, merchantOpCityId, vehicleServiceTier, distanceBucket, version.getDeploymentVersion, pickupZone, dropZone) P.incCounter
 
-incrementRideCancelledCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> m ()
-incrementRideCancelledCount merchantId merchantOpCityId vehicleServiceTier cancellationSource distanceBucket = do
+incrementRideCancelledCount :: (MonadIO m, HasBPPMetrics m r) => Text -> Text -> Text -> Text -> Text -> Text -> Text -> m ()
+incrementRideCancelledCount merchantId merchantOpCityId vehicleServiceTier cancellationSource distanceBucket pickupZone dropZone = do
   bmContainer <- asks (.bppMetrics)
   version <- asks (.version)
-  liftIO $ P.withLabel bmContainer.rideCancelledCounter (merchantId, merchantOpCityId, vehicleServiceTier, cancellationSource, distanceBucket, version.getDeploymentVersion) P.incCounter
+  liftIO $ P.withLabel bmContainer.rideCancelledCounter (merchantId, merchantOpCityId, vehicleServiceTier, cancellationSource, distanceBucket, version.getDeploymentVersion, pickupZone, dropZone) P.incCounter
 
 type SearchMetricsMVar = MVar Milliseconds
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics/Types.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Tools/Metrics/ARDUBPPMetrics/Types.hs
@@ -39,21 +39,24 @@ type SearchDurationMetric = (P.Vector P.Label2 P.Histogram, P.Vector P.Label2 P.
 -- Labels: (merchant, city, distance_bucket, backend_version)
 type SearchRequestCounterMetric = P.Vector P.Label4 P.Counter
 
--- Labels: (merchant, city, vehicle_service_tier, search_repeat_type, distance_bucket, backend_version)
+-- Labels: (merchant, city, vehicle_service_tier, search_repeat_type, distance_bucket, backend_version, pickup_zone, drop_zone)
 -- No pooling labels here: INITIAL tries are created BEFORE the first pool computation
 -- assigns pooling versions (ensurePoolingLogicVersion), so the label would encode try
 -- order ("unknown" for INITIAL, populated for retries), not pooling.
-type SearchTryCounterMetric = P.Vector P.Label6 P.Counter
+-- pickup_zone/drop_zone are the special-location ids of the ride's ends, "none" when
+-- regular — lets Grafana converge the funnel to a special zone (map id->name in Grafana).
+type SearchTryCounterMetric = P.Vector P.Label8 P.Counter
 
 -- Labels: (merchant, city, vehicle_service_tier, distance_bucket, pooling_logic_version, pooling_config_version, backend_version)
 -- For counters emitted inside the allocation flow, where pooling versions are assigned.
 type AllocationFunnelCounterMetric = P.Vector P.Label7 P.Counter
 
--- Labels: (merchant, city, vehicle_service_tier, distance_bucket, backend_version)
-type RideFunnelCounterMetric = P.Vector P.Label5 P.Counter
+-- Labels: (merchant, city, vehicle_service_tier, distance_bucket, backend_version, pickup_zone, drop_zone)
+-- pickup_zone/drop_zone: special-location id of each ride end, "none" when regular.
+type RideFunnelCounterMetric = P.Vector P.Label7 P.Counter
 
--- Labels: (merchant, city, vehicle_service_tier, cancellation_source, distance_bucket, backend_version)
-type RideCancelledCounterMetric = P.Vector P.Label6 P.Counter
+-- Labels: (merchant, city, vehicle_service_tier, cancellation_source, distance_bucket, backend_version, pickup_zone, drop_zone)
+type RideCancelledCounterMetric = P.Vector P.Label8 P.Counter
 
 data BPPMetricsContainer = BPPMetricsContainer
   { searchDurationTimeout :: Seconds,
@@ -99,7 +102,7 @@ registerSearchRequestCounter =
 
 registerSearchTryCounter :: IO SearchTryCounterMetric
 registerSearchTryCounter =
-  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "search_repeat_type", "distance_bucket", "backend_version") . P.counter $
+  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "search_repeat_type", "distance_bucket", "backend_version", "pickup_zone", "drop_zone") . P.counter $
     P.Info "BPP_search_try_count" "Count of search tries (driver allocation attempts) created"
 
 registerAllocationFunnelCounter :: Text -> Text -> IO AllocationFunnelCounterMetric
@@ -109,12 +112,12 @@ registerAllocationFunnelCounter name description =
 
 registerRideFunnelCounter :: Text -> Text -> IO RideFunnelCounterMetric
 registerRideFunnelCounter name description =
-  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "distance_bucket", "backend_version") . P.counter $
+  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "distance_bucket", "backend_version", "pickup_zone", "drop_zone") . P.counter $
     P.Info name description
 
 registerRideCancelledCounter :: IO RideCancelledCounterMetric
 registerRideCancelledCounter =
-  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "cancellation_source", "distance_bucket", "backend_version") . P.counter $
+  P.register . P.vector ("merchant", "city", "vehicle_service_tier", "cancellation_source", "distance_bucket", "backend_version", "pickup_zone", "drop_zone") . P.counter $
     P.Info "BPP_ride_cancelled_count" "Count of bookings cancelled, labelled by cancellation source"
 
 registerCountingDeviationMetric :: IO CountingDeviationMetric


### PR DESCRIPTION
Hotpush cherry-pick of #16614 (`c7571135c4`) onto `prodHotPush-BPP`. Clean pick, no conflicts, diff identical to main.

