### PR TITLE
backend/chore: bump shared-kernel on prodHotPush-BPP to c5af9e39

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4021,11 +4021,11 @@
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1789017080,
-        "narHash": "sha256-fYPzbGbvMsuDaHbJZzTOtcO58HAul6hGJZjsmru/7XM=",
+        "lastModified": 1789027842,
+        "narHash": "sha256-NBaquXM1Muaxes0oq8sle0kwaouMMcJCRTpjCQ9z2oA=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "72de6139649f4c56e590034da8abc3ee625ef42c",
+        "rev": "c5af9e391faacdeedf0c5f50e91b3a64aab0dca2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Updates the `shared-kernel` flake lock on `prodHotPush-BPP` from `72de6139` to `c5af9e39`, the current tip of shared-kernel `prodHotPush-BPP`. Only `flake.lock` changes.

Picks up:
- nammayatri/shared-kernel@c5af9e391faacdeedf0c5f50e91b3a64aab0dca2: cherry-pick of nammayatri/shared-kernel@78257ecf "dynamic logging at requestId level" (only `Kernel/Utils/App.hs` changes)

## Test plan
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127d5jsbVYZdNhxcvoUMZnj