### PR TITLE
backend/fix: use sos/<sosId> dashboard link for ride SOS tickets

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Sos.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/Sos.hs
@@ -362,6 +362,10 @@ createTicketForNewSos person ride riderConfig merchantId merchantOperatingCityId
       void $ callUpdateTicket person result.sosDetails $ Just "SOS Re-Activated"
       return (cast result.sosId, existingSos.ticketId)
     Nothing -> do
+      -- Create the SOS first (ticketId = Nothing) so the dashboard link can use sos/<sosId>,
+      -- then create the ticket and write the ticketId back (mirrors the non-ride flow).
+      result <- SafetySos.createRideBasedSos (cast person.id) (cast ride.id) (cast merchantOperatingCityId) (cast merchantId) req.flow Nothing Nothing mbExternalReferenceId
+      QRide.updateSosId (Just $ cast result.sosId) ride.id
       (mbTicketId, mbTicketRequesterId) <- do
         if riderConfig.enableSupportForSafety && shouldCreateKaptureTicket
           then do
@@ -373,8 +377,8 @@ createTicketForNewSos person ride riderConfig merchantId merchantOperatingCityId
                 mediaLinks =
                   buildDashboardMediaUrls
                     riderConfig.dashboardMediaFileUrlPattern
-                    (Just ride.id.getId)
                     Nothing
+                    (Just result.sosId.getId)
                     merchantShortId
                     rideCityCode
             ticketResponse <- withTryCatch "createTicket:sosTrigger" (createSosTicket person.merchantId person.merchantOperatingCityId (SIVR.mkTicket person phoneNumber mediaLinks (Just rideInfo) req.flow riderConfig.kaptureConfig.disposition kaptureQueue))
@@ -383,9 +387,8 @@ createTicketForNewSos person ride riderConfig merchantId merchantOperatingCityId
               Left _ -> return (Nothing, Nothing)
           else return (Nothing, Nothing)
 
-      -- Create new SOS using shared-services function
-      result <- SafetySos.createRideBasedSos (cast person.id) (cast ride.id) (cast merchantOperatingCityId) (cast merchantId) req.flow Nothing mbTicketId mbExternalReferenceId
-      QRide.updateSosId (Just $ cast result.sosId) ride.id
+      whenJust mbTicketId $ \tId ->
+        SafetySos.updateSosTicketId result.sosDetails (Just tId)
       whenJust mbTicketRequesterId $ \rid ->
         SafetyQSos.updateRequesterId (Just rid) (cast result.sosId)
       return (cast result.sosId, mbTicketId)
@@ -1224,23 +1227,25 @@ resolveLocation mbCustomerLoc person mbRide =
 
 buildDashboardMediaUrls :: Maybe Text -> Maybe Text -> Maybe Text -> Text -> Text -> [Text]
 buildDashboardMediaUrls mbPattern mbRideId mbSosId merchantShortId cityCode =
-  case (mbPattern, mbRideId, mbSosId) of
-    (Just patternS, Just rideId, _) ->
-      maybeToList $
-        mkValidatedDashboardMediaUrl $
-          patternS
-            & T.replace "<RIDES_OR_SOS>" "rides"
-            & T.replace "<ID>" rideId
-            & T.replace "<RIDE_ID>" rideId
-            & T.replace "<MERCHANT_SHORT_ID>" merchantShortId
-            & T.replace "<CITY_CODE>" cityCode
-    (Just patternS, Nothing, Just sosId) ->
+  -- Prefer the sos/<sosId> link whenever a sosId is available (ride and non-ride alike);
+  -- fall back to rides/<rideId> only for legacy callers that have no sosId.
+  case (mbPattern, mbSosId, mbRideId) of
+    (Just patternS, Just sosId, _) ->
       maybeToList $
         mkValidatedDashboardMediaUrl $
           patternS
             & T.replace "<RIDES_OR_SOS>" "sos"
             & T.replace "<ID>" sosId
             & T.replace "<RIDE_ID>" sosId
+            & T.replace "<MERCHANT_SHORT_ID>" merchantShortId
+            & T.replace "<CITY_CODE>" cityCode
+    (Just patternS, Nothing, Just rideId) ->
+      maybeToList $
+        mkValidatedDashboardMediaUrl $
+          patternS
+            & T.replace "<RIDES_OR_SOS>" "rides"
+            & T.replace "<ID>" rideId
+            & T.replace "<RIDE_ID>" rideId
             & T.replace "<MERCHANT_SHORT_ID>" merchantShortId
             & T.replace "<CITY_CODE>" cityCode
     _ -> []

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/SafetyCSAlert.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/Scheduler/Jobs/SafetyCSAlert.hs
@@ -80,6 +80,9 @@ createSafetyTicket person ride = do
   merchantConfig <- CQM.findById (person.merchantId) >>= fromMaybeM (MerchantNotFound person.merchantId.getId)
   let rideMocId = fromMaybe person.merchantOperatingCityId ride.merchantOperatingCityId
   rideMoc <- CQMOC.findById rideMocId >>= fromMaybeM (MerchantOperatingCityNotFound rideMocId.getId)
+  -- Build the SOS first (ticketId = Nothing) so the dashboard link can use sos/<sosId>,
+  -- consistent with the interactive SOS flow; the ticketId is written back after ticket creation.
+  sosDetails <- buildSosDetails person SosReq {flow = SafetyDSos.CSAlertSosTicket, rideId = Just (cast ride.id), isRideEnded = Nothing, notifyAllContacts = Nothing, customerLocation = Nothing, sendPNOnPostRideSOS = Nothing, triggerApiList = Nothing} Nothing
   let merchantShortId = merchantConfig.shortId.getShortId
       dashboardCityCode =
         case A.toJSON rideMoc.city of
