### PR TITLE
backend/feat: FEEDBACK_TICKET issue flow and per-message reply after submit

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/IssueManagement/Issue.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/IssueManagement/Issue.hs
@@ -58,7 +58,13 @@ import qualified Kernel.External.Types
 import qualified Kernel.Prelude
 import qualified Kernel.Types.APISuccess
 import qualified Kernel.Types.Beckn.Context
+import qualified Kernel.Types.Error
 import qualified Kernel.Types.Id
+import qualified Kernel.Utils.Common
+import Lib.ConfigPilot.Interface.Getter (invalidateConfigInMem)
+import qualified Lib.Yudhishthira.Types as LYT
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import qualified Tools.DynamicLogic as DynamicLogic
 
 dashboardIssueHandle :: DAI.ServiceHandle Environment.Flow
 dashboardIssueHandle = AUI.driverIssueHandle
@@ -303,8 +309,15 @@ postIssueConfigUpdate ::
   Kernel.Types.Beckn.Context.City ->
   IssueManagement.Common.Dashboard.Issue.UpdateIssueConfigReq ->
   Environment.Flow Kernel.Types.APISuccess.APISuccess
-postIssueConfigUpdate (Kernel.Types.Id.ShortId merchantShortId) city req =
-  DIssue.updateIssueConfig (Kernel.Types.Id.ShortId merchantShortId) city req dashboardIssueHandle Common.DRIVER
+postIssueConfigUpdate (Kernel.Types.Id.ShortId merchantShortId) city req = do
+  res <- DIssue.updateIssueConfig (Kernel.Types.Id.ShortId merchantShortId) city req dashboardIssueHandle Common.DRIVER
+  -- also clear the config-pilot caches the app reads IssueConfig through
+  merchantOpCity <-
+    CQMOC.findByMerchantShortIdAndCity (Kernel.Types.Id.ShortId merchantShortId) city
+      >>= Kernel.Utils.Common.fromMaybeM (Kernel.Types.Error.MerchantOperatingCityNotFound $ "merchant-short-Id-" <> merchantShortId <> "-city-" <> show city)
+  DynamicLogic.deleteConfigHashKey (Kernel.Types.Id.cast merchantOpCity.id) (LYT.DRIVER_CONFIG LYT.IssueConfig)
+  invalidateConfigInMem LYT.IssueConfigDriver
+  pure res
 
 postIssueCategoryReorder ::
   Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant ->

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/ScheduledBooking.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Dashboard/Management/ScheduledBooking.hs
@@ -489,6 +489,7 @@ getOrCreateScheduledBookingIssueReport booking =
               description = "Scheduled booking operations notes",
               chats = Nothing,
               createTicket = Just False,
+              isFeedback = Nothing,
               ticketBookingId = Nothing
             }
           AUI.driverIssueHandle

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/IssueManagement/Issue.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Dashboard/IssueManagement/Issue.hs
@@ -68,7 +68,13 @@ import qualified Kernel.External.Types
 import qualified Kernel.Prelude
 import qualified Kernel.Types.APISuccess
 import qualified Kernel.Types.Beckn.Context
+import qualified Kernel.Types.Error
 import qualified Kernel.Types.Id
+import qualified Kernel.Utils.Common
+import Lib.ConfigPilot.Interface.Getter (invalidateConfigInMem)
+import qualified Lib.Yudhishthira.Types as LYT
+import qualified Storage.CachedQueries.Merchant.MerchantOperatingCity as CQMOC
+import qualified Tools.DynamicLogic as DynamicLogic
 
 dashboardIssueHandle :: DAI.ServiceHandle Environment.Flow
 dashboardIssueHandle = AUI.customerIssueHandle
@@ -355,8 +361,15 @@ postIssueConfigUpdate ::
   Kernel.Types.Beckn.Context.City ->
   IssueManagement.Common.Dashboard.Issue.UpdateIssueConfigReq ->
   Environment.Flow Kernel.Types.APISuccess.APISuccess
-postIssueConfigUpdate (Kernel.Types.Id.ShortId merchantShortId) city req =
-  DIssue.updateIssueConfig (Kernel.Types.Id.ShortId merchantShortId) city req dashboardIssueHandle Common.CUSTOMER
+postIssueConfigUpdate (Kernel.Types.Id.ShortId merchantShortId) city req = do
+  res <- DIssue.updateIssueConfig (Kernel.Types.Id.ShortId merchantShortId) city req dashboardIssueHandle Common.CUSTOMER
+  -- also clear the config-pilot caches the app reads IssueConfig through
+  merchantOpCity <-
+    CQMOC.findByMerchantShortIdAndCity (Kernel.Types.Id.ShortId merchantShortId) city
+      >>= Kernel.Utils.Common.fromMaybeM (Kernel.Types.Error.MerchantOperatingCityNotFound $ "merchant-short-Id-" <> merchantShortId <> "-city-" <> show city)
+  DynamicLogic.deleteConfigHashKey (Kernel.Types.Id.cast merchantOpCity.id) (LYT.RIDER_CONFIG LYT.IssueConfig)
+  invalidateConfigInMem LYT.IssueConfigRider
+  pure res
 
 postIssueCategoryReorder ::
   Kernel.Types.Id.ShortId Domain.Types.Merchant.Merchant ->

