### PR TITLE
enhc: added cluster for track routes api

### DIFF
--- a/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
+++ b/Backend/app/rider-platform/rider-app/Main/spec/API/MultiModal.yaml
@@ -860,5 +860,6 @@ apis:
         stopCode: Text
       query:
         routeCodes: Text
+        allowClusters: Bool
       response:
         type: "[PassingRoutes]"

--- a/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src-read-only/API/Action/UI/MultimodalConfirm.hs
@@ -615,6 +615,9 @@ type API =
            Kernel.Prelude.Text
       :> "routes"
       :> QueryParam
+           "allowClusters"
+           Kernel.Prelude.Bool
+      :> QueryParam
            "routeCodes"
            Kernel.Prelude.Text
       :> Get
@@ -1070,7 +1073,8 @@ getMultimodalTrackStopRoutes ::
       Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
     ) ->
     Kernel.Prelude.Text ->
+    Kernel.Prelude.Maybe Kernel.Prelude.Bool ->
     Kernel.Prelude.Maybe Kernel.Prelude.Text ->
     Environment.FlowHandler [API.Types.UI.MultimodalConfirm.PassingRoutes]
   )
-getMultimodalTrackStopRoutes a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.MultimodalConfirm.getMultimodalTrackStopRoutes (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a3) a2 a1
+getMultimodalTrackStopRoutes a4 a3 a2 a1 = withFlowHandlerAPI $ Domain.Action.UI.MultimodalConfirm.getMultimodalTrackStopRoutes (Control.Lens.over Control.Lens._1 Kernel.Prelude.Just a4) a3 a2 a1

--- a/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Domain/Action/UI/MultimodalConfirm.hs
@@ -3271,28 +3271,31 @@ getMultimodalTrackStopRoutes ::
     Kernel.Types.Id.Id Domain.Types.Merchant.Merchant
   ) ->
   Kernel.Prelude.Text ->
+  Kernel.Prelude.Maybe Kernel.Prelude.Bool ->
   Kernel.Prelude.Maybe Kernel.Prelude.Text ->
   Environment.Flow [ApiTypes.PassingRoutes]
-getMultimodalTrackStopRoutes (mbPersonId, _merchantId) stopCode mbRouteCodes = do
+getMultimodalTrackStopRoutes (mbPersonId, _merchantId) stopCode mbAllowClusters mbRouteCodes = do
   personId <- mbPersonId & fromMaybeM (InvalidRequest "Person not found")
   person <- QP.findById personId >>= fromMaybeM (PersonNotFound personId.getId)
   integratedBPPConfig <-
     fromMaybeM (InvalidRequest "Integrated BPP config not found") . listToMaybe
       =<< SIBC.findAllIntegratedBPPConfig person.merchantOperatingCityId Enums.BUS DIBC.MULTIMODAL
-  mappings <- OTPRest.getRouteStopMappingByStopCode stopCode integratedBPPConfig
+  mappings <- OTPRest.getRouteStopMappingByStopCodeWithClusters mbAllowClusters stopCode integratedBPPConfig
   let filterRouteCodes = maybe [] (filter (not . T.null) . map T.strip . T.splitOn ",") mbRouteCodes
       passingRouteCodes = nub (map (.routeCode) mappings)
+      stopCodeByRoute = Map.fromListWith (\_new old -> old) [(mapping.routeCode, mapping.stopCode) | mapping <- mappings]
       routeCodes =
         if null filterRouteCodes
           then passingRouteCodes
           else filter (`elem` filterRouteCodes) passingRouteCodes
 
   frfsTierMap <- map (\t -> (t._type, t)) <$> CQFRFSVehicleServiceTier.findAllByMerchantOperatingCityIdAndIntegratedBPPConfigId person.merchantOperatingCityId integratedBPPConfig.id
-  catMaybes <$> mapConcurrently (getRouteEtaAtStop integratedBPPConfig frfsTierMap) routeCodes
+  catMaybes <$> mapConcurrently (getRouteEtaAtStop integratedBPPConfig frfsTierMap stopCodeByRoute) routeCodes
   where
-    etaAtStop etaEntries = listToMaybe (sortOn (.arrivalTimeUnix) (filter (\etaEntry -> etaEntry.stopCode == stopCode) etaEntries))
+    etaAtStop routeStopCode etaEntries = listToMaybe (sortOn (.arrivalTimeUnix) (filter (\etaEntry -> etaEntry.stopCode == routeStopCode) etaEntries))
 
