### PR TITLE
enh: cluster routes for the otp flow in routeServiceAbility

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -2454,8 +2454,44 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) mbAllPassingRoutes r
     handleOtpRoute ctx userRequestedCodes srcCode destCode = do
       (effectiveStops, resolvedLegs) <-
         JMU.measureLatency (resolveLegsViaOtpCached ctx srcCode destCode) ("resolveLegsViaOtpCached src=" <> srcCode <> " dest=" <> destCode)
+      clusteredLegs <-
+        if fromMaybe False req.allowClusteredStops
+          then
+            JMU.measureLatency
+              (mapConcurrently (applyClusterRoutesToLeg ctx) resolvedLegs)
+              ("applyClusterRoutesToLeg legsCount=" <> show (length resolvedLegs))
+          else pure resolvedLegs
+      JMU.measureLatency (getRouteServiceability effectiveStops Nothing userRequestedCodes ctx clusteredLegs) ("getRouteServiceability legsCount=" <> show (length clusteredLegs))
 
-      JMU.measureLatency (getRouteServiceability effectiveStops Nothing userRequestedCodes ctx resolvedLegs) ("getRouteServiceability legsCount=" <> show (length resolvedLegs))
+    applyClusterRoutesToLeg ::
+      RouteServiceabilityContext ->
+      ResolvedLeg ->
+      Environment.Flow ResolvedLeg
+    applyClusterRoutesToLeg ctx leg
+      | T.null leg.rlFromStopCode || T.null leg.rlToStopCode = pure leg
+      | otherwise = do
+        mbConnections <-
+          JMU.measureLatency
+            (JLU.getClusterRoutesFromTo leg.rlFromStopCode leg.rlToStopCode ctx.integratedBPPConfig)
+            ("applyClusterRoutesToLeg: getClusterRoutesFromTo legOrder=" <> show leg.rlOrder <> " src=" <> leg.rlFromStopCode <> " dest=" <> leg.rlToStopCode)
+        case mbConnections of
+          Just connections@(_ : _) -> do
+            let sortedConnections = sortOn (.routeCode) connections
+                clusterRouteCodes = nub $ map (.routeCode) sortedConnections
+                stopsByRoute = map (\c -> (c.routeCode, (c.sourceStopCode, c.destinationStopCode))) sortedConnections
+            logInfo $
+              "applyClusterRoutesToLeg: legOrder="
+                <> show leg.rlOrder
+                <> " src="
+                <> leg.rlFromStopCode
+                <> " dest="
+                <> leg.rlToStopCode
+                <> " otpRoutes="
+                <> show leg.rlRouteCodes
+                <> " clusterRoutes="
+                <> show clusterRouteCodes
+            pure leg {rlRouteCodes = nub (leg.rlRouteCodes <> clusterRouteCodes), rlStopsByRoute = stopsByRoute}
+          _ -> pure leg
 
     makeOtpResolvedRouteKey ::
       RouteServiceabilityContext ->
@@ -2535,8 +2571,8 @@ postMultimodalRouteServiceability (mbPersonId, _merchantId) mbAllPassingRoutes r
               <$> mapConcurrently
                 ( \(r, s) -> do
                     let (routeFromStopCode, routeToStopCode) = fromMaybe (rlFromStopCode, rlToStopCode) (lookup r.routeId rlStopsByRoute)
-                        mbOverrideSource = if routeFromStopCode == rlFromStopCode then Nothing else Just routeFromStopCode
-                        mbOverrideDest = if routeToStopCode == rlToStopCode then Nothing else Just routeToStopCode
+                        mbOverrideSource = if T.null routeFromStopCode then Nothing else Just routeFromStopCode
+                        mbOverrideDest = if T.null routeToStopCode then Nothing else Just routeToStopCode
                     routeSourceLatLong <-
                       if routeFromStopCode == rlFromStopCode
                         then pure mbSourceLatLong


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Clustered-stop routes can now be included when resolving OTP-based journeys.
  - Route-specific stop details are now provided whenever available, improving stop information for supported routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->