### PR TITLE
backend/fix: Remove fallback of default city from getNearestOperatingAndSourceCity

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Beckn/Search.hs
@@ -999,7 +999,7 @@ validateRequest :: DM.Merchant -> DSearchReq -> Flow ValidatedDSearchReq
 validateRequest merchant sReq = do
   isValueAddNP <- CQVAN.isValueAddNP sReq.bapId
   -- This checks for origin serviceability too
-  NearestOperatingAndSourceCity {nearestOperatingCity, sourceCity} <- getNearestOperatingAndSourceCity merchant sReq.pickupLocation
+  NearestOperatingAndSourceCity {nearestOperatingCity, sourceCity} <- getNearestOperatingAndSourceCity merchant sReq.pickupLocation True
   let bapCity = nearestOperatingCity.city
   merchantOpCity <- CQMOC.getMerchantOpCity merchant (Just bapCity)
   let (cityDistanceUnit, merchantOpCityId) = (merchantOpCity.distanceUnit, merchantOpCity.id)
@@ -1040,7 +1040,7 @@ getIsInterCity merchantId apiKey IsIntercityReq {..} = do
   merchant <- CQM.findById merchantId >>= fromMaybeM (MerchantNotFound merchantId.getId)
   unless (Just merchant.internalApiKey == apiKey) $
     throwError $ AuthBlocked "Invalid BPP internal api key"
-  NearestOperatingAndSourceCity {nearestOperatingCity, sourceCity} <- getNearestOperatingAndSourceCity merchant pickupLatLong
+  NearestOperatingAndSourceCity {nearestOperatingCity, sourceCity} <- getNearestOperatingAndSourceCity merchant pickupLatLong True
   let bapCity = nearestOperatingCity.city
   merchantOpCity <- CQMOC.getMerchantOpCity merchant (Just bapCity)
   transporterConfig <- getOneConfig (TransporterConfigDimensions {merchantOperatingCityId = merchantOpCity.id.getId}) Nothing >>= fromMaybeM (TransporterConfigDoesNotExist merchantOpCity.id.getId)
@@ -1158,8 +1158,8 @@ data CityState = CityState
     state :: Context.IndianState
   }
 
-getNearestOperatingAndSourceCity :: DM.Merchant -> LatLong -> Flow NearestOperatingAndSourceCity
-getNearestOperatingAndSourceCity merchant pickupLatLong = do
+getNearestOperatingAndSourceCity :: DM.Merchant -> LatLong -> Bool -> Flow NearestOperatingAndSourceCity
+getNearestOperatingAndSourceCity merchant pickupLatLong allowMerchantFallback = do
   let geoRestriction = merchant.geofencingConfig.origin
   let merchantCityState = CityState {city = merchant.city, state = merchant.state}
   case geoRestriction of
@@ -1169,7 +1169,9 @@ getNearestOperatingAndSourceCity merchant pickupLatLong = do
       {-
         Below logic is to find the nearest operating city for the pickup location.
         If the pickup location is in the operating city, then return the city.
-        If the pickup location is not in the city, then return the nearest city for that state else the merchant default city.
+        If the pickup location is not in the city, then return the nearest city for that state;
+        if none exists, fall back to the merchant's default city when allowMerchantFallback is
+        True, else the ride is not serviceable.
       -}
       geoms <- B.runInReplica $ QGeometry.findGeometriesContaining pickupLatLong regions
       case filter (\geom -> geom.city /= Context.City "AnyCity") geoms of
@@ -1177,8 +1179,16 @@ getNearestOperatingAndSourceCity merchant pickupLatLong = do
           find (\geom -> geom.city == Context.City "AnyCity") geoms & \case
             Just anyCityGeom -> do
               cities <- CQMOC.findAllByMerchantIdAndState merchant.id anyCityGeom.state >>= mapM (\m -> return (distanceBetweenInMeters pickupLatLong m.location, m.city))
-              let nearestOperatingCity = maybe merchantCityState (\p -> CityState {city = snd p, state = anyCityGeom.state}) (listToMaybe $ sortBy (comparing fst) cities)
-              return $ NearestOperatingAndSourceCity {sourceCity = CityState {city = anyCityGeom.city, state = anyCityGeom.state}, nearestOperatingCity}
+              case listToMaybe $ sortBy (comparing fst) cities of
+                Just p -> do
+                  let nearestOperatingCity = CityState {city = snd p, state = anyCityGeom.state}
+                  return $ NearestOperatingAndSourceCity {sourceCity = CityState {city = anyCityGeom.city, state = anyCityGeom.state}, nearestOperatingCity}
+                Nothing
+                  | allowMerchantFallback ->
+                    return $ NearestOperatingAndSourceCity {sourceCity = CityState {city = anyCityGeom.city, state = anyCityGeom.state}, nearestOperatingCity = merchantCityState}
+                  | otherwise -> do
+                    logError $ "No operating city found near pickupLatLong: " <> show pickupLatLong <> " for state: " <> show anyCityGeom.state
+                    throwError RideNotServiceable
             Nothing -> do
               logError $ "No geometry found for pickupLatLong: " <> show pickupLatLong <> " for regions: " <> show regions
               throwError RideNotServiceable

--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/UI/Driver.hs
@@ -1153,7 +1153,7 @@ activateGoHomeFeature (driverId, merchantId, merchantOpCityId) driverHomeLocatio
   pure APISuccess.Success
   where
     checkIfGoToInDifferentGeometry :: DM.Merchant -> LatLong -> LatLong -> Flow Bool
-    checkIfGoToInDifferentGeometry merchant driverLoc = uncurry (liftM2 (\dl hl -> dl == hl && dl /= Context.City "AnyCity" && hl /= Context.City "AnyCity")) . DTE.both ((((.city) . (.nearestOperatingCity)) <$>) . runInReplica . getNearestOperatingAndSourceCity merchant) . (driverLoc,)
+    checkIfGoToInDifferentGeometry merchant driverLoc = uncurry (liftM2 (\dl hl -> dl == hl && dl /= Context.City "AnyCity" && hl /= Context.City "AnyCity")) . DTE.both ((((.city) . (.nearestOperatingCity)) <$>) . runInReplica . \latLong -> getNearestOperatingAndSourceCity merchant latLong True) . (driverLoc,)
 
     withLockDriverId driverId' = do
       isLockSuccussful <- Redis.tryLockRedis (buildActivateGoHomeKey driverId') 30
@@ -3027,7 +3027,7 @@ getCity req = do
   case req.merchantId of -- only for backward compatibility, Nothing part to be removed later
     Just mId -> do
       merchant <- CQM.findById mId >>= fromMaybeM (MerchantDoesNotExist mId.getId)
-      nearestAndSourceCity <- withTryCatch "getNearestOperatingAndSourceCity:getCity" $ getNearestOperatingAndSourceCity merchant latLng
+      nearestAndSourceCity <- withTryCatch "getNearestOperatingAndSourceCity:getCity" $ getNearestOperatingAndSourceCity merchant latLng False
       case nearestAndSourceCity of
         Left _ -> return $ mkResp Nothing Nothing Nothing
         Right nearestSourceCity -> do


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serviceability checks when determining the nearest operating and source city.
  * Driver location checks now correctly identify trips as unavailable when no operating city exists, instead of falling back to the merchant’s default city.
  * Existing search and inter-city validation flows continue to use the established fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->