### PR TITLE
backend./feat: add vehicle energy type handling in ride assignment ov…

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/SharedLogic/CallBAP.hs
@@ -63,6 +63,7 @@ import qualified Beckn.OnDemand.Utils.MSIL.FulfillmentType as MSILFulfillmentTyp
 import qualified Beckn.OnDemand.Utils.MSIL.ItemCompliance as MSILItemCompliance
 import qualified Beckn.OnDemand.Utils.MSIL.StopAuthorization as MSILStopAuthorization
 import qualified Beckn.OnDemand.Utils.MSIL.Terms as MSILTerms
+import qualified Beckn.OnDemand.Utils.MSIL.VehicleEnergyType as MSILVehicleEnergyType
 import qualified Beckn.Types.Core.Taxi.API.OnCancel as API
 import qualified Beckn.Types.Core.Taxi.API.OnConfirm as API
 import qualified Beckn.Types.Core.Taxi.API.OnSelect as API
@@ -646,10 +647,16 @@ rideAssignedCommon booking ride driver veh = do
 -- ONDC Workbench's "fulfillment.id must match selection" check. See
 -- Beckn.OnDemand.Utils.MSIL.FulfillmentId. Also flips the START stop's OTP
 -- authorization.status to "CLAIMED" once the ride has started -- see
--- Beckn.OnDemand.Utils.MSIL.StopAuthorization.
+-- Beckn.OnDemand.Utils.MSIL.StopAuthorization. Also overrides
+-- vehicle.energy_type to a valid ONDC v2.1.0 code -- see
+-- Beckn.OnDemand.Utils.MSIL.VehicleEnergyType; this is the one push family
+-- that has a real driver+vehicle attached (vehicle.energyType is free text
+-- from onboarding, never validated against ONDC's vocabulary), so it's the
+-- one place this override was previously missing.
 applyMsilRideAssignedOrderOverrides :: Bool -> Text -> Bool -> Spec.Order -> Spec.Order
 applyMsilRideAssignedOrderOverrides isScheduled quoteId isRideStarted =
-  MSILTerms.dropNonConformingOrderTags
+  MSILVehicleEnergyType.patchOrderVehicleEnergyType
+    . MSILTerms.dropNonConformingOrderTags
     . MSILFulfillmentType.patchOrderFulfillmentTypes
     . MSILCategory.overrideOrderCategoryIds isScheduled
     . MSILFulfillmentState.overrideOrderFulfillmentState


### PR DESCRIPTION
…errides

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vehicle energy types are now normalized to valid ONDC v2.1.0 codes in ride-assignment updates.
  * Applied consistently across ride confirmation, ride-assigned updates, ride-started status updates, and ride-completed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->