-    getRouteEtaAtStop integratedBPPConfig frfsTierMap routeCode = do
+    getRouteEtaAtStop integratedBPPConfig frfsTierMap stopCodeByRoute routeCode = do
+      let routeStopCode = Map.findWithDefault stopCode routeCode stopCodeByRoute
       mbRoute <- OTPRest.getRouteByRouteId integratedBPPConfig routeCode
       case mbRoute of
         Nothing -> do
@@ -3311,7 +3314,7 @@ getMultimodalTrackStopRoutes (mbPersonId, _merchantId) stopCode mbRouteCodes = d
                   [ (bus.vehicleNumber, busEta)
                     | routeWithBuses <- busesForRoutes,
                       bus <- routeWithBuses.buses,
-                      Just busEta <- [etaAtStop (fromMaybe [] bus.busData.eta_data)]
+                      Just busEta <- [etaAtStop routeStopCode (fromMaybe [] bus.busData.eta_data)]
                   ]
           scheduleVehiclesFork <-
             awaitableFork "getMultimodalTrackStopRoutes->schedules" $ do
@@ -3319,7 +3322,7 @@ getMultimodalTrackStopRoutes (mbPersonId, _merchantId) stopCode mbRouteCodes = d
               pure
                 [ (scheduleDetail.vehicle_no, scheduleDetail.service_tier, detailEta)
                   | scheduleDetail <- schedules,
-                    Just detailEta <- [etaAtStop scheduleDetail.eta]
+                    Just detailEta <- [etaAtStop routeStopCode scheduleDetail.eta]
                 ]
           liveVehicles <-
             L.await Nothing liveVehiclesFork >>= \case
@@ -3337,7 +3340,7 @@ getMultimodalTrackStopRoutes (mbPersonId, _merchantId) stopCode mbRouteCodes = d
           scheduleVehicleInfos <- mapM (mkPassingVehicle integratedBPPConfig frfsTierMap) scheduleVehicles
           routeMappings <- OTPRest.getRouteStopMappingByRouteCode routeCode integratedBPPConfig
           let isLastStop = case sortOn (Down . (.sequenceNum)) routeMappings of
-                (lastStopMapping : _) -> lastStopMapping.stopCode == stopCode
+                (lastStopMapping : _) -> lastStopMapping.stopCode == routeStopCode
                 [] -> False
           pure $
             Just

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/API/Nandi.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/API/Nandi.hs
@@ -8,7 +8,7 @@ import SharedLogic.External.Nandi.Types
 
 type RouteStopMappingByRouteIdAPI = "route-stop-mapping" :> Capture "gtfs_id" Text :> "route" :> Capture "route_code" Text :> Get '[JSON] [RouteStopMappingInMemoryServer]
 
-type RouteStopMappingByStopCodeAPI = "route-stop-mapping" :> Capture "gtfs_id" Text :> "stop" :> Capture "stop_code" Text :> Get '[JSON] [RouteStopMappingInMemoryServer]
+type RouteStopMappingByStopCodeAPI = "route-stop-mapping" :> Capture "gtfs_id" Text :> "stop" :> Capture "stop_code" Text :> QueryParam "allowClusters" Bool :> Get '[JSON] [RouteStopMappingInMemoryServer]
 
 type RouteByRouteIdAPI = "route" :> Capture "gtfs_id" Text :> Capture "route_id" Text :> Get '[JSON] RouteInfoNandi
 
@@ -164,7 +164,7 @@ nandiWaybillMetadataAPI = Proxy
 getNandiGetRouteStopMappingByRouteId :: Text -> Text -> ET.EulerClient [RouteStopMappingInMemoryServer]
 getNandiGetRouteStopMappingByRouteId = ET.client nandiGetRouteStopMappingByRouteIdAPI
 
-getNandiGetRouteStopMappingByStopCode :: Text -> Text -> ET.EulerClient [RouteStopMappingInMemoryServer]
+getNandiGetRouteStopMappingByStopCode :: Text -> Text -> Maybe Bool -> ET.EulerClient [RouteStopMappingInMemoryServer]
 getNandiGetRouteStopMappingByStopCode = ET.client nandiGetRouteStopMappingByStopCodeAPI
 
 getNandiRouteByRouteId :: Text -> Text -> ET.EulerClient RouteInfoNandi

--- a/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Flow.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/SharedLogic/External/Nandi/Flow.hs
@@ -16,9 +16,9 @@ getRouteStopMappingByRouteCode :: (CoreMetrics m, MonadFlow m, MonadReader r m, 
 getRouteStopMappingByRouteCode baseUrl gtfsId routeCode = do
   withShortRetry $ callAPI baseUrl (NandiAPI.getNandiGetRouteStopMappingByRouteId gtfsId routeCode) "getRouteStopMappingByRouteCode" NandiAPI.nandiGetRouteStopMappingByRouteIdAPI >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_NANDI_GET_ROUTE_STOP_MAPPING_BY_ROUTE_CODE_API") baseUrl)
 
-getRouteStopMappingByStopCode :: (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => BaseUrl -> Text -> Text -> m [RouteStopMappingInMemoryServer]
-getRouteStopMappingByStopCode baseUrl gtfsId stopCode = do
-  withShortRetry $ callAPI baseUrl (NandiAPI.getNandiGetRouteStopMappingByStopCode gtfsId stopCode) "getRouteStopMappingByStopCode" NandiAPI.nandiGetRouteStopMappingByStopCodeAPI >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_NANDI_GET_ROUTE_STOP_MAPPING_BY_STOP_CODE_API") baseUrl)
+getRouteStopMappingByStopCode :: (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => BaseUrl -> Text -> Text -> Maybe Bool -> m [RouteStopMappingInMemoryServer]
+getRouteStopMappingByStopCode baseUrl gtfsId stopCode mbAllowClusters = do
+  withShortRetry $ callAPI baseUrl (NandiAPI.getNandiGetRouteStopMappingByStopCode gtfsId stopCode mbAllowClusters) "getRouteStopMappingByStopCode" NandiAPI.nandiGetRouteStopMappingByStopCodeAPI >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_NANDI_GET_ROUTE_STOP_MAPPING_BY_STOP_CODE_API") baseUrl)
 
 getClusterRoutesBetweenStops :: (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => BaseUrl -> Text -> Text -> Text -> m (Maybe [ClusterRouteConnectionNandi])
 getClusterRoutesBetweenStops baseUrl gtfsId fromStopCode toStopCode = do
@@ -58,14 +58,14 @@ getRoutesByGtfsId :: (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurat
 getRoutesByGtfsId baseUrl gtfsId = do
   withShortRetry $ callAPI baseUrl (NandiAPI.getNandiRoutesByGtfsId gtfsId) "getRoutesByGtfsId" NandiAPI.nandiRoutesByGtfsIdAPI >>= fromEitherM (ExternalAPICallError (Just "UNABLE_TO_CALL_NANDI_GET_ROUTES_BY_GTFS_ID_API") baseUrl)
 
-getRouteStopMappingInMemoryServer :: (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => BaseUrl -> Text -> Maybe Text -> Maybe Text -> m [RouteStopMappingInMemoryServer]
-getRouteStopMappingInMemoryServer baseUrl gtfsId routeCode' stopCode' = do
+getRouteStopMappingInMemoryServer :: (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, HasRequestId r, MonadReader r m) => BaseUrl -> Text -> Maybe Text -> Maybe Text -> Maybe Bool -> m [RouteStopMappingInMemoryServer]
+getRouteStopMappingInMemoryServer baseUrl gtfsId routeCode' stopCode' mbAllowClusters = do
   case (routeCode', stopCode') of
     (Just routeCode, Just stopCode) -> do
       routeStopMapping <- getRouteStopMappingByRouteCode baseUrl gtfsId routeCode
       return $ filter (\r -> r.stopCode == stopCode) routeStopMapping
     (Just routeCode, Nothing) -> getRouteStopMappingByRouteCode baseUrl gtfsId routeCode
-    (Nothing, Just stopCode) -> getRouteStopMappingByStopCode baseUrl gtfsId stopCode
+    (Nothing, Just stopCode) -> getRouteStopMappingByStopCode baseUrl gtfsId stopCode mbAllowClusters
     (Nothing, Nothing) -> do
       logError $ "routeCode or stopCode is not provided, skipping gtfs inmemory server rest api calls" <> show (baseUrl, gtfsId)
       throwError $ InternalError "routeCode or stopCode is not provided, skipping gtfs inmemory server rest api calls"

--- a/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/OTPRest/OTPRest.hs
+++ b/Backend/app/rider-platform/rider-app/Main/src/Storage/CachedQueries/OTPRest/OTPRest.hs
@@ -153,7 +153,7 @@ getRouteStopMappingByRouteCode ::
   m [RouteStopMapping]
 getRouteStopMappingByRouteCode routeCode integratedBPPConfig = IM.withInMemCache ["RSM", routeCode, integratedBPPConfig.id.getId] 3600 $ do
   baseUrl <- MM.getOTPRestServiceReq integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
-  routeStopMapping' <- Flow.getRouteStopMappingInMemoryServer baseUrl integratedBPPConfig.feedKey (Just routeCode) Nothing
+  routeStopMapping' <- Flow.getRouteStopMappingInMemoryServer baseUrl integratedBPPConfig.feedKey (Just routeCode) Nothing Nothing
   logDebug $ "routeStopMapping from rest api: " <> show routeStopMapping'
   routeStopMapping <- parseRouteStopMappingInMemoryServer routeStopMapping' integratedBPPConfig integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
   logDebug $ "routeStopMapping from rest api after parsing: " <> show routeStopMapping
@@ -166,7 +166,7 @@ getRouteStopMappingByRouteCodeInMem ::
   m [RouteStopMappingInMemoryServer]
 getRouteStopMappingByRouteCodeInMem routeCode integratedBPPConfig = do
   baseUrl <- MM.getOTPRestServiceReq integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
-  routeStopMapping' <- Flow.getRouteStopMappingInMemoryServer baseUrl integratedBPPConfig.feedKey (Just routeCode) Nothing
+  routeStopMapping' <- Flow.getRouteStopMappingInMemoryServer baseUrl integratedBPPConfig.feedKey (Just routeCode) Nothing Nothing
   logDebug $ "routeStopMapping from rest api: " <> show routeStopMapping'
   return routeStopMapping'
 
@@ -175,9 +175,17 @@ getRouteStopMappingByStopCode ::
   Text ->
   IntegratedBPPConfig ->
   m [RouteStopMapping]
-getRouteStopMappingByStopCode stopCode integratedBPPConfig = do
+getRouteStopMappingByStopCode = getRouteStopMappingByStopCodeWithClusters Nothing
+
+getRouteStopMappingByStopCodeWithClusters ::
+  (CoreMetrics m, MonadFlow m, MonadReader r m, HasShortDurationRetryCfg r c, Log m, CacheFlow m r, EsqDBFlow m r) =>
+  Maybe Bool ->
+  Text ->
+  IntegratedBPPConfig ->
+  m [RouteStopMapping]
+getRouteStopMappingByStopCodeWithClusters mbAllowClusters stopCode integratedBPPConfig = do
   baseUrl <- MM.getOTPRestServiceReq integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
-  routeStopMapping' <- Flow.getRouteStopMappingInMemoryServer baseUrl integratedBPPConfig.feedKey Nothing (Just stopCode)
+  routeStopMapping' <- Flow.getRouteStopMappingInMemoryServer baseUrl integratedBPPConfig.feedKey Nothing (Just stopCode) mbAllowClusters
   logDebug $ "routeStopMapping from rest api: " <> show routeStopMapping'
   routeStopMapping <- parseRouteStopMappingInMemoryServer routeStopMapping' integratedBPPConfig integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
   logDebug $ "routeStopMapping from rest api after parsing: " <> show routeStopMapping
@@ -211,7 +219,7 @@ getRouteStopMappingByStopCodeAndRouteCode ::
   m [RouteStopMapping]
 getRouteStopMappingByStopCodeAndRouteCode stopCode routeCode integratedBPPConfig = do
   baseUrl <- MM.getOTPRestServiceReq integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
-  routeStopMapping' <- Flow.getRouteStopMappingInMemoryServer baseUrl integratedBPPConfig.feedKey (Just routeCode) (Just stopCode)
+  routeStopMapping' <- Flow.getRouteStopMappingInMemoryServer baseUrl integratedBPPConfig.feedKey (Just routeCode) (Just stopCode) Nothing
   logDebug $ "routeStopMapping from rest api: " <> show routeStopMapping'
   routeStopMapping <- parseRouteStopMappingInMemoryServer routeStopMapping' integratedBPPConfig integratedBPPConfig.merchantId integratedBPPConfig.merchantOperatingCityId
   logDebug $ "routeStopMapping from rest api after parsing: " <> show routeStopMapping


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
- [ ] This PR contains API breaking changes
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Screenshot of test results
<!-- Provide screenshot of the test results -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added integration tests for my changes where possible
- [ ] I tested the changes using integration tests
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
- [ ] No leak detected in leakcanary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `allowClusters` parameter to stop-route tracking requests.
  - Stop-route results can now include routes associated with clustered stops when enabled.
  - Improved ETA, vehicle filtering, and last-stop status accuracy for clustered-stop journeys.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->