### PR TITLE
Backend:feat: handled multiple attachmenet upload flow for sendEmail api

### DIFF
--- a/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/NotificationWebhook.hs
+++ b/Backend/app/provider-platform/dynamic-offer-driver-app/Main/src/Domain/Action/Internal/NotificationWebhook.hs
@@ -5,6 +5,7 @@ module Domain.Action.Internal.NotificationWebhook
 where
 
 import qualified Control.Exception as E
+import qualified Data.Text as T
 import qualified Domain.Types.Merchant as DM
 import qualified Domain.Types.MerchantMessage as DMM
 import qualified Domain.Types.MerchantOperatingCity as DMOC
@@ -12,6 +13,7 @@ import qualified Domain.Types.Person as DP
 import qualified Email.Flow as Email
 import Environment
 import EulerHS.Prelude hiding (id, map)
+import qualified IssueManagement.Utils.RemoteFile as RemoteFile
 import Kernel.External.Encryption (decrypt)
 import qualified Kernel.External.Notification as Notification
 import Kernel.Prelude
@@ -127,7 +129,22 @@ sendWhatsapp' contact req = do
 sendEmail' :: Webhook.Contact -> Webhook.EmailArgs -> Flow ()
 sendEmail' _ args = do
   emailServiceConfig <- asks (.emailServiceConfig)
-  result <- liftIO $ E.try @E.SomeException $ Email.sendPlainEmail emailServiceConfig args.from [args.to] args.subject args.body
+  attachments <- traverse (fetchAttachment emailServiceConfig.maxAttachmentBytes) args.attachments
+  result <- liftIO $ E.try @E.SomeException $ case attachments of
+    [] -> Email.sendPlainEmail emailServiceConfig args.from [args.to] args.subject args.body
+    _ -> Email.sendEmailWithAttachments emailServiceConfig args.from [args.to] args.subject args.body attachments
   case result of
     Left err -> throwError (InternalError $ "Email send failed: " <> show err)
     Right () -> pure ()
+
+fetchAttachment :: Int -> Webhook.EmailAttachment -> Flow Email.EmailAttachment
+fetchAttachment maxBytes att = do
+  mbFetched <- liftIO $ E.try @E.SomeException $ RemoteFile.fetchRemoteFile att.url maxBytes
+  rf <- case mbFetched of
+    Right (Just x) -> pure x
+    Right Nothing -> throwError (InvalidRequest $ "Attachment exceeds " <> T.pack (show maxBytes) <> " bytes: " <> att.url)
+    Left err -> throwError (InvalidRequest $ "Attachment fetch failed for " <> att.url <> ": " <> T.pack (show err))
+  let resolvedCT = case att.contentType of
+        Just ct -> ct
+        Nothing -> if T.null rf.contentType then "application/octet-stream" else rf.contentType
+  pure Email.EmailAttachment {content = rf.content, filename = att.filename, contentType = resolvedCT}

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Internal/NotificationWebhook.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/Internal/NotificationWebhook.hs
@@ -5,11 +5,13 @@ module Domain.Action.Internal.NotificationWebhook
 where
 
 import qualified Control.Exception as E
+import qualified Data.Text as T
 import qualified Domain.Types.MerchantOperatingCity as DMOC
 import qualified Domain.Types.Person as DP
 import qualified Email.Flow as Email
 import Environment
 import EulerHS.Prelude hiding (id, map)
+import qualified IssueManagement.Utils.RemoteFile as RemoteFile
 import Kernel.External.Encryption (decrypt)
 import qualified Kernel.External.Notification as Notification
 import Kernel.Prelude
@@ -119,7 +121,22 @@ sendWhatsapp' contact req = do
 sendEmail' :: Webhook.Contact -> Webhook.EmailArgs -> Flow ()
 sendEmail' _ args = do
   emailServiceConfig <- asks (.emailServiceConfig)
-  result <- liftIO $ E.try @E.SomeException $ Email.sendPlainEmail emailServiceConfig args.from [args.to] args.subject args.body
+  attachments <- traverse (fetchAttachment emailServiceConfig.maxAttachmentBytes) args.attachments
+  result <- liftIO $ E.try @E.SomeException $ case attachments of
+    [] -> Email.sendPlainEmail emailServiceConfig args.from [args.to] args.subject args.body
+    _ -> Email.sendEmailWithAttachments emailServiceConfig args.from [args.to] args.subject args.body attachments
   case result of
     Left err -> throwError (InternalError $ "Email send failed: " <> show err)
     Right () -> pure ()
+
+fetchAttachment :: Int -> Webhook.EmailAttachment -> Flow Email.EmailAttachment
+fetchAttachment maxBytes att = do
+  mbFetched <- liftIO $ E.try @E.SomeException $ RemoteFile.fetchRemoteFile att.url maxBytes
+  rf <- case mbFetched of
+    Right (Just x) -> pure x
+    Right Nothing -> throwError (InvalidRequest $ "Attachment exceeds " <> T.pack (show maxBytes) <> " bytes: " <> att.url)
+    Left err -> throwError (InvalidRequest $ "Attachment fetch failed for " <> att.url <> ": " <> T.pack (show err))
+  let resolvedCT = case att.contentType of
+        Just ct -> ct
+        Nothing -> if T.null rf.contentType then "application/octet-stream" else rf.contentType
+  pure Email.EmailAttachment {content = rf.content, filename = att.filename, contentType = resolvedCT}

