### PR TITLE
backend/chore: lock shared-kernel to prodHotPush-BAP head instead of main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4021,11 +4021,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1788897914,
-        "narHash": "sha256-vkFt8tbR1BbQGKgklEn4kFtOkOABPJwWTrDvaznkqeU=",
+        "lastModified": 1788964396,
+        "narHash": "sha256-BqG9fmpc5DNdCsOwwt3gZNKt7lbL56euT8afnwFjEqE=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "9113aefaeecb67c878634e9eec1e6eea7836c571",
+        "rev": "78388a1325a3fdee7f2f046a1f148874ecdb0733",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

`c5753f4bc7` bumped shared-kernel to `9113aef`, which is on **main**. Besides the fork/await fix this hotpush is for, that pulled in four unrelated shared-kernel commits — one of them **replica LTS redis (#1498)**, which adds `HasField "ltsReplicaHedisEnv"` to `HedisLTSFlowEnv`. No app `AppEnv` in this branch has that field, so rider-app fails to build:

```
src/Storage/CachedQueries/Merchant/MultiModalBus.hs:144:19: error:
    * Could not deduce (HasField "ltsReplicaHedisEnv" r (Maybe Hedis.HedisEnv))
        arising from a use of `Hedis.runInMultiCloudLTSRedisForList'
```

## Fix

shared-kernel's own `prodHotPush-BAP` branch now carries the same euler-hs bump at [`78388a13`](https://github.com/nammayatri/shared-kernel/commit/78388a1325a3fdee7f2f046a1f148874ecdb0733) — that is `728add67` plus euler-hs `6290a7e` → `7e23313`, i.e. [nammayatri/euler-hs#75](https://github.com/nammayatri/euler-hs/pull/75) and nothing else. Lock shared-kernel to that instead of main.

- euler-hs stays at `7e23313` either way, so the fork/await fix this hotpush exists for is unaffected.
- `flake.nix` input URLs are unchanged; only the locked rev in `flake.lock` moves (3 lines).
- No rider-app source change is needed under this pin — `prodHotPush-BAP`'s `HedisLTSFlowEnv` is still the three-field version without `ltsReplicaHedisEnv`.

## Alternative considered

Porting the app side of the replica-LTS work (upstream `42fcda8bf8`, "Added-LTS-Replica-Redis-Support") onto this branch. That builds, but it drags a feature and a new **required** `ltsReplicaRedis` dhall field into a prod hotfix line for no reason — the prod dhall configs would have to carry `ltsReplicaRedis = None …` or the app won't start. Re-pointing the lock is the smaller change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGMeMjzjnViwcEqd875qw2