### PR TITLE
backend/chore: bump shared-kernel on prodHotPush-BAP for the fork/await polling fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -730,11 +730,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787042391,
-        "narHash": "sha256-jzw8rcK4ko89AY8agtZrg9gKXrgN+jrr+AKsgOS52jE=",
+        "lastModified": 1788879727,
+        "narHash": "sha256-E2tLidBZan1jsDrX+kMu6VDN9HZBN+ojSBiBxE35Wqs=",
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "6290a7e3bad44e786621f016fa1991ecb48b9802",
+        "rev": "7e233136bafcb5110a568a06c6c3498ae3bbee1f",
         "type": "github"
       },
       "original": {
@@ -4021,11 +4021,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1788782143,
-        "narHash": "sha256-CdXOwHiRvMvk/RKKlaEb/mozMVQp4+8RY8nygZHjclk=",
+        "lastModified": 1788897914,
+        "narHash": "sha256-vkFt8tbR1BbQGKgklEn4kFtOkOABPJwWTrDvaznkqeU=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "728add67998d3c92aad0fdff54ed0924fd3d20a4",
+        "rev": "9113aefaeecb67c878634e9eec1e6eea7836c571",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Hot-push counterpart of #16663 (which targets `main`). Same fix, this time on the branch where it actually changes behaviour.

## Summary

```
shared-kernel  728add67998d3c92aad0fdff54ed0924fd3d20a4  (2026-09-07)
           →   9113aefaeecb67c878634e9eec1e6eea7836c571  (2026-09-08)

euler-hs       6290a7e3bad44e786621f016fa1991ecb48b9802  (2026-08-18)
           →   7e233136bafcb5110a568a06c6c3498ae3bbee1f  (2026-09-08)
```

Produced by `nix flake update shared-kernel`; `flake.lock` was not hand-edited. Six lines, two nodes.

## What comes in with it — please read

`728add67` was the head of shared-kernel's **own** `prodHotPush-BAP` branch, not a rev on `main`. This bump moves the BAP hot push onto shared-kernel `main`. Two consequences:

**1. One commit is dropped, harmlessly.** `728add67` ("aarokya-error-fix") is not an ancestor of `9113aef`. Its patch is byte-identical to `e1e2df5e` on main — same author, same timestamp, same 24/1 line change to `Kernel/External/PartnerSdk/Aarokya/Flow.hs` — so it is a cherry-pick and nothing is lost.

**2. Four unrelated shared-kernel commits ride along**, on top of the euler-hs bump:

```
03ab9935  Hedis/feat/added-replica-lts-redis (#1498)
46544bdc  ench: face verification
9c88843e  ench: add error messages for extraction
9113aefa  backend/chore: bump euler-hs   ← the intended one
```

This was a deliberate choice over a narrower euler-hs-only override, to keep the branch structurally identical to `main`. Worth a look from whoever owns the replica-LTS-redis change before this goes out.

Note also that shared-kernel's `prodHotPush-BAP` branch still points at `728add67`. After this merges, this repo's BAP hot push tracks shared-kernel `main`; anyone hot-pushing shared-kernel next should branch from `9113aef` rather than from that stale head.

## What euler-hs#75 changes

`awaitMVarWithTimeout` in `EulerHS/Framework/Interpreter.hs` blocks on the result MVar instead of polling it:

```haskell
awaitMVarWithTimeout mvar mcs
  | mcs <= 0  = toAwaitResult <$> tryReadMVar mvar
  | otherwise = toAwaitResult <$> timeout mcs (readMVar mvar)
```

The old loop slept `portion = (mcs `div` 10) + 1` between `tryReadMVar` attempts, so an await's resolution was one tenth of its own timeout. `timeout` is from `base` — no new dependency. The `mcs <= 0` path is unchanged and `L.await Nothing` never went through this function; every input yields the same result value, only the wake-up time changes.

## Why BAP and not BPP

`API/UI/Search.hs:520,533` are the only timeout-awaits in the whole backend — rider-app's synchronous ride-search, `L.await (Just syncSearchTimeoutMicros)` with a 5s timeout. That is a 500 ms poll grid: a hard ~500 ms floor plus a mean +250 ms on every successful await, no matter how fast the BPP answers. Every `L.await` in driver-app is `L.await Nothing`, the untouched path, so the equivalent BPP bump would be a behavioural no-op.

## Testing

- Not built locally against the new pin — a full rebuild of everything downstream of euler-hs. Relying on CI.
- Highest-signal post-deploy check: the `/rideSearch?enableSyncSearch=true` latency histogram should lose its bimodality (modes were exactly 500 ms apart), with the lower mode moving down toward the real work time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br3rF7fuayjDMfY5onxuZ7