--- a/Backend/dhall-configs/dev/dynamic-offer-driver-app.dhall
+++ b/Backend/dhall-configs/dev/dynamic-offer-driver-app.dhall
@@ -475,6 +475,7 @@ let bapHostRedirectMap =
 let emailServiceConfig =
       { sendGridUrl = Some "https://api.sendgrid.com/v3/mail/send"
       , isForcedAWS = True
+      , maxAttachmentBytes = +10485760
       }
 
 let rideEventsStream =

--- a/Backend/dhall-configs/dev/rider-app.dhall
+++ b/Backend/dhall-configs/dev/rider-app.dhall
@@ -426,6 +426,7 @@ let noSignatureSubscribers =
 let emailServiceConfig =
       { sendGridUrl = Some "https://api.sendgrid.com/v3/mail/send"
       , isForcedAWS = True
+      , maxAttachmentBytes = +10485760
       }
 
 in  { esqDBCfg

--- a/Backend/lib/communication-engine/src/Lib/CommunicationEngine/Webhook.hs
+++ b/Backend/lib/communication-engine/src/Lib/CommunicationEngine/Webhook.hs
@@ -23,6 +23,7 @@ module Lib.CommunicationEngine.Webhook
     SendNotificationReq (..),
     SmsMsg (..),
     EmailArgs (..),
+    EmailAttachment (..),
     RawTemplate (..),
     MerchantMessageTemplate (..),
     TemplateRequirement (..),
@@ -92,7 +93,15 @@ data SendNotificationReq = SendNotificationReq
     templateId :: Maybe Text,
     variables :: Maybe [Text],
     sender :: Maybe Text,
-    subject :: Maybe Text
+    subject :: Maybe Text,
+    attachments :: Maybe [EmailAttachment]
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+data EmailAttachment = EmailAttachment
+  { url :: Text,
+    filename :: Text,
+    contentType :: Maybe Text
   }
   deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
 
@@ -101,7 +110,13 @@ data SendNotificationReq = SendNotificationReq
 data SmsMsg = SmsMsg {phoneNumber :: Text, body :: Text, sender :: Maybe Text, templateId :: Text}
 
 -- | Email payload handed to the app's raw sender.
-data EmailArgs = EmailArgs {from :: Text, to :: Text, subject :: Text, body :: Text}
+data EmailArgs = EmailArgs
+  { from :: Text,
+    to :: Text,
+    subject :: Text,
+    body :: Text,
+    attachments :: [EmailAttachment]
+  }
 
 -- | A merchant_message row as the app reads it.
 data RawTemplate = RawTemplate
@@ -208,5 +223,5 @@ sendNotificationWebhook h req = do
     EMAIL -> do
       toEmail <- fromMaybeM (InvalidRequest "Recipient email not available") contact.email
       from <- fromMaybeM (InvalidRequest "sender (from email) required for EMAIL channel") req.sender
-      h.sendEmail contact EmailArgs {from = from, to = toEmail, subject = fromMaybe req.title req.subject, body = req.body}
+      h.sendEmail contact EmailArgs {from = from, to = toEmail, subject = fromMaybe req.title req.subject, body = req.body, attachments = fromMaybe [] req.attachments}
   pure Success

--- a/Backend/lib/external/src/Email/AWS/Flow.hs
+++ b/Backend/lib/external/src/Email/AWS/Flow.hs
@@ -132,3 +132,57 @@ buildRawEmail from to subject body pdfBase64 fileName mimeType =
           "",
           "--" <> boundary <> "--"
         ]
+
+sendEmailWithAttachments ::
+  Text ->
+  [Text] ->
+  Text ->
+  Text ->
+  [Email.EmailAttachment] ->
+  IO ()
+sendEmailWithAttachments from to subject bodyText attachments = do
+  let rawEmail = buildMultiAttachmentRawEmail from to subject bodyText attachments
+  env <- AWS.newEnv AWS.discover
+  let rawMessage = newRawMessage (TE.encodeUtf8 rawEmail)
+      sendReq = newSendRawEmail rawMessage
+  void $ AWS.runResourceT $ AWS.send env sendReq
+
+buildMultiAttachmentRawEmail ::
+  Text ->
+  [Text] ->
+  Text ->
+  Text ->
+  [Email.EmailAttachment] ->
+  Text
+buildMultiAttachmentRawEmail from to subject body attachments =
+  let boundary = "----=_Part_0_123456789.987654321"
+      toAddressList = T.intercalate ", " to
+      bodyPart =
+        [ "--" <> boundary,
+          "Content-Type: text/plain; charset=UTF-8",
+          "Content-Transfer-Encoding: 7bit",
+          "",
+          body,
+          ""
+        ]
+      attachmentPart att =
+        let b64 = TE.decodeUtf8 . B64.encode $ att.content
+         in [ "--" <> boundary,
+              "Content-Type: " <> att.contentType <> "; name=\"" <> att.filename <> "\"",
+              "Content-Description: " <> att.filename,
+              "Content-Disposition: attachment; filename=\"" <> att.filename <> "\"",
+              "Content-Transfer-Encoding: base64",
+              "",
+              b64,
+              ""
+            ]
+      headerPart =
+        [ "From: " <> from,
+          "To: " <> toAddressList,
+          "Subject: " <> subject,
+          "MIME-Version: 1.0",
+          "Content-Type: multipart/mixed; boundary=\"" <> boundary <> "\"",
+          ""
+        ]
+      closing = ["--" <> boundary <> "--"]
+   in T.unlines $ headerPart <> bodyPart <> concatMap attachmentPart attachments <> closing

