### PR TITLE
backend/fix: issue-management cache clears run on both clouds' Redis

### DIFF
--- a/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueCategory.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueCategory.hs
@@ -53,7 +53,7 @@ clearAllIssueCategoryByMerchantOpCityIdAndLanguageCache merchantOpCityId identif
 
 clearIssueCategoryByMerchantOpCityIdAndLanguageCache :: BeamFlow m r => Id MerchantOperatingCity -> Language -> Identifier -> m ()
 clearIssueCategoryByMerchantOpCityIdAndLanguageCache merchantOpCityId language identifier = do
-  Hedis.withCrossAppRedis . Hedis.del $ makeIssueCategoryByMerchantOpCityIdAndLanguageKey merchantOpCityId language identifier
+  Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueCategoryByMerchantOpCityIdAndLanguageKey merchantOpCityId language identifier
 
 cacheAllIssueCategoryByMerchantOpCityIdAndLanguage :: CacheFlow m r => Id MerchantOperatingCity -> Language -> Identifier -> [(IssueCategory, Maybe IssueTranslation)] -> m ()
 cacheAllIssueCategoryByMerchantOpCityIdAndLanguage merchantOpCityId language identifier issueCategoryTranslation = do
@@ -66,7 +66,7 @@ makeIssueCategoryByMerchantOpCityIdAndLanguageKey merchantOpCityId language iden
 --------- Caching logic for issue category by id -------------------
 
 clearIssueCategoryByIdCache :: CacheFlow m r => Id IssueCategory -> Identifier -> m ()
-clearIssueCategoryByIdCache issueCategoryId identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueCategoryByIdKey issueCategoryId identifier
+clearIssueCategoryByIdCache issueCategoryId identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueCategoryByIdKey issueCategoryId identifier
 
 cacheIssueCategoryById :: CacheFlow m r => Id IssueCategory -> Identifier -> Maybe IssueCategory -> m ()
 cacheIssueCategoryById issueCategoryId identifier issueCategory = do
@@ -83,7 +83,7 @@ clearAllIssueCategoryByIdAndLanguageCache issueCategoryId identifier = forM_ all
   clearIssueCategoryByIdAndLanguageCache issueCategoryId language identifier
 
 clearIssueCategoryByIdAndLanguageCache :: (CacheFlow m r) => Id IssueCategory -> Language -> Identifier -> m ()
-clearIssueCategoryByIdAndLanguageCache issueCategoryId language identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueCategoryByIdAndLanguageKey issueCategoryId language identifier
+clearIssueCategoryByIdAndLanguageCache issueCategoryId language identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueCategoryByIdAndLanguageKey issueCategoryId language identifier
 
 cacheIssueCategoryByIdAndLanguage :: (CacheFlow m r) => Id IssueCategory -> Language -> Identifier -> Maybe (IssueCategory, Maybe IssueTranslation) -> m ()
 cacheIssueCategoryByIdAndLanguage issueCategoryId language identifier issueCategoryTranslation = do

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueConfig.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueConfig.hs
@@ -35,7 +35,7 @@ findByMerchantOpCityId merchantOpCityId identifier =
 --------- Caching logic -------------------
 
 clearIssueConfigCache :: CacheFlow m r => Id MerchantOperatingCity -> Identifier -> m ()
-clearIssueConfigCache merchantOpCityId identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueConfigKeyByMerchantOpCityId merchantOpCityId identifier
+clearIssueConfigCache merchantOpCityId identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueConfigKeyByMerchantOpCityId merchantOpCityId identifier
 
 updateByPrimaryKey :: BeamFlow m r => IssueConfig -> m ()
 updateByPrimaryKey = Queries.updateByPrimaryKey

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueMessage.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueMessage.hs
@@ -80,8 +80,11 @@ appendMediaFiles identifier =
 
 -- --------- Caching logic for issue message by id -------------------
 
+-- Cache deletes run on both clouds' Redis (primary + secondary): app reads may be
+-- served from either cloud's cross-app Redis, so a single-cloud delete leaves the
+-- other cloud serving the stale message until configsExpTime (24h) expires.
 clearIssueMessageByIdCache :: CacheFlow m r => Id IssueMessage -> Identifier -> m ()
-clearIssueMessageByIdCache issueMessageId identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueMessageById issueMessageId identifier
+clearIssueMessageByIdCache issueMessageId identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueMessageById issueMessageId identifier
 
 cacheIssueMessageById :: CacheFlow m r => Id IssueMessage -> Identifier -> Maybe IssueMessage -> m ()
 cacheIssueMessageById issueMessageId identifier issueMessage = do
@@ -99,7 +102,7 @@ clearAllIssueMessageByIdAndLanguageCache issueMessageId identifier =
     clearIssueMessageByIdAndLanguageCache issueMessageId language identifier
 
 clearIssueMessageByIdAndLanguageCache :: CacheFlow m r => Id IssueMessage -> Language -> Identifier -> m ()