--- a/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0872-issue-message-submit-reply.sql
+++ b/Backend/dev/ddl-migrations/dynamic-offer-driver-app/0872-issue-message-submit-reply.sql
@@ -1,0 +1,2 @@
+-- Per-message auto reply for CREATE_TICKET / AUTO_CREATE_TICKET / FEEDBACK_TICKET messages (configured in the message editor).
+ALTER TABLE atlas_driver_offer_bpp.issue_message ADD COLUMN IF NOT EXISTS on_submit_reply_msgs text[];

--- a/Backend/dev/ddl-migrations/rider-app/1566-issue-message-submit-reply.sql
+++ b/Backend/dev/ddl-migrations/rider-app/1566-issue-message-submit-reply.sql
@@ -1,0 +1,2 @@
+-- Per-message auto reply for CREATE_TICKET / AUTO_CREATE_TICKET / FEEDBACK_TICKET messages (configured in the message editor).
+ALTER TABLE atlas_app.issue_message ADD COLUMN IF NOT EXISTS on_submit_reply_msgs text[];

--- a/Backend/lib/shared-services/src/IssueManagement/Common/Dashboard/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Common/Dashboard/Issue.hs
@@ -370,6 +370,10 @@ data UpsertIssueMessageReq = UpsertIssueMessageReq
     -- string field in the multipart form. Omitting the field on an edit
     -- preserves the message's existing lookup config.
     apiAction :: Maybe IssueMessage.ApiCallAction,
+    -- | Create a parentless message; with an unknown 'issueMessageId', creates it under that id.
+    standalone :: Maybe Bool,
+    -- | Reply message ids posted after submit; [] clears, omitted keeps.
+    onSubmitReplyMsgs :: Maybe [Id IssueMessage],
     mediaFiles :: Maybe [IssueMessageMediaFileUploadReq]
   }
   deriving stock (Eq, Show, Generic)
@@ -409,6 +413,8 @@ instance FromMultipart Tmp UpsertIssueMessageReq where
       <*> parseMaybeInput "deleteExistingFiles"
       <*> parseMaybeInput "messageType"
       <*> parseMaybeJsonInput "apiAction"
+      <*> parseMaybeInput "standalone"
+      <*> parseMaybeJsonInput "onSubmitReplyMsgs"
       <*> pure (Just mediaFiles)
     where
       extractFile f = pure $ IssueMessageMediaFileUploadReq (fdPayload f) (fdFileCType f)
@@ -451,7 +457,9 @@ instance ToMultipart Tmp UpsertIssueMessageReq where
             fmap (Input "isActive" . T.pack . show) req.isActive,
             fmap (Input "deleteExistingFiles" . T.pack . show) req.deleteExistingFiles,
             fmap (Input "messageType" . T.pack . show) req.messageType,
-            fmap (Input "apiAction" . encodeJson) req.apiAction
+            fmap (Input "apiAction" . encodeJson) req.apiAction,
+            fmap (Input "standalone" . T.pack . show) req.standalone,
+            fmap (Input "onSubmitReplyMsgs" . encodeJson) req.onSubmitReplyMsgs
           ]
       files = maybe [] (map mkFileData) req.mediaFiles
       mkFileData (IssueMessageMediaFileUploadReq filePath contType) =
@@ -503,6 +511,7 @@ data IssueMessageDetailRes = IssueMessageDetailRes
     priority :: Int,
     messageType :: IssueMessage.IssueMessageType,
     apiAction :: Maybe IssueMessage.ApiCallAction,
+    onSubmitReplyMsgs :: Maybe [Id IssueMessage],
     isActive :: Bool,
     mediaFiles :: [MediaFile],
     translations :: DetailedTranslationRes,

--- a/Backend/lib/shared-services/src/IssueManagement/Common/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Common/UI/Issue.hs
@@ -40,6 +40,8 @@ data IssueReportReq = IssueReportReq
     description :: Text,
     chats :: Maybe [Chat],
     createTicket :: Maybe Bool,
+    -- | FEEDBACK_TICKET: store the report as CLOSED, no ticket raised.
+    isFeedback :: Maybe Bool,
     ticketBookingId :: Maybe (Id FRFSTicketBooking)
   }
   deriving (Generic, FromJSON, ToSchema, Show)

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/Beckn/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/Beckn/Issue.hs
@@ -166,7 +166,7 @@ openBecknIssue dIssue@ValidatedDIssue {..} iHandle = do
   mbOption <- QIO.findByIGMIssueSubCategory issueSubCategory
   let optionId = mbOption <&> (.id)
       description = maybe "No description provided" (.option) mbOption
-  let issueReport = Common.IssueReportReq (Just $ cast ride.id) [] optionId category.id description Nothing (Just True) Nothing -- insert ticketbookingId, which is given by UI
+  let issueReport = Common.IssueReportReq (Just $ cast ride.id) [] optionId category.id description Nothing (Just True) Nothing Nothing -- insert ticketbookingId, which is given by UI
   driverId <- fromMaybeM (RideFieldNotPresent "Driver not found") $ ride.driverId
   void $ Common.createIssueReport (cast driverId, cast dIssue.merchant.id) Nothing issueReport iHandle Common.DRIVER (Just issueId)
   pure $

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/Dashboard/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/Dashboard/Issue.hs
@@ -808,6 +808,7 @@ createIssueMessages merchantShortId city merchantOperatingCity issueCategoryId m
         DIM.IssueMessage
           { categoryId = maybe (Just issueCategoryId) (const Nothing) mbIssueOptionId,
             apiAction = Nothing,
+            onSubmitReplyMsgs = Nothing,
             isActive = fromMaybe True isActive,
             optionId = mbIssueOptionId,
             messageType = issueMessageType,
@@ -971,13 +972,15 @@ updateIssueOption merchantShortId city issueOptionId req issueHandle identifier 
 
 upsertIssueMessage :: (BeamFlow m r, MonadTime m, MonadReader r m, HasField "s3Env" r (S3.S3Env m)) => ShortId Merchant -> Context.City -> Common.UpsertIssueMessageReq -> ServiceHandle m -> Identifier -> m Common.UpsertIssueMessageRes
 upsertIssueMessage merchantShortId city req issueHandle identifier = do
+  let isStandalone = req.standalone == Just True
   existingIssueMessage <-
     traverse
       ( \issueMessageId ->
           CQIM.findById issueMessageId identifier
-            >>= fromMaybeM (IssueMessageDoesNotExist issueMessageId.getId)
+            >>= (if isStandalone then pure else fmap Just . fromMaybeM (IssueMessageDoesNotExist issueMessageId.getId))
       )
       req.issueMessageId
+      <&> join
   merchantOperatingCity <-
     issueHandle.findMOCityByMerchantShortIdAndCity merchantShortId city
       >>= fromMaybeM (MerchantOperatingCityNotFound $ "merchant-short-Id-" <> merchantShortId.getShortId <> "-city-" <> show city)
@@ -999,10 +1002,14 @@ upsertIssueMessage merchantShortId city req issueHandle identifier = do
     then do
       QIM.updateByPrimaryKey updatedIssueMessage
       clearIssueMessageIdCaches updatedIssueMessage
-      whenJust existingIssueMessage $ \extIM -> clearOptionAndCategoryCache extIM
+      whenJust existingIssueMessage $ \extIM -> do
+        clearOptionAndCategoryCache extIM
+        retireDroppedReplies extIM updatedIssueMessage
       clearOptionAndCategoryCache updatedIssueMessage
     else do
       QIM.create updatedIssueMessage
+      -- drop any cached "not found" for a caller-supplied id
+      clearIssueMessageIdCaches updatedIssueMessage
       clearOptionAndCategoryCache updatedIssueMessage
   return $
     Common.UpsertIssueMessageRes
@@ -1012,11 +1019,16 @@ upsertIssueMessage merchantShortId city req issueHandle identifier = do
     mkIssueMessage :: (BeamFlow m r, Common.MonadTime m, MonadReader r m, HasField "s3Env" r (S3.S3Env m)) => Maybe DIM.IssueMessage -> MerchantOperatingCity -> ServiceHandle m -> m DIM.IssueMessage
     mkIssueMessage mbIssueMessage merchantOperatingCity iHandle = do
       (mbOptionId, mbCategoryId) <- getAndValidateOptionAndCategoryId mbIssueMessage
-      mbParentCategory <- findIssueCategory mbOptionId mbCategoryId
+      let allowOrphan = isJust mbIssueMessage || req.standalone == Just True
+      mbParentCategory <- findIssueCategory allowOrphan mbOptionId mbCategoryId
+      -- reply ids must belong to this city
+      forM_ (fromMaybe [] req.onSubmitReplyMsgs) $ \replyId -> do
+        reply <- CQIM.findById (cast replyId) identifier >>= fromMaybeM (IssueMessageDoesNotExist replyId.getId)
+        when (reply.merchantOperatingCityId /= merchantOperatingCity.id) $ throwError AccessDenied
       whenJust mbParentCategory $ \parentCategory ->
         when (parentCategory.merchantOperatingCityId /= merchantOperatingCity.id) $ throwError AccessDenied
       (referenceOptionId, referenceCategoryId) <- getAndValidateReferenceOptionAnCategoryId mbIssueMessage ((.categoryType) <$> mbParentCategory)
-      id <- maybe generateGUID (return . (.id)) mbIssueMessage
+      id <- maybe (maybe generateGUID pure req.issueMessageId) (return . (.id)) mbIssueMessage
       now <- getCurrentTime
       message <- fromMaybeM (InvalidRequest "Message is required field for creating a new issue message") $ req.message <|> ((.message) <$> mbIssueMessage)
       priority <- fromMaybeM (InvalidRequest "Priority is required field for creating a new issue message") $ req.priority <|> ((.priority) <$> mbIssueMessage)
@@ -1040,6 +1052,7 @@ upsertIssueMessage merchantShortId city req issueHandle identifier = do
             messageTitle = req.messageTitle <|> ((.messageTitle) =<< mbIssueMessage),
             messageAction = req.messageAction <|> ((.messageAction) =<< mbIssueMessage),
             apiAction = mbApiAction,
+            onSubmitReplyMsgs = (map cast <$> req.onSubmitReplyMsgs) <|> (mbIssueMessage >>= (.onSubmitReplyMsgs)),
             isActive = fromMaybe True (req.isActive <|> (mbIssueMessage <&> (.isActive))),
             ..
           }
@@ -1065,6 +1078,18 @@ upsertIssueMessage merchantShortId city req issueHandle identifier = do
         unless (option.issueMessageId == Just editedMessageId.getId) $
           throwError $ InvalidRequest $ "apiAction branch option " <> targetOptionId <> " is not a child option of this message"
 
+    -- deactivate parentless reply messages dropped from onSubmitReplyMsgs
+    retireDroppedReplies :: BeamFlow m r => DIM.IssueMessage -> DIM.IssueMessage -> m ()
+    retireDroppedReplies oldMsg newMsg = do
+      let dropped = filter (`notElem` fromMaybe [] newMsg.onSubmitReplyMsgs) (fromMaybe [] oldMsg.onSubmitReplyMsgs)
+      forM_ dropped $ \replyId -> do
+        mbReply <- CQIM.findById replyId identifier
+        whenJust mbReply $ \reply ->
+          when (reply.merchantOperatingCityId == oldMsg.merchantOperatingCityId && isNothing reply.categoryId && isNothing reply.optionId && reply.isActive) $ do
+            QIM.updateIsActive replyId False
+            CQIM.clearAllIssueMessageByIdAndLanguageCache replyId identifier
+            CQIM.clearIssueMessageByIdCache replyId identifier
+
     clearIssueMessageIdCaches :: BeamFlow m r => DIM.IssueMessage -> m ()
     clearIssueMessageIdCaches im = do
       CQIM.clearAllIssueMessageByIdAndLanguageCache im.id identifier
@@ -1086,20 +1111,19 @@ upsertIssueMessage merchantShortId city req issueHandle identifier = do
         (_, Just categoryId, _) -> do
           void $ CQIC.findById categoryId identifier >>= fromMaybeM (IssueCategoryDoesNotExist categoryId.getId)
           return (Nothing, Just categoryId)
-        _ -> throwError $ InvalidRequest "Either categoryId or optionId required to create a message."
+        _
+          | req.standalone == Just True -> return (Nothing, Nothing)
+          | otherwise -> throwError $ InvalidRequest "Either categoryId or optionId required to create a message."
 
-    findIssueCategory :: BeamFlow m r => Maybe (Id DIO.IssueOption) -> Maybe (Id DIC.IssueCategory) -> m (Maybe DIC.IssueCategory)
-    findIssueCategory mbOptionId mbCategoryId = do
-      categoryId <- case mbCategoryId of
-        Just cId -> return (Just cId)
-        Nothing -> (.issueCategoryId) <$> findIssueOption
+    findIssueCategory :: BeamFlow m r => Bool -> Maybe (Id DIO.IssueOption) -> Maybe (Id DIC.IssueCategory) -> m (Maybe DIC.IssueCategory)
+    findIssueCategory allowOrphan mbOptionId mbCategoryId = do
+      categoryId <- case (mbCategoryId, mbOptionId) of
+        (Just cId, _) -> return (Just cId)
+        (Nothing, Just optionId) -> (.issueCategoryId) <$> (CQIO.findById optionId identifier >>= fromMaybeM (IssueOptionNotFound optionId.getId))
+        (Nothing, Nothing)
+          | allowOrphan -> return Nothing
+          | otherwise -> throwError $ InvalidRequest "Either categoryId or optionId is required"
       maybe (return Nothing) (\(catId :: Id DIC.IssueCategory) -> CQIC.findById catId identifier) categoryId
-      where
-        findIssueOption =
-          maybe
-            (throwError $ InvalidRequest "Either categoryId or optionId is required")
-            (\optionId -> CQIO.findById optionId identifier >>= fromMaybeM (IssueOptionNotFound optionId.getId))
-            mbOptionId
 
     getAndValidateReferenceOptionAnCategoryId :: BeamFlow m r => Maybe DIM.IssueMessage -> Maybe DIC.CategoryType -> m (Maybe (Id DIO.IssueOption), Maybe (Id DIC.IssueCategory))
     getAndValidateReferenceOptionAnCategoryId mbIm mbCategoryType = do
@@ -1911,6 +1935,7 @@ copyIssueCategory merchantShortId city req issueHandle identifier = do
             priority = msg.priority,
             messageType = msg.messageType,
             apiAction = Nothing,
+            onSubmitReplyMsgs = Nothing, -- reply ids are city-scoped; configure in the target city
             isActive = msg.isActive,
             mediaFiles = msg.mediaFiles,
             referenceCategoryId = msg.referenceCategoryId,
@@ -1957,6 +1982,7 @@ copyIssueCategory merchantShortId city req issueHandle identifier = do
             priority = msg.priority,
             messageType = msg.messageType,
             apiAction = Nothing,
+            onSubmitReplyMsgs = Nothing, -- reply ids are city-scoped; configure in the target city
             isActive = msg.isActive,
             mediaFiles = msg.mediaFiles,
             referenceCategoryId = msg.referenceCategoryId,
@@ -2101,6 +2127,7 @@ mkMessageDetailRes language identifier (msg, translation, _mediaFileUrls) = do
         priority = msg.priority,
         messageType = msg.messageType,
         apiAction = decodeFromText =<< msg.apiAction,
+        onSubmitReplyMsgs = map cast <$> msg.onSubmitReplyMsgs,
         isActive = msg.isActive,
         mediaFiles = mediaFiles,
         translations =

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Action/UI/Issue.hs
@@ -737,7 +737,7 @@ createIssueReportWithContext creationContext args@(personId, _merchantId) mbLang
   -- the guard for the case it's meant to catch.
 
   let scheduledBookingTransactionId = creationContext >>= (.scheduledBookingTransactionId)
-      dedupKey = "IssueSubmitDedup:" <> personId.getId <> ":" <> categoryId.getId <> ":" <> maybe "" (.getId) optionId <> ":" <> maybe "" (.getId) rideId <> ":" <> maybe "" show createTicket <> ":" <> maybe "" (.getId) ticketBookingId <> ":" <> maybe "" (<> ":") scheduledBookingTransactionId <> T.take 200 description
+      dedupKey = "IssueSubmitDedup:" <> personId.getId <> ":" <> categoryId.getId <> ":" <> maybe "" (.getId) optionId <> ":" <> maybe "" (.getId) rideId <> ":" <> maybe "" show createTicket <> ":" <> show (fromMaybe False isFeedback) <> ":" <> maybe "" (.getId) ticketBookingId <> ":" <> maybe "" (<> ":") scheduledBookingTransactionId <> T.take 200 description
   -- Atomic claim (SETNX-style): only the request that actually creates the
   -- key proceeds to do the work. A plain GET-then-SET has a race window —
   -- two requests that both arrive before either has written the cache can
@@ -803,20 +803,40 @@ createIssueReportImpl creationContext (personId, merchantId) mbLanguage Common.I
       >>= fromMaybeM (MerchantOperatingCityNotFound $ "MerchantOpCityId - " <> show mocId)
   language <- getLanguage personId mbLanguage issueHandle
   issueConfig <- issueHandle.findIssueConfig mocId identifier >>= fromMaybeM (IssueConfigNotFound mocId.getId)
-  let shouldCreateTicket = isNothing createTicket || fromJust createTicket
-      onCreateIssueMsgs = if shouldCreateTicket then issueConfig.onCreateIssueMsgs else []
+  -- FEEDBACK_TICKET: stored as CLOSED, no ticket raised
+  let isFeedbackFlow = fromMaybe False isFeedback
+      shouldCreateTicket = not isFeedbackFlow && (isNothing createTicket || fromJust createTicket)
+      -- auto reply: the submitted-from message's onSubmitReplyMsgs, else IssueConfig (tickets only)
+      submitLabels
+        | isFeedbackFlow = ["FEEDBACK_TICKET"]
+        | shouldCreateTicket = ["CREATE_TICKET", "AUTO_CREATE_TICKET"]
+        | otherwise = []
+  submitMessages <-
+    if null submitLabels
+      then pure []
+      else case optionId of
+        Just justOptionId -> map (\(m, _, _) -> m) <$> CQIM.findAllActiveByOptionIdAndLanguage justOptionId language identifier
+        Nothing -> map (\(m, _, _) -> m) <$> CQIM.findAllActiveByCategoryIdAndLanguage categoryId language identifier
+  let shownIds = [c.chatId | c <- fromMaybe [] chats, c.chatType == IssueMessage]
+      labelled = [m | m <- submitMessages, m.label `elem` map Just submitLabels, Just ids <- [m.onSubmitReplyMsgs], not (null ids)]
+      -- prefer the labelled message the customer was actually shown (present in chats)
+      messageOverride = (.onSubmitReplyMsgs) =<< (listToMaybe [m | m <- labelled, m.id.getId `elem` shownIds] <|> listToMaybe labelled)
+      onCreateIssueMsgs
+        | isFeedbackFlow = fromMaybe [] messageOverride
+        | shouldCreateTicket = fromMaybe issueConfig.onCreateIssueMsgs messageOverride
+        | otherwise = []
   issueMessageTranslationList <- mapM (\messageId -> CQIM.findByIdAndLanguage messageId language identifier) onCreateIssueMsgs
   now <- getCurrentTime
   mbRideInfoRes <- traverse (issueHandle.getRideInfo merchantId mocId) rideId
   let messages = mkIssueMessageList (Just $ catMaybes issueMessageTranslationList) language issueConfig mbRideInfoRes
       chats_ = fromMaybe [] chats