--- a/Backend/lib/external/src/Email/Flow.hs
+++ b/Backend/lib/external/src/Email/Flow.hs
@@ -18,6 +18,7 @@ module Email.Flow
     sendMagicLinkEmail,
     sendBusinessVerificationEmail,
     sendEmailWithAttachment,
+    sendEmailWithAttachments,
     module Email.Types,
   )
 where
@@ -92,6 +93,23 @@ sendEmailWithAttachment serviceConfig from to subject bodyText filePath fileName
       UNAVAILABLE -> do
         putStrLn ("ERROR: Email.Flow: CloudType UNAVAILABLE" :: Text)
         error "CloudType UNAVAILABLE: Cannot route email with attachment"
+
+sendEmailWithAttachments ::
+  EmailServiceConfig ->
+  Text ->
+  [Text] ->
+  Text ->
+  Text ->
+  [EmailAttachment] ->
+  IO ()
+sendEmailWithAttachments serviceConfig from to subject bodyText attachments = do
+  handleEmailRouting serviceConfig "sendEmailWithAttachments" $ \cloudType ->
+    case cloudType of
+      AWS -> AWS.sendEmailWithAttachments from to subject bodyText attachments
+      GCP -> GCP.sendEmailWithAttachments (getSendGridUrl serviceConfig) from to subject bodyText attachments
+      UNAVAILABLE -> do
+        putStrLn ("ERROR: Email.Flow: CloudType UNAVAILABLE" :: Text)
+        error "CloudType UNAVAILABLE: Cannot route email with attachments"
 
 handleEmailRouting :: EmailServiceConfig -> Text -> (CloudType -> IO ()) -> IO ()
 handleEmailRouting config _ action = do

--- a/Backend/lib/external/src/Email/GCP/Flow.hs
+++ b/Backend/lib/external/src/Email/GCP/Flow.hs
@@ -18,6 +18,7 @@ module Email.GCP.Flow
     sendMagicLinkEmail,
     sendBusinessVerificationEmail,
     sendEmailWithAttachment,
+    sendEmailWithAttachments,
   )
 where
 
@@ -196,3 +197,24 @@ sendEmailWithAttachment apiUrl from to subject bodyText pdfPath fileName = do
       emailData = buildEmail from to subject bodyText (Just [attachment])
 
   sendViaSendGrid apiUrl emailData
+
+sendEmailWithAttachments ::
+  String ->
+  Text ->
+  [Text] ->
+  Text ->
+  Text ->
+  [Email.EmailAttachment] ->
+  IO ()
+sendEmailWithAttachments apiUrl from to subject bodyText attachments = do
+  let sgAttachments = map toSg attachments
+      emailData = buildEmail from to subject bodyText (Just sgAttachments)
+  sendViaSendGrid apiUrl emailData
+  where
+    toSg a =
+      Attachment
+        { attachmentContent = TE.decodeUtf8 . B64.encode $ a.content,
+          filename = a.filename,
+          attachmentType = a.contentType,
+          disposition = "attachment"
+        }

--- a/Backend/lib/external/src/Email/Types.hs
+++ b/Backend/lib/external/src/Email/Types.hs
@@ -17,6 +17,7 @@ module Email.Types
     EmailMagicLinkConfig (..),
     EmailBusinessVerificationConfig (..),
     EmailServiceConfig (..),
+    EmailAttachment (..),
   )
 where
 
@@ -33,9 +34,16 @@ import Sequelize.SQLObject (SQLObject (..), ToSQLObject (..))
 
 data EmailServiceConfig = EmailServiceConfig
   { sendGridUrl :: Maybe Text,
-    isForcedAWS :: Bool
+    isForcedAWS :: Bool,
+    maxAttachmentBytes :: Int
   }
   deriving (Generic, FromDhall)
+
+data EmailAttachment = EmailAttachment
+  { content :: ByteString,
+    filename :: Text,
+    contentType :: Text
+  }
 
 data EmailOTPConfig = EmailOTPConfig
   { fromEmail :: Text,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Webhook-triggered emails now support multiple file attachments from remote URLs.
  - Attachments preserve filenames and content types when available.
  - Email delivery supports attachments through supported AWS and SendGrid providers.
- **Bug Fixes**
  - Invalid or oversized attachments are rejected before delivery.
  - Attachment downloads are limited to 10 MiB in development environments.
  - Emails without attachments continue using the standard delivery flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->