### PR TITLE
Added Support for Arrays for Auto Assign

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboardingV2.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/DriverOnboardingV2.hs
@@ -634,7 +634,7 @@ postDriverUpdateServiceTiers (mbPersonId, _, merchantOperatingCityId) API.Types.
     person <- PersonQuery.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
     now <- getCurrentTime
     let hasAutoAssignTag tier =
-          Yudhishthira.elemTagNameValue (LYT.TagNameValue ("AutoAssign#" <> show tier)) (Yudhishthira.filterExpiredTags' now (fromMaybe [] person.driverTag))
+          Yudhishthira.elemTagValue (LYT.TagName "AutoAssign") (show tier) (Yudhishthira.filterExpiredTags' now (fromMaybe [] person.driverTag))
 
     -- Single pass over the driver's own filtered tier list, not cityVehicleServiceTiers -- force-select must never bypass isUsageRestricted.
     driverVehicleServiceTierTypes <- fetchVehicleTierForDriverWithUsageRestriction AllowedVariants (Just driverInfo) (Just vehicle) Nothing (Just cityVehicleServiceTiers) personId merchantOperatingCityId

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPoolUnified.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/Allocator/Jobs/SendSearchRequestToDrivers/Handle/Internal/DriverPoolUnified.hs
@@ -539,12 +539,14 @@ hasAnyPriorityTag tagNames dp = case dp.driverPoolResult.driverTags of
   Object keymap -> any (\name -> AKM.member (AK.fromText name) keymap) tagNames
   _ -> False
 
--- | driverTags is keyed by bare category (e.g. {"AutoAssign": "COMFY"}), so this checks
--- the value equals the tier name, unlike hasAnyPriorityTag's key-membership check above.
+-- | True if the driver's AutoAssign tag names this tier. Matches on the value, unlike
+-- hasAnyPriorityTag above which checks key membership. convertTags renders a single value as a
+-- string and a multi-tier "TierA&TierB" tag as an array, so both shapes are accepted.
 hasPriorityTag :: Text -> DriverPoolWithActualDistResult -> Bool
 hasPriorityTag tierName dp = case dp.driverPoolResult.driverTags of
   Object keymap -> case AKM.lookup (AK.fromString "AutoAssign") keymap of
     Just (String v) -> v == tierName
+    Just (Array vs) -> String tierName `elem` vs
     _ -> False
   _ -> False
 

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Person/GetNearestDrivers.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Storage/Queries/Person/GetNearestDrivers.hs
@@ -215,14 +215,15 @@ getNearestDrivers req fetchPoolData = do
 -- `selectedServiceTiers` alone for a cohort-gated tier. The cohort tag itself is always
 -- ops-assigned (via the dashboard); no tier-selection change ever writes it.
 --
--- The cohort tag's value is always "Cohort#<tier>" -- the same string as the tier itself, not a
--- separately configured short code -- so no Redis-backed short-code-to-tier mapping is needed
--- anywhere (Haskell or location-tracking-service) to answer "which tier does this cohort gate."
+-- The cohort tag's value is the tier name itself -- "Cohort#<tier>", or "Cohort#<tierA>&<tierB>"
+-- for a driver in several cohorts -- not a separately configured short code, so no Redis-backed
+-- short-code-to-tier mapping is needed anywhere (Haskell or location-tracking-service) to answer
+-- "which tier does this cohort gate." elemTagValue matches the tier within that "&"-separated set.
 isTierEligibleForDriver :: UTCTime -> Maybe [LYT.TagNameValueExpiry] -> HashMap.HashMap ServiceTierType DVST.VehicleServiceTier -> ServiceTierType -> Bool
 isTierEligibleForDriver now driverTag tierConfigs tier =
   case HashMap.lookup tier tierConfigs >>= (.availabilityCheckConfig) of
     Nothing -> True
-    Just _ -> Yudhishthira.elemTagNameValue (LYT.TagNameValue ("Cohort#" <> show tier)) (Yudhishthira.filterExpiredTags' now (fromMaybe [] driverTag))
+    Just _ -> Yudhishthira.elemTagValue (LYT.TagName "Cohort") (show tier) (Yudhishthira.filterExpiredTags' now (fromMaybe [] driverTag))
 
 -- | Whether the driver is eligible for a scheduled booking of the given tier: not a scheduled ride
 -- at all, within the R4 open-to-all threshold, or the tier's configured eligibility tags intersect

--- a/Backend/lib/yudhishthira/src/Lib/Yudhishthira/Tools/Utils.hs
+++ b/Backend/lib/yudhishthira/src/Lib/Yudhishthira/Tools/Utils.hs
@@ -218,6 +218,14 @@ elemTagNameValue tag tags = convertToTagNameValue tag `elem` (convertToTagNameVa
 elemTagName :: (HasTagNameValue tag1, HasTagNameValue tag2) => tag1 -> [tag2] -> Bool
 elemTagName tag tags = parseTagName tag `elem` (parseTagName <$> tags)
 
+-- | True if `value` is one of the "&"-separated values stored under `tagName`.
+elemTagValue :: HasTagNameValue tag => LYT.TagName -> Text -> [tag] -> Bool
+elemTagValue (LYT.TagName name) value tags = any matches tags
+  where
+    matches tag = case T.splitOn "#" (LYT.getTagNameValue (convertToTagNameValue tag)) of
+      (tagName : tagValue : _) -> tagName == name && value `elem` T.splitOn "&" tagValue
+      _ -> False
+
 -- this way older value will be replaced to new one with upated expiry
 replaceTagNameValue :: HasTagNameValue tag => Maybe [tag] -> tag -> [tag]
 replaceTagNameValue Nothing tag = [tag]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved driver eligibility checks for service tiers represented by multi-tier tag values.
  - Drivers with multiple auto-assignment tiers are now correctly recognized during tier updates and search requests.
  - Cohort-based eligibility now supports drivers assigned to multiple cohorts without requiring separate tags.
  - Tier matching is more consistent across onboarding, driver allocation, and nearby-driver searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->