-      updatedChats = updateChats chats_ shouldCreateTicket messages uploadedMediaFiles now
+      updatedChats = updateChats chats_ (shouldCreateTicket || isFeedbackFlow) isFeedbackFlow messages uploadedMediaFiles now
   mbSubCategoryOptionId <- resolveSubCategoryOptionId chats_ optionId category.category identifier
   mbSubCategoryOption <- maybe (pure Nothing) (`CQIO.findById` identifier) mbSubCategoryOptionId
   config <- issueHandle.findMerchantConfig merchantId mocId (Just personId)
   let mbIssueReportType = mbOption >>= (.label) >>= A.decode . A.encode
   processIssueReportTypeActions (personId, merchantId) mbIssueReportType mbRide (Just config) True identifier issueHandle
-  issueReport <- mkIssueReport mocId updatedChats shouldCreateTicket now
+  issueReport <- mkIssueReport mocId updatedChats shouldCreateTicket isFeedbackFlow now
   let isLOFeedback = (identifier == CUSTOMER) && checkForLOFeedback config.sensitiveWords config.sensitiveWordsForExactMatch (Just description)
   when isLOFeedback $
     fork "notify on slack" $ do
@@ -874,7 +894,7 @@ createIssueReportImpl creationContext (personId, merchantId) mbLanguage Common.I
         logTagInfo "Create Ticket API failed - " $ show err
   pure $ Common.IssueReportRes {issueReportId = issueReport.id, issueReportShortId = issueReport.shortId, messages}
   where
-    mkIssueReport mocId updatedChats shouldCreateTicket now = do
+    mkIssueReport mocId updatedChats shouldCreateTicket isFeedbackFlow now = do
       id <- generateGUID
       shortId <- generateShortId
       pure $
@@ -891,7 +911,7 @@ createIssueReportImpl creationContext (personId, merchantId) mbLanguage Common.I
             categoryId = Just categoryId,
             mediaFiles = mediaFiles,
             assignee = Nothing,
-            status = if shouldCreateTicket then OPEN else NOT_APPLICABLE,
+            status = if shouldCreateTicket then OPEN else (if isFeedbackFlow then CLOSED else NOT_APPLICABLE),
             deleted = False,
             ticketId = Nothing,
             additionalTicketIds = Nothing,
@@ -1127,8 +1147,8 @@ createIssueReportImpl creationContext (personId, merchantId) mbLanguage Common.I
           area = (.area) =<< mbLocAPIEnt
         }
 
-    updateChats :: [Chat] -> Bool -> [Common.Message] -> [D.MediaFile] -> UTCTime -> [Chat]
-    updateChats issueChats shouldCreateTicket messages mediaFiles_ now =
+    updateChats :: [Chat] -> Bool -> Bool -> [Common.Message] -> [D.MediaFile] -> UTCTime -> [Chat]
+    updateChats issueChats shouldCreateTicket alwaysAppendReplies messages mediaFiles_ now =
       let issueDescriptionChats = [mkIssueChat IssueDescription "" now]
           issueMediaFileChats = map (\mediaFile -> mkIssueChat MediaFile mediaFile.id.getId now) mediaFiles_
           chatsWithDescAndMediaFiles =
@@ -1136,7 +1156,7 @@ createIssueReportImpl creationContext (personId, merchantId) mbLanguage Common.I
               then issueChats ++ issueDescriptionChats ++ issueMediaFileChats
               else issueChats
        in chatsWithDescAndMediaFiles