-clearIssueMessageByIdAndLanguageCache issueMessageId language identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueMessageByIdAndLanguage issueMessageId language identifier
+clearIssueMessageByIdAndLanguageCache issueMessageId language identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueMessageByIdAndLanguage issueMessageId language identifier
 
 cacheIssueMessageByIdAndLanguage :: CacheFlow m r => Id IssueMessage -> Language -> Identifier -> Maybe (IssueMessage, DetailedTranslation, [Text]) -> m ()
 cacheIssueMessageByIdAndLanguage issueMessageId language identifier issueMessageTranslation = do
@@ -117,7 +120,7 @@ clearAllIssueMessageByCategoryIdAndLanguageCache issueCategoryId identifier =
     clearIssueMessageByCategoryIdAndLanguageCache issueCategoryId language identifier
 
 clearIssueMessageByCategoryIdAndLanguageCache :: CacheFlow m r => Id IssueCategory -> Language -> Identifier -> m ()
-clearIssueMessageByCategoryIdAndLanguageCache issueCategoryId language identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueMessageByLanguageAndCategory issueCategoryId language identifier
+clearIssueMessageByCategoryIdAndLanguageCache issueCategoryId language identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueMessageByLanguageAndCategory issueCategoryId language identifier
 
 cacheAllIssueMessageByCategoryIdAndLanguage :: CacheFlow m r => Id IssueCategory -> Language -> Identifier -> [(IssueMessage, DetailedTranslation, [Text])] -> m ()
 cacheAllIssueMessageByCategoryIdAndLanguage issueCategoryId language identifier issueMessageTranslation = do
@@ -135,7 +138,7 @@ clearAllIssueMessageByOptionIdAndLanguageCache issueOptionId identifier =
     clearIssueMessageByOptionIdAndLanguageCache issueOptionId language identifier
 
 clearIssueMessageByOptionIdAndLanguageCache :: CacheFlow m r => Id IssueOption -> Language -> Identifier -> m ()
-clearIssueMessageByOptionIdAndLanguageCache issueOptionId language identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueMessageByLanguageAndOption issueOptionId language identifier
+clearIssueMessageByOptionIdAndLanguageCache issueOptionId language identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueMessageByLanguageAndOption issueOptionId language identifier
 
 cacheAllIssueMessageByOptionIdAndLanguage :: CacheFlow m r => Id IssueOption -> Language -> Identifier -> [(IssueMessage, DetailedTranslation, [Text])] -> m ()
 cacheAllIssueMessageByOptionIdAndLanguage issueOptionId language identifier issueMessageTranslation = do

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueOption.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueOption.hs
@@ -59,7 +59,7 @@ findByIdAndCategoryId issueOptionId issueCategoryId identifier =
 --------- Caching logic for issue option by issueCategoryId & language -------------------
 
 clearIssueOptionByCategoryAndLanguageCache :: CacheFlow m r => Id IssueCategory -> Language -> Identifier -> m ()
-clearIssueOptionByCategoryAndLanguageCache issueCategoryId language identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByCategoryAndLanguageKey issueCategoryId language identifier
+clearIssueOptionByCategoryAndLanguageCache issueCategoryId language identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByCategoryAndLanguageKey issueCategoryId language identifier
 
 cacheAllIssueOptionByCategoryAndLanguage :: CacheFlow m r => Id IssueCategory -> Language -> Identifier -> [(IssueOption, Maybe IssueTranslation)] -> m ()
 cacheAllIssueOptionByCategoryAndLanguage issueCategoryId language identifier issueOptionTranslation = do
@@ -72,7 +72,7 @@ makeIssueOptionByCategoryAndLanguageKey issueCategoryId language identifier = sh
 --------- Caching logic for issue option by id -------------------
 
 clearIssueOptionByIdCache :: CacheFlow m r => Id IssueOption -> Identifier -> m ()
-clearIssueOptionByIdCache issueOptionId identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByIdKey issueOptionId identifier
+clearIssueOptionByIdCache issueOptionId identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByIdKey issueOptionId identifier
 
 cacheIssueOptionById :: CacheFlow m r => Id IssueOption -> Identifier -> Maybe IssueOption -> m ()
 cacheIssueOptionById issueOptionId identifier issueOption = do
@@ -90,7 +90,7 @@ clearAllIssueOptionByIdAndLanguageCache issueOptionId identifier =
     clearIssueOptionByIdAndLanguageCache issueOptionId language identifier
 
 clearIssueOptionByIdAndLanguageCache :: CacheFlow m r => Id IssueOption -> Language -> Identifier -> m ()
