### PR TITLE
backend/chore: bump shared-kernel to pick up the fork/await polling fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -730,11 +730,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787042391,
-        "narHash": "sha256-jzw8rcK4ko89AY8agtZrg9gKXrgN+jrr+AKsgOS52jE=",
+        "lastModified": 1788879727,
+        "narHash": "sha256-E2tLidBZan1jsDrX+kMu6VDN9HZBN+ojSBiBxE35Wqs=",
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "6290a7e3bad44e786621f016fa1991ecb48b9802",
+        "rev": "7e233136bafcb5110a568a06c6c3498ae3bbee1f",
         "type": "github"
       },
       "original": {
@@ -4021,11 +4021,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1788778958,
-        "narHash": "sha256-Z3wzJi70OmVW3RUBkW9m2OtN2kYIv1N8C8uTC/vvamI=",
+        "lastModified": 1788897914,
+        "narHash": "sha256-vkFt8tbR1BbQGKgklEn4kFtOkOABPJwWTrDvaznkqeU=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "9c88843e77097c7da39915357fcc34ba4845cb51",
+        "rev": "9113aefaeecb67c878634e9eec1e6eea7836c571",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps `shared-kernel` in `flake.lock`, which carries the `euler-hs` bump with it:

```
shared-kernel  9c88843e77097c7da39915357fcc34ba4845cb51  (2026-09-07)
           →   9113aefaeecb67c878634e9eec1e6eea7836c571  (2026-09-08)

euler-hs       6290a7e3bad44e786621f016fa1991ecb48b9802  (2026-08-18)
           →   7e233136bafcb5110a568a06c6c3498ae3bbee1f  (2026-09-08)
```

`9113aef` is the merge of [nammayatri/shared-kernel#1508](https://github.com/nammayatri/shared-kernel/pull/1508) and is current shared-kernel `main`; `7e23313` is the merge of [nammayatri/euler-hs#75](https://github.com/nammayatri/euler-hs/pull/75) and is current euler-hs `main`. Each is exactly **one commit ahead** of its old pin, and those two commits are the shared-kernel lock bump and the euler-hs fix respectively — nothing else is re-locked. Diff is six lines across those two nodes.

euler-hs is a direct input of shared-kernel, not of this repo, so it is pinned there and inherited here; this PR deliberately does not add a local `follows` override.

## What euler-hs#75 changes

`awaitMVarWithTimeout` in `EulerHS/Framework/Interpreter.hs` blocks on the result MVar instead of polling it:

```haskell
awaitMVarWithTimeout mvar mcs
  | mcs <= 0  = toAwaitResult <$> tryReadMVar mvar
  | otherwise = toAwaitResult <$> timeout mcs (readMVar mvar)
```

The old loop slept `portion = (mcs `div` 10) + 1` between `tryReadMVar` attempts, so the resolution of an await was one tenth of its own timeout — the more patient the caller, the coarser the grain on every *successful* await. `timeout` is from `base`, so no new dependency. The `mcs <= 0` path is unchanged, and `L.await Nothing` never went through this function. Every input still yields the same result value; only the wake-up time changes.

## Impact here

`API/UI/Search.hs:520,533` calls `L.await (Just syncSearchTimeoutMicros)` with a 5s timeout on the synchronous ride-search path. Under the old code that is a 500 ms poll grid: a hard ~500 ms floor plus a mean +250 ms on every successful await, no matter how fast the BPP answers. euler-hs#75 has the production latency histogram showing the resulting bimodality, modes exactly 500 ms apart.

## Testing

- `nix flake update shared-kernel` produced the diff; `flake.lock` was not hand-edited.
- Not built locally against the new pin — a full rebuild of everything downstream of euler-hs, and exe linking segfaults on this machine. Relying on CI.
- **Wants UAT before prod** given euler-hs's blast radius. Highest-signal check: the `/rideSearch?enableSyncSearch=true` latency histogram should lose its bimodality, with the lower mode moving down toward the real work time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br3rF7fuayjDMfY5onxuZ7