-            ++ ( if not $ null issueChats
+            ++ ( if not (null issueChats) || alwaysAppendReplies
                    then map (\message -> mkIssueChat IssueMessage message.id.getId now) messages
                    else []
                )

--- a/Backend/lib/shared-services/src/IssueManagement/Domain/Types/Issue/IssueMessage.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Domain/Types/Issue/IssueMessage.hs
@@ -30,6 +30,8 @@ data IssueMessage = IssueMessage
     -- (IssueApiIntegration) and the flow auto-descends into the branch option whose
     -- condition matches the extracted response fields.
     apiAction :: Maybe Text,
+    -- | Auto reply posted after submit from a CREATE_TICKET / AUTO_CREATE_TICKET / FEEDBACK_TICKET message.
+    onSubmitReplyMsgs :: Maybe [Id IssueMessage],
     isActive :: Bool,
     createdAt :: UTCTime,
     updatedAt :: UTCTime

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/Issue/IssueMessage.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/Beam/Issue/IssueMessage.hs
@@ -37,6 +37,7 @@ data IssueMessageT f = IssueMessageT
     messageAction :: B.C f (Maybe Text),
     messageType :: B.C f DIM.IssueMessageType,
     apiAction :: B.C f (Maybe Text),
+    onSubmitReplyMsgs :: B.C f (Maybe [Text]),
     isActive :: B.C f Bool,
     createdAt :: B.C f UTCTime,
     updatedAt :: B.C f UTCTime

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueMessage.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueMessage.hs
@@ -47,21 +47,21 @@ findAllActiveByCategoryIdAndLanguage :: BeamFlow m r => Id IssueCategory -> Lang
 findAllActiveByCategoryIdAndLanguage issueCategoryId language identifier =
   Hedis.withCrossAppRedis (Hedis.safeGet $ makeIssueMessageByLanguageAndCategory issueCategoryId language identifier) >>= \case
     Just a -> pure a
-    Nothing ->
-      cacheAllIssueMessageByCategoryIdAndLanguage issueCategoryId language identifier
-        /=<< ( appendMediaFiles identifier
-                 =<< Queries.findAllActiveByCategoryIdAndLanguage issueCategoryId language
-             )
+    Nothing -> do
+      -- never cache an empty list (KV drainer lag after a dashboard write)
+      result <- appendMediaFiles identifier =<< Queries.findAllActiveByCategoryIdAndLanguage issueCategoryId language
+      unless (null result) $ cacheAllIssueMessageByCategoryIdAndLanguage issueCategoryId language identifier result
+      pure result
 
 findAllActiveByOptionIdAndLanguage :: BeamFlow m r => Id IssueOption -> Language -> Identifier -> m [(IssueMessage, DetailedTranslation, [Text])]
 findAllActiveByOptionIdAndLanguage issueOptionId language identifier =
   Hedis.withCrossAppRedis (Hedis.safeGet $ makeIssueMessageByLanguageAndOption issueOptionId language identifier) >>= \case
     Just a -> pure a
-    Nothing ->
-      cacheAllIssueMessageByOptionIdAndLanguage issueOptionId language identifier
-        /=<< ( appendMediaFiles identifier
-                 =<< Queries.findAllActiveByOptionIdAndLanguage issueOptionId language
-             )
+    Nothing -> do
+      -- never cache an empty list
+      result <- appendMediaFiles identifier =<< Queries.findAllActiveByOptionIdAndLanguage issueOptionId language
+      unless (null result) $ cacheAllIssueMessageByOptionIdAndLanguage issueOptionId language identifier result
+      pure result
 
 appendMediaFiles :: BeamFlow m r => Identifier -> [(IssueMessage, DetailedTranslation)] -> m [(IssueMessage, DetailedTranslation, [Text])]
 appendMediaFiles identifier =

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueOption.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/CachedQueries/Issue/IssueOption.hs
@@ -30,13 +30,20 @@ findAllByCategoryAndLanguage :: BeamFlow m r => Id IssueCategory -> Language -> 
 findAllByCategoryAndLanguage issueCategoryId language identifier =
   Hedis.withCrossAppRedis (Hedis.safeGet $ makeIssueOptionByCategoryAndLanguageKey issueCategoryId language identifier) >>= \case
     Just a -> pure a
-    Nothing -> cacheAllIssueOptionByCategoryAndLanguage issueCategoryId language identifier /=<< Queries.findAllByCategoryAndLanguage issueCategoryId language
+    Nothing -> do
+      -- never cache an empty list
+      result <- Queries.findAllByCategoryAndLanguage issueCategoryId language
+      unless (null result) $ cacheAllIssueOptionByCategoryAndLanguage issueCategoryId language identifier result
+      pure result
 
 findAllActiveByMessageAndLanguage :: BeamFlow m r => Id IssueMessage -> Language -> Identifier -> m [(IssueOption, Maybe IssueTranslation)]
 findAllActiveByMessageAndLanguage issueMessageId language identifier =
   Hedis.withCrossAppRedis (Hedis.safeGet $ makeIssueOptionByMessageAndLanguageKey issueMessageId language identifier) >>= \case
     Just a -> pure a
-    Nothing -> cacheAllIssueOptionByMessageAndLanguage issueMessageId language identifier /=<< Queries.findAllActiveByMessageAndLanguage issueMessageId language
+    Nothing -> do
+      result <- Queries.findAllActiveByMessageAndLanguage issueMessageId language
+      unless (null result) $ cacheAllIssueOptionByMessageAndLanguage issueMessageId language identifier result
+      pure result
 
 findById :: BeamFlow m r => Id IssueOption -> Identifier -> m (Maybe IssueOption)
 findById issueOptionId identifier =

--- a/Backend/lib/shared-services/src/IssueManagement/Storage/Queries/Issue/IssueMessage.hs
+++ b/Backend/lib/shared-services/src/IssueManagement/Storage/Queries/Issue/IssueMessage.hs
@@ -36,6 +36,7 @@ updateByPrimaryKey IssueMessage {..} =
       Set BeamIM.mediaFiles (getId <$> mediaFiles),
       Set BeamIM.messageType messageType,
       Set BeamIM.apiAction apiAction,
+      Set BeamIM.onSubmitReplyMsgs (map getId <$> onSubmitReplyMsgs),
       Set BeamIM.createdAt createdAt,
       Set BeamIM.updatedAt updatedAt
     ]