-clearIssueOptionByIdAndLanguageCache issueOptionId language identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByIdAndLanguageKey issueOptionId language identifier
+clearIssueOptionByIdAndLanguageCache issueOptionId language identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByIdAndLanguageKey issueOptionId language identifier
 
 cacheIssueOptionByIdAndLanguage :: CacheFlow m r => Id IssueOption -> Language -> Identifier -> Maybe (IssueOption, Maybe IssueTranslation) -> m ()
 cacheIssueOptionByIdAndLanguage issueOptionId language identifier issueOptionTranslation = do
@@ -103,7 +103,7 @@ makeIssueOptionByIdAndLanguageKey id language identifier = show identifier <> ":
 --------- Caching logic for issue option by id and issueCategoryId -------------------
 
 clearIssueOptionByIdAndIssueCategoryIdCache :: CacheFlow m r => Id IssueOption -> Id IssueCategory -> Identifier -> m ()
-clearIssueOptionByIdAndIssueCategoryIdCache issueOptionId issueCategoryId identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByIdAndIssueCategoryIdKey issueOptionId issueCategoryId identifier
+clearIssueOptionByIdAndIssueCategoryIdCache issueOptionId issueCategoryId identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByIdAndIssueCategoryIdKey issueOptionId issueCategoryId identifier
 
 cacheIssueOptionByIdAndIssueCategoryId :: CacheFlow m r => Id IssueOption -> Id IssueCategory -> Identifier -> Maybe IssueOption -> m ()
 cacheIssueOptionByIdAndIssueCategoryId issueOptionId issueCategoryId identifier issueOptionTranslation = do
@@ -121,7 +121,7 @@ clearAllIssueOptionByMessageAndLanguageCache issueMessageId identifier =
     clearIssueOptionByMessageAndLanguageCache issueMessageId language identifier
 
 clearIssueOptionByMessageAndLanguageCache :: CacheFlow m r => Id IssueMessage -> Language -> Identifier -> m ()
-clearIssueOptionByMessageAndLanguageCache issueMessageId language identifier = Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByMessageAndLanguageKey issueMessageId language identifier
+clearIssueOptionByMessageAndLanguageCache issueMessageId language identifier = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeIssueOptionByMessageAndLanguageKey issueMessageId language identifier
 
 cacheAllIssueOptionByMessageAndLanguage :: CacheFlow m r => Id IssueMessage -> Language -> Identifier -> [(IssueOption, Maybe IssueTranslation)] -> m ()
 cacheAllIssueOptionByMessageAndLanguage issueMessageId language identifier issueOption = do

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/MediaFile.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/MediaFile.hs
@@ -40,7 +40,7 @@ findAllInForIssueReportId mediaFileIds issueReportId identifier =
 --------- Caching logic for media file by id -------------------
 
 clearMediaFileByIdCache :: CacheFlow m r => Identifier -> Id MediaFile -> m ()
-clearMediaFileByIdCache identifier mediaFileId = Hedis.withCrossAppRedis . Hedis.del $ makeMediaFileByIdKey mediaFileId identifier
+clearMediaFileByIdCache identifier mediaFileId = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeMediaFileByIdKey mediaFileId identifier
 
 cacheMediaFileById :: CacheFlow m r => Id MediaFile -> Identifier -> Maybe MediaFile -> m ()
 cacheMediaFileById mediaFileId identifier mediaFile = do
@@ -53,7 +53,7 @@ makeMediaFileByIdKey id identifier = show identifier <> ":CachedQueries:MediaFil
 --------- Caching logic for media files by issue report id -------------------
 
 clearMediaFileByIssueReportIdCache :: CacheFlow m r => Identifier -> Id IssueReport -> m ()
-clearMediaFileByIssueReportIdCache identifier issueReportId = Hedis.withCrossAppRedis . Hedis.del $ makeMediaFileByIssueReportIdKey issueReportId identifier
+clearMediaFileByIssueReportIdCache identifier issueReportId = Hedis.runInMultiCloudRedisWrite . Hedis.withCrossAppRedis . Hedis.del $ makeMediaFileByIssueReportIdKey issueReportId identifier
 
 cacheMediaFileByIssueReportId :: CacheFlow m r => Id IssueReport -> Identifier -> [MediaFile] -> m ()
 cacheMediaFileByIssueReportId issueReportId identifier mediaFiles = do


### PR DESCRIPTION
CC edits to issue messages/categories/options/config cleared the cross-app cache only on the current cloud's Redis; app requests served by the other cloud kept the stale content until configsExpTime (24h) expired. Wrap every clear in runInMultiCloudRedisWrite (per the fare-cache convention) so a dashboard save is visible on the next app fetch in both clouds.


Claude-Session: https://claude.ai/code/session_01TuN4GKEjDC6DGc8QyCNKQu

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache invalidation for issue categories, configurations, messages, options, and media files.
  - Updates and deletions now consistently clear cached data across all cloud environments.
  - Reduced the likelihood of stale issue-related information being displayed after changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->