### PR TITLE
backend/chore: bump shared-kernel on prodHotPush-BAP to df226962

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4021,11 +4021,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1789017056,
-        "narHash": "sha256-Hu4FU1g9SUk78qxS/ghZx825WlLBU9A9rKRseBxmBmY=",
+        "lastModified": 1789027842,
+        "narHash": "sha256-wVzFdiCNUJdw58rSQq4QKdmD5kMJ4gez/0fL/mmeJVM=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "75abf877b49c81d4aed1dc18ed7175fef77e1ce0",
+        "rev": "df2269626d8769bf012dff2cf1b15cf8d271243c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Updates the `shared-kernel` flake lock on `prodHotPush-BAP` from `75abf877` to `df226962`, the current tip of shared-kernel `prodHotPush-BAP`. Only `flake.lock` changes.

Picks up:
- nammayatri/shared-kernel@df2269626d8769bf012dff2cf1b15cf8d271243c: cherry-pick of nammayatri/shared-kernel@78257ecf "dynamic logging at requestId level" (only `Kernel/Utils/App.hs` changes)

## Test plan
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127d5jsbVYZdNhxcvoUMZnj