### PR TITLE
Backend/fix: lock driver fee during execution

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/DriverFee.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Types/Extra/DriverFee.hs
@@ -18,5 +18,11 @@ manualPaymentInProgressTtl = 1800
 mandateProcessingLockKey :: Text -> Text
 mandateProcessingLockKey driverId = "Mandate:Processing:DriverId" <> driverId
 
+mandateExecutionInProgressKey :: Text -> Text
+mandateExecutionInProgressKey driverFeeId = "Mandate:Execution:InProgress:DriverFeeId:" <> driverFeeId
+
+mandateExecutionInProgressTtl :: Int
+mandateExecutionInProgressTtl = 300
+
 billNumberGenerationLockKey :: Text -> Text
 billNumberGenerationLockKey billNumberKey = "DriverFee:BillNumber:Processing:" <> billNumberKey

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Mandate/Execution.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/Mandate/Execution.hs
@@ -3,6 +3,7 @@ module SharedLogic.Allocator.Jobs.Mandate.Execution where
 import qualified Control.Monad.Catch as C
 import Data.List (nubBy)
 import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
 import Domain.Types.DriverFee as DF
 import Domain.Types.DriverInformation as DI
 import Domain.Types.DriverPlan as DP
@@ -21,6 +22,7 @@ import qualified Kernel.External.Payment.Interface.Types as PaymentInterface
 import qualified Kernel.External.Payment.Juspay.Types as JuspayTypes
 import Kernel.Prelude
 import qualified Kernel.Storage.Esqueleto as Esq
+import qualified Kernel.Storage.Hedis as Redis
 import Kernel.Streaming.Kafka.Producer.Types (HasKafkaProducer)
 import Kernel.Types.Error
 import Kernel.Types.Id (Id (Id), cast)
@@ -193,21 +195,33 @@ asyncExecutionCall ::
   Id DMOC.MerchantOperatingCity ->
   m ()
 asyncExecutionCall ExecutionData {..} merchantId merchantOperatingCityId = do
-  driverFeeForExecution <- QDF.findById driverFee.id
-  driver <- QP.findById driverFee.driverId >>= fromMaybeM (PersonDoesNotExist driverFee.driverId.getId)
-  let serviceName = invoice.serviceName
-  subscriptionConfig <-
-    CQSC.findSubscriptionConfigsByMerchantOpCityIdAndServiceName merchantOperatingCityId Nothing serviceName
-      >>= fromMaybeM (NoSubscriptionConfigForService merchantOperatingCityId.getId $ show serviceName)
-  paymentService <- TPayment.decidePaymentServiceForRecurring subscriptionConfig.paymentServiceName driver.id merchantOperatingCityId subscriptionConfig.serviceName
-  if (driverFeeForExecution <&> (.status)) == Just PAYMENT_PENDING && (driverFeeForExecution <&> (.feeType)) == Just DF.RECURRING_EXECUTION_INVOICE
-    then do
-      exec <- withTryCatch "createExecutionService:asyncExecutionCall" (APayments.createExecutionService (executionRequest, invoice.id.getId) (cast merchantId) (Just $ cast merchantOperatingCityId) (TPayment.mandateExecution merchantId merchantOperatingCityId paymentService (Just driver.id.getId)))
-      case exec of
-        Left err -> do
+  lockAcquired <- Redis.tryLockRedis (DF.mandateExecutionInProgressKey driverFee.id.getId) DF.mandateExecutionInProgressTtl
+  if not lockAcquired
+    then logWarning ("Skipping execution for driverFeeId : " <> driverFee.id.getId <> " as an execution is already in progress for it")
+    else executeMandate
+  where
+    executeMandate = do
+      driverFeeForExecution <- QDF.findById driverFee.id
+      driver <- QP.findById driverFee.driverId >>= fromMaybeM (PersonDoesNotExist driverFee.driverId.getId)
+      let serviceName = invoice.serviceName
+      subscriptionConfig <-
+        CQSC.findSubscriptionConfigsByMerchantOpCityIdAndServiceName merchantOperatingCityId Nothing serviceName
+          >>= fromMaybeM (NoSubscriptionConfigForService merchantOperatingCityId.getId $ show serviceName)
+      paymentService <- TPayment.decidePaymentServiceForRecurring subscriptionConfig.paymentServiceName driver.id merchantOperatingCityId subscriptionConfig.serviceName
+      if (driverFeeForExecution <&> (.status)) == Just PAYMENT_PENDING && (driverFeeForExecution <&> (.feeType)) == Just DF.RECURRING_EXECUTION_INVOICE
+        then do
+          exec <- withTryCatch "createExecutionService:asyncExecutionCall" (APayments.createExecutionService (executionRequest, invoice.id.getId) (cast merchantId) (Just $ cast merchantOperatingCityId) (TPayment.mandateExecution merchantId merchantOperatingCityId paymentService (Just driver.id.getId)))
+          case exec of
+            Left err
+              | isDuplicateOrderIdError err ->
+                logError ("Execution already done for driverFeeId : " <> invoice.driverFeeId.getId <> ", keeping it on autopay. error : " <> show err)
+              | otherwise -> do
+                QINV.updateInvoiceStatusByDriverFeeIdsAndMbPaymentMode INV.INACTIVE [driverFee.id] Nothing
+                QDF.updateAutoPayToManual driverFee.id
+                logError ("Execution failed for driverFeeId : " <> invoice.driverFeeId.getId <> " error : " <> show err)
+            Right _ -> pure ()
+        else do
           QINV.updateInvoiceStatusByDriverFeeIdsAndMbPaymentMode INV.INACTIVE [driverFee.id] Nothing
-          QDF.updateAutoPayToManual driverFee.id
-          logError ("Execution failed for driverFeeId : " <> invoice.driverFeeId.getId <> " error : " <> show err)
-        Right _ -> pure ()
-    else do
-      QINV.updateInvoiceStatusByDriverFeeIdsAndMbPaymentMode INV.INACTIVE [driverFee.id] Nothing
+
+isDuplicateOrderIdError :: SomeException -> Bool
+isDuplicateOrderIdError err = any (`T.isInfixOf` T.pack (show err)) ["DUPLICATE_ORDER_ID", "Order already exists with the given order_id"]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
- Add lock on driver fee during mandate execution
- Do not convert fees to manual on `DUPLICATE_ORDER_ID` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate or overlapping mandate executions for the same driver fee.
  - Improved handling of duplicate-order errors so autopay remains enabled when appropriate.
  - Other mandate execution failures now deactivate the related invoice and switch autopay to manual payment.
  - Added safeguards to skip processing when another mandate execution is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->