@@ -90,9 +93,9 @@ createSafetyTicket person ride = do
           []
           ( \patternS ->
               [ patternS
-                  & T.replace "<RIDES_OR_SOS>" "rides"
-                  & T.replace "<ID>" ride.id.getId
-                  & T.replace "<RIDE_ID>" ride.id.getId
+                  & T.replace "<RIDES_OR_SOS>" "sos"
+                  & T.replace "<ID>" sosDetails.id.getId
+                  & T.replace "<RIDE_ID>" sosDetails.id.getId
                   & T.replace "<MERCHANT_SHORT_ID>" merchantShortId
                   & T.replace "<CITY_CODE>" dashboardCityCode
               ]
@@ -112,9 +115,8 @@ createSafetyTicket person ride = do
       Left err -> do
         logError $ "Ticket didn't created when rider didn't picked up call with error : " <> show err
         return Nothing
-  sosDetails <- buildSosDetails person SosReq {flow = SafetyDSos.CSAlertSosTicket, rideId = Just (cast ride.id), isRideEnded = Nothing, notifyAllContacts = Nothing, customerLocation = Nothing, sendPNOnPostRideSOS = Nothing, triggerApiList = Nothing} ticketId
-  -- SOS persistence via shared-services Safety library
-  void $ SafetySos.createSos sosDetails
+  -- SOS persistence via shared-services Safety library (with the resolved ticketId)
+  void $ SafetySos.createSos sosDetails {SafetyDSos.ticketId = ticketId}
 
 mkTicket :: DP.Person -> Maybe Text -> [Text] -> Maybe Ticket.RideInfo -> SafetyDSos.SosType -> Text -> Text -> Ticket.CreateTicketReq
 mkTicket person phoneNumber mediaLinks mbInfo flow disposition queue = do


### PR DESCRIPTION
## Problem

Ride-based SOS tickets embedded a **`rides/<rideId>`** dashboard link in the
ticket `mediaFiles` (Zendesk/Kapture), while non-ride SOS used
**`sos/<sosId>`**. This inconsistency meant CS agents opening a ride SOS
ticket landed on the ride page instead of the SOS page.

Root cause: for a ride SOS the ticket was created **before** the SOS row
existed, so only `rideId` was available to build the link. The non-ride flow
already did it the other way around (create SOS → build link from `sosId` →
write `ticketId` back).

## Change

Unify every SOS ticket/dashboard link on **`sos/<sosId>`**.

- **`buildDashboardMediaUrls`** — prefer `sosId` (emit `sos/<sosId>`) whenever
  present; fall back to `rides/<rideId>` only when no `sosId` is available.
- **`createTicketForNewSos`** (interactive SOS) — reordered to create the ride
  SOS first (`ticketId = Nothing`), build the ticket link from the resulting
  `sosId`, then write the `ticketId` back via `updateSosTicketId`. Mirrors the
  proven non-ride ordering.
- **`SafetyCSAlert` job** (night-safety follow-back) — same reorder so the
  auto-created CS-alert ticket also links via `sos/<sosId>`.

`postSosUpdateToRide` (non-ride → ride conversion) now resolves to `sos/<sosId>`
automatically via the builder change — no call-site edit needed.

## Files touched

- `rider-app/.../Domain/Action/UI/Sos.hs`
- `rider-app/.../SharedLogic/Scheduler/Jobs/SafetyCSAlert.hs`

No YAML/spec, DB migration, or shared-services signature changes.

## Path coverage

| Path | Before | After |
|------|--------|-------|
| Ride SOS (support ticket) | `rides/<rideId>` | `sos/<sosId>` |
| Ride SOS (reactivation) | keeps original link | `sos/<sosId>` |
| Non-ride SOS | `sos/<sosId>` | `sos/<sosId>` (unchanged) |
| Media upload on ride SOS | `sos/<sosId>` | `sos/<sosId>` (unchanged) |
| Non-ride → ride conversion | `rides/<rideId>` | `sos/<sosId>`
| CS-alert follow-back job | `rides/<rideId>` | `sos/<sosId>` |
| IssueManagement ride link | `rides/<rideId>` | `rides/<rideId>

## Behavioral notes

- No regression in field-write ordering: `ticketId` then `reques
  the same final SOS row as before; if ticket creation fails, `ticketId` stays
  `Nothing` exactly as today.
- The SOS is always created regardless of whether a ticket is created (POLICE-
  only vs support-ticket paths behave identically to before).
- There is a brief window where the SOS row has `ticketId = Nothing` before the
  ticket is created — this is the same pattern the non-ride flow
  production.

## Testing

- [ ] `cabal build rider-app`
- [ ] Trigger a ride SOS → confirm ticket `mediaFiles` link is `
- [ ] Trigger a non-ride SOS → link unchanged (`sos/<sosId>`)
- [ ] Convert non-ride → ride (`/sos/{sosId}/updateToRide`) → li
- [ ] Night-safety follow-back (missed IVR) → CS-alert ticket link is `sos/<sosId>`
- [ ] Confirm the control-center `sos/<sosId>` route resolves ri

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SOS ticket creation and linking to ensure safety records and support tickets remain correctly associated.
  - Updated dashboard media links for SOS cases to use the SOS reference when available, improving access to the relevant safety information.
  - Standardized media links across ride-based and non-ride SOS tickets for more consistent dashboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->