### PR TITLE
dynamic-offer-driver-app/perf: search estimate build — fare pipeline once per search, lookup-free search-request writes

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -64,7 +64,6 @@ import qualified Domain.Types.TransporterConfig as DTMT
 import qualified Domain.Types.VehicleServiceTier as DVST
 import qualified Domain.Types.VehicleVariant as DVST
 import qualified Domain.Types.Yudhishthira as Y
-import Domain.Utils (mapConcurrently)
 import Environment
 import qualified EulerHS.Language as L
 import EulerHS.Prelude ((+||), (||+))
@@ -343,7 +342,7 @@ handler ValidatedDSearchReq {..} sReq = withTimeAPI "search" "handler" $ do
   localTime <- getLocalCurrentTime localTimeZoneSeconds
   configVersionMap <- pure [] -- getConfigVersionMapForStickiness (cast merchantOpCityId) -- TODO: isn't used much, so fo
   (_, mbVersion) <- withTimeAPI "search" "getAppDynamicLogic" $ getAppDynamicLogic (cast merchantOpCityId) LYT.DYNAMIC_PRICING_UNIFIED localTime Nothing Nothing
-  allFarePoliciesProduct <- withTimeAPI "search" "getAllFarePolicies" $ combineFarePoliciesProducts <$> (mapConcurrently (\tripCategory -> withTimeAPI "search" "getAllFarePoliciesProduct" $ getAllFarePoliciesProduct merchant.id merchantOpCityId sReq.isDashboardRequest sReq.pickupLocation sReq.dropLocation sReq.fromSpecialLocationId sReq.toSpecialLocationId (Just (TransactionId (Id sReq.transactionId))) fromLocGeohashh toLocGeohash mbDistance mbDuration mbVersion tripCategory configVersionMap dpInputsSharing) possibleTripOption.tripCategories)
+  allFarePoliciesProduct <- withTimeAPI "search" "getAllFarePolicies" $ getAllFarePoliciesProducts merchant.id merchantOpCityId sReq.isDashboardRequest sReq.pickupLocation sReq.dropLocation sReq.fromSpecialLocationId sReq.toSpecialLocationId (Just (TransactionId (Id sReq.transactionId))) fromLocGeohashh toLocGeohash mbDistance mbDuration mbVersion possibleTripOption.tripCategories configVersionMap dpInputsSharing
   when (null allFarePoliciesProduct.farePolicies) $ logError $ "No fare policies resolved for transactionId: " <> sReq.transactionId <> ", merchantOpCityId: " <> merchantOpCityId.getId <> ", tripCategories: " <> show possibleTripOption.tripCategories <> ", area: " <> show allFarePoliciesProduct.area <> ", specialLocationTag: " <> show allFarePoliciesProduct.specialLocationTag
   let mbAreaForVST =
         allFarePoliciesProduct.mbPickupDropArea
@@ -454,18 +453,6 @@ handler ValidatedDSearchReq {..} sReq = withTimeAPI "search" "handler" $ do
       if ((.canQueueUpOnGate) <$> mbPickupZone) == Just True
         then pure (True, fmap (toHighPrecMoney . Money) . (.defaultDriverExtra) =<< mbPickupZone, (.id.getId) <$> mbPickupZone)
         else pure (False, Nothing, Nothing)