@@ -155,6 +156,7 @@ instance FromTType' BeamIM.IssueMessage IssueMessage where
             referenceCategoryId = Id <$> referenceCategoryId,
             referenceOptionId = Id <$> referenceOptionId,
             mediaFiles = Id <$> mediaFiles,
+            onSubmitReplyMsgs = map Id <$> onSubmitReplyMsgs,
             ..
           }
 
@@ -173,6 +175,7 @@ instance ToTType' BeamIM.IssueMessage IssueMessage where
         BeamIM.messageAction = messageAction,
         BeamIM.messageType = messageType,
         BeamIM.apiAction = apiAction,
+        BeamIM.onSubmitReplyMsgs = map getId <$> onSubmitReplyMsgs,
         BeamIM.isActive = isActive,
         BeamIM.priority = priority,
         BeamIM.merchantId = getId merchantId,


### PR DESCRIPTION
## What

Backend for a **FEEDBACK_TICKET** issue flow and a **per-message reply after submit**, configured from the control-center message editor.

### Feedback flow
- `IssueReportReq.isFeedback` (optional). When true, the report is stored with ride, category, option and the customer's text, status `CLOSED`, and no ticket is raised on the ticketing service. `createTicket` is forced off for it.

### Reply after submit
- New column `issue_message.on_submit_reply_msgs text[]` (message ids). It is the auto reply posted right after the customer submits from a `CREATE_TICKET` / `AUTO_CREATE_TICKET` / `FEEDBACK_TICKET` message.
- Resolution order on submit: the labelled message the customer submitted from (looked up by the selected option, or the category's top level) → for ticket creation the existing city-level `IssueConfig.onCreateIssueMsgs` → for feedback, nothing.
- Message upsert: `onSubmitReplyMsgs` (send `[]` to clear, omit to keep), and `standalone` to create a parentless message, optionally under a caller-supplied id. Replies dropped from a message on save are deactivated (soft delete, parentless rows only).
- Message detail returns `onSubmitReplyMsgs`.

### Cache fixes found while testing on a local stack
- Dashboard issue-config updates now invalidate the config-pilot L1 (in-mem) and L2 (Redis hash) caches that rider-app and driver-app read `IssueConfig` through (`Tools.ConfigPilot` pattern). Before this, Settings edits were invisible until the pod restarted or the 1h TTL expired.
- `findAllActiveByCategoryIdAndLanguage` / `findAllActiveByOptionIdAndLanguage` (messages) and the option list lookups no longer cache an empty result. `issue_message` / `issue_option` are KV tables keyed only by id, so a by-category read right after a dashboard write hits Postgres before the drainer lands the rows and used to pin "no messages" until expiry.

## Migrations
- `dev/ddl-migrations/rider-app/1566-issue-message-submit-reply.sql`
- `dev/ddl-migrations/dynamic-offer-driver-app/0872-issue-message-submit-reply.sql`

Both are a single `ALTER TABLE … ADD COLUMN IF NOT EXISTS on_submit_reply_msgs text[]`. Backward compatible: older app builds that don't send `isFeedback` behave exactly as before.

## Counterparts
- Control-center: nammayatri/control-center#1910
- Customer app: nammayatri/ny-react-native#7717

## Verified
- `cabal build` of shared-services, rider-app, dynamic-offer-driver-app, provider-dashboard and rider-dashboard on the feature tree; on this rebased branch shared-services built locally and the app executables are left to CI (draft until green).
- End to end on a local stack via the control-center proxy and rider-app API: reply created / edited / removed from the dialog and read back immediately; feedback submit returns the message-level reply, stores a `CLOSED` report with no `ticket_id`; ticket submit without a message reply falls back to the city-level message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added feedback-only issue submissions that close without creating a support ticket.
  * Added configurable automatic replies after issue submission, including feedback-specific replies.
  * Added support for standalone issue messages and reply-message associations.
  * Added visibility of post-submission reply settings in issue-message details.

* **Bug Fixes**
  * Improved configuration updates so changes are reflected immediately.
  * Improved automatic-reply selection and feedback reply handling.
  * Prevented empty issue-message results from being cached, allowing newly available content to appear correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->