-
-    combineFarePoliciesProducts :: [FarePoliciesProduct] -> FarePoliciesProduct
-    combineFarePoliciesProducts products =
-      FarePoliciesProduct
-        { farePolicies = concatMap farePolicies products,
-          area = maybe SL.Default (.area) $ listToMaybe products,
-          specialLocationTag = listToMaybe products >>= (.specialLocationTag),
-          specialLocationName = listToMaybe products >>= (.specialLocationName),
-          specialLocationSupportNumber = listToMaybe products >>= (.specialLocationSupportNumber),
-          fareSettlementType = listToMaybe products >>= (.fareSettlementType),
-          mbPickupDropArea = listToMaybe products >>= (.mbPickupDropArea)
-        }
 
     processPolicy ::
       (Bool -> DVST.VehicleServiceTier -> DFP.FullFarePolicy -> Flow DEst.Estimate) ->

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -380,7 +380,7 @@ handler ValidatedDSearchReq {..} sReq = withTimeAPI "search" "handler" $ do
   whenJust mbSetRouteInfo $ \setRouteInfo -> setRouteInfo sReq.transactionId
   unless sReq.isShadowSearch $
     triggerSearchEvent SearchEventData {searchRequest = searchReq, merchantId = merchantId'}
-  void $ withTimeAPI "search" "createSearchRequest" $ QSR.createDSReq searchReq
+  void $ withTimeAPI "search" "createSearchRequest" $ QSR.createDSReqFresh searchReq
 
   unless sReq.isShadowSearch $ do
     fork "Add Namma Tags" $ do

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FarePolicy.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/FarePolicy.hs
@@ -194,31 +194,39 @@ isDynamicPricingTripCategory (DTC.OneWay v) = v /= MeterRide
 isDynamicPricingTripCategory _ = False
 
 getAllFarePoliciesProduct :: (CacheFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r, BeamFlow m r, CH.HasClickhouseEnv CH.APP_SERVICE_CLICKHOUSE m, HasFlowEnv m r '["internalEndPointHashMap" ::: HM.HashMap BaseUrl BaseUrl], ClickhouseFlow m r, HasField "enableAPILatencyLogging" r Bool, HasField "enableAPIPrometheusMetricLogging" r Bool) => Id Merchant -> Id DMOC.MerchantOperatingCity -> Bool -> LatLong -> Maybe LatLong -> Maybe (Id SL.SpecialLocation) -> Maybe (Id SL.SpecialLocation) -> Maybe CacKey -> Maybe Text -> Maybe Text -> Maybe Meters -> Maybe Seconds -> Maybe Int -> DTC.TripCategory -> [LYT.ConfigVersionMap] -> Maybe DpInputsSharing -> m FarePoliciesProduct
-getAllFarePoliciesProduct merchantId merchantOpCityId isDashboard fromlocaton mbToLocation mbFromSpecialLocationId mbToSpecialLocationId txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion tripCategory configsInExperimentVersions mbDpInputsSharing = do
+getAllFarePoliciesProduct merchantId merchantOpCityId isDashboard fromlocaton mbToLocation mbFromSpecialLocationId mbToSpecialLocationId txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion tripCategory configsInExperimentVersions mbDpInputsSharing =
+  getAllFarePoliciesProducts merchantId merchantOpCityId isDashboard fromlocaton mbToLocation mbFromSpecialLocationId mbToSpecialLocationId txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion [tripCategory] configsInExperimentVersions mbDpInputsSharing
+
+data ResolvedCategory = ResolvedCategory
+  { tripCategory :: DTC.TripCategory,
+    allFareProducts :: FareProduct.FareProducts,
+    mbResolvedSpecialZoneId :: Maybe Text,
+    mbBaseVariantCarFareProduct :: Maybe FareProduct.FareProduct,
+    resolvedFareProducts :: [(FareProduct.FareProduct, Maybe DVST.VehicleServiceTier)]
+  }
+
+getAllFarePoliciesProducts :: (CacheFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r, BeamFlow m r, CH.HasClickhouseEnv CH.APP_SERVICE_CLICKHOUSE m, HasFlowEnv m r '["internalEndPointHashMap" ::: HM.HashMap BaseUrl BaseUrl], ClickhouseFlow m r, HasField "enableAPILatencyLogging" r Bool, HasField "enableAPIPrometheusMetricLogging" r Bool) => Id Merchant -> Id DMOC.MerchantOperatingCity -> Bool -> LatLong -> Maybe LatLong -> Maybe (Id SL.SpecialLocation) -> Maybe (Id SL.SpecialLocation) -> Maybe CacKey -> Maybe Text -> Maybe Text -> Maybe Meters -> Maybe Seconds -> Maybe Int -> [DTC.TripCategory] -> [LYT.ConfigVersionMap] -> Maybe DpInputsSharing -> m FarePoliciesProduct
+getAllFarePoliciesProducts merchantId merchantOpCityId isDashboard fromlocaton mbToLocation mbFromSpecialLocationId mbToSpecialLocationId txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion tripCategories configsInExperimentVersions mbDpInputsSharing = do
   let searchSources = FareProduct.getSearchSources isDashboard
-  allFareProducts <- withTimeAPI "farePolicy" "getAllFareProducts" $ FareProduct.getAllFareProducts merchantId merchantOpCityId searchSources fromlocaton mbToLocation mbFromSpecialLocationId mbToSpecialLocationId tripCategory
-  let mbResolvedSpecialZoneId = ((.getId) <$> mbFromSpecialLocationId) <|> SL.pickupSpecialZoneIdFromArea allFareProducts.area
-  (mbBaseVariantCarFareProduct :: Maybe FareProduct.FareProduct) <-
-    return . getFareProduct allFareProducts
-      =<< CQVST.findBaseServiceTierTypeByCategoryAndCityIdInRideFlow (Just DVC.CAR) merchantOpCityId mbResolvedSpecialZoneId
   transporterConfig <- getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = merchantOpCityId.getId}) Nothing >>= fromMaybeM (TransporterConfigNotFound merchantOpCityId.getId)
-  -- Resolve each fareProduct's vehicle-service-tier item once and reuse it for
-  -- both the per-vehicleCategory dynamic-pricing inputs and inside
-  -- 'getFullFarePolicy', so the (cached) lookup isn't repeated per service tier.
-  resolvedFareProducts <- withTimeAPI "farePolicy" "resolveVehicleServiceTiers" $ forM allFareProducts.fareProducts $ \fareProduct -> (fareProduct,) <$> CQVST.findByServiceTierTypeAndCityIdInRideFlow fareProduct.vehicleServiceTier merchantOpCityId mbResolvedSpecialZoneId
-  -- Pre-resolve the dynamic-pricing Redis inputs once for the whole search: the
-  -- congestion/rain/toss part is shared and the QAR/supply-demand part is fetched
-  -- per distinct vehicleCategory, so service tiers sharing a category don't
-  -- re-hit Redis. Skipped (falls back to per-tier fetch) when dynamic pricing
-  -- isn't applicable for this search.
-  dpInputsList <-
-    case (transporterConfig.isDynamicPricingQARCalEnabled == Just True && isDynamicPricingTripCategory tripCategory, mbDistance) of
+  resolvedCategories <- withTimeAPI "farePolicy" "getAllFareProducts" $
+    forM tripCategories $ \tripCategory -> do
+      allFareProducts <- FareProduct.getAllFareProducts merchantId merchantOpCityId searchSources fromlocaton mbToLocation mbFromSpecialLocationId mbToSpecialLocationId tripCategory
+      let mbResolvedSpecialZoneId = ((.getId) <$> mbFromSpecialLocationId) <|> SL.pickupSpecialZoneIdFromArea allFareProducts.area
+      (mbBaseVariantCarFareProduct :: Maybe FareProduct.FareProduct) <-
+        return . getFareProduct allFareProducts
+          =<< CQVST.findBaseServiceTierTypeByCategoryAndCityIdInRideFlow (Just DVC.CAR) merchantOpCityId mbResolvedSpecialZoneId
+      resolvedFareProducts <- forM allFareProducts.fareProducts $ \fareProduct -> (fareProduct,) <$> CQVST.findByServiceTierTypeAndCityIdInRideFlow fareProduct.vehicleServiceTier merchantOpCityId mbResolvedSpecialZoneId
+      pure ResolvedCategory {..}
+  let dpCategories = List.filter (isDynamicPricingTripCategory . (.tripCategory)) resolvedCategories
+      dpVehicleCategories = List.nub $ List.concatMap (\rc -> List.map (\(_, mbItem) -> maybe Nothing (.vehicleCategory) mbItem) rc.resolvedFareProducts) dpCategories
+  sharedDpInputs <-
+    case (transporterConfig.isDynamicPricingQARCalEnabled == Just True && not (null dpCategories), mbDistance) of
       (True, Just distance) -> do
         now <- getCurrentTime
         let geohash = fromMaybe (fromMaybe "" $ T.pack <$> Geohash.encode (fromMaybe 5 transporterConfig.dpGeoHashPercision) (fromlocaton.lat, fromlocaton.lon)) mbFromLocGeohash
-            vehicleCategories = map (\(_, mbItem) -> maybe Nothing (.vehicleCategory) mbItem) resolvedFareProducts
             qarRadius = fromMaybe 5.0 transporterConfig.qarCalRadiusInKm
-            build = withTimeAPI "farePolicy" "buildDynamicPricingInputs" $ buildDynamicPricingInputs now fromlocaton qarRadius (mkDropQARConfig transporterConfig mbToLocation) geohash mbToLocGeohash distance.getMeters merchantOpCityId.getId vehicleCategories
+            build = withTimeAPI "farePolicy" "buildDynamicPricingInputs" $ buildDynamicPricingInputs now fromlocaton qarRadius (mkDropQARConfig transporterConfig mbToLocation) geohash mbToLocGeohash distance.getMeters merchantOpCityId.getId dpVehicleCategories
         -- Absent a sharing mode this is just 'build' with no Redis involved, which is
         -- every search that has no walk-and-save suggestion attached to it.
         case mbDpInputsSharing of
@@ -237,17 +245,32 @@ getAllFarePoliciesProduct merchantId merchantOpCityId isDashboard fromlocaton mb
                 logWarning $ "dynamic_pricing: no published inputs for parent " <> parentTxnId <> "; pricing shadow on its own"
                 build
       _ -> pure []
-  baseVariantFareAmountCar <- withTimeAPI "farePolicy" "getBaseVariantFarePolicy" $ getBaseVariantFarePolicy transporterConfig (Just fromlocaton) mbToLocation merchantOpCityId mbBaseVariantCarFareProduct txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion configsInExperimentVersions allFareProducts.specialLocationName mbResolvedSpecialZoneId dpInputsList
-  farePolicies <- withTimeAPI "farePolicy" "getFullFarePolicies" $ catMaybes <$> mapConcurrently (\(fareProduct, mbVehicleServiceTierItem) -> getFullFarePolicy (Just fromlocaton) mbToLocation mbFromLocGeohash mbToLocGeohash mbDistance mbDuration txnId Nothing baseVariantFareAmountCar mbAppDynamicLogicVersion allFareProducts.specialLocationName mbResolvedSpecialZoneId fareProduct configsInExperimentVersions dpInputsList (Just transporterConfig) (Just mbVehicleServiceTierItem)) resolvedFareProducts
+  let dpInputsFor rc = if isDynamicPricingTripCategory rc.tripCategory then sharedDpInputs else []
+  baseVariantFares <- withTimeAPI "farePolicy" "getBaseVariantFarePolicy" $
+    forM resolvedCategories $ \rc ->
+      getBaseVariantFarePolicy transporterConfig (Just fromlocaton) mbToLocation merchantOpCityId rc.mbBaseVariantCarFareProduct txnId mbFromLocGeohash mbToLocGeohash mbDistance mbDuration mbAppDynamicLogicVersion configsInExperimentVersions rc.allFareProducts.specialLocationName rc.mbResolvedSpecialZoneId (dpInputsFor rc)
+  let productJobs =
+        List.concat $
+          List.zipWith
+            (\rc baseVariantFareAmountCar -> List.map (\(fareProduct, mbVehicleServiceTierItem) -> (rc, baseVariantFareAmountCar, fareProduct, mbVehicleServiceTierItem)) rc.resolvedFareProducts)
+            resolvedCategories
+            baseVariantFares
+  farePolicies <-
+    withTimeAPI "farePolicy" "getFullFarePolicies" $
+      catMaybes
+        <$> mapConcurrently
+          (\(rc, baseVariantFareAmountCar, fareProduct, mbVehicleServiceTierItem) -> getFullFarePolicy (Just fromlocaton) mbToLocation mbFromLocGeohash mbToLocGeohash mbDistance mbDuration txnId Nothing baseVariantFareAmountCar mbAppDynamicLogicVersion rc.allFareProducts.specialLocationName rc.mbResolvedSpecialZoneId fareProduct configsInExperimentVersions (dpInputsFor rc) (Just transporterConfig) (Just mbVehicleServiceTierItem))
+          productJobs
+  let mbFirst = (.allFareProducts) <$> listToMaybe resolvedCategories
   return $
     FarePoliciesProduct
       { farePolicies,
-        area = allFareProducts.area,
-        specialLocationTag = allFareProducts.specialLocationTag,
-        specialLocationName = allFareProducts.specialLocationName,
-        specialLocationSupportNumber = allFareProducts.specialLocationSupportNumber,
-        fareSettlementType = allFareProducts.fareSettlementType,
-        mbPickupDropArea = allFareProducts.mbPickupDropArea
+        area = maybe SL.Default (.area) mbFirst,
+        specialLocationTag = mbFirst >>= (.specialLocationTag),
+        specialLocationName = mbFirst >>= (.specialLocationName),
+        specialLocationSupportNumber = mbFirst >>= (.specialLocationSupportNumber),
+        fareSettlementType = mbFirst >>= (.fareSettlementType),
+        mbPickupDropArea = mbFirst >>= (.mbPickupDropArea)
       }
 
 getBaseVariantFarePolicy :: (CacheFlow m r, EsqDBFlow m r, EsqDBReplicaFlow m r, BeamFlow m r, CH.HasClickhouseEnv CH.APP_SERVICE_CLICKHOUSE m, HasFlowEnv m r '["internalEndPointHashMap" ::: HM.HashMap BaseUrl BaseUrl], ClickhouseFlow m r) => TransporterConfig -> Maybe LatLong -> Maybe LatLong -> Id DMOC.MerchantOperatingCity -> Maybe FareProduct.FareProduct -> Maybe CacKey -> Maybe Text -> Maybe Text -> Maybe Meters -> Maybe Seconds -> Maybe Int -> [LYT.ConfigVersionMap] -> Maybe Text -> Maybe Text -> [(Maybe DVC.VehicleCategory, DynamicPricingInputs)] -> m (Maybe HighPrecMoney)

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SearchRequestExtra.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/SearchRequestExtra.hs
@@ -4,9 +4,11 @@ import qualified Domain.Types.Location as DL
 import qualified Domain.Types.LocationMapping as DLM
 import qualified Domain.Types.RiderDetails as RD
 import Domain.Types.SearchRequest as Domain
+import qualified EulerHS.Language as L
 import EulerHS.Prelude (whenNothingM_)
 import Kernel.Beam.Functions
 import Kernel.Prelude
+import Kernel.Types.Error
 import Kernel.Types.Id
 import Kernel.Utils.Common
 import qualified Sequelize as Se
@@ -44,6 +46,44 @@ createDSReq searchRequest = do
 
 createStopsLocation :: (MonadFlow m, CacheFlow m r, EsqDBFlow m r) => [DL.Location] -> m ()
 createStopsLocation = QL.createMany
+
+createDSReqFresh :: (MonadFlow m, EsqDBFlow m r, CacheFlow m r) => SearchRequest -> m ()
+createDSReqFresh searchRequest = do
+  now <- getCurrentTime
+  let entityId = searchRequest.id.getId
+      stops = searchRequest.stops
+      mkMapping locationId order = do
+        id <- generateGUID
+        pure
+          DLM.LocationMapping
+            { id,
+              entityId,
+              locationId,
+              order,
+              tag = DLM.SEARCH_REQUEST,
+              version = QLM.latestTag,
+              merchantId = Just searchRequest.providerId,
+              merchantOperatingCityId = Just searchRequest.merchantOperatingCityId,
+              createdAt = now,
+              updatedAt = now
+            }
+  fromMapping <- mkMapping searchRequest.fromLocation.id 0
+  stopMappings <- zipWithM (\stop order -> mkMapping stop.id order) stops [1 ..]
+  mbToMapping <- forM searchRequest.toLocation $ \toLocation -> mkMapping toLocation.id (length stops + 1)
+  let locations = searchRequest.fromLocation : stops <> maybeToList searchRequest.toLocation
+      mappings = fromMapping : stopMappings <> maybeToList mbToMapping
+  runWritesConcurrently $
+    map (\loc -> ("createDSReqFresh:location", QL.create loc)) locations
+      <> map (\m -> ("createDSReqFresh:locationMapping", QLM.create m)) mappings
+      <> [("createDSReqFresh:searchRequest", createDSReq' searchRequest)]
+
+runWritesConcurrently :: (MonadFlow m) => [(Text, m ())] -> m ()
+runWritesConcurrently writes = do
+  awaitables <- forM writes $ \(tag, write) -> awaitableFork tag write
+  forM_ (zip (map fst writes) awaitables) $ \(tag, awaitable) ->
+    L.await Nothing awaitable >>= \case
+      Right () -> pure ()
+      Left err -> throwError $ InternalError $ tag <> " failed: " <> show err
 
 updateAutoAssign ::
   (MonadFlow m, EsqDBFlow m r, CacheFlow m r) =>

--- a/Backend/dev/docs/search-latency-notes.md
+++ b/Backend/dev/docs/search-latency-notes.md
@@ -1,0 +1,198 @@
+# Ride search latency: findings and plan
+
+Status: on hold after PR #16670 (2026-09-10). Resume from section 8.
+
+Companion pages (claude.ai artifacts, private): ranked audit
+`https://claude.ai/code/artifact/180cd185-09f6-40f9-a1b7-9c2246fd7257`, flow diagrams
+`https://claude.ai/code/artifact/292916ea-cf33-4b20-b17e-23f880c685fa`.
+
+## 1. What the Grafana metric measures
+
+`beckn_search_round_trip` (rider-app) starts at `Domain/Action/UI/Search.hs` after maps,
+geocoding and passetto work, just before the Beckn fork, and stops in
+`Domain/Action/Beckn/OnSearch.hs` when on_search has been persisted. It excludes the
+`/rideSearch` pre-work and the results poll. Buckets are 0.5 s wide, so a TP50 under 1 s
+is interpolated. The panel query was already TP99; only the legend said TP50.
+
+Per-stage averages exist through `withTimeAPI`, exported as
+`datastore_operation_duration{datastore, operation}`:
+
+| datastore     | what it covers                                   |
+|---------------|--------------------------------------------------|
+| `search`      | driver-app estimate build (`handler` and stages) |
+| `farePolicy`  | fare pipeline inside `getAllFarePolicies`        |
+| `rideSearch`  | rider-app `/rideSearch`                          |
+| `syncSearch`  | driver-app internal sync endpoint                |
+
+Panel query for an average per stage:
+
+```
+sum(rate(datastore_operation_duration_sum[5m])) by (operation)
+  / sum(rate(datastore_operation_duration_count[5m])) by (operation)
+```
+
+with legend `{{operation}}`.
+
+## 2. Measurements (Bangalore, NAMMA_YATRI, 2026-09-08)
+
+Driver-app estimate build, averages in seconds:
+
+| Stage                     | Off-peak 12-14h | Morning peak 10-11h | Evening 16-20h |
+|---------------------------|-----------------|---------------------|----------------|
+| handler (whole build)     | 0.45            | 1.0-1.35            | 0.6-1.1        |
+| getAllFarePolicies        | 0.25            | 0.6-0.85            | 0.35-0.75      |
+| per trip category         | 0.14            | 0.3-0.47            | 0.2-0.45       |
+| buildEstimatesAndQuotes   | 0.07            | 0.1-0.2             | 0.1-0.2        |
+| createEstimates           | 0.07            | 0.1-0.2             | 0.1-0.2        |
+| createSearchRequest       | 0.03            | 0.25                | 0.1-0.2        |
+| everything else           | 0.03            |                     |                |
+
+Inside the fare pipeline: `getFullFarePolicies` 0.05 off-peak rising to 0.25 at peak,
+`buildDynamicPricingInputs` (QAR and friends) flat at about 0.06, `getAllFareProducts`
+0.03 with cache-refill spikes, `getBaseVariantFarePolicy` 0.02.
+
+Round-trip TP50 was 0.6-0.8 s off-peak, of which `handler` is about 0.45. The rest is
+three signed hops, the gateway registry lookup and the rider-app on_search pre-ack and
+persist.
+
+## 3. Why the 09-11h and 16-20h plateau
+
+- Bangalore pricing time bounds (`time_bound_config`, DYNAMIC-PRICING-UNIFIED):
+  MorningPeakHours 08-09 and 10-11, MorningSuperPeakHours 09-10, PeakHours 16-17 and
+  20-21, SuperPeakHours 17-20, NightHours 22-05.
+- Inside a bound the per-tier dynamic pricing logic runs in `getFullFarePolicy`: the logic
+  is refetched per tier and the full logic AST is info-logged per tier. That stage is 4-5x
+  slower in-window and is the plateau. QAR inputs are not peak-sensitive.
+- Pricing rollout edits during peak coincided with every rise. Rollout rows carry up to
+  62 KB of embedded logic and the whole domain list is decoded on a sticky-version miss.
+- Search volume does not explain it: peak volume was 09:00-09:50, the latency plateau
+  10:00-11:00 with a sharp edge at 11:00.
+- ML pricing is off for Bangalore and there are no time-bounded fare products there.
+
+## 4. Sync search shadow (`sync_search_shadow:total`)
+
+This is the "walk and save" shadow search. When `/rideSearch` finds a pickup or drop
+point on the resolved route that removes a detour, the rider-app creates a second search
+request with its own transaction id and a pointer to the parent, and sends it straight to
+the driver-app internal `sync_search` endpoint, in parallel with the real search
+(`API/UI/Search.hs`, `SharedLogic/BetterRoutePointSearch.hs`). The driver-app tags the
+span `sync_search_shadow:total`; it wraps validation, the full `handler` build, the
+value-add check and the on_search payload (`SharedLogic/SearchRequestProcessing.hs`).
+
+Why it runs 0.3-0.4 s above `handler`: the shadow is priced against the parent's
+dynamic-pricing inputs so it never gets a different congestion charge. It polls Redis for
+the inputs the parent publishes, up to 10 tries at 100 ms (`SharedLogic/FarePolicy.hs`,
+`waitForPublishedDpInputs`). Both searches are dispatched at the same moment, so the
+shadow usually arrives before the parent has published and spends a few hundred
+milliseconds waiting. Shadows are a small share of traffic, so their average is noisy;
+isolated spikes to several seconds need the request count before being read as a
+systematic issue. `handler` already includes shadow searches, so every customer search
+with a suggestion doubles the driver-app estimate work.
+
+Levers, in order: publish the inputs before dispatching the shadow, or subscribe instead
+of polling; give shadows a fares-only path that skips estimate and quote persistence.
+
+## 5. Full backlog
+
+Phase 0, measure: named stage panels (done), results-poll timer around `getQuotes'` in
+`API/UI/Quote.hs`, external-host panel.
+
+Phase 1, driver-app parallelism: concurrent reverse geocodes in `Search.hs`, concurrent
+LTS per tier, concurrent estimate loop, batched estimate and quote inserts, concurrent
+per-category QAR fetch.
+
+Phase 2, driver-app dedupe: fare pipeline once per search (item 1, done in PR #16670),
+cache resolved QAR 30-60 s, congestion MGET, city in QAR GEO keys, settlement type once,
+transporter config once in `FareProduct.hs`, logic once per search with quiet logs,
+ambulance double calculation.
+
+Phase 3, rider-app on_search and poll: ack earlier in `API/Beckn/OnSearch.hs`, cache the
+whitelist count in `WhiteListOrgExtra.hs`, scope and back off the estimate-build lock
+shared by on_search and the quotes poll, insurance config once, bulk inserts, skip
+journey-leg update on taxi, fork auto-select, lighten the poll.
+
+Phase 4, rider-app before the metric starts: bound the maps call, take passetto decrypts
+off the path, concurrent enrichment, trim `createDSReq` (item 6, done in PR #16670),
+rider config once, index `cached_route_response`, remove serial 5 s awaits.
+
+Phase 5, transport: cache the gateway BPP lookup, floor the registry TTL, per-action
+timeouts with sub-second backoff instead of 4 s and 8 s sleeps, `managerConnCount`,
+replace the 45 s metrics sleeper, sync path for on-us searches.
+
+Phase 6, process: no pricing rollout edits in peak, slim rollout rows, confirm prod flags.
+
+## 6. What PR #16670 changes
+
+Branch `dynamic-offer-driver-app/perf/search-fare-pipeline-write-chain`, rebased on
+main at `d24459f886`.
+
+### Item 6: `createDSReqFresh` (`Storage/Queries/SearchRequestExtra.hs`)
+
+The generic `createDSReq` is written for entities that may already have location
+mappings. For each mapping it first demotes the previous version at that order, for the
+drop it reads the current max order, and each location insert is guarded by a
+`findById`. For a search request created in the search handler all five reads are
+guaranteed misses, and a KV miss falls through to Postgres. With the five sequential
+writes that was about ten sequential DB operations per search, and the stage went from
+0.03 s off-peak to 0.25 s under load.
+
+`createDSReqFresh` builds the mappings in memory with orders known up front (pickup 0,
+stops 1..n, drop n+1, version LATEST), issues no lookups, and runs the location, mapping
+and search-request writes concurrently through `runWritesConcurrently`, which rethrows
+the first failed write instead of dropping it. The handler calls it; `createDSReq` stays
+for callers that remap existing entities.
+
+### Item 1: `getAllFarePoliciesProducts` (`SharedLogic/FarePolicy.hs`)
+
+A search prices several trip categories at once (a plain one-way search prices both
+`OneWay RideOtp` and `OneWay OnDemandDynamicOffer`). The handler ran the whole fare
+pipeline once per category. Only fare products and full fare policies are category
+specific; transporter config, special-location resolution and the dynamic-pricing Redis
+inputs were fetched once per category, and the wrapper span (0.25 s) was well above the
+per-category span (0.14 s), so the two runs did not even overlap well.
+
+The new function takes every category of the search and works in four steps:
+per-category fare products and tier resolution (cached reads), dynamic-pricing inputs
+built once for the union of vehicle categories, base CAR fare per category, then one
+concurrent `getFullFarePolicy` batch across all products of all categories. The result
+is combined the way the handler's removed `combineFarePoliciesProducts` did.
+`getAllFarePoliciesProduct` is kept as a single-category wrapper for the other callers.
+
+Behaviour change to flag to the pricing owner: the random toss used for percentage
+rollouts is now drawn once per search rather than once per category, so all categories
+of a search land in the same rollout arm.
+
+Panel note: the per-category span `withTimeAPI "search" "getAllFarePoliciesProduct"` no
+longer exists. `getAllFarePolicies` and the `farePolicy` spans remain.
+
+## 7. Verification state
+
+- Before the rebase, all three modules compiled under `-Wall -Werror` in a full
+  `cabal build` pass and loaded clean in `cabal repl`.
+- After the rebase, the local machine cannot build the driver-app library at all: GHC
+  9.2.7 panics at the start of the library build (`lookupModuleWithSuggestions` on
+  `Domain.Types.Ride`), identically on untouched main, after clearing the package build
+  directory, its in-place registration and the cabal plan cache. The rebased code has not
+  been compiled yet. Build on the dev box (`, run-cabal-build-devbox`).
+- Not yet run: before/after estimate comparison for a fixed search in dev.
+
+## 8. Resume checklist
+
+1. Dev-box build of the PR branch; fix anything the upstream fare-policy revamp changed
+   around `getFullFarePolicy` arguments if the build complains.
+2. Fixed test search in dev, compare estimate count and fares before and after.
+3. Tell the pricing owner about the shared toss.
+4. Release, then read the `datastore="search"` panel: `createSearchRequest` should sit
+   at or under 0.01 s and stop rising with load, `getAllFarePolicies` should approach
+   the old per-category value or below, `handler` down by the sum. Expected roughly
+   -0.1 s off-peak and -0.3 s at peak on `handler`.
+5. Fix the round-trip panel legend (TP50 vs TP99 per query) and remove any panel query
+   that still references the `getAllFarePoliciesProduct` span.
+6. Pick the next items: the shadow-search wait (section 4), then Phase 1 parallelism.
+
+## 9. Open questions
+
+- What was the 0.1 s non-overlap between `getAllFarePolicies` and its per-category span?
+  Answerable from the panels after release.
+- Which stage carried the 14:15 and 14:35 spikes on 2026-09-08 (no config change then)?
+- Poll endpoint `/rideSearch/{id}/results` latency is unmeasured until the timer lands.


### PR DESCRIPTION
## Why

Per-stage latency panels (`datastore_operation_duration{datastore="search"}`) for Bangalore on 2026-09-08 showed the driver-app estimate build (`handler`) at ~0.45 s off-peak and 1.0–1.35 s in the morning pricing peak, which is most of the Beckn search round trip. Two stages stood out:

| Stage | Off-peak | Peak / under load |
|---|---|---|
| `getAllFarePolicies` | 0.25 s (per-category span 0.14 s) | 0.6–0.85 s |
| `createSearchRequest` | 0.03 s | 0.25 s |

This PR addresses exactly those two, as two independent commits, so their effect can be read off the same panels after release.

## Commit 1 — persist fresh search requests without empty lookups

`createDSReq` is written for entities that may already have mappings: it demotes the previous mapping version at each order, reads the current max order for the drop, and guards each location create with a `findById`. For a search request created in the search handler all five of those reads are guaranteed misses, and each miss falls through KV to a Postgres read. With the five sequential writes that is ~10 sequential DB operations per search, and it is what made the stage load-sensitive.

`createDSReqFresh` knows the orders up front (pickup 0, stops 1..n, drop n+1, all `LATEST`), issues no lookups, and runs the location, mapping and search-request writes concurrently. A failed write is rethrown rather than dropped. The generic path is kept for callers that remap existing entities.

## Commit 2 — resolve fare policies for all trip categories in one pass

A plain one-way search prices two trip categories (`OneWay RideOtp`, `OneWay OnDemandDynamicOffer`) and the handler ran the entire fare pipeline once per category. Only fare products and full fare policies are category-specific; transporter config, special-location resolution and the dynamic-pricing Redis inputs (QAR, congestion, rain, supply-demand) were fetched once per category.

`getAllFarePoliciesProducts` takes every category of the search: category-specific resolution first (cached / in-memory), dynamic-pricing inputs built once for the union of vehicle categories, then one concurrent batch of `getFullFarePolicy` across all products of all categories. The result is combined the way the handler used to combine per-category results. `getAllFarePoliciesProduct` stays as a single-category wrapper for the update and fare-calculator callers.

**Behaviour note for pricing:** the random `toss` used for percentage rollouts is now drawn once per search rather than once per category, so both categories of a search land in the same rollout arm.

**Panel note:** the per-category span `withTimeAPI "search" "getAllFarePoliciesProduct"` no longer exists; `getAllFarePolicies` and the `farePolicy` spans remain.

## Verification

- Before the rebase onto main (`d24459f886`), all three modules compiled under the package's `-Wall -Werror` in a full `cabal build` pass and loaded clean via `cabal repl`.
- The rebased code has **not** been compiled yet: the local machine hits a GHC 9.2.7 panic at the start of the driver-app library build, identically on untouched main, so this needs a dev-box `cabal build all` before review.
- Not yet run: a before/after estimate comparison for a fixed search in dev.

## Status

On hold. Findings, measurements, the shadow-search analysis, the full backlog and a resume checklist are in `Backend/dev/docs/search-latency-notes.md` (third commit).

## Expected effect

`createSearchRequest` should settle near 0.01 s and stop rising with load; `getAllFarePolicies` should drop toward the single-category value. Roughly −0.1 s off-peak and −0.3 s at peak on `handler`.

## Follow-ups (not in this PR)

Concurrent estimate loop and batched inserts, per-tier LTS calls in parallel, dynamic-pricing logic fetched once per search with the per-tier info logs demoted, QAR result caching, and the rider-app on_search lock scoping. Full list in the search-latency working notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFZJxXJ6QXHP438kShAS9d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Fare policies are resolved across multiple trip categories in a single operation, improving search efficiency.
  * Search request information is saved concurrently, helping reduce search persistence time.

* **Reliability**
  * Failures while saving search requests are now reported explicitly, reducing the risk of incomplete records.

* **Bug Fixes**
  * Fare policy results remain correctly organized by trip category while sharing applicable pricing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->